### PR TITLE
zml: sharding

### DIFF
--- a/examples/benchmark/main.zig
+++ b/examples/benchmark/main.zig
@@ -78,8 +78,8 @@ pub fn asyncMain() !void {
     var args = std.process.args();
     const cli_args = flags.parse(&args, CliArgs);
 
-    const left_shape = zml.Shape.init(.{ cli_args.size, cli_args.size }, cli_args.dtype).withTags(.{ .m, .k }).withSharding(.{.k});
-    const right_shape = left_shape.withTags(.{ .k, .n }).withSharding(.{.k});
+    const a_shape = zml.Shape.init(.{ cli_args.size, cli_args.size }, cli_args.dtype).withTags(.{ .m, .k }).withSharding(.{.k});
+    const b_shape = a_shape.withTags(.{ .k, .n }).withSharding(.{.k});
     var timer = try std.time.Timer.start();
 
     std.debug.print("\nCompiling model to MLIR....\n", .{});
@@ -87,7 +87,7 @@ pub fn asyncMain() !void {
     // Start compiling.
     // The shape of the input tensor, we have to pass in manually.
     timer.reset();
-    var compilation = try async_(zml.module.compileModel, .{ allocator, Benchmark{}, .forward, .{ left_shape, right_shape }, platform });
+    var compilation = try async_(zml.module.compileModel, .{ allocator, Benchmark{}, .forward, .{ a_shape, b_shape }, platform });
 
     // Wait for compilation to finish
     const compiled = try compilation.await_();
@@ -102,9 +102,9 @@ pub fn asyncMain() !void {
     var rng = std.Random.DefaultPrng.init(0);
     const random = rng.random();
 
-    var a_buffer = try createRandomBuffer(allocator, platform, left_shape, random);
+    var a_buffer = try createRandomBuffer(allocator, platform, a_shape, random);
     defer a_buffer.deinit();
-    var b_buffer = try createRandomBuffer(allocator, platform, right_shape, random);
+    var b_buffer = try createRandomBuffer(allocator, platform, b_shape, random);
     defer b_buffer.deinit();
 
     std.debug.print("\nRunning benchmark....\n", .{});

--- a/examples/benchmark/main.zig
+++ b/examples/benchmark/main.zig
@@ -79,7 +79,7 @@ pub fn asyncMain() !void {
     const cli_args = flags.parse(&args, CliArgs);
 
     const left_shape = zml.Shape.init(.{ cli_args.size, cli_args.size }, cli_args.dtype).withTags(.{ .m, .k }).withSharding(.{.k});
-    const right_shape = left_shape.withTags(.{ .n, .k }).withSharding(.{.k});
+    const right_shape = left_shape.withTags(.{ .k, .n }).withSharding(.{.k});
     var timer = try std.time.Timer.start();
 
     std.debug.print("\nCompiling model to MLIR....\n", .{});
@@ -124,10 +124,6 @@ pub fn asyncMain() !void {
     const elapsed_s = @as(f64, @floatFromInt(elapsed_ns)) / std.time.ns_per_s;
 
     std.debug.print("\n✅ Benchmark done!\n\n", .{});
-
-    const res = try result.toHostAlloc(allocator);
-    defer res.deinit(allocator);
-    std.debug.print("vals = [{}, {}, {}]", .{ res.data[0], res.data[8192 + 5], res.data[8192 * 8192 - 1] });
 
     const floating_op_count = 2 * cli_args.size * cli_args.size * cli_args.size;
     const flops = @as(f64, @floatFromInt(floating_op_count)) / elapsed_s;

--- a/examples/simple_layer/main.zig
+++ b/examples/simple_layer/main.zig
@@ -41,9 +41,9 @@ pub fn asyncMain() !void {
     const platform = context.autoPlatform();
 
     // Our weights and bias to use
-    var weights = [3]f16{ 2.0, 2.0, 2.0 };
-    var bias = [3]f16{ 1.0, 2.0, 3.0 };
-    const input_shape = zml.Shape.init(.{3}, .f16);
+    var weights = [4]f16{ 2.0, 2.0, 2.0, 2.0 };
+    var bias = [4]f16{ 1.0, 2.0, 3.0, 4.0 };
+    const input_shape = zml.Shape.init(.{4}, .f16);
 
     // We manually produce a BufferStore. You would not normally do that.
     // A BufferStore is usually created by loading model data from a file.
@@ -59,7 +59,9 @@ pub fn asyncMain() !void {
 
     // A clone of our model, consisting of shapes. We only need shapes for compiling.
     // We use the BufferStore to infer the shapes.
-    const model_shapes = try zml.aio.populateModel(Layer, allocator, buffer_store);
+    var model_shapes = try zml.aio.populateModel(Layer, allocator, buffer_store);
+    model_shapes.weight = model_shapes.weight.withSharding(.{-1});
+    model_shapes.bias = model_shapes.bias.?.withSharding(.{-1});
 
     // Start compiling. This uses the inferred shapes from the BufferStore.
     // The shape of the input tensor, we have to pass in manually.
@@ -68,7 +70,7 @@ pub fn asyncMain() !void {
     // Produce a bufferized weights struct from the fake BufferStore.
     // This is like the inferred shapes, but with actual values.
     // We will need to send those to the computation device later.
-    var model_weights = try zml.aio.loadBuffers(Layer, .{}, buffer_store, arena, platform);
+    var model_weights = try zml.aio.loadModelBuffers(Layer, model_shapes, buffer_store, arena, platform);
     defer zml.aio.unloadBuffers(&model_weights); // for good practice
 
     // Wait for compilation to finish
@@ -82,7 +84,7 @@ pub fn asyncMain() !void {
     // Here, we use zml.HostBuffer.fromSlice to show how you would create a HostBuffer
     // with a specific shape from an array.
     // For situations where e.g. you have an [4]f16 array but need a .{2, 2} input shape.
-    var input = [3]f16{ 5.0, 5.0, 5.0 };
+    var input = [4]f16{ 5.0, 5.0, 5.0, 5.0 };
     var input_buffer = try zml.Buffer.from(platform, zml.HostBuffer.fromSlice(input_shape, &input));
     defer input_buffer.deinit();
 

--- a/mlir/mlir.zig
+++ b/mlir/mlir.zig
@@ -497,6 +497,10 @@ pub fn IntegerAttribute(comptime it: IntegerTypes) type {
         pub fn get(value: IntAttr) ZigType {
             return @intCast(getter(value.inner()));
         }
+
+        pub fn asAttr(self: IntAttr) Attribute {
+            return .{ ._inner = self._inner };
+        }
     };
 }
 

--- a/pjrt/pjrt.zig
+++ b/pjrt/pjrt.zig
@@ -724,11 +724,11 @@ pub const Event = opaque {
         return ret.is_ready;
     }
 
-    pub fn getEventError(self: *const Event, api: *const Api) ApiError!?*Error {
-        const ret = try api.call(.PJRT_Event_Error, .{
-            .event = self.inner(),
-        });
-        return @ptrCast(ret);
+    pub fn getEventError(self: *const Event, api: *const Api) ?*Error {
+        var args: Api.CallFnArgType(.PJRT_Event_Error) = .{ .event = self.inner() };
+        args = pjrtStruct(args);
+        const result: ?*c.PJRT_Error = api.inner.PJRT_Event_Error.?(&args);
+        return @ptrCast(result);
     }
 
     pub fn await_(self: *const Event, api: *const Api) ApiError!void {

--- a/zml/aio.zig
+++ b/zml/aio.zig
@@ -403,7 +403,12 @@ pub fn loadModelBuffers(
 ) !zml.Bufferized(Model) {
     return try loadModelBuffersWithPrefix(Model, model, buffer_store, allocator, platform, "");
 }
-
+/// Creates a bufferized version of a Model from the given BufferStore and the given prefix.
+/// For details about bufferization, see the documentation of Bufferized(T).
+///
+/// This will represent the weights of the model, loaded on a specific platform.
+/// It can be used with a `module.Exe` (a compiled version of the same Model), to make a
+/// `module.ExeWithWeights` ready to be called.
 pub fn loadModelBuffersWithPrefix(
     comptime Model: type,
     model: Model,
@@ -413,44 +418,18 @@ pub fn loadModelBuffersWithPrefix(
     prefix: []const u8,
 ) !zml.Bufferized(Model) {
     // Allocate the bufferized version.
-    // We set fields to undefined, cause visitStructAndLoadBuffer is responsible
+    // We copy the shape, and let visitStructAndLoadBuffer write the other fields.
     // to write them just afterward.
     var res: zml.Bufferized(Model) = undefined;
     try zml.meta.mapAlloc(struct {
-        pub fn initBuffer(_: void, _: zml.Tensor) zml.Buffer {
-            return undefined;
+        pub fn initBuffer(_: void, tensor: zml.Tensor) zml.Buffer {
+            return .{ ._shape = tensor.shape(), ._api = undefined, ._shards = undefined };
         }
     }.initBuffer, allocator, {}, model, &res);
 
     var prefix_builder: PrefixBuilder = .{};
     try prefix_builder.push(allocator, prefix);
     defer prefix_builder.deinit(allocator);
-
-    try visitStructAndLoadBuffer(allocator, &prefix_builder, buffer_store, &res, platform);
-    return res;
-}
-
-/// Creates a bufferized version of a Model from the given BufferStore and the given prefix.
-/// For details about bufferization, see the documentation of Bufferized(T).
-///
-/// This will represent the weights of the model, loaded on a specific platform.
-/// It can be used with a `module.Exe` (a compiled version of the same Model), to make a
-/// `module.ExeWithWeights` ready to be called.
-pub fn loadBuffersFromModelWithPrefix(comptime Model: type, model: Model, buffer_store: BufferStore, allocator: std.mem.Allocator, prefix: []const u8, platform: zml.Platform) !zml.Bufferized(Model) {
-
-    // Allocate the bufferized version.
-    // We set fields to undefined, cause visitStructAndLoadBuffer is responsible
-    // to write them just afterward.
-    var res: zml.Bufferized(Model) = undefined;
-    try zml.meta.mapAlloc(struct {
-        pub fn initBuffer(_: void, _: zml.Tensor) zml.Buffer {
-            return undefined;
-        }
-    }.initBuffer, allocator, {}, model, &res);
-
-    var prefix_builder: PrefixBuilder = .{};
-    defer prefix_builder.deinit(allocator);
-    try prefix_builder.push(allocator, prefix);
 
     try visitStructAndLoadBuffer(allocator, &prefix_builder, buffer_store, &res, platform);
     return res;
@@ -479,7 +458,12 @@ fn visitStructAndLoadBuffer(allocator: std.mem.Allocator, prefix_builder: *Prefi
     const prefix = prefix_builder.data.items;
     if (T == zml.Buffer) {
         return if (buffer_store.get(prefix)) |host_buffer| {
-            obj.* = try zml.Buffer.from(platform, host_buffer);
+            // obj._shape has been set inside `loadModelBuffersWithPrefix`, before calling us.
+            var buf_with_metadata = host_buffer;
+            log.warn("loading {s} ({})", .{ prefix, obj._shape });
+            zml.meta.assert(host_buffer.shape().eql(obj._shape), "loadModelBuffers expects to find the same shapes in the model and in the buffer store, got {} and {} for tensor {s}", .{ obj._shape, host_buffer, prefix });
+            buf_with_metadata._shape = obj._shape;
+            obj.* = try zml.Buffer.from(platform, buf_with_metadata);
         } else {
             return error.BufferNotFound;
         };
@@ -489,10 +473,7 @@ fn visitStructAndLoadBuffer(allocator: std.mem.Allocator, prefix_builder: *Prefi
         .Pointer => |ptr_info| {
             if (ptr_info.size == .Slice) {
                 for (obj.*, 0..) |*value, i| {
-                    var buffer: [100]u8 = undefined;
-                    const new_prefix = std.fmt.bufPrint(&buffer, "{d}", .{i}) catch unreachable;
-
-                    try prefix_builder.push(allocator, new_prefix);
+                    try prefix_builder.pushDigit(allocator, i);
                     defer prefix_builder.pop();
 
                     try visitStructAndLoadBuffer(allocator, prefix_builder, buffer_store, value, platform);
@@ -507,13 +488,9 @@ fn visitStructAndLoadBuffer(allocator: std.mem.Allocator, prefix_builder: *Prefi
                 try visitStructAndLoadBuffer(allocator, prefix_builder, buffer_store, &@field(obj, field.name), platform);
             }
         },
-        .Optional => |opt_info| {
-            var child = @as(opt_info.child, undefined);
-            if (visitStructAndLoadBuffer(allocator, prefix_builder, buffer_store, &child, platform)) {
-                obj.* = child;
-            } else |err| switch (err) {
-                error.BufferNotFound => {},
-                else => return err,
+        .Optional => {
+            if (obj.*) |*obj_val| {
+                try visitStructAndLoadBuffer(allocator, prefix_builder, buffer_store, obj_val, platform);
             }
         },
         else => {},

--- a/zml/aio.zig
+++ b/zml/aio.zig
@@ -330,7 +330,6 @@ fn _populateStruct(
                     }
                 }
             }
-
             return true;
         },
         .Optional => |opt_info| {

--- a/zml/aio.zig
+++ b/zml/aio.zig
@@ -331,10 +331,6 @@ fn _populateStruct(
                 }
             }
 
-            if (@hasDecl(T, "postInit")) {
-                // Allow postInit to mark the initialization has failed.
-                return obj.postInit();
-            }
             return true;
         },
         .Optional => |opt_info| {

--- a/zml/aio.zig
+++ b/zml/aio.zig
@@ -330,6 +330,11 @@ fn _populateStruct(
                     }
                 }
             }
+
+            if (@hasDecl(T, "postInit")) {
+                // Allow postInit to mark the initialization has failed.
+                return obj.postInit();
+            }
             return true;
         },
         .Optional => |opt_info| {

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -25,14 +25,9 @@ pub const Buffer = struct {
     _shape: Shape,
     _api: *const pjrt.Api,
     _shards: Shards,
-    _sharding_info: ShardingInfo,
 
     pub const MAX_NUM_SHARDS: u8 = 8;
     pub const Shards = std.BoundedArray(*pjrt.Buffer, MAX_NUM_SHARDS);
-    const ShardingInfo = @Vector(Shape.MAX_RANK, bool);
-    comptime {
-        std.debug.assert(@sizeOf(ShardingInfo) == 1);
-    }
 
     /// Copies the content of the given buffer from host memory to the accelerator memory.
     pub fn from(platform: Platform, buf: HostBuffer) !Buffer {
@@ -40,7 +35,6 @@ pub const Buffer = struct {
             ._api = platform.pjrt_api,
             ._shape = buf.shape(),
             ._shards = .{},
-            ._sharding_info = @splat(false),
         };
 
         for (platform.getDevices()) |dev| {
@@ -72,7 +66,6 @@ pub const Buffer = struct {
                 dtypeFromBufferType(pjrt_buffers[0].getElementType(platform.pjrt_api)),
             ),
             ._shards = shards,
-            ._sharding_info = @splat(false),
         };
     }
 
@@ -154,7 +147,6 @@ pub const Buffer = struct {
             ._api = platform.pjrt_api,
             ._shape = buf.shape(),
             ._shards = shards,
-            ._sharding_info = @splat(true),
         };
     }
 
@@ -239,7 +231,7 @@ pub const Buffer = struct {
 
     fn hasShardedAxis(self: Buffer) bool {
         if (self._shards.len == 1) return false;
-        return @reduce(.Or, self._sharding_info);
+        return @reduce(.Or, self._shape._sharding_info);
     }
 };
 

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -39,7 +39,9 @@ pub const Buffer = struct {
             ._shards = .{},
         };
 
-        const sharding_ax: ?u3 = std.simd.lastTrue(host_buffer.shape()._sharding_info);
+        // We shard only on the first axis so that the chunks are still contiguous.
+        // TODO: support more advanced sharding specs
+        const sharding_ax: ?u3 = std.simd.firstTrue(host_buffer.shape()._sharding_info);
         const n_devices: i64 = @intCast(platform.getDevices().len);
         const chunk_size = if (sharding_ax) |ax| cs: {
             // This kind of sharding error should be detected earlier on.

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -990,12 +990,6 @@ fn computeModuleHash(platform: Platform, module: mlir.Module) u64 {
     const api_version = platform.pjrt_api.version();
     writer.writeInt(i64, api_version.major, .little) catch unreachable;
     writer.writeInt(i64, api_version.minor, .little) catch unreachable;
-    const opts = platform.compilation_options;
-    writer.writeByte(if (opts.sharding_enabled) 1 else 0) catch unreachable;
-    writer.writeByte(opts.sharding_axes.len) catch unreachable;
-    for (opts.sharding_axes.constSlice()) |sharding_ax| {
-        writer.print("{s}", .{sharding_ax}) catch unreachable;
-    }
 
     return hasher.final();
 }

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -649,7 +649,7 @@ fn fillBuffers(v: anytype, buffers: []const [*]*pjrt.Buffer, start: u32, len: u3
         index: u32,
         buffers: []const [*]*pjrt.Buffer,
     };
-    var capture: LocalContext = .{
+    var context: LocalContext = .{
         .index = start,
         .buffers = buffers,
     };
@@ -663,8 +663,8 @@ fn fillBuffers(v: anytype, buffers: []const [*]*pjrt.Buffer, start: u32, len: u3
             }
             ctx.index += 1;
         }
-    }).cb, &capture, v);
-    assert(capture.index == start + len);
+    }).cb, &context, v);
+    assert(context.index == start + len);
 }
 
 /// Visit the given struct and override tensors by creating a new one using the provided PJRT buffers.

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -577,7 +577,8 @@ fn fillBuffers(v: anytype, buffers: []*pjrt.Buffer) void {
     meta.visit((struct {
         fn cb(inner_context: *LocalContext, buffer: *const Buffer) void {
             // meta.assert(!buffer._data.isDeleted(), "Can't use {} (argument buffer {}) because its pjrt buffer has been donated", .{ buffer, inner_context.index });
-            inner_context.buffers[inner_context.index] = buffer._data;
+            meta.internalAssert(buffer._shards.len == 1, "TODO: support sharded Buffer", .{});
+            inner_context.buffers[inner_context.index] = buffer._shards.get(0);
             inner_context.index += 1;
         }
     }).cb, &ctx, v);
@@ -600,7 +601,7 @@ pub fn assignRawBuffers(v: anytype, platform: Platform, buffers: []*pjrt.Buffer)
         fn cb(inner_context: *LocalContext, buffer: *Buffer) void {
             const i = inner_context.index;
             if (i < inner_context.buffers.len) {
-                buffer.* = Buffer.fromPjrtBuffer(inner_context.platform, inner_context.buffers[i]);
+                buffer.* = Buffer.fromPjrtBuffers(inner_context.platform, &.{inner_context.buffers[i]});
             }
             inner_context.index += 1;
         }

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -25,14 +25,6 @@ pub const Linear = struct {
     weight: Tensor,
     bias: ?Tensor = null,
 
-    pub fn postInit(self: *Linear) bool {
-        self.weight._shape = self.weight._shape.withSharding(.{-1});
-        if (self.bias) |*bias| {
-            bias._shape = bias._shape.withSharding(.{-1});
-        }
-        return true;
-    }
-
     pub fn forward(self: Linear, x: Tensor) Tensor {
         var y = x.dotGeneral(self.weight.convert(x.dtype()), &.{.{ -1, -1 }}, &.{});
         // If self.weight doesn't have tags, preserve tags from x.

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -25,6 +25,14 @@ pub const Linear = struct {
     weight: Tensor,
     bias: ?Tensor = null,
 
+    pub fn postInit(self: *Linear) bool {
+        self.weight._shape = self.weight._shape.withSharding(.{-1});
+        if (self.bias) |*bias| {
+            bias._shape = bias._shape.withSharding(.{-1});
+        }
+        return true;
+    }
+
     pub fn forward(self: Linear, x: Tensor) Tensor {
         var y = x.dotGeneral(self.weight.convert(x.dtype()), &.{.{ -1, -1 }}, &.{});
         // If self.weight doesn't have tags, preserve tags from x.

--- a/zml/pjrtx.zig
+++ b/zml/pjrtx.zig
@@ -15,6 +15,7 @@ const Target = @import("platform.zig").Target;
 
 const log = std.log.scoped(.zml);
 
+pub const Buffer = pjrt.Buffer;
 pub const Device = pjrt.Device;
 pub const DeviceDescription = pjrt.DeviceDescription;
 pub const Api = pjrt.Api;
@@ -26,6 +27,12 @@ pub const GetCostAnalysisError = pjrt.GetCostAnalysisError;
 pub const SerializeResult = pjrt.SerializeResult;
 pub const Executable = pjrt.Executable;
 pub const ExecuteError = ApiError;
+
+test {
+    std.testing.refAllDecls(Client);
+    std.testing.refAllDecls(Event);
+    // std.testing.refAllDecls(LoadedExecutable);
+}
 
 fn InnerMixin(comptime innerT: type) type {
     return struct {
@@ -63,7 +70,7 @@ pub const Client = opaque {
         const buffer, const event_ = try self.inner().bufferFromHostBuffer(api, args);
         const event: *Event = @ptrCast(event_);
         try event.await_(api);
-        return @ptrCast(buffer);
+        return buffer;
     }
 
     pub fn deserializeAndLoad(self: *const Client, api: *const Api, bytes: []const u8) ApiError!*LoadedExecutable {
@@ -169,74 +176,44 @@ pub const Client = opaque {
     }
 };
 
-pub const Buffer = opaque {
-    const inner = InnerMixin(pjrt.Buffer).inner;
+// pub const GpuCustomCallRegistry = struct {
+//     pub usingnamespace WrapperMixin(GpuCustomCallRegistry, pjrt.GpuCustomCallRegistry);
 
-    pub const BufferType = pjrt.BufferType;
+//     inner: GpuCustomCallRegistry.UnionType,
 
-    pub fn BufferTypeFromDType(dt: dtype.DataType) BufferType {
-        return switch (dt) {
-            .bool => .PRED,
-            .f8e4m3b11fnuz => .F8E4M3B11FNUZ,
-            .f8e4m3fn => .F8E4M3FN,
-            .f8e4m3fnuz => .F8E4M3FNUZ,
-            .f8e5m2 => .F8E5M2,
-            .f8e5m2fnuz => .F8E5M2FNUZ,
-            .bf16 => .BF16,
-            .f16 => .F16,
-            .f32 => .F32,
-            .f64 => .F64,
-            .i8 => .S8,
-            .i4 => .S4,
-            .i16 => .S16,
-            .i32 => .S32,
-            .i64 => .S64,
-            .u4 => .U4,
-            .u8 => .U8,
-            .u16 => .U16,
-            .u32 => .U32,
-            .u64 => .U64,
-            .c64 => .C64,
-            .c128 => .C128,
-        };
-    }
+//     pub fn registerCustomCall(self: GpuCustomCallRegistry, api_version: usize, name: []const u8, func: pjrt.CustomCallSignature) ApiError!void {
+//         return switch (self.inner) {
+//             inline else => |v| v.registerCustomCall(api_version, name, func),
+//         };
+//     }
+// };
 
-    pub const HostBufferSemantics = pjrt.HostBufferSemantics;
-    pub const MemoryLayoutType = pjrt.MemoryLayoutType;
-
-    pub fn deinit(self: *Buffer, api: *const Api) void {
-        self.inner().deinit(api);
-    }
-
-    pub fn delete(self: *Buffer, api: *const Api) void {
-        self.inner().delete(api);
-    }
-
-    pub fn toHostBuffer(self: *const Buffer, api: *const Api, dst: []u8) ApiError!void {
-        var event = try self.inner().toHostBuffer(api, dst);
-        try event.await_(api);
-    }
-
-    pub fn getDimensions(self: *const Buffer, api: *const Api) []const i64 {
-        return self.inner().getDimensions(api);
-    }
-
-    pub fn getElementType(self: *const Buffer, api: *const Api) BufferType {
-        return self.inner().getElementType(api);
-    }
-
-    pub fn isDeleted(self: *const Buffer, api: *const Api) bool {
-        return self.inner().isDeleted(api);
-    }
-
-    pub fn getDevice(self: *const Buffer, api: *const Api) ApiError!*Device {
-        return @ptrCast(try self.inner().getDevice(api));
-    }
-
-    pub fn getOpaqueDeviceMemoryDataPointer(self: *const Buffer, api: *const Api) ApiError!*anyopaque {
-        return self.inner().getOpaqueDeviceMemoryDataPointer(api);
-    }
-};
+pub fn bufferTypeFromDtype(dt: dtype.DataType) pjrt.BufferType {
+    return switch (dt) {
+        .bool => .PRED,
+        .f8e4m3b11fnuz => .F8E4M3B11FNUZ,
+        .f8e4m3fn => .F8E4M3FN,
+        .f8e4m3fnuz => .F8E4M3FNUZ,
+        .f8e5m2 => .F8E5M2,
+        .f8e5m2fnuz => .F8E5M2FNUZ,
+        .bf16 => .BF16,
+        .f16 => .F16,
+        .f32 => .F32,
+        .f64 => .F64,
+        .i8 => .S8,
+        .i4 => .S4,
+        .i16 => .S16,
+        .i32 => .S32,
+        .i64 => .S64,
+        .u4 => .U4,
+        .u8 => .U8,
+        .u16 => .U16,
+        .u32 => .U32,
+        .u64 => .U64,
+        .c64 => .C64,
+        .c128 => .C128,
+    };
+}
 
 pub const Event = opaque {
     pub const inner = InnerMixin(pjrt.Event).inner;
@@ -249,7 +226,7 @@ pub const Event = opaque {
         return self.inner().isReady(api);
     }
 
-    pub fn getEventError(self: *const Event, api: *const Api) ApiError!?*Error {
+    pub fn getEventError(self: *const Event, api: *const Api) ?*Error {
         return self.inner().getEventError(api);
     }
 

--- a/zml/pjrtx.zig
+++ b/zml/pjrtx.zig
@@ -31,7 +31,7 @@ pub const ExecuteError = ApiError;
 test {
     std.testing.refAllDecls(Client);
     std.testing.refAllDecls(Event);
-    // std.testing.refAllDecls(LoadedExecutable);
+    std.testing.refAllDecls(LoadedExecutable);
 }
 
 fn InnerMixin(comptime innerT: type) type {
@@ -176,18 +176,6 @@ pub const Client = opaque {
     }
 };
 
-// pub const GpuCustomCallRegistry = struct {
-//     pub usingnamespace WrapperMixin(GpuCustomCallRegistry, pjrt.GpuCustomCallRegistry);
-
-//     inner: GpuCustomCallRegistry.UnionType,
-
-//     pub fn registerCustomCall(self: GpuCustomCallRegistry, api_version: usize, name: []const u8, func: pjrt.CustomCallSignature) ApiError!void {
-//         return switch (self.inner) {
-//             inline else => |v| v.registerCustomCall(api_version, name, func),
-//         };
-//     }
-// };
-
 pub const Event = opaque {
     pub const inner = InnerMixin(pjrt.Event).inner;
 
@@ -238,9 +226,9 @@ pub const Event = opaque {
 pub const LoadedExecutable = opaque {
     const inner = InnerMixin(pjrt.LoadedExecutable).inner;
 
-    pub fn deinit(self: *LoadedExecutable, api: *const Api) void {
-        self.inner().deinit(api);
-    }
+    // pub fn deinit(self: *LoadedExecutable, api: *const Api) void {
+    //     self.inner().deinit(api);
+    // }
 
     pub fn delete(self: *LoadedExecutable, api: *const Api) void {
         self.inner().delete(api);
@@ -250,9 +238,10 @@ pub const LoadedExecutable = opaque {
         return self.inner().isDeleted(api);
     }
 
-    pub fn getAddressableDevices(self: *const LoadedExecutable, api: *const Api) []*const Device {
-        return self.inner().getAddressableDevices(api);
-    }
+    // TODO fix me
+    // pub fn getAddressableDevices(self: *const LoadedExecutable, api: *const Api) []*const Device {
+    //     return self.inner().getAddressableDevices(api);
+    // }
 
     pub fn execute(self: *const LoadedExecutable, api: *const Api, args: struct {
         arguments: []const [*]const *const Buffer,

--- a/zml/pjrtx.zig
+++ b/zml/pjrtx.zig
@@ -188,33 +188,6 @@ pub const Client = opaque {
 //     }
 // };
 
-pub fn bufferTypeFromDtype(dt: dtype.DataType) pjrt.BufferType {
-    return switch (dt) {
-        .bool => .PRED,
-        .f8e4m3b11fnuz => .F8E4M3B11FNUZ,
-        .f8e4m3fn => .F8E4M3FN,
-        .f8e4m3fnuz => .F8E4M3FNUZ,
-        .f8e5m2 => .F8E5M2,
-        .f8e5m2fnuz => .F8E5M2FNUZ,
-        .bf16 => .BF16,
-        .f16 => .F16,
-        .f32 => .F32,
-        .f64 => .F64,
-        .i8 => .S8,
-        .i4 => .S4,
-        .i16 => .S16,
-        .i32 => .S32,
-        .i64 => .S64,
-        .u4 => .U4,
-        .u8 => .U8,
-        .u16 => .U16,
-        .u32 => .U32,
-        .u64 => .U64,
-        .c64 => .C64,
-        .c128 => .C128,
-    };
-}
-
 pub const Event = opaque {
     pub const inner = InnerMixin(pjrt.Event).inner;
 

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -32,7 +32,7 @@ pub const CompilationOptions = struct {
     xla_dump_to: ?[]const u8 = null,
     xla_dump_fusion_visualization: bool = false,
     cache_location: ?[]const u8 = null,
-    sharding_enabled: bool = true,
+    sharding_enabled: bool = false,
     sharding_axes: std.BoundedArray([*:0]const u8, 8) = .{},
 };
 
@@ -66,8 +66,19 @@ pub const Platform = struct {
         return all_devices;
     }
 
-    pub fn numDevices(self: Platform) u8 {
-        return @intCast(self.getDevices().len);
+    pub const Sharding = struct { num_replicas: u8, num_partitions: u8 };
+
+    pub fn sharding(self: Platform) Sharding {
+        // replicas run the same function but with different inputs,
+        // while partitions contribute to one evaluation over a shared input.
+        // Inside an inference process, we generally don't want replicas,
+        // as it's best to fully isolate replicas on different processes.
+        // For now we hardcode num_replicas = 1.
+        const num_devices: u8 = @intCast(self.getDevices().len);
+        return if (self.compilation_options.sharding_enabled)
+            .{ .num_replicas = 1, .num_partitions = num_devices }
+        else
+            .{ .num_replicas = 1, .num_partitions = 1 };
     }
 
     pub fn withCompilationOptions(self: Platform, opts: CompilationOptions) Platform {

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -6,6 +6,7 @@ const meta = @import("meta.zig");
 const module = @import("module.zig");
 const pjrt = @import("pjrtx.zig");
 const pjrt_core = @import("pjrt");
+const log = std.log.scoped(.zml);
 
 pub const Target = enum {
     cpu,
@@ -41,8 +42,14 @@ pub const Platform = struct {
     pjrt_client: *pjrt.Client,
     compilation_options: CompilationOptions = .{},
 
+    pub const MAX_NUM_DEVICES: u8 = 8;
+
     pub fn init(target: Target, api: *const pjrt.Api) !Platform {
         const pjrt_client = try pjrt.Client.init(api, &.{});
+        const true_num_devices = pjrt_client.getAddressableDevices(api).len;
+        if (true_num_devices > MAX_NUM_DEVICES) {
+            log.warn("platform {} got {} devices, but ZML only support up to {} devices. Some devices won't be used.", .{ target, true_num_devices, MAX_NUM_DEVICES });
+        }
         return .{
             .target = target,
             .pjrt_api = api,
@@ -52,7 +59,15 @@ pub const Platform = struct {
     }
 
     pub fn getDevices(self: Platform) []const *const pjrt_core.Device {
-        return self.pjrt_client.getAddressableDevices(self.pjrt_api);
+        const all_devices = self.pjrt_client.getAddressableDevices(self.pjrt_api);
+        if (all_devices.len > MAX_NUM_DEVICES) {
+            return all_devices[0..MAX_NUM_DEVICES];
+        }
+        return all_devices;
+    }
+
+    pub fn numDevices(self: Platform) u8 {
+        return @intCast(self.getDevices().len);
     }
 
     pub fn withCompilationOptions(self: Platform, opts: CompilationOptions) Platform {

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -31,6 +31,8 @@ pub const CompilationOptions = struct {
     xla_dump_to: ?[]const u8 = null,
     xla_dump_fusion_visualization: bool = false,
     cache_location: ?[]const u8 = null,
+    sharding_enabled: bool = true,
+    sharding_axes: std.BoundedArray([*:0]const u8, 8) = .{},
 };
 
 pub const Platform = struct {

--- a/zml/shape.zig
+++ b/zml/shape.zig
@@ -700,7 +700,8 @@ pub const Shape = struct {
         }
     }
 
-    pub fn computeStrides(self: Shape, base_stride: u32) std.BoundedArray(i64, MAX_RANK) {
+    pub fn computeStrides(self: Shape) std.BoundedArray(i64, MAX_RANK) {
+        const base_stride = self.dtype().sizeOf();
         const rk = self.rank();
         var strides: std.BoundedArray(i64, MAX_RANK) = .{ .len = @intCast(self.rank()) };
         if (rk == 0) return strides;

--- a/zml/shape.zig
+++ b/zml/shape.zig
@@ -71,7 +71,7 @@ pub const Shape = struct {
             return .{ dims_, tags_ };
         }
 
-        meta.compileError("Wrong type, got {}", .{T});
+        meta.compileError("expected a dimension tuple eg '.{{ .a = 10, .b = 20}}' or '.{{ 10, 20 }}', got {}", .{T});
     }
 
     test parseDimensions {
@@ -385,6 +385,9 @@ pub const Shape = struct {
                 try writer.print("{s}.{s}={d}", .{ prefix, t, d });
             } else {
                 try writer.print("{s}{d}", .{ prefix, d });
+            }
+            if (self._sharding_info[i]) {
+                try writer.writeByte('!');
             }
         }
         _ = try writer.print("}}, dtype=.{s}", .{@tagName(self.dtype())});

--- a/zml/shape.zig
+++ b/zml/shape.zig
@@ -671,6 +671,8 @@ pub const Shape = struct {
 
     pub fn withSharding(self: Shape, axes_: anytype) Shape {
         var res = self;
+        // Reset sharding.
+        res._sharding_info = @splat(false);
         for (self.axes(axes_).constSlice()) |ax| {
             res._sharding_info[ax] = true;
         }

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -196,11 +196,6 @@ pub const Tensor = struct {
         return res;
     }
 
-    /// Returns a slice containing the strides for a Tensor.
-    pub inline fn computeStrides(self: Tensor) []const i64 {
-        return self._shape.computeStrides(self.dtype().sizeOf()).constSlice();
-    }
-
     var _global_tensor_counter: u64 = 0;
 
     /// Internal use

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -159,6 +159,12 @@ pub const Tensor = struct {
         return res;
     }
 
+    pub fn withSharding(self: Tensor, axes_: anytype) Tensor {
+        var res = self;
+        res._shape = self._shape.withSharding(axes_);
+        return res;
+    }
+
     /// Returns a Tensor with new tag names.
     pub fn rename(self: Tensor, renames: anytype) Tensor {
         var res = self;


### PR DESCRIPTION
First rough support for in-process sharding.
The goal of sharding is to allow leveraging several GPUs to collaborate to run one big model.

Current implementation:
* added `platform.sharding()` describing how the set of devices managed by the current process should be used.
* added a `_sharding_info` to shape.
* A tensor / shape axis can be marked as needing sharding using `.withSharding(.{ .a })` or `.withSharding(.{ 1 })`.
* When using `populateModelWeights` tensors with sharded axes, will be populated by sharded buffers.
* when generating the MLIR bytecode for a ZML function the **input** arguments, will see their `_sharding_info` converted into `mhlo.sharding` attributes