### PR TITLE
zml: makeBlocks returns the inner tensor to propagate tags

### DIFF
--- a/stdx/meta.zig
+++ b/stdx/meta.zig
@@ -146,7 +146,7 @@ pub fn TupleRangeX(comptime T: type, comptime start: usize, comptime end: usize)
 }
 
 pub fn FnParam(comptime func: anytype, comptime n: comptime_int) type {
-    return @typeInfo(@TypeOf(func)).Fn.params[n].type orelse compileError("anytype is not supported");
+    return @typeInfo(@TypeOf(func)).Fn.params[n].type orelse @compileError("anytype is not supported");
 }
 
 pub fn FnArgs(comptime func: anytype) type {

--- a/stdx/meta.zig
+++ b/stdx/meta.zig
@@ -110,11 +110,11 @@ pub fn asSlice(comptime T: type) type {
             .One => switch (@typeInfo(info.child)) {
                 // As Zig, convert pointer to Array as a slice.
                 .Array => |arr_info| arr_info.child,
-                else => compileError(err_msg),
+                else => @compileError(err_msg),
             },
-            else => compileError(err_msg),
+            else => @compileError(err_msg),
         },
-        else => compileError(err_msg),
+        else => @compileError(err_msg),
     };
 }
 

--- a/zml/aio.zig
+++ b/zml/aio.zig
@@ -526,7 +526,7 @@ pub fn loadBuffers(
     if (@hasDecl(Model, "init")) {
         @call(.auto, Model.init, .{&model} ++ init_args);
     } else {
-        zml.meta.assertComptime(@TypeOf(init_args) == void or @TypeOf(init_args) == @TypeOf(.{}), "Model of type {} has no init function, so `loadBuffers` should be call with init_args set to {{}} (void)", .{Model});
+        stdx.debug.assertComptime(@TypeOf(init_args) == void or @TypeOf(init_args) == @TypeOf(.{}), "Model of type {} has no init function, so `loadBuffers` should be call with init_args set to {{}} (void)", .{Model});
     }
 
     return loadModelBuffersWithPrefix(Model, model, buffer_store, allocator, platform, "");
@@ -623,7 +623,7 @@ fn visitStructAndLoadBuffer(allocator: std.mem.Allocator, prefix_builder: *Prefi
 
                     try visitStructAndLoadBuffer(allocator, prefix_builder, buffer_store, value, platform);
                 }
-            } else zml.meta.compileError("type not supported by visitStructAndLoadBuffer: {}", .{T});
+            } else stdx.debug.compileError("type not supported by visitStructAndLoadBuffer: {}", .{T});
         },
         .Array => {
             for (obj, 0..) |*value, i| {

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -47,8 +47,7 @@ pub fn while_(
         @compileError("cond_fn and body_fn signatures don't match ! " ++ @typeName(@TypeOf(cond_fn)) ++ " and " ++ @typeName(@TypeOf(body_fn)));
     }
     const ctx = CompilationContext.current();
-    const cond_block, const predicate = ctx.makeBlock(CondS, &cond_fn, blkctx, inputs);
-    _ = predicate;
+    const cond_block, _ = ctx.makeBlock(CondS, &cond_fn, blkctx, inputs);
 
     const body_block, const body_res = ctx.makeBlock(BodyS, &body_fn, blkctx, inputs);
     var input_values: [BodyS.nIn]mlir.Value = undefined;
@@ -139,8 +138,7 @@ pub fn reduce(
     var init_values: [N]mlir.Value = undefined;
     ctx.extractValues(&inits, &init_values);
 
-    const body_block, const scalar = ctx.makeBlock(BodyS, &body_fn, {}, .{ inits, inits });
-    _ = scalar;
+    const body_block, _ = ctx.makeBlock(BodyS, &body_fn, {}, .{ inits, inits });
 
     const loc = ctx.mlirCtx().location(@src());
 
@@ -229,8 +227,7 @@ pub fn reduceWindow(
         if (BodyS.Return != @TypeOf(inputs)) @compileError("reduce body function need to have the following signature `fn (left: T, right: T) T`, got: " ++ @typeName(body_fn));
     }
     const ctx = CompilationContext.current();
-    const body_block, const body_res = ctx.makeBlock(BodyS, &body_fn, {}, .{ inits, inits });
-    _ = body_res;
+    const body_block, _ = ctx.makeBlock(BodyS, &body_fn, {}, .{ inits, inits });
     const N = comptime @divExact(BodyS.nIn, 2);
     var input_values: [N]mlir.Value = undefined;
     ctx.extractValues(&inputs, &input_values);
@@ -469,8 +466,7 @@ pub fn sort(
         inits[i * 2 + 1] = Tensor{ ._shape = arg_shape, ._id = undefined, ._donation = .no_buffer };
     }
     const ctx = CompilationContext.current();
-    const block, const cmp_res = ctx.makeBlock(BodyS, &comp_fn, blkctx, inits);
-    _ = cmp_res;
+    const block, _ = ctx.makeBlock(BodyS, &comp_fn, blkctx, inits);
     var input_values: [@divExact(BodyS.nIn, 2)]mlir.Value = undefined;
     ctx.extractValues(&inputs, &input_values);
 

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -47,8 +47,10 @@ pub fn while_(
         @compileError("cond_fn and body_fn signatures don't match ! " ++ @typeName(@TypeOf(cond_fn)) ++ " and " ++ @typeName(@TypeOf(body_fn)));
     }
     const ctx = CompilationContext.current();
-    const cond_block = ctx.makeBlock(CondS, &cond_fn, blkctx, inputs);
-    const body_block = ctx.makeBlock(BodyS, &body_fn, blkctx, inputs);
+    const cond_block, const predicate = ctx.makeBlock(CondS, &cond_fn, blkctx, inputs);
+    _ = predicate;
+
+    const body_block, const body_res = ctx.makeBlock(BodyS, &body_fn, blkctx, inputs);
     var input_values: [BodyS.nIn]mlir.Value = undefined;
     ctx.extractValues(&inputs, &input_values);
 
@@ -63,9 +65,7 @@ pub fn while_(
         .location = loc,
     });
 
-    var res: BodyS.Args = inputs;
-    module.assignResults(&res, null, op);
-    return res;
+    return fromMlirOperationWithTags(op, body_res);
 }
 
 test "simple while" {
@@ -139,7 +139,8 @@ pub fn reduce(
     var init_values: [N]mlir.Value = undefined;
     ctx.extractValues(&inits, &init_values);
 
-    const body_block = ctx.makeBlock(BodyS, &body_fn, {}, .{ inits, inits });
+    const body_block, const scalar = ctx.makeBlock(BodyS, &body_fn, {}, .{ inits, inits });
+    _ = scalar;
 
     const loc = ctx.mlirCtx().location(@src());
 
@@ -228,7 +229,8 @@ pub fn reduceWindow(
         if (BodyS.Return != @TypeOf(inputs)) @compileError("reduce body function need to have the following signature `fn (left: T, right: T) T`, got: " ++ @typeName(body_fn));
     }
     const ctx = CompilationContext.current();
-    const body_block = ctx.makeBlock(BodyS, &body_fn, {}, .{ inits, inits });
+    const body_block, const body_res = ctx.makeBlock(BodyS, &body_fn, {}, .{ inits, inits });
+    _ = body_res;
     const N = comptime @divExact(BodyS.nIn, 2);
     var input_values: [N]mlir.Value = undefined;
     ctx.extractValues(&inputs, &input_values);
@@ -255,9 +257,7 @@ pub fn reduceWindow(
         .location = loc,
     });
 
-    var res: BodyS.Return = inputs;
-    module.assignResults(&res, null, op);
-    return res;
+    return fromMlirOperationWithTags(op, inputs);
 }
 
 /// Runs a given function for several steps, and returns a stack of each step output.
@@ -407,10 +407,11 @@ pub fn if_(
         @compileError("true_branch_fn and false_branch_fn return types don't match ! " ++ @typeName(TrueBlockSignature.Return) ++ " and " ++ @typeName(FalseBlockSignature.Return));
     }
     const ctx = CompilationContext.current();
-    const true_branch_block = ctx.makeBlock(TrueBlockSignature, &true_branch_fn, blkctx, {});
-    const false_branch_block = ctx.makeBlock(TrueBlockSignature, &false_branch_fn, blkctx, {});
-    const loc = ctx.mlirCtx().location(@src());
+    const true_branch_block, const true_branch_res = ctx.makeBlock(TrueBlockSignature, &true_branch_fn, blkctx, {});
+    const false_branch_block, const false_branch_res = ctx.makeBlock(TrueBlockSignature, &false_branch_fn, blkctx, {});
+    stdx.debug.assert(false_branch_res.shape().eqlWithTags(true_branch_res.shape()), "zml.ops.if_ expects true and false branch to produce outputs of the same shape, but it produced true={} and false={}", .{ true_branch_res, false_branch_res });
 
+    const loc = ctx.mlirCtx().location(@src());
     const op = mlir.Operation.make(ctx.mlirCtx(), "stablehlo.if", .{
         .operands = &.{pred.value()},
         .result_type_inference = true,
@@ -420,9 +421,7 @@ pub fn if_(
         .location = loc,
     });
 
-    var res: TrueBlockSignature.Return = undefined;
-    module.assignResults(&res, null, op);
-    return res;
+    return fromMlirOperationWithTags(op, true_branch_res);
 }
 
 test "if" {
@@ -470,7 +469,8 @@ pub fn sort(
         inits[i * 2 + 1] = Tensor{ ._shape = arg_shape, ._id = undefined, ._donation = .no_buffer };
     }
     const ctx = CompilationContext.current();
-    const block = ctx.makeBlock(BodyS, &comp_fn, blkctx, inits);
+    const block, const cmp_res = ctx.makeBlock(BodyS, &comp_fn, blkctx, inits);
+    _ = cmp_res;
     var input_values: [@divExact(BodyS.nIn, 2)]mlir.Value = undefined;
     ctx.extractValues(&inputs, &input_values);
 
@@ -616,6 +616,31 @@ pub fn staticCountTensors(comptime T: type) ?usize {
         },
         else => 0,
     };
+}
+
+/// Create a Tensor struct similar to base, keeping base tags,
+/// but using mlir value and dims from the mlir operation.
+pub fn fromMlirOperationWithTags(op: mlir.Operation, base: anytype) @TypeOf(base) {
+    const LocalContext = struct {
+        index: usize,
+        op: mlir.Operation,
+    };
+    var context = LocalContext{ .index = 0, .op = op };
+    var res = base;
+    meta.visit((struct {
+        fn cb(inner_ctx: *LocalContext, tensor: *Tensor) void {
+            var new = Tensor.fromMlirValue(inner_ctx.op.result(inner_ctx.index));
+            stdx.debug.internalAssert(new.rank() == tensor.rank(), "expected operand result to have rank {} but got {}", .{ tensor.rank(), new });
+            // copy tags and sharding info over
+            // some ops can change dims eg reduceWindow, so we trust mlir here.
+            new._shape._tags = tensor._shape._tags;
+            new._shape._sharding_info = tensor._shape._sharding_info;
+            tensor.* = new;
+            inner_ctx.index += 1;
+        }
+    }).cb, &context, &res);
+    assert(context.index == op.numResults());
+    return res;
 }
 
 /// Produces a custom call to `name` that takes a tensor and returns it.

--- a/zml/shape.zig
+++ b/zml/shape.zig
@@ -60,7 +60,7 @@ pub const Shape = struct {
                 } else if (comptime isAutoDim(fv)) {
                     dims_.appendAssumeCapacity(-1);
                 } else {
-                    stdx.meta.compileError("Field {s} should be an integer or an auto dimension", .{field.name});
+                    stdx.debug.compileError("Field {s} should be an integer or an auto dimension", .{field.name});
                 }
                 if (comptime stdx.meta.isTuple(T)) {
                     tags_.appendAssumeCapacity(TagUnknown);
@@ -72,7 +72,7 @@ pub const Shape = struct {
             return .{ dims_, tags_ };
         }
 
-        stdx.meta.compileError("expected a dimension tuple eg '.{{ .a = 10, .b = 20}}' or '.{{ 10, 20 }}', got {}", .{T});
+        stdx.debug.compileError("expected a dimension tuple eg '.{{ .a = 10, .b = 20}}' or '.{{ 10, 20 }}', got {}", .{T});
     }
 
     test parseDimensions {
@@ -109,7 +109,7 @@ pub const Shape = struct {
             return .{ axes_, tags_ };
         }
 
-        stdx.meta.compileError("Wrong type, got {}. Expected .{{.a, .b}}", .{T});
+        stdx.debug.compileError("Wrong type, got {}. Expected .{{.a, .b}}", .{T});
     }
 
     pub fn parseTags(v: anytype) TagsArray {
@@ -181,7 +181,7 @@ pub const Shape = struct {
             EnumLiteral => @tagName(v).ptr,
             std.builtin.Type.StructField => v.name.ptr,
             Tag => v,
-            else => stdx.meta.compileError("Value should be an EnumLiteral, a Shape.Tag or a StructField, got {}", .{T}),
+            else => stdx.debug.compileError("Value should be an EnumLiteral, a Shape.Tag or a StructField, got {}", .{T}),
         };
     }
 
@@ -239,7 +239,7 @@ pub const Shape = struct {
             return true;
         }
 
-        stdx.meta.compileError("Expected tuple of tags, got {any}", .{T});
+        stdx.debug.compileError("Expected tuple of tags, got {any}", .{T});
     }
 
     pub fn isFullyTagged(self: Shape) bool {
@@ -261,7 +261,7 @@ pub const Shape = struct {
             return self.axisFromTag(toTag(axis_));
         }
 
-        stdx.meta.compileError("Wrong axis type, expected .literal, or an integer, got: {any}", .{T});
+        stdx.debug.compileError("Wrong axis type, expected .literal, or an integer, got: {any}", .{T});
     }
 
     pub fn axes(self: Shape, axes_: anytype) AxesArray {
@@ -289,7 +289,7 @@ pub const Shape = struct {
             return res;
         }
 
-        stdx.meta.compileError("axes expects an int-tuple or a tuple of enum literal, got {}", .{T});
+        stdx.debug.compileError("axes expects an int-tuple or a tuple of enum literal, got {}", .{T});
     }
 
     fn axisFromInt(self: Shape, d: isize) u3 {
@@ -590,7 +590,7 @@ pub const Shape = struct {
             return res;
         }
 
-        stdx.meta.compileError("Expected a tuple of enum literals eg: .{ .a, .b, .c } got: {any}", .{@TypeOf(tagz)});
+        stdx.debug.compileError("Expected a tuple of enum literals eg: .{ .a, .b, .c } got: {any}", .{@TypeOf(tagz)});
     }
 
     test withTags {
@@ -637,7 +637,7 @@ pub const Shape = struct {
             return res;
         }
 
-        stdx.meta.compileError("Expected a tuple of enum literals eg: .{ .a, .b, .c } got: {any}", .{@TypeOf(tagz)});
+        stdx.debug.compileError("Expected a tuple of enum literals eg: .{ .a, .b, .c } got: {any}", .{@TypeOf(tagz)});
     }
 
     test withPartialTags {
@@ -934,7 +934,7 @@ pub const Shape = struct {
             return .{ vals_, tags_ };
         }
 
-        stdx.meta.compileError("parseStruct expects struct or tuple, got {}", .{V});
+        stdx.debug.compileError("parseStruct expects struct or tuple, got {}", .{V});
     }
 
     test parseStruct {
@@ -967,7 +967,7 @@ pub const Shape = struct {
             return res;
         }
 
-        stdx.meta.compileError("parseStruct expects struct or tuple, got {}", .{V});
+        stdx.debug.compileError("parseStruct expects struct or tuple, got {}", .{V});
     }
 
     test parseAxesOptions {

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -2459,8 +2459,7 @@ pub const Tensor = struct {
 
         const _scalar: Tensor = .{ ._shape = Shape.init(.{}, self.dtype()), ._id = undefined };
         const UpdateS = ops.BlockSign(ScatterOpts.increment);
-        const update_block, const update_res = ctx.makeBlock(UpdateS, opts.update_fn, opts.update_fn_ctx, .{ _scalar, _scalar });
-        _ = update_res;
+        const update_block, _ = ctx.makeBlock(UpdateS, opts.update_fn, opts.update_fn_ctx, .{ _scalar, _scalar });
 
         const op = dialect.stablehlo.scatter(
             mlir_ctx,

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1306,7 +1306,7 @@ pub const Tensor = struct {
         var padding = [_][2]i64{.{ 0, 0 }} ** MAX_RANK;
         padding[a] = .{ self.dim(a) - 1, 0 };
 
-        var res = ops.reduceWindow(
+        return ops.reduceWindow(
             Tensor.add,
             self,
             Tensor.scalar(0, self.dtype()),
@@ -1318,8 +1318,6 @@ pub const Tensor = struct {
                 .padding = padding[0..rk],
             },
         );
-        res._shape = self._shape;
-        return res;
     }
 
     test cumulativeSum {
@@ -1328,7 +1326,11 @@ pub const Tensor = struct {
 
         const Local = struct {
             pub fn _cumsum(input: Tensor) Tensor {
-                return input.withPartialTags(.{.n}).cumulativeSum(.n);
+                const x = input.withPartialTags(.{.n});
+                const y = x.cumulativeSum(.n);
+                // Check that tags are propagated
+                std.debug.assert(y.shape().eqlWithTags(x.shape()));
+                return y;
             }
         };
 
@@ -2457,7 +2459,8 @@ pub const Tensor = struct {
 
         const _scalar: Tensor = .{ ._shape = Shape.init(.{}, self.dtype()), ._id = undefined };
         const UpdateS = ops.BlockSign(ScatterOpts.increment);
-        const update_block = ctx.makeBlock(UpdateS, opts.update_fn, opts.update_fn_ctx, .{ _scalar, _scalar });
+        const update_block, const update_res = ctx.makeBlock(UpdateS, opts.update_fn, opts.update_fn_ctx, .{ _scalar, _scalar });
+        _ = update_res;
 
         const op = dialect.stablehlo.scatter(
             mlir_ctx,

--- a/zml/testing.zig
+++ b/zml/testing.zig
@@ -23,7 +23,8 @@ pub fn env() zml.Platform {
 
         _ctx = zml.Context.init() catch unreachable;
     }
-    return _ctx.?.platforms.get(.cpu).?.withCompilationOptions(_test_compile_opts);
+
+    return _ctx.?.autoPlatform().withCompilationOptions(_test_compile_opts);
 }
 
 var _test_compile_opts: zml.CompilationOptions = .{};

--- a/zml/testing.zig
+++ b/zml/testing.zig
@@ -108,12 +108,7 @@ pub fn expectClose(left_: anytype, right_: anytype, tolerance: f32) !void {
         },
         inline .bool, .u4, .u8, .u16, .u32, .u64, .i4, .i8, .i16, .i32, .i64 => |t| {
             const T = t.toZigType();
-            const left_data = left.items(T);
-            const right_data = right.items(T);
-            if (!std.mem.eql(T, left_data, right_data)) {
-                log.err("left.data ({any}) != right.data ({any})", .{ left_data[0..10], right_data[0..10] });
-                return error.TestUnexpectedResult;
-            }
+            return std.testing.expectEqualSlices(T, left.items(T), right.items(T));
         },
         .c64, .c128 => @panic("TODO: support comparison of complex"),
     }


### PR DESCRIPTION
Now zml.ops.makeBlock returns both the mlir.Block created and also the Tensors returned by `func`.

The returned tensors should not be returned to the user,
because their `mlir.Value` must not escape the block that created them. But their shapes/tags can be safely propagated further.

This makes `zml.ops.makeBlock` a bit more footgunny, but also it's a utility function that most users shouldn't use. And it allows to use tags created inside the block and apply them to the return value. In particular tags and sharding info should now be propagated more consistently for while loops, summation, reduceWindow, ...

I've also enabled tests to run on non-cpu platform.
this is useful to figure out if a specific platform has limitation in it's pjrt support