### PR TITLE
examples: small cleanup

### DIFF
--- a/examples/benchmark/main.zig
+++ b/examples/benchmark/main.zig
@@ -3,8 +3,6 @@ const zml = @import("zml");
 const asynk = @import("async");
 const flags = @import("tigerbeetle/flags");
 
-const asyncc = asynk.asyncc;
-
 // set log level to debug to print the generated IR
 pub const std_options = .{
     .log_level = .debug,
@@ -92,7 +90,7 @@ pub fn asyncMain() !void {
     // Start compiling.
     // The shape of the input tensor, we have to pass in manually.
     timer.reset();
-    var compilation = try asyncc(zml.module.compileModel, .{ allocator, Benchmark{}, .forward, .{ a_shape, b_shape }, platform });
+    var compilation = try asynk.asyncGeneric(zml.module.compileModel, .{ allocator, Benchmark{}, .forward, .{ a_shape, b_shape }, platform });
 
     // Wait for compilation to finish
     const compiled = try compilation.await_();

--- a/examples/simple_layer/main.zig
+++ b/examples/simple_layer/main.zig
@@ -2,8 +2,6 @@ const std = @import("std");
 const zml = @import("zml");
 const asynk = @import("async");
 
-const asyncc = asynk.asyncc;
-
 /// Model definition
 const Layer = struct {
     bias: ?zml.Tensor = null,
@@ -65,7 +63,7 @@ pub fn asyncMain() !void {
 
     // Start compiling. This uses the inferred shapes from the BufferStore.
     // The shape of the input tensor, we have to pass in manually.
-    var compilation = try asyncc(zml.compileModel, .{ allocator, model_shapes, .forward, .{input_shape}, platform });
+    var compilation = try asynk.asyncGeneric(zml.compileModel, .{ allocator, model_shapes, .forward, .{input_shape}, platform });
 
     // Produce a bufferized weights struct from the fake BufferStore.
     // This is like the inferred shapes, but with actual values.


### PR DESCRIPTION
Changes were made to `asynk` and not applied everywhere