### PR TITLE
zml/test_runner: add optional filtering on test functions list

### DIFF
--- a/zml/test_runner.zig
+++ b/zml/test_runner.zig
@@ -39,8 +39,8 @@ pub fn asyncMain() void {
     // Skip executable path
     _ = args.next().?;
 
-    const filter_query = if (args.next()) |arg| blk: {
-        std.debug.print("Only tests with name including `{s}` will be ran\n", .{arg});
+    const identifier_query = if (args.next()) |arg| blk: {
+        std.debug.print("Only tests with identifiers that includes `{s}` will be ran\n", .{arg});
         break :blk arg;
     } else blk: {
         break :blk "";
@@ -49,7 +49,7 @@ pub fn asyncMain() void {
     var leaks: usize = 0;
 
     for (test_fn_list, 0..) |test_fn, i| {
-        if (std.mem.indexOf(u8, test_fn.name, filter_query) == null) {
+        if (std.mem.indexOf(u8, test_fn.name, identifier_query) == null) {
             continue;
         }
 

--- a/zml/test_runner.zig
+++ b/zml/test_runner.zig
@@ -40,7 +40,7 @@ pub fn asyncMain() void {
     _ = args.next().?;
 
     const identifier_query = if (args.next()) |arg| blk: {
-        std.debug.print("Only tests with identifiers that includes `{s}` will be ran\n", .{arg});
+        std.debug.print("Only tests with identifiers that includes `{s}` will be run\n", .{arg});
         break :blk arg;
     } else blk: {
         break :blk "";


### PR DESCRIPTION
**Motivation**

In some contexts we want to run only a subset of our test suite. 
This allow us to debug and trace more easily what's going on with failing tests.
Since we maintain our own test runner mainly to run in a async stack,
we can easily filter the list filled by `builtin.test_functions`

**Implementation**

I purpose a simple filtering without flags management, based on the first process argument.
- `bazel run -c opt //zml:test` will ran the full test suite as before this pull request.
- `bazel run -c opt //zml:test -- sdpa` or `bazel run -c opt //zml:test -- "sdpaMemEfficient without mask"` will run 
only tests with these words in the function name.

For later, it will gives us the opportunity to have a testing strategy.
Eg: `test "sdpaMemEfficient without mask - [tag1, tag2]" { ...} `

**Caveats**

- While we are able to call a subset of test functions, the tests target need to compile 
every necessary deps and sources, so your code should compile without failure.
- Maybe we will have to add cumulative arguments to create matrix tests
