### PR TITLE
Add StableHLO bindings for functions related to versioning

### DIFF
--- a/mlir/mlir.zig
+++ b/mlir/mlir.zig
@@ -30,7 +30,7 @@ pub fn registerPasses(comptime passes: []const u8) void {
     @field(c, "mlirRegister" ++ passes ++ "Passes")();
 }
 
-fn successOr(res: c.MlirLogicalResult, err: anytype) !void {
+pub fn successOr(res: c.MlirLogicalResult, err: anytype) !void {
     return if (res.value == 0) err;
 }
 


### PR DESCRIPTION
These functions can be used to serialize stablehlo in a portable way.