### PR TITLE
zml: Use correct init values for `Tensor.min()` and `Tensor.max()`

### DIFF
--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -2248,7 +2248,7 @@ pub const Tensor = struct {
                 }
             }.cmp,
             self,
-            Tensor.scalar(0, self.dtype()),
+            Tensor.constant(&.{}, self.dtype().minValue()),
             &.{a},
         );
     }
@@ -2263,7 +2263,7 @@ pub const Tensor = struct {
                 }
             }.cmp,
             self,
-            Tensor.scalar(0, self.dtype()),
+            Tensor.constant(&.{}, self.dtype().maxValue()),
             &.{a},
         );
     }


### PR DESCRIPTION
When doing a `max` over a dimension, you have to start with the minimum value possible, otherwise you might miss the maximum.

Example:
Let's imagine you have a Tensor with the following values: `[-5, -4, -3, -2, -1]`
If you start with a value of `0`, the `max` in reduce will always return 0. Thus in the end, you get a maximum of `0` whereas `0` is not in the set of values.

Same for `min`