### PR TITLE
Try to read normalizer setting from the huggingface json

### DIFF
--- a/zml/aio/gguf.zig
+++ b/zml/aio/gguf.zig
@@ -57,14 +57,16 @@ pub fn getGgufTokenizer(self: zml.aio.BufferStore, allocator: std.mem.Allocator)
     };
 
     // default options
-    const gguf_normalizer: zml.tokenizer.Normalizer = .{ .flags = .{
-        .escape_whitespaces = true,
-        .remove_extra_whitespaces = true,
-        .add_dummy_prefix = true,
-        .add_dummy_suffix = false,
-        .lower_case_ascii = false,
-        .split_on_punct_ascii = false,
-    } };
+    const gguf_normalizer: zml.tokenizer.Normalizer = .{
+        .escape_whitespaces = zml.tokenizer.Normalizer.sentencepiece_space,
+        .flags = .{
+            .remove_extra_whitespaces = true,
+            .add_dummy_prefix = true,
+            .add_dummy_suffix = false,
+            .lower_case_ascii = false,
+            .split_on_punct_ascii = false,
+        },
+    };
 
     const extra_tokens: u8 = if (tokenizer_impl == .gpt2) 1 else 0;
     const n_tokens: u32 = @intCast(tokens.len + extra_tokens);
@@ -100,7 +102,7 @@ pub fn getGgufTokenizer(self: zml.aio.BufferStore, allocator: std.mem.Allocator)
     // Gpt2 tokenizer always splits on spaces.
     if (tokenizer_impl == .gpt2) {
         tokenizer.normalizer.?.flags.add_dummy_prefix = true;
-        tokenizer.normalizer.?.flags.escape_whitespaces = false;
+        tokenizer.normalizer.?.escape_whitespaces = null;
         tokenizer.special_tokens.hard_space = tokenizer.next_token_id;
         tokenizer.addOwnedToken(0, " ");
     }

--- a/zml/aio/gguf.zig
+++ b/zml/aio/gguf.zig
@@ -56,17 +56,10 @@ pub fn getGgufTokenizer(self: zml.aio.BufferStore, allocator: std.mem.Allocator)
         .pad = pad orelse NOT_FOUND,
     };
 
-    // default options
-    const gguf_normalizer: zml.tokenizer.Normalizer = .{
-        .escape_whitespaces = zml.tokenizer.Normalizer.sentencepiece_space,
-        .flags = .{
-            .remove_extra_whitespaces = true,
-            .add_dummy_prefix = true,
-            .add_dummy_suffix = false,
-            .lower_case_ascii = false,
-            .split_on_punct_ascii = false,
-        },
-    };
+    const gguf_normalizer = if (tokenizer_impl == .gpt2)
+        zml.tokenizer.Normalizer.wellKnown(.gpt2)
+    else
+        zml.tokenizer.Normalizer.wellKnown(.sentencepiece);
 
     const extra_tokens: u8 = if (tokenizer_impl == .gpt2) 1 else 0;
     const n_tokens: u32 = @intCast(tokens.len + extra_tokens);
@@ -101,8 +94,6 @@ pub fn getGgufTokenizer(self: zml.aio.BufferStore, allocator: std.mem.Allocator)
 
     // Gpt2 tokenizer always splits on spaces.
     if (tokenizer_impl == .gpt2) {
-        tokenizer.normalizer.?.flags.add_dummy_prefix = true;
-        tokenizer.normalizer.?.escape_whitespaces = null;
         tokenizer.special_tokens.hard_space = tokenizer.next_token_id;
         tokenizer.addOwnedToken(0, " ");
     }

--- a/zml/aio/sentencepiece.zig
+++ b/zml/aio/sentencepiece.zig
@@ -75,9 +75,15 @@ pub fn normalizerFromSpec(spec: sentencepiece_proto.NormalizerSpec) Normalizer {
     if (!std.mem.eql(u8, spec.name.?.getSlice(), "identity")) std.debug.panic("Normalizer only supports NormalizerSpec with name \"identity\", got \"{s}\"", .{spec.name.?.getSlice()});
     if (!spec.escape_whitespaces.?) std.debug.panic("Normalizer only supports NormalizerSpec with \"escape_whitespaces\" flag set", .{});
     if (spec.remove_extra_whitespaces) |_| {} else std.debug.panic("Normalizer only supports NormalizerSpec with \"remove_extra_whitespaces\" flag set", .{});
-    if (spec.add_dummy_prefix) |_| {} else std.debug.panic("Normalizer only supports NormalizerSpec with \"add_dummy_prefix\" flag set", .{});
-    return .{ .flags = .{
-        .remove_extra_whitespaces = spec.remove_extra_whitespaces orelse false,
-        .add_dummy_prefix = spec.add_dummy_prefix orelse true,
-    } };
+
+    return .{
+        .escape_whitespaces = if (spec.escape_whitespaces orelse false) Normalizer.sentencepiece_space else null,
+        .flags = .{
+            .remove_extra_whitespaces = spec.remove_extra_whitespaces orelse false,
+            .add_dummy_prefix = spec.add_dummy_prefix orelse false,
+            .add_dummy_suffix = false,
+            .lower_case_ascii = false,
+            .split_on_punct_ascii = false,
+        },
+    };
 }

--- a/zml/aio/sentencepiece.zig
+++ b/zml/aio/sentencepiece.zig
@@ -76,14 +76,14 @@ pub fn normalizerFromSpec(spec: sentencepiece_proto.NormalizerSpec) Normalizer {
     if (!spec.escape_whitespaces.?) std.debug.panic("Normalizer only supports NormalizerSpec with \"escape_whitespaces\" flag set", .{});
     if (spec.remove_extra_whitespaces) |_| {} else std.debug.panic("Normalizer only supports NormalizerSpec with \"remove_extra_whitespaces\" flag set", .{});
 
-    return .{
-        .escape_whitespaces = if (spec.escape_whitespaces orelse false) Normalizer.sentencepiece_space else null,
-        .flags = .{
+    return Normalizer.init(
+        .{
             .remove_extra_whitespaces = spec.remove_extra_whitespaces orelse false,
             .add_dummy_prefix = spec.add_dummy_prefix orelse false,
             .add_dummy_suffix = false,
             .lower_case_ascii = false,
             .split_on_punct_ascii = false,
         },
-    };
+        if (spec.escape_whitespaces orelse false) Normalizer.sentencepiece_space else null,
+    );
 }

--- a/zml/tokenizer.zig
+++ b/zml/tokenizer.zig
@@ -301,11 +301,13 @@ pub const Tokenizer = struct {
             var piece = self.lookupPiece(id);
 
             // Convert `▁` to a regular space.
-            if (escaped != null and std.mem.startsWith(u8, piece, escaped.?)) {
-                piece = piece[escaped.?.len..];
-
-                // don't output a space at beginning of text.
-                if (output.items.len > 0) try output.append(' ');
+            if (escaped) |escspc| {
+                // we modify piece inside the loop, so we can use it in the condition
+                while (std.mem.startsWith(u8, piece, escaped.?)) {
+                    piece = piece[escspc.len..];
+                    // don't output a space at beginning of text.
+                    if (output.items.len > 0) try output.append(' ');
+                }
             }
 
             try output.appendSlice(piece);

--- a/zml/tokenizer.zig
+++ b/zml/tokenizer.zig
@@ -128,13 +128,15 @@ pub const Tokenizer = struct {
         add_bos: bool = true,
         add_eos: bool = false,
         pad_to: u32 = 0,
+        // Print tokenization intermediary steps.
+        debug: bool = false,
     };
 
     pub fn encode(self: *const Tokenizer, allocator: std.mem.Allocator, raw: []const u8, options: EncodeOptions) ![]u32 {
-        // log.debug("Tokenizer.encode('{s}')", .{raw});
+        if (options.debug) log.debug("Tokenizer.encode('{s}')", .{raw});
         const input = if (self.normalizer) |n| try n.normalize(allocator, raw) else raw;
         defer if (self.normalizer) |_| allocator.free(input);
-        // log.debug("Tokenizer.encode.normalize -> '{s}'", .{input});
+        if (options.debug) log.debug("Tokenizer.encode.normalize -> '{s}'", .{input});
 
         // Allocate a buffer that can fit all indices as well as extra character if requested.
         // We then slice it so that the token merging code doesn't see the bos token.
@@ -158,7 +160,12 @@ pub const Tokenizer = struct {
         var stable_off: usize = 0;
         while (true) {
             // Step by step visualization of the progress.
-            // log.debug("tokens: {d} -> {s}", .{ tok_buff[0..num_tokens], try self.decodeWithOpts(allocator, tok_buff[0..num_tokens], .{ .sep = "|" }) });
+            if (options.debug) {
+                var _debug_buf: [256]u8 = undefined;
+                var debug_progress: std.ArrayList(u8) = .{ .items = _debug_buf[0..0], .capacity = _debug_buf.len, .allocator = undefined };
+                self.decodeWithOpts(&debug_progress, tok_buff[0..num_tokens], .{ .sep = "|" }) catch {};
+                log.debug("tokens: {d} -> {s}", .{ tok_buff[0..num_tokens], debug_progress.items });
+            }
             var best_score: f32 = -1e10;
             var best_token: u32 = 0;
             var best_idx: ?usize = null;
@@ -273,7 +280,7 @@ pub const Tokenizer = struct {
     /// Converts the given slice of tokens back into bytes.
     /// Note that if the tokenizer allows sub-unicode bytes, it's possible
     /// the output is not valid utf8.
-    pub fn decode(self: *const Tokenizer, allocator: std.mem.Allocator, input: []const u32) ![]u8 {
+    pub fn decode(self: *const Tokenizer, allocator: std.mem.Allocator, input: []const u32) error{OutOfMemory}![]u8 {
         var output = std.ArrayList(u8).init(allocator);
         errdefer output.deinit();
 
@@ -286,7 +293,7 @@ pub const Tokenizer = struct {
         output: *std.ArrayList(u8),
         input: []const u32,
         opts: struct { sep: []const u8 = "" },
-    ) !void {
+    ) error{OutOfMemory}!void {
         const escaped = if (self.normalizer) |n| n.escape_whitespaces else null;
         // Flag used to indicate if the first dummy whitespace has been consumed.
         for (input) |id| {
@@ -800,15 +807,14 @@ pub fn fromHfJson(allocator: std.mem.Allocator, tokenizer_path: []const u8) !Tok
     const file = try std.fs.cwd().openFile(tokenizer_path, .{});
     defer file.close();
 
-    const file_content = try file.readToEndAlloc(allocator, 32 * 1024 * 1024);
-    defer allocator.free(file_content);
-    // TODO create local arena and use parseFromSliceLeaky.
-    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, file_content, .{
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const file_content = try file.readToEndAlloc(arena, 32 * 1024 * 1024);
+
+    const info = try std.json.parseFromSliceLeaky(std.json.Value, arena, file_content, .{
         .duplicate_field_behavior = .use_last,
     });
-    defer parsed.deinit();
-    const info = parsed.value;
-
     const main_object = switch (info) {
         .object => |obj| if (obj.get("added_tokens") == null or obj.get("model") == null) {
             return error.InvalidFormat;


### PR DESCRIPTION
We had issues with the CodeLlama tokenizer. https://huggingface.co/codellama/CodeLlama-7b-hf

Looking at the config, it's actually a "sentencepiece" tokenizer, that uses the special "▁" token to represent spaces.

```
"normalizer": {
    "type": "Sequence",
    "normalizers": [
      {
        "type": "Prepend",
        "prepend": "▁"
      },
      {
        "type": "Replace",
        "pattern": {
          "String": " "
        },
        "content": "▁"
      }
    ]
  },
```

I've added a `Normalizer.fromHfJson` that reads this json and tries to convert this style to our options.
This config can express more things than we can, so it's a best effort.
I've also made the magic space token configurable, requiring adding a small buffer in Normalizer to store it.

There is a small change that can have importance, is that now in most cases the setting "remove_extra_whitespaces" will not be set, meaning that user input will be tokenized differently in face of double spaces. I generally don't think this  is a good practice, but it respect HF defaults.

I've also added a `debug` boolean on the tokenizer struct that shows the individual merges of tokens.
It helped me previously when debugging tokenizer issues.
Before you needed to explicitly uncomment some code to use it, now it's behind a runtime boolean.