### PR TITLE
stablehlo: add DotAlgorithm support to stablehlo.dot_general

### DIFF
--- a/mlir/mlir.zig
+++ b/mlir/mlir.zig
@@ -434,14 +434,16 @@ pub const TypeAttribute = struct {
         .dump_fn = c.mlirAttributeDump,
         .equal_fn = c.mlirAttributeEqual,
     });
-    const Self = TypeAttribute;
-
-    pub fn init(type_: Type) Self {
-        return Self.wrap(c.mlirTypeAttrGet(type_.inner()));
+    pub fn init(type_: Type) TypeAttribute {
+        return TypeAttribute.wrap(c.mlirTypeAttrGet(type_.inner()));
     }
 
-    pub fn typ(self: Self) Type {
+    pub fn typ(self: TypeAttribute) Type {
         return Type.wrap(c.mlirAttributeGetType(self.inner()));
+    }
+
+    pub fn asAttr(self: TypeAttribute) Attribute {
+        return self.as(Attribute).?;
     }
 };
 
@@ -788,9 +790,9 @@ pub const Operation = struct {
         ) orelse Error.InvalidMlir;
     }
 
-    pub fn make(ctx: Context, op_name: [:0]const u8, args: struct {
-        pub const AttrTuple = struct { [:0]const u8, Attribute };
+    pub const AttrTuple = struct { [:0]const u8, Attribute };
 
+    pub fn make(ctx: Context, op_name: [:0]const u8, args: struct {
         operands: ?[]const Value = null,
         variadic_operands: ?[]const []const Value = null,
         results: ?[]const Type = null,
@@ -1301,6 +1303,13 @@ pub const FloatTypes = enum {
     f64,
 
     unknown,
+
+    pub fn asType(self: FloatTypes, ctx: Context) ?Type {
+        return switch (self) {
+            .unknown => null,
+            inline else => |ft| FloatType(ft).init(ctx).asType(),
+        };
+    }
 };
 
 pub fn FloatType(comptime ft: FloatTypes) type {
@@ -1352,6 +1361,10 @@ pub fn FloatType(comptime ft: FloatTypes) type {
                 }
             }
             return false;
+        }
+
+        pub fn asType(self: Float) Type {
+            return self.as(Type).?;
         }
     };
 }

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1163,19 +1163,22 @@ pub const Tensor = struct {
             res_shape = res_shape.appendDim(rhs._shape.dim(r), rhs._shape.tag(r));
         }
 
-        const loc = lhs.getContext().mlirCtx().location(@src());
+        const mlir_ctx = lhs.getContext().mlirCtx();
+        const loc = mlir_ctx.location(@src());
         const op = dialect.stablehlo.dot_general(
-            lhs.getContext().mlirCtx(),
+            mlir_ctx,
             lhs.value(),
             rhs.value(),
-            mlir.ext.mlirType(lhs.getContext().mlirCtx(), res_shape),
+            mlir.ext.mlirType(mlir_ctx, res_shape),
             loc,
             .{
                 .lhs_batching_dimensions = lhs_batching_axes.constSlice(),
                 .rhs_batching_dimensions = rhs_batching_axes.constSlice(),
                 .lhs_contracting_dimensions = lhs_contracting_axes.constSlice(),
                 .rhs_contracting_dimensions = rhs_contracting_axes.constSlice(),
-                .precision = &.{ .DEFAULT, .DEFAULT },
+                .precision = .fast,
+                // .precision = .highest,
+                // .precision = .{ .algorithm = .{ .accumulation = .f32 } },
             },
         );
         return _result(res_shape, op.result(0));


### PR DESCRIPTION
In the API I merge the "precision" and "algorithm" attributes into a union because according to the spec,
precision must be default when algorithm is set, and precision=default means "fast" when algorithm is not set.

https://github.com/openxla/stablehlo/blob/main/docs/spec.md#dot_general

For now it's not exposed to users because the API is a bit limited. 
In particular only a subset of algorithm are supported by openxla, and only a subset of that is supported by chips.

I was able to successfully change the accumulation type for dot on Cuda, but want to experiment more before deciding what to expose.