### PR TITLE
Add custom call support, and tensor.print()

### DIFF
--- a/zml/context.zig
+++ b/zml/context.zig
@@ -144,6 +144,12 @@ pub const Context = struct {
         }
         return platform_ orelse @panic("No platform found !");
     }
+
+    pub const HostCallbackCtx = struct {
+        host: HostBuffer,
+        mutex: std.Thread.Mutex = std.Thread.Mutex{},
+    };
+    pub const HostCallback = fn (HostBuffer) void;
 };
 
 const cuda = struct {
@@ -184,20 +190,14 @@ const cuda = struct {
         }
     };
 
-    pub const CallbackCtx = struct {
-        host: HostBuffer,
-        mutex: std.Thread.Mutex = std.Thread.Mutex{},
-    };
-    pub const Callback = fn (HostBuffer) void;
-
-    fn getContext(args: [*]const u8, args_len: usize) struct { *const Callback, *CallbackCtx } {
+    fn getContext(args: [*]const u8, args_len: usize) struct { *const Context.HostCallback, *Context.HostCallbackCtx } {
         std.debug.assert(args_len == @sizeOf(*anyopaque) * 2);
 
         const raw_fn_ptr: usize = @bitCast(args[0..@sizeOf(*anyopaque)].*);
-        const fn_ptr: *const Callback = @ptrFromInt(raw_fn_ptr);
+        const fn_ptr: *const Context.HostCallback = @ptrFromInt(raw_fn_ptr);
 
         const raw_ctx_ptr: usize = @bitCast(args[@sizeOf(*anyopaque)..][0..@sizeOf(*anyopaque)].*);
-        const ctx_ptr: *CallbackCtx = @ptrFromInt(raw_ctx_ptr);
+        const ctx_ptr: *Context.HostCallbackCtx = @ptrFromInt(raw_ctx_ptr);
         return .{ fn_ptr, ctx_ptr };
     }
 


### PR DESCRIPTION
* restore the integration with PJRT custom call extension
* add a generic `zmlHostBufferCallback` custom call that copies the received tensor to the host, and call a user supplied callback on it.
* add a default "print" method on `Tensor` that print the runtime value of a given tensor
* print itself has very little code, it's easy for a user to define their own print if they don't like ours.

limitations:
* only supported on Cuda atm
* pre allocates a buffer on the host to copy the content of the device buffer,
 this buffer won't be freed. There is exactly one buffer per "print" call in the IR.
* it uses cuda api, maybe I should be using `createViewOfDeviceBuffer` to make it less cuda specific