### PR TITLE
aio: fix `refAllDecls` for `yaml`/`nemo`

### DIFF
--- a/zml/aio.zig
+++ b/zml/aio.zig
@@ -21,14 +21,12 @@ const HostBuffer = @import("hostbuffer.zig").HostBuffer;
 test {
     std.testing.refAllDecls(@This());
     std.testing.refAllDecls(gguf);
-    // TODO(@cryptodeal)
-    // std.testing.refAllDecls(nemo);
+    std.testing.refAllDecls(nemo);
     std.testing.refAllDecls(safetensors);
     std.testing.refAllDecls(sentencepiece);
     std.testing.refAllDecls(tinyllama);
     std.testing.refAllDecls(torch);
-    // TODO(@cryptodeal)
-    // std.testing.refAllDecls(yaml);
+    std.testing.refAllDecls(yaml);
 }
 
 /// Detects the format of the model file (base on filename) and open it.

--- a/zml/aio/nemo.zig
+++ b/zml/aio/nemo.zig
@@ -34,7 +34,7 @@ pub fn open(allocator: std.mem.Allocator, path: []const u8) !zml.aio.BufferStore
             const parsed = try yaml.Yaml.load(arena, yaml_data);
 
             var prefix_buf: [1024]u8 = undefined;
-            try zml.aio.yaml.parseMetadata(arena, &res, StringBuilder.initBuffer(&prefix_buf), parsed.docs.items[0].map);
+            try zml.aio.yaml.parseMetadata(arena, &res, StringBuilder.initBuffer(&prefix_buf), parsed.docs.items[0]);
         } else if (std.mem.endsWith(u8, file.name, ".ckpt") or std.mem.endsWith(u8, file.name, ".pt")) {
             const start = try mapped_file.file.getPos();
             var tmp: zml.aio.torch.PickleData = .{

--- a/zml/aio/torch.zig
+++ b/zml/aio/torch.zig
@@ -148,7 +148,7 @@ pub const PickleData = struct {
             if (local_header.last_modification_date != entry.last_modification_date)
                 return error.ZipMismatchModDate;
 
-            if (@as(u16, @bitCast(local_header.flags)) != @as(u16, @bitCast(entry.flags)))
+            if (@as(u16, @bitCast(local_header.flags)) != entry.flags)
                 return error.ZipMismatchFlags;
             if (local_header.crc32 != 0 and local_header.crc32 != entry.crc32)
                 return error.ZipMismatchCrc32;

--- a/zml/aio/yaml.zig
+++ b/zml/aio/yaml.zig
@@ -19,12 +19,8 @@ pub fn open(allocator: Allocator, path: []const u8) !zml.aio.BufferStore {
     const yaml_data = try file.reader().readAllAlloc(arena, (try file.metadata()).size());
     const parsed = try yaml.Yaml.load(arena, yaml_data);
 
-    const map = parsed.docs.items[0].map;
-    var map_iter = map.iterator();
-    while (map_iter.next()) |entry| {
-        var prefix_buf: [1024]u8 = undefined;
-        try parseMetadata(arena, &res, StringBuilder.initBuffer(&prefix_buf), entry.key, entry.value);
-    }
+    var prefix_buf: [1024]u8 = undefined;
+    try parseMetadata(arena, &res, StringBuilder.initBuffer(&prefix_buf), parsed.docs.items[0]);
     return res;
 }
 


### PR DESCRIPTION
Fix issues causing `std.testing.refAllDecls` to fail for `zml/aio/nemo.zig` and `zml/aio/yaml.zig`. Picks up where #18 left off.