### PR TITLE
zml.aio.json: fix loading empty array

### DIFF
--- a/examples/loader/main.zig
+++ b/examples/loader/main.zig
@@ -60,7 +60,7 @@ pub fn asyncMain() !void {
     while (it.next()) |entry| : (i += 1) {
         const host_buffer = entry.value_ptr.*;
         total_bytes += host_buffer.data.len;
-        std.debug.print("Buffer: {any} / {any}\n", .{ i + 1, buffer_store.buffers.count() });
+        std.debug.print("Buffer: {s} ({any} / {any})\n", .{ entry.key_ptr.*, i + 1, buffer_store.buffers.count() });
         buffers[i] = try zml.Buffer.from(platform, host_buffer);
     }
 

--- a/zml/aio/torch/eval.zig
+++ b/zml/aio/torch/eval.zig
@@ -398,7 +398,7 @@ pub fn evaluate(allocator: std.mem.Allocator, x: []const PickleOp, resolve_refs:
             }),
             .list => try stack.values.append(.{ .seq = .{ .type = .list, .values = try stack.popMark(allocator) } }),
             .inst => |v| try stack.values.append(blk: {
-                const tup_items = try allocator.dupe(Value, &.{ .{ .string = v[0] }, .{ .string = v[1] } });
+                const tup_items = try allocator.dupe(Value, &.{ .{ .string = v.module }, .{ .string = v.class } });
                 break :blk .{ .object = try Object.init(allocator, .{ .seq = .{ .type = .tuple, .values = tup_items } }, try stack.popMark(allocator)) };
             }),
             .obj => try stack.values.append(blk: {

--- a/zml/aio/torch/parser.zig
+++ b/zml/aio/torch/parser.zig
@@ -240,13 +240,12 @@ pub const Decoder = struct {
                 },
                 .append => try results.append(.{ .append = {} }),
                 .build => try results.append(.{ .build = {} }),
-                .global => {
-                    const buf0 = try reader.readUntilDelimiterAlloc(allocator, '\n', len);
-                    errdefer allocator.free(buf0);
-                    const buf1 = try reader.readUntilDelimiterAlloc(allocator, '\n', len);
-                    errdefer allocator.free(buf1);
-                    _ = (buf1.len + 1);
-                    try results.append(.{ .global = .{ buf0, buf1 } });
+                .global, .inst => {
+                    const module = try reader.readUntilDelimiterAlloc(allocator, '\n', len);
+                    errdefer allocator.free(module);
+                    const class = try reader.readUntilDelimiterAlloc(allocator, '\n', len);
+                    errdefer allocator.free(class);
+                    try results.append(.{ .global = .{ .module = module, .class = class } });
                 },
                 .dict => try results.append(.{ .dict = {} }),
                 .empty_dict => try results.append(.{ .empty_dict = {} }),
@@ -257,14 +256,6 @@ pub const Decoder = struct {
                     try results.append(.{ .get = buf });
                 },
                 .binget => try results.append(.{ .binget = try reader.readByte() }),
-                .inst => {
-                    const buf0 = try reader.readUntilDelimiterAlloc(allocator, '\n', len);
-                    errdefer allocator.free(buf0);
-                    const buf1 = try reader.readUntilDelimiterAlloc(allocator, '\n', len);
-                    errdefer allocator.free(buf1);
-                    _ = (buf1.len + 1);
-                    try results.append(.{ .inst = .{ buf0, buf1 } });
-                },
                 .long_binget => try results.append(.{ .long_binget = try reader.readInt(u32, .little) }),
                 .list => try results.append(.{ .list = {} }),
                 .empty_list => try results.append(.{ .empty_list = {} }),

--- a/zml/aio/torch/value.zig
+++ b/zml/aio/torch/value.zig
@@ -265,7 +265,7 @@ pub const Value = union(ValueType) {
             },
             .string => |v| try writer.print("\"{s}\"", .{v}),
             .raw => |v| switch (v) {
-                .global => |raw_global| try writer.print("\"{s}\", \"{s}\"", .{ raw_global[0], raw_global[1] }),
+                .global => |py_type| try writer.print("\"{s}\", \"{s}\"", .{ py_type.module, py_type.class }),
                 else => try writer.print("{any}", .{v}),
             },
             inline else => |v| {


### PR DESCRIPTION
safetensor loader was segfaulting when loading metadata with an empty json array.

I also rewrote some of the torch loader code to improve the readability.
Notably every slice in `ops.zig` is now const. I've also realized that our strategy to load Pytorch tensor is not future proof see the warning at: https://pytorch.org/docs/stable/storage.html

we need to support the "UntypedStorage". @cryptodeal can you follow up on that ?