### PR TITLE
zml/pjrtx: use framework's stablehlo version if plugin provided version is newer

### DIFF
--- a/mlir/dialects/stablehlo.zig
+++ b/mlir/dialects/stablehlo.zig
@@ -1261,6 +1261,29 @@ pub fn stablehloVersionFromCompatibilityRequirement(requirement: c.MlirStablehlo
     return state.call(requirement);
 }
 
+pub fn stablehloGetSmallerVersion(version1: []const u8, version2: []const u8) []const u8 {
+    const state = struct {
+        var buf: [32]u8 = undefined;
+
+        fn call(v1: []const u8, v2: []const u8) []const u8 {
+            var stream = std.io.fixedBufferStream(&buf);
+            var context = .{ .writer = stream.writer() };
+            const WriterContext = @TypeOf(context);
+
+            _ = c.stablehloGetSmallerVersion(mlir.stringRef(v1), mlir.stringRef(v2), (struct {
+                pub fn callback(mlir_str: c.MlirStringRef, userdata: ?*anyopaque) callconv(.C) void {
+                    const inner_ctx: *WriterContext = @ptrCast(@alignCast(userdata));
+                    _ = inner_ctx.writer.write(mlir.fromStringRef(mlir_str)) catch unreachable;
+                }
+            }).callback, &context);
+
+            return buf[0..stream.pos];
+        }
+    };
+
+    return state.call(version1, version2);
+}
+
 pub fn getCurrentVersion() []const u8 {
     const state = struct {
         var buf: [32]u8 = undefined;

--- a/zml/pjrtx.zig
+++ b/zml/pjrtx.zig
@@ -106,8 +106,6 @@ pub const Client = opaque {
             break :blk dialects.stablehlo.stablehloVersionFromCompatibilityRequirement(c.WEEK_12);
         };
 
-        std.debug.print("stablehlo_version: {s}\n", .{stablehlo_version});
-
         dialects.stablehlo.serializePortableArtifact(bytecode.items, stablehlo_version, serialized_buffer.writer()) catch |err| {
             log.err("failed to serialize to portable artifact: {}", .{err});
             return err;


### PR DESCRIPTION
Discovered use case:

- PJRT plugin attribute `stablehlo_current_version` is `1.7.8`
- `stablehloVersionFromCompatibilityRequirement(WEEK_12)` is `1.1.0`
-  `stablehloGetCurrentVersion` is `1.7.6`

The target version for artifact serialization is `1.7.8` but should be `1.7.6`.

XLA ref: https://github.com/openxla/xla/commit/2f99455cdf99e844ddad17de9f4714997023d243#diff-7f335a78926dafcc06a6940ab5c1d5496f74a3431629e17e54df961e720e7574R213