### PR TITLE
Add missing `load` in dockerize_models.md

### DIFF
--- a/docs/howtos/dockerize_models.md
+++ b/docs/howtos/dockerize_models.md
@@ -41,6 +41,7 @@ use their rules to define our 5 additional targets:
 load("@aspect_bazel_lib//lib:tar.bzl", "mtree_spec", "tar")
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
+load("@zml//bazel:zig.bzl", "zig_cc_binary")
 
 zig_cc_binary(
     name = "simple_layer",


### PR DESCRIPTION
Added the missing import `zig_cc_binary` in the simple layer example, even though it seems obvious when you read the error