### PR TITLE
zml/nn: fix resize

### DIFF
--- a/mlir/dialects/stablehlo.zig
+++ b/mlir/dialects/stablehlo.zig
@@ -384,18 +384,6 @@ pub fn reverse(ctx: mlir.Context, operand: mlir.Value, dimensions: []const i64, 
     });
 }
 
-pub fn reverseMany(ctx: mlir.Context, operand: mlir.Value, dimensions: []const i64, location: mlir.Location) mlir.Operation {
-    const result_type = operand.getType();
-    return mlir.Operation.make(ctx, "stablehlo.reverse", .{
-        .operands = &.{operand},
-        .results = &.{result_type},
-        .attributes = &.{
-            .{ "dimensions", mlir.DenseArrayAttribute(.i64).init(ctx, dimensions).as(mlir.Attribute).? },
-        },
-        .location = location,
-    });
-}
-
 pub fn compare(ctx: mlir.Context, lhs: mlir.Value, rhs: mlir.Value, comparison_direction: ComparisonDirection, compare_type: CompareType, location: mlir.Location) mlir.Operation {
     return mlir.Operation.make(ctx, "stablehlo.compare", .{
         .operands = &.{ lhs, rhs },

--- a/zml/aio.zig
+++ b/zml/aio.zig
@@ -20,6 +20,15 @@ const HostBuffer = @import("hostbuffer.zig").HostBuffer;
 
 test {
     std.testing.refAllDecls(@This());
+    std.testing.refAllDecls(gguf);
+    // TODO(@cryptodeal)
+    // std.testing.refAllDecls(nemo);
+    std.testing.refAllDecls(safetensors);
+    std.testing.refAllDecls(sentencepiece);
+    std.testing.refAllDecls(tinyllama);
+    std.testing.refAllDecls(torch);
+    // TODO(@cryptodeal)
+    // std.testing.refAllDecls(yaml);
 }
 
 /// Detects the format of the model file (base on filename) and open it.

--- a/zml/aio.zig
+++ b/zml/aio.zig
@@ -18,6 +18,10 @@ pub const log = std.log.scoped(.zml_aio);
 pub const Value = @import("aio/value.zig").Value;
 const HostBuffer = @import("hostbuffer.zig").HostBuffer;
 
+test {
+    std.testing.refAllDecls(@This());
+}
+
 /// Detects the format of the model file (base on filename) and open it.
 pub fn detectFormatAndOpen(allocator: std.mem.Allocator, model_path: []const u8) !BufferStore {
     return if (std.mem.endsWith(u8, model_path, ".safetensors"))
@@ -584,8 +588,4 @@ fn visitStructAndLoadBuffer(allocator: std.mem.Allocator, prefix_builder: *Prefi
         //},
         else => {},
     }
-}
-
-test {
-    std.testing.refAllDecls(@This());
 }

--- a/zml/aio/yaml.zig
+++ b/zml/aio/yaml.zig
@@ -30,9 +30,9 @@ pub fn open(allocator: Allocator, path: []const u8) !zml.aio.BufferStore {
 
 pub fn parseMetadata(allocator: Allocator, store: *zml.aio.BufferStore, key: StringBuilder, val: yaml.Value) !void {
     switch (val) {
-        .int => |v| try store.metadata.put(allocator, try allocator.dupe(u8, key.items), .{ .int64 = v }),
-        .float => |v| try store.metadata.put(allocator, try allocator.dupe(u8, key.items), .{ .float64 = v }),
-        .string => |v| try store.metadata.put(allocator, try allocator.dupe(u8, key.items), .{ .string = v }),
+        .int => |v| try store._metadata.put(allocator, try allocator.dupe(u8, key.items), .{ .int64 = v }),
+        .float => |v| try store._metadata.put(allocator, try allocator.dupe(u8, key.items), .{ .float64 = v }),
+        .string => |v| try store._metadata.put(allocator, try allocator.dupe(u8, key.items), .{ .string = v }),
         .list => |v| switch (validSlice(v)) {
             true => {
                 if (v.len == 0) return;
@@ -41,13 +41,13 @@ pub fn parseMetadata(allocator: Allocator, store: *zml.aio.BufferStore, key: Str
                         const values = try allocator.alloc(i64, v.len);
                         errdefer allocator.free(values);
                         for (v, 0..) |item, i| values[i] = item.int;
-                        try store.metadata.put(allocator, try allocator.dupe(u8, key.items), .{ .array = .{ .item_type = .int64, .data = utils.toVoidSlice(values) } });
+                        try store._metadata.put(allocator, try allocator.dupe(u8, key.items), .{ .array = .{ .item_type = .int64, .data = std.mem.sliceAsBytes(values) } });
                     },
                     .float => {
                         const values = try allocator.alloc(f64, v.len);
                         errdefer allocator.free(values);
                         for (v, 0..) |item, i| values[i] = item.float;
-                        try store.metadata.put(allocator, try allocator.dupe(u8, key.items), .{ .array = .{ .item_type = .float64, .data = utils.toVoidSlice(values) } });
+                        try store._metadata.put(allocator, try allocator.dupe(u8, key.items), .{ .array = .{ .item_type = .float64, .data = std.mem.sliceAsBytes(values) } });
                     },
                     .string => {
                         const values = try allocator.alloc([]const u8, v.len);
@@ -55,7 +55,7 @@ pub fn parseMetadata(allocator: Allocator, store: *zml.aio.BufferStore, key: Str
                         for (v, 0..) |item, i| {
                             values[i] = try allocator.dupe(u8, item.string);
                         }
-                        try store.metadata.put(allocator, try allocator.dupe(u8, key.items), .{ .array = .{ .item_type = .string, .data = utils.toVoidSlice(values) } });
+                        try store._metadata.put(allocator, try allocator.dupe(u8, key.items), .{ .array = .{ .item_type = .string, .data = std.mem.sliceAsBytes(values) } });
                     },
                     .list => unreachable,
                     else => {},

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -14,6 +14,10 @@ const Data = @import("dtype.zig").Data;
 const DataType = @import("dtype.zig").DataType;
 const Target = @import("platform.zig").Target;
 
+test {
+    std.testing.refAllDecls(Buffer);
+}
+
 /// Buffer is a multi-dimension array, whose memory is allocated on an accelerator.
 ///
 /// * contains a handle that the ZML runtime can use to convert into a physical address, but there is no guarantee this address is visible from the CPU.

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -6,12 +6,11 @@ const pjrt = @import("pjrt");
 const pjrtx = @import("pjrtx.zig");
 
 const Context = @import("context.zig").Context;
-const HostBuffer = @import("hostbuffer.zig").HostBuffer;
-const Shape = @import("shape.zig").Shape;
-const Tensor = @import("tensor.zig").Tensor;
 const Data = @import("dtype.zig").Data;
 const DataType = @import("dtype.zig").DataType;
+const HostBuffer = @import("hostbuffer.zig").HostBuffer;
 const Platform = @import("platform.zig").Platform;
+const Shape = @import("shape.zig").Shape;
 
 test {
     std.testing.refAllDecls(Buffer);
@@ -200,7 +199,7 @@ pub const Buffer = struct {
     ) !void {
         _ = fmt;
         _ = options;
-        try writer.print("Tensor({_})", .{self._shape});
+        try writer.print("Buffer({_})", .{self._shape});
     }
 
     fn _shapeFromPjrtBuffer(platform: Platform, buf: *pjrtx.Buffer) Shape {
@@ -233,12 +232,4 @@ pub const Buffer = struct {
 
         return Shape.init(buf.getDimensions(platform.pjrt_api), dt);
     }
-
-    pub const From = meta.MapType(Tensor, Buffer).map;
 };
-
-/// Returns a mirrored version of T where each Tensor has been replaced by a Buffer.
-pub fn Bufferized(comptime T: type) type {
-    const M = meta.MapType(Tensor, Buffer);
-    return M.map(T);
-}

--- a/zml/hostbuffer.zig
+++ b/zml/hostbuffer.zig
@@ -1,12 +1,11 @@
 const std = @import("std");
 
+const meta = @import("meta.zig");
 const Buffer = @import("buffer.zig").Buffer;
-const Shape = @import("shape.zig").Shape;
-const Tensor = @import("tensor.zig").Tensor;
 const Data = @import("dtype.zig").Data;
 const DataType = @import("dtype.zig").DataType;
 const Platform = @import("platform.zig").Platform;
-const meta = @import("meta.zig");
+const Shape = @import("shape.zig").Shape;
 
 test {
     std.testing.refAllDecls(HostBuffer);
@@ -99,10 +98,16 @@ pub const HostBuffer = struct {
         };
     }
 
+    pub const ArangeArgs = struct {
+        start: i64 = 0,
+        end: i64,
+        step: i64 = 1,
+    };
+
     /// Allocates a HostBuffer with the given shape.
     /// The memory is initialized with increasing numbers.
     /// The caller owns the memory, and need to call `deinit()`.
-    pub fn arange(allocator: std.mem.Allocator, args: Tensor.ArangeArgs, dt: DataType) !HostBuffer {
+    pub fn arange(allocator: std.mem.Allocator, args: ArangeArgs, dt: DataType) !HostBuffer {
         meta.assert(args.start < args.end, "arange expects 'args.start' to be less than 'args.end', got {} and {}", .{ args.start, args.end });
         meta.assert(args.step > 0, "arange expects 'args.step' to be positive, got {}", .{args.step});
 

--- a/zml/hostbuffer.zig
+++ b/zml/hostbuffer.zig
@@ -158,8 +158,9 @@ pub const HostBuffer = struct {
         return self._shape.dtype();
     }
 
-    pub fn strides(self: HostBuffer) ?[]const i64 {
-        return self._strides;
+    pub fn strides(self: *const HostBuffer) ?[]const i64 {
+        // Pass strides per pointer otherwise we return a pointer to this stack frame.
+        return if (self._strides) |*strd| strd[0..self.rank()] else null;
     }
 
     pub fn data(self: HostBuffer) []const u8 {

--- a/zml/hostbuffer.zig
+++ b/zml/hostbuffer.zig
@@ -9,7 +9,7 @@ const Platform = @import("platform.zig").Platform;
 const meta = @import("meta.zig");
 
 test {
-    std.testing.refAllDecls(@This());
+    std.testing.refAllDecls(HostBuffer);
 }
 
 /// Represents a tensor with associated data allocated by user code.
@@ -135,12 +135,6 @@ pub const HostBuffer = struct {
             defer x.deinit(std.testing.allocator);
             try std.testing.expectEqualSlices(i32, &.{ -3, -1, 1, 3, 5, 7, 9, 11 }, x.items(i32));
         }
-    }
-
-    /// Embeds a tensor with concrete values into an Mlir program.
-    /// The content is copied, so the HostBuffer can be safely `deinit`.
-    pub fn toStaticTensor(self: HostBuffer) Tensor {
-        return Tensor.staticTensor(self.shape(), self.data);
     }
 
     /// Copies this HostBuffer to the given accelerator.

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -23,7 +23,7 @@ const Tensor = @import("tensor.zig").Tensor;
 const ShapeOf = @import("tensor.zig").ShapeOf;
 const Shape = @import("shape.zig").Shape;
 const Buffer = @import("buffer.zig").Buffer;
-const Bufferized = @import("buffer.zig").Bufferized;
+const Bufferized = @import("tensor.zig").Bufferized;
 const Tracer = @import("tools/tracer.zig").Tracer;
 
 const log = std.log.scoped(.zml_module);

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -610,8 +610,12 @@ pub fn resizeCubic1d(image: Tensor, axis: i8, new_len: u63, opt: ResizeOpts) Ten
     std.debug.assert(pos.dim(0) == new_len);
     std.debug.assert(pos.dim(1) == 4);
 
-    const context = scaled.floor().addConstant(-1).convert(.i32).maximum(Tensor.scalar(0, .i32));
-    const values = image.gatherSlices1d(axis, 4, context, .{ .indices_are_sorted = true });
+    const neighbors = scaled.floor().addConstant(-1).convert(.i32).maximum(Tensor.scalar(0, .i32));
+    var slice = image.shape();
+    for (0..slice.rank()) |i| {
+        slice = slice.set(i, if (i == axis) 4 else 1);
+    }
+    const values = image.gatherSlices(slice, neighbors, .{ .indices_are_sorted = true });
 
     const weights_: [4][4]f32 = .{
         .{ 0, 1, 0, 0 },

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -16,6 +16,11 @@ const log = std.log.scoped(.zml_tensor);
 
 const cuda = @import("nn/cuda.zig");
 
+test {
+    _ = cuda;
+    std.testing.refAllDecls(@This());
+}
+
 pub const Linear = struct {
     weight: Tensor,
     bias: ?Tensor = null,
@@ -302,7 +307,7 @@ test "real/img" {
 }
 
 test "rope" {
-    const platofrm = zml.testing.env();
+    const platform = zml.testing.env();
 
     const TestRope = struct {
         fn forward(x: Tensor, opts: RopeOpts) Tensor {
@@ -326,9 +331,9 @@ test "rope" {
 
     // x is made such as the interleaved and sequential reps are the same.
     // So the two implementations should give the same results.
-    const x = try zml.Buffer.fromSlice(platofrm, .{ 1, 5, 4 }, &[_]f32{ 1.0, 0.1, -1.0, -0.5 } ** 5);
-    const res1 = try zml.testing.compileAndCall(platofrm, TestRope.forward, .{ x, RopeOpts{ .impl = .interleaved } });
-    const res2 = try zml.testing.compileAndCall(platofrm, TestRope.forward, .{ x, RopeOpts{ .impl = .sequential } });
+    const x = try zml.Buffer.fromSlice(platform, .{ 1, 5, 4 }, &[_]f32{ 1.0, 0.1, -1.0, -0.5 } ** 5);
+    const res1 = try zml.testing.compileAndCall(platform, TestRope.forward, .{ x, RopeOpts{ .impl = .interleaved } });
+    const res2 = try zml.testing.compileAndCall(platform, TestRope.forward, .{ x, RopeOpts{ .impl = .sequential } });
 
     try zml.testing.expectClose(res1, res2, 1e-4);
 }
@@ -516,36 +521,63 @@ test nearest {
     }
 }
 
-pub const ResizeOpts = struct { original_len: ?Tensor = null };
+pub const ResizeOpts = struct { original_len: ?Tensor = null, precision: ?zml.DataType = null };
 
-pub fn resizeBilinear(image: Tensor, axes: []const i8, dims: []const u63, opt: ResizeOpts) Tensor {
+pub fn resizeBilinear(image: Tensor, resized_axes: anytype, opt: ResizeOpts) Tensor {
+    const new_size, const tags_ = Shape.parseStruct(u63, resized_axes);
     var out = image;
-    for (axes, dims) |a, d| {
+    for (new_size.constSlice(), tags_.constSlice()) |d, t| {
+        const ax = image.shape().axis(t);
         const child_opt: ResizeOpts = .{
-            .original_len = if (opt.original_len) |o| o.choose1d(0, a) else null,
+            .original_len = if (opt.original_len) |o| o.choose1d(0, ax) else null,
         };
-        out = resizeLinear1d(out, a, d, child_opt);
+        out = resizeLinear1d(out, ax, d, child_opt);
     }
     return out;
 }
 
+test resizeBilinear {
+    const platform = zml.testing.env();
+
+    // Only test shapes
+    var comp = try zml.module.CompilationContext.init(std.heap.page_allocator, "test", platform);
+    defer comp.deinit();
+    comp.activate();
+    defer comp.deactivate();
+
+    inline for (.{
+        .{ .{ .a = 10, .b = 10 }, .{ .a = 20 }, .{ .a = 20, .b = 10 } },
+        .{ .{ .a = 10, .b = 10 }, .{ .b = 5 }, .{ .a = 10, .b = 5 } },
+        .{ .{ .a = 10, .b = 10 }, .{ .a = 20, .b = 5 }, .{ .a = 20, .b = 5 } },
+    }) |testcase| {
+        const x_shape, const resizing, const res_shape = testcase;
+        const x = Tensor.constant(x_shape, .{ .f16 = 0 });
+        const y = resizeBilinear(x, resizing, .{});
+        try zml.testing.expectEqualShapes(Shape.init(res_shape, .f16), y.shape());
+        try std.testing.expect(y.value().owner().verify());
+    }
+}
+
 pub fn resizeLinear1d(image: Tensor, axis: i8, new_len: u63, opt: ResizeOpts) Tensor {
-    const og_len = opt.original_len orelse Tensor.scalar(image.dim(axis), .f32);
-    const ratio = og_len.convert(.f32).scale(meta.divFloat(f32, 1, new_len));
-    const scaled = Tensor.arange(.{ .end = new_len }, .f32).mul(ratio);
+    const res_shape = image.shape().set(axis, new_len);
+
+    const dtype = opt.precision orelse image.dtype();
+    const og_len = opt.original_len orelse Tensor.scalar(image.dim(axis), dtype);
+    const ratio = og_len.convert(dtype).scale(meta.divFloat(f32, 1, new_len));
+    const scaled = Tensor.arange(.{ .end = new_len }, dtype).mul(ratio);
     const left = scaled.floor();
     const right = left.addConstant(1);
 
-    const values = image.gatherSlices1d(axis, 2, left.convert(.i32), .{ .indices_are_sorted = true });
-    const left_val, const right_val = helpers.mapTensors(
-        Tensor.squeeze,
-        values.convert(.f32).chunkExact(2, axis + 1),
-        .{@as(i64, @intCast(axis + 1))},
-    );
-    const left_weight = right.sub(scaled).broadcast(left_val.shape(), &.{axis});
-    const right_weight = scaled.sub(left).broadcast(left_val.shape(), &.{axis});
+    // TODO: check that two gather isn't too bad perf wise.
+    // Normally we should use gatherSlices to collect the values 2 by 2,
+    // but gatherSlices messes up with the order of axes.
+    const left_val = image.gatherValues(axis, left.convert(.i32), .{ .indices_are_sorted = true }).convert(dtype);
+    const right_val = image.gatherValues(axis, right.convert(.i32), .{ .indices_are_sorted = true }).convert(dtype);
 
-    return left_val.mul(left_weight).add(right_val.mul(right_weight)).convert(image.dtype());
+    const left_weight = right.sub(scaled).broadcast(res_shape, &.{axis});
+    const right_weight = scaled.sub(left).broadcast(res_shape, &.{axis});
+
+    return left_val.mul(left_weight).add(right_val.mul(right_weight)).convert(image.dtype()).withTags(image.shape().tags());
 }
 
 /// Bicubic interpolation of the given image.
@@ -926,8 +958,4 @@ pub fn sampleTokens(activations: Tensor, opts: SamplingStrategy, rng: Tensor.Rng
     const next_tokens = topk.indices.gatherValues(.voc, topk_idx.squeeze(.topk), .{});
     // log.debug("sampleTokens({}) -> {} -> {} -> {}", .{ activations, topk.indices, topk_idx, next_tokens });
     return .{ next_tokens, next_rng };
-}
-
-test {
-    _ = cuda;
 }

--- a/zml/shape.zig
+++ b/zml/shape.zig
@@ -9,7 +9,7 @@ const EnumLiteral = @TypeOf(.enum_literal);
 const log = std.log.scoped(.shape);
 
 test {
-    std.testing.refAllDecls(@This());
+    std.testing.refAllDecls(Shape);
 }
 
 /// Represent the shape of a tensor.

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -2444,7 +2444,7 @@ pub const Tensor = struct {
         return result;
     }
 
-    pub fn chunkExact(self: Tensor, n_chunks: comptime_int, axis_: i64) [n_chunks]Tensor {
+    pub fn chunkExact(self: Tensor, n_chunks: comptime_int, axis_: anytype) [n_chunks]Tensor {
         const a = self.axis(axis_);
         const length = self.dim(a);
         _ = @divExact(length, n_chunks);

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -29,6 +29,10 @@ test {
 
 const scoped_log = std.log.scoped(.zml_tensor);
 
+test {
+    std.testing.refAllDecls(Tensor);
+}
+
 /// Represents an abstract Tensor object, which can be the input,
 /// output, weight or activations of a neural network.
 /// Tensor are abstract in the sense they only represent a computation,
@@ -1868,14 +1872,6 @@ pub const Tensor = struct {
 
         const loc = self.getContext().mlirCtx().location(@src()).namedFmt(self.getContext().mlirCtx(), "reverse({any})", .{axes_});
         const reverse_op = dialect.stablehlo.reverse(self.getContext().mlirCtx(), self.value(), toI64(actual_axes.constSlice()), loc);
-        return _result(self._shape, reverse_op.result(0));
-    }
-
-    /// Returns a Tensor with the given axes reversed.
-    pub fn reverseMany(self: Tensor, axes_: []const i64) Tensor {
-        const actual_axes = self._shape.axes(axes_).constSlice();
-        const loc = self.getContext().mlirCtx().location(@src()).namedFmt(self.getContext().mlirCtx(), "reverse({d})", .{actual_axes});
-        const reverse_op = dialect.stablehlo.reverseMany(self.getContext().mlirCtx(), self.value(), @ptrCast(actual_axes), loc);
         return _result(self._shape, reverse_op.result(0));
     }
 

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -468,7 +468,7 @@ pub const Tensor = struct {
             };
         }
 
-        pub fn init(platform: Platform, seed: u128) !Buffer.From(Rng) {
+        pub fn init(platform: Platform, seed: u128) !Bufferized(Rng) {
             const bits: [2]u64 = @bitCast(seed);
             return .{
                 ._state = try Buffer.fromSlice(platform, Shape.init(.{2}, .u64), &bits),
@@ -1599,11 +1599,7 @@ pub const Tensor = struct {
         return _result(self._shape, expm1_op.result(0));
     }
 
-    pub const ArangeArgs = struct {
-        start: i64 = 0,
-        end: i64,
-        step: i64 = 1,
-    };
+    pub const ArangeArgs = HostBuffer.ArangeArgs;
 
     /// Returns a Tensor containing evenly spaced values within a given interval.
     pub fn arange(args: ArangeArgs, dt: DataType) Tensor {
@@ -3497,4 +3493,10 @@ fn _collectAxes(T: type, bounded_array: std.BoundedArray(T, Tensor.MAX_RANK), va
         }
     }
     return res;
+}
+
+/// Returns a mirrored version of T where each Tensor has been replaced by a Buffer.
+pub fn Bufferized(comptime T: type) type {
+    const M = meta.MapType(Tensor, Buffer);
+    return M.map(T);
 }

--- a/zml/zml.zig
+++ b/zml/zml.zig
@@ -4,7 +4,7 @@
 //!
 
 pub const Buffer = @import("buffer.zig").Buffer;
-pub const Bufferized = @import("buffer.zig").Bufferized;
+pub const Bufferized = @import("tensor.zig").Bufferized;
 pub const CompilationOptions = @import("platform.zig").CompilationOptions;
 pub const Context = @import("context.zig").Context;
 pub const Data = @import("dtype.zig").Data;


### PR DESCRIPTION
Add more `refAllDecl`

I had to fix resizeBilinear / resizeBicubic.
(85 tests now)

@cryptodeal  can you take over and fix nemo and yaml parsers ?