### PR TITLE
third_party/modules/zig-protobuf: revert indentation changes

### DIFF
--- a/third_party/modules/zig-protobuf/20240722.0-c644d11/source.json
+++ b/third_party/modules/zig-protobuf/20240722.0-c644d11/source.json
@@ -1,13 +1,13 @@
 {
-  "strip_prefix": "zig-protobuf-c644d1105caaca4d9a48d3536e253687052f74c8",
-  "url": "https://github.com/gwenzek/zig-protobuf/archive/c644d1105caaca4d9a48d3536e253687052f74c8.tar.gz",
-  "integrity": "sha256-KoZp8MLLEQQgS7Uip4sdjw7TYmhzKPdpilQYKp5iYV4=",
-  "overlay": {
-    "MODULE.bazel": "",
-    "BUILD.bazel": ""
-  },
-  "patch_strip": 1,
-  "patches": {
-    "0001-USE_MODULES-true.patch": ""
-  }
+    "strip_prefix": "zig-protobuf-c644d1105caaca4d9a48d3536e253687052f74c8",
+    "url": "https://github.com/gwenzek/zig-protobuf/archive/c644d1105caaca4d9a48d3536e253687052f74c8.tar.gz",
+    "integrity": "sha256-KoZp8MLLEQQgS7Uip4sdjw7TYmhzKPdpilQYKp5iYV4=",
+    "overlay": {
+        "MODULE.bazel": "",
+        "BUILD.bazel": ""
+    },
+    "patch_strip": 1,
+    "patches": {
+        "0001-USE_MODULES-true.patch": ""
+    }
 }


### PR DESCRIPTION
This was breaking old branches that didn't have these indentation changes