### PR TITLE
aio: cleanup torch model parsing

### DIFF
--- a/zml/aio/torch.zig
+++ b/zml/aio/torch.zig
@@ -379,6 +379,7 @@ pub const PickleData = struct {
                         const key, const val = seq_values[0..2].*;
                         switch (key) {
                             .string => |s| {
+                                // Handle Pytorch specific fields
                                 if (std.mem.eql(u8, s, "_modules") or std.mem.eql(u8, s, "_parameters") or std.mem.eql(u8, s, "_buffers")) {
                                     try self.parseValue(allocator, store, prefix, val);
                                 } else {

--- a/zml/aio/torch.zig
+++ b/zml/aio/torch.zig
@@ -101,12 +101,12 @@ pub const PickleData = struct {
 
     fn isTensor(v: Value) bool {
         if (basicTypeCheck(v, "torch._utils", "_rebuild_tensor_v2")) {
-            const args = v.global.args[0].seq[1];
+            const args = v.global.args[0].seq.values;
             if (args.len >= 5 and
                 args[0] == .pers_id and
                 args[1] == .int64 and
-                args[2] == .seq and args[2].seq[0] == .tuple and
-                args[3] == .seq and args[3].seq[0] == .tuple)
+                args[2] == .seq and args[2].seq.type == .tuple and
+                args[3] == .seq and args[3].seq.type == .tuple)
             {
                 return true;
             } else @panic("Unexpected value in call to torch._utils._rebuild_tensor_v2");
@@ -174,15 +174,15 @@ pub const PickleData = struct {
         return switch (v) {
             .global => |object| {
                 if (isTensor(v)) {
-                    const args = object.args[0].seq[1];
+                    const args = object.args[0].seq.values;
                     const pidval: *PersId, var offs: u64, const raw_shape: Sequence, const raw_strides: Sequence = .{ args[0].pers_id, @intCast(args[1].int64), args[2].seq, args[3].seq };
-                    const rank = raw_shape[1].len;
-                    const shape = dimsFromValues(raw_shape[1]);
-                    var strides = dimsFromValues(raw_strides[1]);
+                    const rank = raw_shape.values.len;
+                    const shape = dimsFromValues(raw_shape.values);
+                    var strides = dimsFromValues(raw_strides.values);
                     const stype: []const u8, const sfile: []const u8, const sdev: []const u8 = switch (pidval.ref) {
                         .seq => |seq| blk: {
-                            const sargs = seq[1];
-                            if (seq[0] == .tuple and
+                            const sargs = seq.values;
+                            if (seq.type == .tuple and
                                 sargs.len >= 5 and
                                 sargs[0] == .string and std.mem.eql(u8, sargs[0].string, "storage") and
                                 sargs[1] == .raw and sargs[1].raw == .global and
@@ -231,7 +231,7 @@ pub const PickleData = struct {
                     );
                     return true;
                 } else if (basicTypeCheck(v, "torch", "Size")) {
-                    const size = object.args[0].seq[1][0].seq[1];
+                    const size = object.args[0].seq.values[0].seq.values;
                     const key = try allocator.dupe(u8, prefix.items);
                     const entry = try store._metadata.getOrPut(allocator, key);
                     if (entry.found_existing) {
@@ -243,7 +243,7 @@ pub const PickleData = struct {
                     entry.value_ptr.* = .{ .array = .{ .item_type = .int64, .data = std.mem.sliceAsBytes(d) } };
                     return true;
                 } else if (basicTypeCheck(v, "fractions", "Fraction")) {
-                    const fraction_str = object.args[0].seq[1][0].string;
+                    const fraction_str = object.args[0].seq.values[0].string;
                     if (std.mem.indexOfScalar(u8, fraction_str, '/')) |split_idx| {
                         {
                             var new_prefix = prefix;
@@ -271,8 +271,8 @@ pub const PickleData = struct {
                     try self.parseValue(allocator, store, prefix, object.member);
                     for (object.args) |item| {
                         // if possible, coerce to `kv_tuple` (only if key val doesn't match root of prefix)
-                        if (item == .seq and item.seq[0] == .tuple and item.seq[1].len == 2 and item.seq[1][0] == .string) {
-                            try self.parseValue(allocator, store, prefix, .{ .seq = .{ .kv_tuple, item.seq[1] } });
+                        if (item == .seq and item.seq.type == .tuple and item.seq.values.len == 2 and item.seq.values[0] == .string) {
+                            try self.parseValue(allocator, store, prefix, .{ .seq = .{ .type = .kv_tuple, .values = item.seq.values } });
                         } else try self.parseValue(allocator, store, prefix, item);
                     }
                 }
@@ -313,12 +313,11 @@ pub const PickleData = struct {
             },
             .pers_id => |pers_id| try self.parseValue(allocator, store, prefix, pers_id.ref),
             .seq => |seq| {
-                const seq_type, const seq_values = seq;
-                switch (seq_type) {
+                switch (seq.type) {
                     .list, .tuple, .set, .frozen_set => {
-                        if (seq_values.len == 0) return;
+                        if (seq.values.len == 0) return;
                         var valid_slice = true;
-                        switch (seq_values[0]) {
+                        switch (seq.values[0]) {
                             inline .int64, .float64, .boolval => |val0, tag| {
                                 const ItemType = switch (tag) {
                                     .int64 => i64,
@@ -328,7 +327,7 @@ pub const PickleData = struct {
                                 };
                                 var values: std.ArrayListUnmanaged(ItemType) = .{};
                                 try values.append(allocator, val0);
-                                for (seq_values[1..], 1..) |val, i| {
+                                for (seq.values[1..], 1..) |val, i| {
                                     if (std.meta.activeTag(val) != tag) valid_slice = false;
                                     if (valid_slice) {
                                         try values.append(allocator, @field(val, @tagName(tag)));
@@ -342,24 +341,25 @@ pub const PickleData = struct {
                                     }
                                 }
 
-                                switch (valid_slice) {
-                                    true => try store._metadata.put(
+                                if (valid_slice) {
+                                    try store._metadata.put(
                                         allocator,
                                         try allocator.dupe(u8, prefix.items),
                                         .{ .array = .{ .item_type = std.meta.stringToEnum(zml.aio.Value.Slice.ItemType, @tagName(tag)).?, .data = std.mem.sliceAsBytes(try values.toOwnedSlice(allocator)) } },
-                                    ),
-                                    false => for (values.items, 0..) |val, i| {
+                                    );
+                                } else {
+                                    for (values.items, 0..) |val, i| {
                                         var new_prefix = prefix;
                                         if (prefix.items.len > 0) {
                                             new_prefix.appendAssumeCapacity('.');
                                         }
                                         new_prefix.items.len += std.fmt.formatIntBuf(new_prefix.unusedCapacitySlice(), i, 10, .lower, .{});
                                         try store._metadata.put(allocator, try allocator.dupe(u8, new_prefix.items), @unionInit(zml.aio.Value, @tagName(tag), val));
-                                    },
+                                    }
                                 }
                             },
                             else => {
-                                for (seq_values, 0..) |item, i| {
+                                for (seq.values, 0..) |item, i| {
                                     var new_prefix = prefix;
                                     if (v.isPrimitive()) {
                                         if (prefix.items.len > 0) {
@@ -372,11 +372,11 @@ pub const PickleData = struct {
                             },
                         }
                     },
-                    .dict => for (seq_values) |item| {
+                    .dict => for (seq.values) |item| {
                         try self.parseValue(allocator, store, prefix, item);
                     },
                     .kv_tuple => {
-                        const key, const val = seq_values[0..2].*;
+                        const key, const val = seq.values[0..2].*;
                         switch (key) {
                             .string => |s| {
                                 // Handle Pytorch specific fields

--- a/zml/aio/torch/parser.zig
+++ b/zml/aio/torch/parser.zig
@@ -418,16 +418,16 @@ test "Read pickle (simple)" {
                 try testing.expect(key == .string);
                 try testing.expectEqualStrings("int", key.string);
                 const value = kv.seq[1][1];
-                try testing.expect(value == .int);
-                try testing.expect(value.int == 1);
+                try testing.expect(value == .int64);
+                try testing.expect(value.int64 == 1);
             },
             2 => {
                 const key = kv.seq[1][0];
                 try testing.expect(key == .string);
                 try testing.expectEqualStrings("float", key.string);
                 const value = kv.seq[1][1];
-                try testing.expect(value == .float);
-                try testing.expectEqual(@as(f64, 3.141592), value.float);
+                try testing.expect(value == .float64);
+                try testing.expectEqual(@as(f64, 3.141592), value.float64);
             },
             3 => {
                 const key = kv.seq[1][0];
@@ -437,8 +437,8 @@ test "Read pickle (simple)" {
                 try testing.expect(value == .seq);
                 try testing.expect(value.seq[0] == .list);
                 for (value.seq[1], 0..) |item, j| {
-                    try testing.expect(item == .int);
-                    try testing.expect(item.int == @as(i64, @intCast(j)));
+                    try testing.expect(item == .int64);
+                    try testing.expect(item.int64 == @as(i64, @intCast(j)));
                 }
             },
             4 => {
@@ -450,8 +450,8 @@ test "Read pickle (simple)" {
                 try testing.expect(value.seq[0] == .tuple);
                 try testing.expect(value.seq[1][0] == .string);
                 try testing.expectEqualStrings("a", value.seq[1][0].string);
-                try testing.expect(value.seq[1][1] == .int);
-                try testing.expect(value.seq[1][1].int == 10);
+                try testing.expect(value.seq[1][1] == .int64);
+                try testing.expect(value.seq[1][1].int64 == 10);
             },
             else => unreachable,
         }

--- a/zml/aio/torch/value.zig
+++ b/zml/aio/torch/value.zig
@@ -100,11 +100,11 @@ pub const ValueType = enum {
     seq,
     string,
     bytes,
-    int,
+    int64,
     bigint,
-    float,
+    float64,
     raw_num,
-    bool,
+    boolval,
     none,
 };
 
@@ -160,7 +160,7 @@ pub const Value = union(ValueType) {
     /// An integer, but not the crazy kind that comes as a string
     /// that has to be parsed. You can look in `Value.raw_num` for
     /// those.
-    int: i64,
+    int64: i64,
 
     /// An integer that can't fit in i64.
     bigint: big_int.Managed,
@@ -168,13 +168,13 @@ pub const Value = union(ValueType) {
     /// An float, but not the crazy kind that comes as a string
     /// that has to be parsed. You can look in `Value.raw_num` for
     /// those.
-    float: f64,
+    float64: f64,
 
     /// Some kind of weird number we can't handle.
     raw_num: PickleOp,
 
     /// A boolean value.
-    bool: bool,
+    boolval: bool,
 
     /// Python `None`.
     none: void,
@@ -205,7 +205,7 @@ pub const Value = union(ValueType) {
         try writeIndents(indents + 1, writer);
         try writer.print(".{s} = ", .{@tagName(std.meta.activeTag(value))});
         switch (value) {
-            inline .ref, .int, .float => |v| try writer.print("{d} ", .{v}),
+            inline .ref, .int64, .float64 => |v| try writer.print("{d} ", .{v}),
             .app, .object, .global => |v| {
                 try writer.writeAll(".{\n");
                 try internalFormat(v.member, indents + 2, writer);
@@ -295,7 +295,7 @@ pub const Value = union(ValueType) {
 
     pub fn isPrimitive(self: Value) bool {
         return switch (self) {
-            .int, .bigint, .float, .string, .bytes, .bool, .none => true,
+            .int64, .bigint, .float64, .string, .bytes, .boolval, .none => true,
             .seq => |seq| utils.allTrue(seq[1], Value.isPrimitive),
             else => false,
         };
@@ -336,7 +336,7 @@ pub const Value = union(ValueType) {
     pub fn coerceFromRaw(self: Value, allocator: std.mem.Allocator) !Value {
         return switch (self) {
             .raw => |raw_val| switch (raw_val) {
-                .binint, .binint1, .binint2 => |val| .{ .int = val },
+                .binint, .binint1, .binint2 => |val| .{ .int64 = val },
                 .long1, .long4 => |b| if (b.len != 0) {
                     var bint = try big_int.Managed.initCapacity(allocator, std.math.big.int.calcTwosCompLimbCount(b.len));
                     var mutable = bint.toMutable();
@@ -345,10 +345,10 @@ pub const Value = union(ValueType) {
                     const max_comp = bint.toConst().order(BI64MAX);
                     if ((min_comp == .gt or min_comp == .eq) and (max_comp == .lt or max_comp == .eq)) {
                         defer bint.deinit();
-                        return .{ .int = try bint.to(i64) };
+                        return .{ .int64 = try bint.to(i64) };
                     } else return .{ .bigint = bint };
                 } else .{ .raw_num = raw_val },
-                .binfloat => |val| .{ .float = val },
+                .binfloat => |val| .{ .float64 = val },
                 .binunicode, .binunicode8, .short_binunicode => |s| .{ .string = s },
                 .binbytes, .binbytes8, .short_binbytes, .bytearray8 => |b| .{ .bytes = b },
                 // This isn't how Pickle actually works but we just try to UTF8 decode the
@@ -356,17 +356,17 @@ pub const Value = union(ValueType) {
                 // actually cares they can just fix values themselves or recover the raw bytes
                 // from the UTF8 string (it's guaranteed to be reversible, as far as I know).
                 .binstring, .short_binstring => |b| if (std.unicode.utf8ValidateSlice(b)) .{ .string = b } else .{ .bytes = b },
-                .newtrue => .{ .bool = true },
-                .newfalse => .{ .bool = false },
+                .newtrue => .{ .boolval = true },
+                .newfalse => .{ .boolval = false },
                 .none => .{ .none = {} },
                 inline .int,
                 .float,
                 .long,
                 => |v, tag| {
                     if (tag == .int and std.mem.eql(u8, v, "01")) {
-                        return .{ .bool = true };
+                        return .{ .boolval = true };
                     } else if (tag == .int and std.mem.eql(u8, v, "00")) {
-                        return .{ .bool = false };
+                        return .{ .boolval = false };
                     } else {
                         return .{ .raw_num = raw_val };
                     }


### PR DESCRIPTION
Improve readability parsing pytorch model; optimize for reading slice w/o a single type as tuple.