### PR TITLE
zml/nn: rework LayerNorm and normalizeVariance2 for more precision

### DIFF
--- a/mlir/mlir.zig
+++ b/mlir/mlir.zig
@@ -947,8 +947,11 @@ pub const Operation = struct {
             c.mlirBytecodeWriterConfigDesiredEmitVersion(cfg, v);
         }
 
-        var writer_context = .{ .writer = writer };
-        const WriterContext = @TypeOf(writer_context);
+        const WriterContext = struct {
+            writer: @TypeOf(writer),
+            write_error: ?@TypeOf(writer).Error = null,
+        };
+        var writer_context: WriterContext = .{ .writer = writer };
 
         try successOr(c.mlirOperationWriteBytecodeWithConfig(
             self.inner(),
@@ -956,11 +959,15 @@ pub const Operation = struct {
             (struct {
                 pub fn callback(str: c.MlirStringRef, ctx_: ?*anyopaque) callconv(.C) void {
                     const inner_writer_context: *WriterContext = @ptrCast(@alignCast(ctx_));
-                    _ = inner_writer_context.writer.write(str.data[0..str.length]) catch unreachable;
+                    _ = inner_writer_context.writer.write(str.data[0..str.length]) catch |err| {
+                        inner_writer_context.write_error = err;
+                    };
                 }
             }).callback,
             &writer_context,
         ), error.InvalidMlirBytecodeVersion);
+
+        if (writer_context.write_error) |err| return err;
     }
 
     /// Enable a full dump of the IR.

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -96,7 +96,7 @@ pub fn chainModules(module_list: anytype, input: Tensor) Tensor {
 pub const LayerNorm = struct {
     weight: Tensor,
     bias: ?Tensor = null,
-    eps: f32 = 1e-6,
+    eps: f32 = 1e-5,
 
     pub fn forward(self: LayerNorm, x: Tensor) Tensor {
         const xf32 = x.convert(.f32);

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -1010,3 +1010,118 @@ pub fn sampleTokens(activations: Tensor, opts: SamplingStrategy, rng: Tensor.Rng
     // log.debug("sampleTokens({}) -> {} -> {} -> {}", .{ activations, topk.indices, topk_idx, next_tokens });
     return .{ next_tokens, next_rng };
 }
+
+pub const DynamicSamplingStrategy = struct {
+    max_top_k: u32,
+    top_k: Tensor,
+    temperature: Tensor,
+    top_p: Tensor,
+    min_p: Tensor,
+
+    pub fn shapes(dtype: DataType, max_top_k: u32) zml.ShapeOf(DynamicSamplingStrategy) {
+        const scalar_shape = Shape.init(.{}, dtype);
+        return .{
+            .max_top_k = max_top_k,
+            .top_k = scalar_shape,
+            .temperature = scalar_shape,
+            .top_p = scalar_shape,
+            .min_p = scalar_shape,
+        };
+    }
+
+    pub fn makeBuffers(
+        platform: zml.Platform,
+        dtype: zml.DataType,
+        args: struct {
+            top_k: u32,
+            temperature: f32 = 1.0,
+            top_p: f32 = 1.0,
+            min_p: f32 = 0.0,
+        },
+    ) !zml.Bufferized(DynamicSamplingStrategy) {
+        return .{
+            .max_top_k = 0,
+            .top_k = try zml.Buffer.scalar(platform, args.top_k, dtype),
+            .temperature = try zml.Buffer.scalar(platform, args.temperature, dtype),
+            .top_p = try zml.Buffer.scalar(platform, args.top_p, dtype),
+            .min_p = try zml.Buffer.scalar(platform, args.min_p, dtype),
+        };
+    }
+};
+
+/// Given the output of the last layer of a LM with a `.voc` axis,
+/// Compute indices for the next tokens, following the given sampling strategy.
+/// The dynamic sampling strategy is more expressive but top_p requires computing the softmax.
+pub fn sampleTokensDynamic(logits: Tensor, opts: DynamicSamplingStrategy, rng: Tensor.Rng) struct { Tensor, Tensor.Rng } {
+    var x, const topk_indices = fixupLogits(logits, opts);
+
+    // the rest is similar to sampleTokens
+    const next_rng, const gumbel_noise = rng.gumbel(x.shape());
+    x = x.add(gumbel_noise);
+
+    const topk_idx = x.argMax(.topk, .i32).indices;
+    const next_tokens = topk_indices.gatherValues(.voc, topk_idx.squeeze(.topk), .{});
+    return .{ next_tokens, next_rng };
+}
+
+fn fixupLogits(logits: Tensor, opts: DynamicSamplingStrategy) [2]Tensor {
+    const min_inf = Tensor.constant(.{}, logits.dtype().minValue());
+
+    // First reduce the vocab size to a reasonable sub set of candidate.
+    const full_topk = if (opts.max_top_k > 0)
+        logits.topK(opts.max_top_k, .voc, .{ .descending = true })
+    else
+        logits.sort(.voc, .{ .descending = true });
+
+    // After the topk, we don't have .voc indices, anymore, only topk.
+    var x = full_topk.values.rename(.{ .voc = .topk });
+    // mask values above the dynamic top_k
+    x = Tensor.iota(x.shape(), .topk).cmp(.GE, opts.top_k).select(min_inf, x);
+    x = x.mul(opts.temperature);
+
+    const probs = x.softmax(.topk);
+    const probs_sum = probs.cumulativeSum(.topk);
+    const probs_max = probs.slice1d(.topk, .{ .start = 0, .end = 1 });
+
+    // Ensure top_p is at least greater than the probability of the top token, otherwise all tokens are masked.
+    const top_p = probs_max.maximum(opts.top_p).broad(x.shape());
+    x = probs_sum.cmp(.GT, top_p).select(min_inf, x);
+
+    const min_p = probs_max.mul(opts.min_p).broad(x.shape());
+    x = probs.cmp(.LT, min_p).select(min_inf, x);
+    return .{ x, full_topk.indices };
+}
+
+test sampleTokensDynamic {
+    const platform = zml.testing.env();
+    const allocator = std.testing.allocator;
+
+    const ___ = @log(0.0);
+    const logits = [_]f32{ @log(2.0), @log(1.0), @log(4.0), @log(3.0) };
+    const top_k_indices = [_]i32{ 2, 3, 0, 1 };
+    const logits_buff = try zml.Buffer.fromArray(platform, logits);
+    const mod = try zml.compileFn(allocator, fixupLogits, .{ Shape.init(.{ .voc = logits.len }, .f32), DynamicSamplingStrategy.shapes(.f32, 0) }, platform);
+    defer mod.deinit();
+
+    inline for (.{
+        // top_k == logits.len -> just sort the input
+        .{ .{ .top_k = 4 }, [_]f32{ @log(4.0), @log(3.0), @log(2.0), @log(1.0) } },
+        .{ .{ .top_k = 2 }, [_]f32{ @log(4.0), @log(3.0), ___, ___ } },
+        .{ .{ .top_k = 2, .temperature = 0.1 }, [_]f32{ @log(4.0) * 0.1, @log(3.0) * 0.1, ___, ___ } },
+        // top_k == logits.len and small top_p  -> make sure at least one is returned
+        .{ .{ .top_k = 4, .top_p = 0.1 }, [_]f32{ @log(4.0), ___, ___, ___ } },
+        .{ .{ .top_k = 4, .top_p = 0.701 }, [_]f32{ @log(4.0), @log(3.0), ___, ___ } },
+        .{ .{ .top_k = 4, .top_p = 0.901 }, [_]f32{ @log(4.0), @log(3.0), @log(2.0), ___ } },
+        // Here top_p is computed on the top 3 items, so 0.701 isn't enougth anymore to allow @log(3.0)
+        .{ .{ .top_k = 3, .top_p = 0.701 }, [_]f32{ @log(4.0), ___, ___, ___ } },
+        // Here top_p allows the first 3 results, but min_p only accepts the first two.
+        .{ .{ .top_k = 4, .top_p = 0.901, .min_p = 0.6 }, [_]f32{ @log(4.0), @log(3.0), ___, ___ } },
+    }) |args_expected| {
+        const args, const expected = args_expected;
+        log.warn("sampleTokensDynamic: {}", .{args});
+        // Top_k == logits.len, so this just sort the items
+        const new_logits, const indices = mod.call(.{ logits_buff, try DynamicSamplingStrategy.makeBuffers(platform, .f32, args) });
+        try std.testing.expectEqual(top_k_indices, try indices.getValue(@TypeOf(top_k_indices)));
+        try zml.testing.expectEqual(expected, try new_logits.getValue(@TypeOf(expected)));
+    }
+}

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -102,7 +102,7 @@ pub const LayerNorm = struct {
         const xf32 = x.convert(.f32);
         const ax = x.axis(-1);
 
-        const normed = normalizeVariance2(xf32, self.eps);
+        const normed = normalizeVariance(xf32, self.eps);
 
         var out = normed.mul(self.weight.convert(.f32).broadcast(xf32.shape(), &.{ax}));
         if (self.bias) |bias| out = out.add(bias.broadcast(xf32.shape(), &.{ax}));
@@ -114,7 +114,7 @@ pub const LayerNorm = struct {
 /// Center and scale by the variance.
 /// normalize(x, eps) = (x - mean(x)) / sqrt(var(x) + eps)
 /// Work on the last axis.
-pub fn normalizeVariance2(x: Tensor, eps_: f32) Tensor {
+pub fn normalizeVariance(x: Tensor, eps_: f32) Tensor {
     const xf32 = x.convert(.f32);
     const channels = Tensor.scalar(xf32.dim(-1), xf32.dtype());
     const eps = Tensor.scalar(eps_, xf32.dtype());

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1748,14 +1748,13 @@ pub const Tensor = struct {
     }
 
     /// Returns a Tensor containing values in increasing order starting from 0 along the given axis.
-    pub fn iota(sh: Shape, dt: DataType, axis_: anytype) Tensor {
+    pub fn iota(sh: Shape, axis_: anytype) Tensor {
         const ctx = CompilationContext.current();
         const loc = ctx.mlirCtx().location(@src()).namedFmt(ctx.mlirCtx(), "iota({}, {})", .{ sh, axis_ });
 
         const a = sh.axis(axis_);
-        const res_shape = sh.withDtype(dt);
-        var op = dialect.stablehlo.iota(ctx.mlirCtx(), @intCast(a), mlir.ext.RankedTensorType.fromShape(ctx.mlirCtx(), res_shape).as(mlir.Type).?, loc);
-        return _result(res_shape, op.result(0));
+        var op = dialect.stablehlo.iota(ctx.mlirCtx(), @intCast(a), mlir.ext.RankedTensorType.fromShape(ctx.mlirCtx(), sh).as(mlir.Type).?, loc);
+        return _result(sh, op.result(0));
     }
 
     pub const LinspaceArgs = struct {
@@ -2693,7 +2692,7 @@ pub const Tensor = struct {
     pub const SortRes = ArgMaxRes;
 
     /// Returns two Tensors. The first contains the sorted values and the second one contains the sorted indices.
-    pub fn sort(self: Tensor, axis_: i64, opts: struct { descending: bool = false }) SortRes {
+    pub fn sort(self: Tensor, axis_: anytype, opts: struct { descending: bool = false }) SortRes {
         const a = self.axis(axis_);
         const indices = Tensor.arange(.{ .end = self.dim(a) }, .i32).broadcast(self._shape, &.{a});
         const res = ops.sort(
@@ -2822,7 +2821,7 @@ pub const Tensor = struct {
 
         return ops.reduceWindow(
             MaxPoolRes.cmp,
-            .{ .values = self, .indices = iota(self._shape, .i32, a) },
+            .{ .values = self, .indices = iota(self._shape.withDtype(.i32), a) },
             .{ .values = Tensor.constant(.{}, self.dtype().minValue()), .indices = Tensor.scalar(0, .i32) },
             .{
                 .window_dimensions = window_dimensions[0..self.rank()],
@@ -2860,7 +2859,7 @@ pub const Tensor = struct {
 
         return ops.reduceWindow(
             MaxPoolRes.cmp,
-            .{ .values = self, .indices = iota(self._shape, .i32, a) },
+            .{ .values = self, .indices = iota(self._shape.withDtype(.i32), a) },
             .{ .values = Tensor.constant(.{}, self.dtype().minValue()), .indices = Tensor.scalar(0, .i32) },
             .{
                 .window_dimensions = window_dimensions[0..self.rank()],
@@ -3335,8 +3334,8 @@ pub const Tensor = struct {
         const values = self.insertAxes(a + 1, .{new_tags[1]}).broad(res_shape);
         const zeros = Tensor.constant(res_shape, self.dtype().zero());
 
-        const x = Tensor.iota(res_shape, .i32, a);
-        const y = Tensor.iota(res_shape, .i32, a + 1);
+        const x = Tensor.iota(res_shape.withDtype(.i32), a);
+        const y = Tensor.iota(res_shape.withDtype(.i32), a + 1);
         var res = x.cmp(.EQ, y).select(values, zeros);
         res._shape = res_shape;
         return res;
@@ -3385,8 +3384,8 @@ pub const Tensor = struct {
         meta.assertComptime(meta.isTuple(@TypeOf(axes_)) and axes_.len == 2, "triangular expects exactly two axes to work on.", .{});
         const _axes = self.axes(axes_);
 
-        const x = Tensor.iota(self.shape(), .i32, _axes.get(0));
-        const y = Tensor.iota(self.shape(), .i32, _axes.get(1));
+        const x = Tensor.iota(self.shape().withDtype(.i32), _axes.get(0));
+        const y = Tensor.iota(self.shape().withDtype(.i32), _axes.get(1));
 
         const zeros = Tensor.constant(self.shape(), self.dtype().zero());
         return x.addConstant(num_diagonals).cmp(.GE, y).select(self, zeros);
@@ -3447,6 +3446,14 @@ pub const Tensor = struct {
     pub fn select(bool_tensor: Tensor, on_true: Tensor, on_false: Tensor) Tensor {
         meta.assert(bool_tensor.dtype() == .bool, "select expects input tensor type to be a boolean, got {}", .{bool_tensor.dtype()});
         meta.assert(on_true.dtype() == on_false.dtype(), "select expects 'on_true' and 'on_false' tensor types to be equal, got {} and {}", .{ on_true.dtype(), on_false.dtype() });
+
+        if (bool_tensor.rank() != 0 and on_true.rank() == 0) {
+            return bool_tensor.select(on_true.broad(bool_tensor.shape()), on_false);
+        }
+        if (bool_tensor.rank() != 0 and on_false.rank() == 0) {
+            return bool_tensor.select(on_true, on_false.broad(bool_tensor.shape()));
+        }
+
         meta.assert(bool_tensor._shape.eqlDims(on_true._shape), "select expects input tensor and 'on_true' tensor dimensions to match, got {} and {}", .{ bool_tensor._shape, on_true._shape });
         meta.assert(bool_tensor._shape.eqlDims(on_false._shape), "select expects input tensor and 'on_false' tensor dimensions to match, got {} and {}", .{ bool_tensor._shape, on_false._shape });
 

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1163,19 +1163,22 @@ pub const Tensor = struct {
             res_shape = res_shape.appendDim(rhs._shape.dim(r), rhs._shape.tag(r));
         }
 
-        const loc = lhs.getContext().mlirCtx().location(@src());
+        const mlir_ctx = lhs.getContext().mlirCtx();
+        const loc = mlir_ctx.location(@src());
         const op = dialect.stablehlo.dot_general(
-            lhs.getContext().mlirCtx(),
+            mlir_ctx,
             lhs.value(),
             rhs.value(),
-            mlir.ext.mlirType(lhs.getContext().mlirCtx(), res_shape),
+            mlir.ext.mlirType(mlir_ctx, res_shape),
             loc,
             .{
                 .lhs_batching_dimensions = lhs_batching_axes.constSlice(),
                 .rhs_batching_dimensions = rhs_batching_axes.constSlice(),
                 .lhs_contracting_dimensions = lhs_contracting_axes.constSlice(),
                 .rhs_contracting_dimensions = rhs_contracting_axes.constSlice(),
-                .precision = &.{ .DEFAULT, .DEFAULT },
+                .precision = .fast,
+                // .precision = .highest,
+                // .precision = .{ .algorithm = .{ .accumulation = .f32 } },
             },
         );
         return _result(res_shape, op.result(0));


### PR DESCRIPTION
New IR:

```mlir
module @nn.LayerNorm.forward attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
  func.func @main(%arg0: tensor<8448xbf16>, %arg1: tensor<637x8448xbf16>) -> tensor<637x8448xbf16> {
    %cst = stablehlo.constant dense<-5.000000e-01> : tensor<f32>
    %cst_0 = stablehlo.constant dense<-3.03164883E-13> : tensor<f32>
    %cst_1 = stablehlo.constant dense<2.000000e+00> : tensor<f32>
    %cst_2 = stablehlo.constant dense<8.448000e+03> : tensor<f32>
    %cst_3 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
    %0 = stablehlo.convert %arg1 : (tensor<637x8448xbf16>) -> tensor<637x8448xf32>
    %1 = stablehlo.reduce(%0 init: %cst_3) across dimensions = [1] : (tensor<637x8448xf32>, tensor<f32>) -> tensor<637xf32>
     reducer(%arg2: tensor<f32>, %arg3: tensor<f32>)  {
      %22 = stablehlo.add %arg3, %arg2 : tensor<f32>
      stablehlo.return %22 : tensor<f32>
    }
    %2 = stablehlo.broadcast_in_dim %1, dims = [0] : (tensor<637xf32>) -> tensor<637x1xf32>
    %3 = stablehlo.broadcast_in_dim %cst_2, dims = [] : (tensor<f32>) -> tensor<637x1xf32>
    %4 = stablehlo.divide %2, %3 : tensor<637x1xf32>
    %5 = stablehlo.broadcast_in_dim %4, dims = [0, 1] : (tensor<637x1xf32>) -> tensor<637x8448xf32>
    %6 = stablehlo.subtract %0, %5 : tensor<637x8448xf32>
    %7 = stablehlo.broadcast_in_dim %cst_1, dims = [] : (tensor<f32>) -> tensor<637x8448xf32>
    %8 = stablehlo.power %6, %7 : tensor<637x8448xf32>
    %9 = stablehlo.reduce(%8 init: %cst_3) across dimensions = [1] : (tensor<637x8448xf32>, tensor<f32>) -> tensor<637xf32>
     reducer(%arg2: tensor<f32>, %arg3: tensor<f32>)  {
      %22 = stablehlo.add %arg3, %arg2 : tensor<f32>
      stablehlo.return %22 : tensor<f32>
    }
    %10 = stablehlo.broadcast_in_dim %9, dims = [0] : (tensor<637xf32>) -> tensor<637x1xf32>
    %11 = stablehlo.divide %10, %3 : tensor<637x1xf32>
    %12 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<637x1xf32>
    %13 = stablehlo.add %11, %12 : tensor<637x1xf32>
    %14 = stablehlo.broadcast_in_dim %cst, dims = [] : (tensor<f32>) -> tensor<637x1xf32>
    %15 = stablehlo.power %13, %14 : tensor<637x1xf32>
    %16 = stablehlo.broadcast_in_dim %15, dims = [0, 1] : (tensor<637x1xf32>) -> tensor<637x8448xf32>
    %17 = stablehlo.multiply %6, %16 : tensor<637x8448xf32>
    %18 = stablehlo.convert %arg0 : (tensor<8448xbf16>) -> tensor<8448xf32>
    %19 = stablehlo.broadcast_in_dim %18, dims = [1] : (tensor<8448xf32>) -> tensor<637x8448xf32>
    %20 = stablehlo.multiply %17, %19 : tensor<637x8448xf32>
    %21 = stablehlo.convert %20 : (tensor<637x8448xf32>) -> tensor<637x8448xbf16>
    return %21 : tensor<637x8448xbf16>
  }
}
```

IR before:

```mlir
module @nn.LayerNorm.forward attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
  func.func @main(%arg0: tensor<8448xbf16>, %arg1: tensor<637x8448xbf16>) -> tensor<637x8448xbf16> {
    %cst = stablehlo.constant dense<-3.03164883E-13> : tensor<f32>
    %cst_0 = stablehlo.constant dense<1.18371216E-4> : tensor<f32>
    %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
    %0 = stablehlo.convert %arg1 : (tensor<637x8448xbf16>) -> tensor<637x8448xf32>
    %1 = stablehlo.reduce(%0 init: %cst_1) across dimensions = [1] : (tensor<637x8448xf32>, tensor<f32>) -> tensor<637xf32>
     reducer(%arg2: tensor<f32>, %arg3: tensor<f32>)  {
      %19 = stablehlo.add %arg3, %arg2 : tensor<f32>
      stablehlo.return %19 : tensor<f32>
    }
    %2 = stablehlo.broadcast_in_dim %1, dims = [0] : (tensor<637xf32>) -> tensor<637x1xf32>
    %3 = stablehlo.broadcast_in_dim %cst_0, dims = [] : (tensor<f32>) -> tensor<637x1xf32>
    %4 = stablehlo.multiply %2, %3 : tensor<637x1xf32>
    %5 = stablehlo.broadcast_in_dim %4, dims = [0, 1] : (tensor<637x1xf32>) -> tensor<637x8448xf32>
    %6 = stablehlo.subtract %0, %5 : tensor<637x8448xf32>
    %7 = stablehlo.multiply %6, %6 : tensor<637x8448xf32>
    %8 = stablehlo.reduce(%7 init: %cst_1) across dimensions = [1] : (tensor<637x8448xf32>, tensor<f32>) -> tensor<637xf32>
     reducer(%arg2: tensor<f32>, %arg3: tensor<f32>)  {
      %19 = stablehlo.add %arg3, %arg2 : tensor<f32>
      stablehlo.return %19 : tensor<f32>
    }
    %9 = stablehlo.broadcast_in_dim %8, dims = [0] : (tensor<637xf32>) -> tensor<637x1xf32>
    %10 = stablehlo.multiply %9, %3 : tensor<637x1xf32>
    %11 = stablehlo.broadcast_in_dim %cst, dims = [] : (tensor<f32>) -> tensor<637x1xf32>
    %12 = stablehlo.add %10, %11 : tensor<637x1xf32>
    %13 = stablehlo.rsqrt %12 : tensor<637x1xf32>
    %14 = stablehlo.broadcast_in_dim %13, dims = [0, 1] : (tensor<637x1xf32>) -> tensor<637x8448xf32>
    %15 = stablehlo.multiply %6, %14 : tensor<637x8448xf32>
    %16 = stablehlo.convert %15 : (tensor<637x8448xf32>) -> tensor<637x8448xbf16>
    %17 = stablehlo.broadcast_in_dim %arg0, dims = [1] : (tensor<8448xbf16>) -> tensor<637x8448xbf16>
    %18 = stablehlo.multiply %16, %17 : tensor<637x8448xbf16>
    return %18 : tensor<637x8448xbf16>
  }
}
```
