### PR TITLE
make `zml/test_runner.zig` public

### DIFF
--- a/zml/BUILD.bazel
+++ b/zml/BUILD.bazel
@@ -15,6 +15,10 @@ zig_library(
         "aio/**/*.zig",
         "nn/**/*.zig",
         "ops/**/*.zig",
+        # TODO: test_runner.zig should not be here.
+        # It's here for now because it seems that test_runner property in zig_test is misbehaving.
+        # See https://github.com/zml/rules_zig/issues/2
+        "test_runner.zig",
     ]),
     copts = ["-lc"],
     main = "zml.zig",
@@ -60,8 +64,14 @@ zig_cc_test(
         "aio/torch/simple.pt",
         "aio/torch/simple_test.pickle",
     ],
-    test_runner = "test_runner.zig",
+    test_runner = ":test_runner",
     deps = [":zml"],
+)
+
+filegroup(
+    name = "test_runner",
+    srcs = ["test_runner.zig"],
+    visibility = ["//visibility:public"],
 )
 
 filegroup(


### PR DESCRIPTION
The end goal is to allow zml users to use our async test runner in their project.

This approach works but is a bit hacky because it relies on the fact that `test_runner.zig` is part of the `zml` library
otherwise `zig_test` doesn't correctly put the test_runner into the build sandbox.

I made this dependency explicit, but it was already the case because of the glob pattern used in zml library.

And I think `test_runner` should be `zig_library` in the first place, and not a filegroup.
See https://github.com/zml/rules_zig/issues/2 for follow up.