### PR TITLE
zml/tensor: use stablehlo.logistic for silu and remove logistic to implement it in sigmoid [BREAKING CHANGE]

### DIFF
--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1252,7 +1252,7 @@ pub const Tensor = struct {
     /// silu(x) = x σ(x)
     /// https://paperswithcode.com/method/silu
     pub fn silu(x: Tensor) Tensor {
-        return x.mul(x.sigmoid());
+        return x.mul(x.logistic());
     }
 
     /// Returns a Tensor containing the softmax function applied to each element of the input Tensor.

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -293,13 +293,6 @@ pub const Tensor = struct {
         return _result(self._shape.withDtype(.bool), op.result(0));
     }
 
-    /// Returns a Tensor containing the element-wise logistic operation on the input Tensor.
-    pub fn logistic(self: Tensor) Tensor {
-        const loc = self.getContext().mlirCtx().location(@src());
-        const op = dialect.stablehlo.logistic(self.getContext().mlirCtx(), self.value(), loc);
-        return _result(self._shape, op.result(0));
-    }
-
     /// Returns a Tensor containing the element-wise number of bits set in the input Tensor.
     pub fn popcnt(self: Tensor) Tensor {
         meta.assert(self.dtype().isInteger(), "popcnt expects tensor type to be an integer, got {}", .{self.dtype()});
@@ -1190,9 +1183,9 @@ pub const Tensor = struct {
 
     /// Returns a Tensor containing the sigmoid function applied to each element of the input Tensor.
     pub fn sigmoid(self: Tensor) Tensor {
-        // until the metal plugin supports `stablehlo.logistics`, implement in the way JAX does it
-        const one = Tensor.constant(&.{}, self.dtype().one()).broadcast(self._shape, &.{});
-        return one.div(one.add(self.negate().exp()));
+        const loc = self.getContext().mlirCtx().location(@src());
+        const op = dialect.stablehlo.logistic(self.getContext().mlirCtx(), self.value(), loc);
+        return _result(self._shape, op.result(0));
     }
 
     /// Returns a Tensor containing the ReLU activation function applied to each element of the input Tensor.
@@ -1252,7 +1245,7 @@ pub const Tensor = struct {
     /// silu(x) = x σ(x)
     /// https://paperswithcode.com/method/silu
     pub fn silu(x: Tensor) Tensor {
-        return x.mul(x.logistic());
+        return x.mul(x.sigmoid());
     }
 
     /// Returns a Tensor containing the softmax function applied to each element of the input Tensor.

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1188,6 +1188,8 @@ pub const Tensor = struct {
         return _result(self._shape, op.result(0));
     }
 
+    pub const logistic = sigmoid;
+
     /// Returns a Tensor containing the ReLU activation function applied to each element of the input Tensor.
     pub fn relu(self: Tensor) Tensor {
         return self.maximum(Tensor.constant(self.dims(), self.dtype().zero()));


### PR DESCRIPTION
For `silu`, `logistic` is more precise than `sigmoid` since the first one is bound to StableHLO while the second one is a custom implementation. 

edit: after the discussion below I removed duplicated `logistic` operator to move the StableHLO call directly in `sigmoid`. The name is more "findable" than `logistic` and more aligned with what we have regarding activations functions; also if the user try to find `logistic` he will find it in the `sigmoid` implementation while the inverse is not true. I added a breaking change mention in the PR title too.