### PR TITLE
zml: iota default to .i32

### DIFF
--- a/mlir/mlir.zig
+++ b/mlir/mlir.zig
@@ -1509,6 +1509,10 @@ pub const RankedTensorType = struct {
     pub fn getDimension(self: RankedTensorType, dim: usize) i64 {
         return c.mlirShapedTypeGetDimSize(self.inner(), @intCast(dim));
     }
+
+    pub fn asType(self: RankedTensorType) Type {
+        return self.as(Type).?;
+    }
 };
 
 pub const Dialect = struct {

--- a/mlir/mlir.zig
+++ b/mlir/mlir.zig
@@ -434,14 +434,16 @@ pub const TypeAttribute = struct {
         .dump_fn = c.mlirAttributeDump,
         .equal_fn = c.mlirAttributeEqual,
     });
-    const Self = TypeAttribute;
-
-    pub fn init(type_: Type) Self {
-        return Self.wrap(c.mlirTypeAttrGet(type_.inner()));
+    pub fn init(type_: Type) TypeAttribute {
+        return TypeAttribute.wrap(c.mlirTypeAttrGet(type_.inner()));
     }
 
-    pub fn typ(self: Self) Type {
+    pub fn typ(self: TypeAttribute) Type {
         return Type.wrap(c.mlirAttributeGetType(self.inner()));
+    }
+
+    pub fn asAttr(self: TypeAttribute) Attribute {
+        return self.as(Attribute).?;
     }
 };
 
@@ -788,9 +790,9 @@ pub const Operation = struct {
         ) orelse Error.InvalidMlir;
     }
 
-    pub fn make(ctx: Context, op_name: [:0]const u8, args: struct {
-        pub const AttrTuple = struct { [:0]const u8, Attribute };
+    pub const AttrTuple = struct { [:0]const u8, Attribute };
 
+    pub fn make(ctx: Context, op_name: [:0]const u8, args: struct {
         operands: ?[]const Value = null,
         variadic_operands: ?[]const []const Value = null,
         results: ?[]const Type = null,
@@ -1301,6 +1303,13 @@ pub const FloatTypes = enum {
     f64,
 
     unknown,
+
+    pub fn asType(self: FloatTypes, ctx: Context) ?Type {
+        return switch (self) {
+            .unknown => null,
+            inline else => |ft| FloatType(ft).init(ctx).asType(),
+        };
+    }
 };
 
 pub fn FloatType(comptime ft: FloatTypes) type {
@@ -1352,6 +1361,10 @@ pub fn FloatType(comptime ft: FloatTypes) type {
                 }
             }
             return false;
+        }
+
+        pub fn asType(self: Float) Type {
+            return self.as(Type).?;
         }
     };
 }

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1163,19 +1163,22 @@ pub const Tensor = struct {
             res_shape = res_shape.appendDim(rhs._shape.dim(r), rhs._shape.tag(r));
         }
 
-        const loc = lhs.getContext().mlirCtx().location(@src());
+        const mlir_ctx = lhs.getContext().mlirCtx();
+        const loc = mlir_ctx.location(@src());
         const op = dialect.stablehlo.dot_general(
-            lhs.getContext().mlirCtx(),
+            mlir_ctx,
             lhs.value(),
             rhs.value(),
-            mlir.ext.mlirType(lhs.getContext().mlirCtx(), res_shape),
+            mlir.ext.mlirType(mlir_ctx, res_shape),
             loc,
             .{
                 .lhs_batching_dimensions = lhs_batching_axes.constSlice(),
                 .rhs_batching_dimensions = rhs_batching_axes.constSlice(),
                 .lhs_contracting_dimensions = lhs_contracting_axes.constSlice(),
                 .rhs_contracting_dimensions = rhs_contracting_axes.constSlice(),
-                .precision = &.{ .DEFAULT, .DEFAULT },
+                .precision = .fast,
+                // .precision = .highest,
+                // .precision = .{ .algorithm = .{ .accumulation = .f32 } },
             },
         );
         return _result(res_shape, op.result(0));


### PR DESCRIPTION
It's midly annoying to have to specify iota dtype everywhere to .i32.

In practice if people want to work with floating point range of number they generally use arange.
Also `iota(x.shape(), 0).convert(.f32)` also work and isn't much work than saying `iota(x.shape(), .f32, 0)`

For good measure I've added a fallback to .i64 when the given axis has too many elements. I don't think this would cause much trouble, just because the tensor that big aren't very common in the first place.