### PR TITLE
Module-cache: increase max_pjrt_executable_size to 400MB

### DIFF
--- a/zml/module.zig
+++ b/zml/module.zig
@@ -1089,7 +1089,7 @@ fn computeModuleHash(platform: Platform, module: mlir.Module) u64 {
     return hasher.final();
 }
 
-const max_pjrt_executable_size = 20 * 1024 * 1024;
+const max_pjrt_executable_size = 400 * 1024 * 1024;
 
 fn loadPjrtExecutable(arena: std.mem.Allocator, platform: Platform, module_hash: u64, compilation_cache_location: []const u8) !*pjrt.LoadedExecutable {
     const resolved_path = try std.fs.cwd().realpathAlloc(arena, compilation_cache_location);


### PR DESCRIPTION
Some PJRT executables get really large (e.g. ca. 300MB). We want to be able to load them.