### PR TITLE
zml.tensor: add cumulativeSum, small refactor of maxPoolND

### DIFF
--- a/mlir/dialects/stablehlo.zig
+++ b/mlir/dialects/stablehlo.zig
@@ -481,7 +481,7 @@ pub fn round_nearest_even(ctx: mlir.Context, value: mlir.Value, location: mlir.L
 pub const PadOpts = struct {
     low: []const i64,
     high: []const i64,
-    interior: ?[]const i64,
+    interior: []const i64,
 };
 
 pub fn pad(ctx: mlir.Context, value: mlir.Value, padding_value: mlir.Value, opts: PadOpts, location: mlir.Location) mlir.Operation {
@@ -491,7 +491,7 @@ pub fn pad(ctx: mlir.Context, value: mlir.Value, padding_value: mlir.Value, opts
         .attributes = &.{
             .{ "edge_padding_low", mlir.DenseArrayAttribute(.i64).init(ctx, opts.low).as(mlir.Attribute).? },
             .{ "edge_padding_high", mlir.DenseArrayAttribute(.i64).init(ctx, opts.high).as(mlir.Attribute).? },
-            .{ "interior_padding", mlir.DenseArrayAttribute(.i64).init(ctx, opts.interior.?).as(mlir.Attribute).? },
+            .{ "interior_padding", mlir.DenseArrayAttribute(.i64).init(ctx, opts.interior).as(mlir.Attribute).? },
         },
         .location = location,
     });

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1316,7 +1316,7 @@ pub const Tensor = struct {
         else
             .{ self.dim(a) - 1, 0 };
 
-        return ops.reduceWindow(
+        var res = ops.reduceWindow(
             Tensor.add,
             self,
             Tensor.scalar(0, self.dtype()),
@@ -1328,6 +1328,8 @@ pub const Tensor = struct {
                 .padding = padding[0..rk],
             },
         );
+        res._shape = self._shape;
+        return res;
     }
 
     test cumulativeSum {

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1268,7 +1268,7 @@ pub const Tensor = struct {
     }
 
     /// Returns a Tensor containing the sum of elements over the given axis.
-    /// Ouput shape is the input shape with the axis_ dim set to 1.
+    /// Output shape is the input shape with the axis_ dim set to 1.
     pub fn sum(self: Tensor, axis_: anytype) Tensor {
         const a = self.axis(axis_);
         return ops.reduce(
@@ -1284,13 +1284,13 @@ pub const Tensor = struct {
     }
 
     /// Returns a Tensor containing the mean of elements over the given axis.
-    /// Ouput shape is the input shape with the axis_ dim set to 1.
+    /// Output shape is the input shape with the axis_ dim set to 1.
     pub fn mean(self: Tensor, axis_: anytype) Tensor {
         return self.sum(axis_).divByConst(self.dim(axis_));
     }
 
     /// Returns a Tensor containing the cumulative sum of elements over the given axis.
-    /// Ouput shape is the same as input shape.
+    /// Output shape is the same as input shape.
     /// [0, 1, 0, 1, 0, 0, 1, 1].cumulativeSum(0) -> [0, 1, 1, 2, 2, 2, 3, 4]
     /// The last value contains the sum of all element in the array.
     pub fn cumulativeSum(self: Tensor, axis_: anytype) Tensor {

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -3139,6 +3139,7 @@ pub const Tensor = struct {
     /// Tensor(.{ .a = 2, .b = 5 }).dynamicUpdateSlice(.{ .a = scalar(1, .i32) }, Tensor(.{ .b = 5 }));
     /// ```
     pub fn dynamicUpdateSlice(self: Tensor, offset_: anytype, update_: Tensor) Tensor {
+        // TODO: add updateSlice for when the offset isn't dynamic
         meta.assert(self.dtype() == update_.dtype(), "dynamicUpdateSlice expects input and 'update_' tensors to be of the same type, got {} and {}", .{ self.dtype(), update_.dtype() });
 
         const offset, const offset_tags = Shape.parseStruct(Tensor, offset_);

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1289,6 +1289,54 @@ pub const Tensor = struct {
         return self.sum(axis_).divByConst(self.dim(axis_));
     }
 
+    /// Returns a Tensor containing the cumulative sum of elementes over the given axis.
+    /// Ouput shape is the same as input shape.
+    /// [0, 1, 0, 1, 0, 0, 1, 1].cumulativeSum(0) -> [0, 1, 1, 2, 2, 2, 3, 4]
+    pub fn cumulativeSum(self: Tensor, axis_: anytype) Tensor {
+        const rk = self.rank();
+        const a = self.axis(axis_);
+
+        const ones = [_]i64{1} ** MAX_RANK;
+        var window_dimensions = ones;
+        window_dimensions[a] = self.dim(a);
+        var padding = [_][2]i64{.{ 0, 0 }} ** MAX_RANK;
+        padding[a] = .{ self.dim(a) - 1, 0 };
+        return ops.reduceWindow(
+            Tensor.add,
+            self,
+            Tensor.scalar(0, self.dtype()),
+            .{
+                .base_dilations = ones[0..rk],
+                .window_dilations = ones[0..rk],
+                .window_strides = ones[0..rk],
+                .window_dimensions = window_dimensions[0..rk],
+                .padding = padding[0..rk],
+            },
+        );
+    }
+
+    test cumulativeSum {
+        const zml = @import("zml.zig");
+        const platform = zml.testing.env();
+
+        // Wrap slice1d to hide the anytype in the signature.
+        const Local = struct {
+            pub fn _cumsum(input: Tensor) Tensor {
+                return input.cumulativeSum(-1);
+            }
+        };
+
+        const x = try zml.Buffer.fromArray(
+            platform,
+            [2][5]f32{ .{ 0, 1, 1, 0, 1 }, .{ 3, 1, 0, 2, 1 } },
+        );
+        const res = try zml.testing.compileAndCall(platform, Local._cumsum, .{x});
+        try testing.expectEqual(
+            [2][5]f32{ .{ 0, 1, 2, 2, 3 }, .{ 3, 4, 4, 6, 7 } },
+            try res.getValue([2][5]f32),
+        );
+    }
+
     /// Returns a transposed Tensor computed using the given axes.
     pub fn transpose(self: Tensor, axes_: anytype) Tensor {
         const axes__ = self.axes(axes_).constSlice();


### PR DESCRIPTION
This PR adds the "cumulative sum" operator.

This is based on what jax does, which is leveraging reduce window operator,
where for each n in [0..N] you compute the some of elements [0..n] 
I'm not sure how this get optimized in complex programs, to be investigated.

**BREAKING CHANGES**:
* `reduceWindow` is still pretty hard to used but I merged the `padding_shape` and `padding_value` into one operator and made the signature more explicit.
* this also lead me to change a bit how `maxPool1D` and `maxPool2D` take arguments, using proper tuples instead of slices that need to be of specific len.
* `pad` now take options using 
     * "tagged syntax":`x.pad(0, .{ .a = .{ .low = 1, .high = -1 }});` 
     * or the "AOS syntax":  `x.pad(0, &.{.{}, { .low = 1, .high = -1 }});`
     * the "SOA syntax" is **REMOVED**: `x.pad(0, .{ .low = &.{1}, .high = &.{-1} });`