### PR TITLE
zml/pjrtx.zig: call `bufferFromHostBuffer` on the thread pool

### DIFF
--- a/zml/pjrtx.zig
+++ b/zml/pjrtx.zig
@@ -64,7 +64,7 @@ pub const Client = opaque {
 
     pub const BufferFromHostBufferArgs = pjrt.Client.BufferFromHostBufferArgs;
     pub fn bufferFromHostBuffer(self: *const Client, api: *const Api, args: BufferFromHostBufferArgs) !*Buffer {
-        const buffer, const event_ = try self.inner().bufferFromHostBuffer(api, args);
+        const buffer, const event_ = try asynk.callBlocking(pjrt.Client.bufferFromHostBuffer, .{ self.inner(), api, args });
         if (event_) |event__| {
             const event: *Event = @ptrCast(event__);
             try event.await_(api);

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -28,7 +28,7 @@ pub const Platform = struct {
     pjrt_client: *pjrt.Client,
     compilation_options: CompilationOptions = .{},
 
-    pub const MAX_NUM_DEVICES: u8 = 8;
+    pub const MAX_NUM_DEVICES: u8 = 32;
 
     pub fn init(target: Target, api: *const pjrt.Api) !Platform {
         const pjrt_client = try pjrt.Client.init(api, &.{});


### PR DESCRIPTION
This was causing very bad performance for weight loading on Neuron because the calls are blocking