### PR TITLE
workspace: log message before return NotFound 

### DIFF
--- a/pjrt/pjrt.zig
+++ b/pjrt/pjrt.zig
@@ -80,6 +80,7 @@ pub const Api = struct {
                 break :blk .{
                     .inner = .{
                         .handle = c.dlopen(&library_c, c.RTLD_LAZY | c.RTLD_LOCAL | c.RTLD_NODELETE) orelse {
+                            log.err("Unable to dlopen plugin: {s}", .{library});
                             return error.FileNotFound;
                         },
                     },

--- a/zml/context.zig
+++ b/zml/context.zig
@@ -98,7 +98,11 @@ pub const Context = struct {
                 num_platforms += 1;
             }
         }
-        if (num_platforms == 0) return error.NotFound;
+        if (num_platforms == 0) {
+            log.err("Zero platform available", .{});
+            return error.NotFound;
+        }
+
         return .{
             .platforms = platforms,
         };

--- a/zml/context.zig
+++ b/zml/context.zig
@@ -99,8 +99,8 @@ pub const Context = struct {
             }
         }
         if (num_platforms == 0) {
-            log.err("Zero platform available", .{});
-            return error.NotFound;
+            log.err("No platform available", .{});
+            return error.NoPlatformAvailable;
         }
 
         return .{


### PR DESCRIPTION
This allow us to find which NotFound is raised

-- 
~~require #106 to be merged before~~