### PR TITLE
Cleaned dialect related imports

### DIFF
--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -14,9 +14,7 @@ const DataType = @import("dtype.zig").DataType;
 const Buffer = buffer.Buffer;
 const EnumLiteral = @TypeOf(.enum_literal);
 
-const dialect = struct {
-    const stablehlo = @import("mlir/dialects").stablehlo;
-};
+const dialect = @import("mlir/dialects");
 
 const assert = std.debug.assert;
 const log = std.log.scoped(.zml_tensor);

--- a/zml/pjrtx.zig
+++ b/zml/pjrtx.zig
@@ -2,6 +2,7 @@ const builtin = @import("builtin");
 const std = @import("std");
 
 const mlir = @import("mlir");
+const dialect = @import("mlir/dialects");
 const pjrt = @import("pjrt");
 const dtype = @import("dtype.zig");
 const meta = @import("meta.zig");

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -19,9 +19,7 @@ const DataType = @import("dtype.zig").DataType;
 const Platform = @import("platform.zig").Platform;
 const EnumLiteral = @TypeOf(.enum_literal);
 
-const dialect = struct {
-    const stablehlo = @import("mlir/dialects").stablehlo;
-};
+const dialect = @import("mlir/dialects");
 
 const scoped_log = std.log.scoped(.zml_tensor);
 


### PR DESCRIPTION
We were creating useless struct to reexpose `dialect.stablehlo`.