### PR TITLE
PJRT: handle rank-0 special case in `getDimensions`

### DIFF
--- a/pjrt/pjrt.zig
+++ b/pjrt/pjrt.zig
@@ -668,6 +668,9 @@ pub const Buffer = opaque {
         const ret = api.call(.PJRT_Buffer_Dimensions, .{
             .buffer = self.inner(),
         }) catch unreachable;
+        if (ret.num_dims == 0) {
+            return &.{};
+        }
         return ret.dims[0..ret.num_dims];
     }
 


### PR DESCRIPTION
On some platforms, the returned pointer is null so we can't use it as a slice, even if `num_dims` is 0.