### PR TITLE
examples: fixes related to recent async changes

### DIFF
--- a/examples/benchmark/main.zig
+++ b/examples/benchmark/main.zig
@@ -60,7 +60,7 @@ pub fn asyncMain() !void {
     // Start compiling.
     // The shape of the input tensor, we have to pass in manually.
     timer.reset();
-    var compilation = try asynk.asyncGeneric(zml.module.compileModel, .{ allocator, Benchmark{}, .forward, .{ a_shape, b_shape }, platform });
+    var compilation = try asynk.asyncc(zml.module.compileModel, .{ allocator, Benchmark.forward, Benchmark{}, .{ a_shape, b_shape }, platform });
 
     // Wait for compilation to finish
     const compiled = try compilation.await_();

--- a/examples/simple_layer/main.zig
+++ b/examples/simple_layer/main.zig
@@ -62,7 +62,7 @@ pub fn asyncMain() !void {
 
     // Start compiling. This uses the inferred shapes from the BufferStore.
     // The shape of the input tensor, we have to pass in manually.
-    var compilation = try asynk.asyncGeneric(zml.compileModel, .{ allocator, model_shapes, .forward, .{input_shape}, platform });
+    var compilation = try asynk.asyncc(zml.compileModel, .{ allocator, Layer.forward, model_shapes, .{input_shape}, platform });
 
     // Produce a bufferized weights struct from the fake BufferStore.
     // This is like the inferred shapes, but with actual values.


### PR DESCRIPTION
Recent changes to the `async` module reverted `asyncGeneric` to `asyncc` but examples were not updated