### PR TITLE
zml.tensor: add triangular and toDiagonal

### DIFF
--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -52,6 +52,7 @@ pub const Activation = union(enum) {
     tanh,
     relu,
     leakyReLU: f32,
+    elu: f32,
     silu,
     gelu,
     quick_gelu,
@@ -63,9 +64,17 @@ pub const Activation = union(enum) {
             .relu => x.relu(),
             .silu => x.silu(),
             .gelu => x.gelu(),
+            .elu => |alpha| elu(x, alpha),
             .quick_gelu => x.quickGelu(),
             .leakyReLU => |slope| x.leakyReLU(slope),
         };
+    }
+
+    pub fn elu(x: Tensor, alpha: f32) Tensor {
+        return x.cmp(.GE, Tensor.scalar(0, x.dtype())).select(
+            x,
+            x.exp().addConstant(-1).scale(alpha),
+        );
     }
 };
 

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -701,7 +701,6 @@ pub fn causalAttnMask(
     }
 
     if (dtype.isFloat()) {
-        meta.guard(dtype.isFloat(), @src()); // -inf only exists for floats
         const zeros = Tensor.constant(mask.shape(), dtype.zero());
         const minus_inf = Tensor.constant(mask.shape(), dtype.minValue());
         mask = Tensor.select(mask, zeros, minus_inf);

--- a/zml/shape.zig
+++ b/zml/shape.zig
@@ -523,11 +523,11 @@ pub const Shape = struct {
         return res;
     }
 
-    pub fn remove(self: Shape, d: anytype) Shape {
+    pub fn remove(self: Shape, axis_: anytype) Shape {
         var res = self;
-        const d_ = self.axis(d);
-        _ = res._dims.orderedRemove(d_);
-        _ = res._tags.orderedRemove(d_);
+        const a = self.axis(axis_);
+        _ = res._dims.orderedRemove(a);
+        _ = res._tags.orderedRemove(a);
         return res;
     }
 

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1829,27 +1829,6 @@ pub const Tensor = struct {
         return left.mul(right);
     }
 
-    /// Creates a 2D Tensor with its diagonal set to the input vector.
-    pub fn diag(self: Tensor) Tensor {
-        meta.assert(self.rank() == 1, "diag only supports tensor of rank 1, got {}", .{self.rank()}); // TODO: support 2D tensors
-        //
-        const indices = Tensor.arange(.{ .end = self.dim(0) }, .i64);
-        const sh = Shape.init(.{ self.dim(0), self.dim(0) }, self.dtype());
-        const indices_1 = indices.broadcast(sh, &.{1});
-        const indices_0 = indices.broadcast(sh, &.{0});
-
-        const loc = self.getContext().mlirCtx().location(@src());
-        // TODO: handle more complex cases (2D, specifying `diagonal` index).
-        const op = dialect.stablehlo.select(
-            self.getContext().mlirCtx(),
-            indices_1.cmp(.EQ, indices_0).value(),
-            self.broadcast(sh, &.{1}).value(),
-            Tensor.constant(self.dims(), self.dtype().zero()).value(),
-            loc,
-        );
-        return _result(sh, op.result(0));
-    }
-
     /// Given a tensor and a shape of the same rank,
     /// will "broadcast" the given axes, so that `self` has the given shape.
     /// This happens by virtually repeating the data several time along each give axes.
@@ -1895,7 +1874,7 @@ pub const Tensor = struct {
     pub fn broad(self: Tensor, other: Shape) Tensor {
         // Non ambiguous broadcasting
         if (self._shape.rank() == 0 or self._shape.rank() == other.rank()) {
-            return self.broadcast(other, Shape.range(self._shape.rank(), self.dtype()).dims());
+            return self.broadcast(other, Shape.range(self._shape.rank(), .bool).dims());
         }
 
         // check that each axis of self maps to an axis of other
@@ -3338,6 +3317,55 @@ pub const Tensor = struct {
         );
 
         return _result(self._shape.withDtype(.bool), op.result(0));
+    }
+
+    /// For each vector in the input tensor,
+    /// creates a diagonal-matrix where diagonal values are set to the vector values.
+    pub fn toDiagonal(self: Tensor, axis_: anytype, new_tags: [2]EnumLiteral) Tensor {
+        meta.assert(self.rank() < MAX_RANK - 1, "toDiagonal expects input up to {} rank, got {}", .{ MAX_RANK - 1, self });
+        const a = self.axis(axis_);
+        const d = self.dim(a);
+        var res_shape = self._shape;
+        res_shape._dims.replaceRange(a, 1, &.{ d, d }) catch unreachable;
+        res_shape._tags.replaceRange(a, 1, &.{ @tagName(new_tags[0]), @tagName(new_tags[1]) }) catch unreachable;
+
+        const values = self.insertAxes(a + 1, .{new_tags[1]}).broad(res_shape);
+        const zeros = Tensor.constant(res_shape, self.dtype().zero());
+
+        const x = Tensor.iota(res_shape, .i32, a);
+        const y = Tensor.iota(res_shape, .i32, a + 1);
+        var res = x.cmp(.EQ, y).select(values, zeros);
+        res._shape = res_shape;
+        return res;
+    }
+
+    test toDiagonal {
+        const zml = @import("zml.zig");
+        const platform = zml.testing.env();
+
+        const Local = struct {
+            pub fn _toDiag(input: Tensor) Tensor {
+                const res = input.toDiagonal(-1, .{ .x, .y });
+                std.debug.assert(res.dim(.x) == input.dim(-1));
+                std.debug.assert(res.dim(.y) == input.dim(-1));
+                return res;
+            }
+        };
+
+        const x = try zml.Buffer.fromArray(platform, [2][2]u8{ .{ 1, 2 }, .{ 3, 4 } });
+        {
+            const res = try zml.testing.compileAndCall(platform, Local._toDiag, .{x});
+            try testing.expectEqual(
+                [2][2][2]u8{ .{
+                    .{ 1, 0 },
+                    .{ 0, 2 },
+                }, .{
+                    .{ 3, 0 },
+                    .{ 0, 4 },
+                } },
+                try res.getValue([2][2][2]u8),
+            );
+        }
     }
 
     /// For each matrix specified by the two axes, returns the lower triangular part of it.


### PR DESCRIPTION
- triangular: zeroes out the upper right part of a matrix. Options control how much is actually zeroes with offset from the diagonal.
- toDiagonal: equivalent to pytorch "diag_embed". The base case is converting a vector into a diagonal matrix. We already have a `diag` operator doing this, but the name was wrong cause in general `diag` does the reverse operation of extracting the diagonal from a matrix into a vector. Also it was using old style ZML, and was a bit too restrictive on input shapes.
- elu: one more activation function. it's getting a bit out of hand, I'm thinking about moving them out of Tensor namespace into zml.nn.Activation wdyt ?