### PR TITLE
zml: fix memory usage of sdpaMemEfficient

### DIFF
--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -12,6 +12,7 @@ common          --lockfile_mode=update
 
 # Needed by LLVM and/or XLA
 common          --experimental_repo_remote_exec
+common          --experimental_remote_cache_eviction_retries=5
 
 # Self explanatory
 common          --enable_platform_specific_config

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -771,10 +771,13 @@ fn assignResults(op: mlir.Operation, v: anytype, shapes: []Shape) void {
     var context = LocalContext{ .index = 0, .op = op, .shapes = shapes };
     meta.visit((struct {
         fn cb(inner_ctx: *LocalContext, tensor: *Tensor) void {
-            tensor.* = Tensor.fromMlirValue(inner_ctx.op.result(inner_ctx.index));
+            var new = Tensor.fromMlirValue(inner_ctx.op.result(inner_ctx.index));
             if (inner_ctx.shapes) |sh| {
-                tensor._shape = sh[inner_ctx.index];
+                new._shape = sh[inner_ctx.index];
+            } else {
+                new._shape._tags = tensor._shape._tags;
             }
+            tensor.* = new;
             inner_ctx.index += 1;
         }
     }).cb, &context, v);

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -1101,7 +1101,7 @@ pub fn compileFn(
     comptime func: anytype,
     args: ShapeOf(stdx.meta.FnArgs(func)),
     platform: Platform,
-) !ExeWithWeights(FnWithVoidArg(func)) {
+) !FnExe(func) {
     const name = @typeName(@TypeOf(func));
     var context = try CompilationContext.init(allocator, name, platform);
     defer context.deinit();
@@ -1117,6 +1117,10 @@ pub fn compileFn(
     const raw_module = try compileInternal(allocator, &context, Local.forward, void_model, .{args});
     // But we set the signature so that you can call the module as you would call the function.
     return try ExeWithWeights(FnWithVoidArg(func)).initFromModel(allocator, raw_module, void_model);
+}
+
+pub fn FnExe(comptime func: anytype) type {
+    return ExeWithWeights(FnWithVoidArg(func));
 }
 
 fn FnWithVoidArg(comptime func: anytype) type {

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -752,7 +752,7 @@ pub fn sdpa(q_: Tensor, k_: Tensor, v_: Tensor, opts: SdpaOpts) Tensor {
     stdx.debug.assert(k.shape().hasTags(.{ .h, .k, .hd }), err_template ++ "k is missing tags {{.h, .k, .hd}}", err_args);
     stdx.debug.assert(v.shape().hasTags(.{ .h, .k, .hd }), err_template ++ "v is missing tags {{.h, .k, .hd}}", err_args);
 
-    if (opts.allow_cudnn and cuda.canUseCudnnSdpa(q.dim(.hd), q.dtype())) {
+    if (opts.allow_cudnn and cuda.canUseCudnnSdpa(q.shape())) {
         return cuda.sdpa(q, k, v, opts);
     }
 

--- a/zml/nn/cuda.zig
+++ b/zml/nn/cuda.zig
@@ -12,16 +12,18 @@ const DataType = @import("../dtype.zig").DataType;
 const Data = @import("../dtype.zig").Data;
 const CompilationContext = module.CompilationContext;
 
-pub fn canUseCudnnSdpa(head_dim: i64, dtype: DataType) bool {
+pub fn canUseCudnnSdpa(q_shape: Shape) bool {
     const ctx = CompilationContext.current();
     // TODO(Corendos): Check cuda version, cudnn version, device compatibility.
     if (!ctx.targetIs(.cuda)) return false;
 
+    if (q_shape.rank() != 4) return false;
+
     // NOTE(Corentin): In Cudnn fused MHA head_dim is limited to 128.
-    if (head_dim > 128) return false;
+    if (q_shape.dim(.hd) > 128) return false;
 
     // NOTE(Corentin): In Cudnn fused MHA data type is limited to F16 and BF16.
-    if (dtype != .f16 and dtype != .bf16) return false;
+    if (q_shape.dtype() != .f16 and q_shape.dtype() != .bf16) return false;
 
     return true;
 }

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -3171,7 +3171,7 @@ pub const Tensor = struct {
             var prev_ax: i8 = -1;
             for (self._shape.tags(), 0..) |t, self_ax| {
                 if (update._shape.hasTag(t)) |up_ax| {
-                    stdx.debug.assert(up_ax == prev_ax + 1, "dynamicUpdateSlice expects 'update_' and input tensor axis to have the same order, got {} and {}. (hint: you need to explicitly transpose 'update_')", .{ update_._shape, self._shape });
+                    stdx.debug.assert(up_ax == prev_ax + 1, "dynamicUpdateSlice expects 'update_' and input tensor axis to have the same order, got {} and {}. (hint: you need to explicitly transpose 'update_')", .{ update_, self });
 
                     update_shape._dims.set(self_ax, update.dim(up_ax));
                     prev_ax = up_ax;
@@ -3182,7 +3182,7 @@ pub const Tensor = struct {
             update = update.reshape(update_shape);
         }
 
-        stdx.debug.assert(self.rank() == update.rank(), "dynamicUpdateSlice expects input and computed update tensors to have the same rank, got {} and {} (hint: it's probably an issue on our side)", .{ self.rank(), update.rank() });
+        stdx.debug.assert(self.rank() == update.rank(), "dynamicUpdateSlice expects input and computed update tensors to have the same rank, got {} and {}", .{ self, update });
 
         for (self.dims(), update.dims(), 0..) |self_d, up_d, ax| {
             const t = self._shape.debugTag(ax);

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -2677,7 +2677,7 @@ pub const Tensor = struct {
 
         return ops.reduce(
             ArgMaxRes.cmp,
-            .{ .values = x, .indices = Tensor.arange(.{ .end = x.dim(a) }, index_dtype).broadcast(x._shape.withDtype(index_dtype), &.{a}) },
+            .{ .values = x, .indices = Tensor.arange(.{ .end = x.dim(a) }, index_dtype).broadcast(x.shape(), &.{a}) },
             .{ .values = Tensor.constant(&.{}, x.dtype().minValue()), .indices = Tensor.scalar(0, index_dtype) },
             &.{a},
         );

--- a/zml/testing.zig
+++ b/zml/testing.zig
@@ -17,6 +17,7 @@ pub fn env() zml.Platform {
             .{
                 .cache_location = "/tmp/zml/tests/cache",
                 .xla_dump_to = "/tmp/zml/tests/",
+                .sharding_enabled = true,
             }
         else
             .{};
@@ -197,7 +198,7 @@ pub fn testLayerOut(
         log.warn("Reference models uses {d} inputs, but implementation uses {d}", .{ n_in_exp, n_in });
     }
 
-    const exe = try zml.compileModel(alloc, layer, .forward, input_shapes, platform);
+    const exe = try zml.compileModel(alloc, fwd, layer, input_shapes, platform);
 
     const n_out_exp = activations.countLayers(out_name);
     if (exe.inner.result_buffer_count != n_out_exp) {


### PR DESCRIPTION
Unroll the loop over key chunks manually in Zig.
We could use `zml.ops.while` but it's a bit verbose for when you just want to run a fixed number of steps.
`zml.ops.for_` was suppose to help with that,
but because it concatenates intermediary results, it wasn't saving memory.
Maybe we need to make `zml.ops.for` work similarly to `zml.ops.while` and add a `zml.ops.scan` for when we want to collect all intermediary results.

I hesitated to rewrite `sdpa` to call `sdpaChunk(q,k,v,opts).finalize()` but it doesn't work with `cuda.sdpa`