### PR TITLE
zml: configure runfiles env at context start

### DIFF
--- a/zml/posix.h
+++ b/zml/posix.h
@@ -1,1 +1,2 @@
+#include <stdlib.h>
 #include <sys/mman.h>


### PR DESCRIPTION
If we start bazel built binaries inside a ZML process, the environment has to be configured properly for the sub processes to find their runfiles properly.
Do it process wide at context start.