### PR TITLE
examples/llama+neuron: enable buffer donation

### DIFF
--- a/examples/llama/llama.zig
+++ b/examples/llama/llama.zig
@@ -104,7 +104,7 @@ pub const LlamaLM = struct {
     }
 
     pub fn increment(_: u8, token_index: Tensor) Tensor {
-        return token_index.addConstant(1).reuseBuffer(token_index);
+        return token_index.addConstant(1);
     }
 
     /// Run the generation entirely within pjrt.
@@ -367,12 +367,12 @@ pub const KvCache = struct {
                 .{ .layer = self.layer_index, .k = token_index },
                 // transpose to match kv-cache layout
                 new_k.contiguous(.{ .h, .k, .hd }),
-            ).reuseBuffer(self.k),
+            ),
             .v = self.v.dynamicUpdateSlice(
                 .{ .layer = self.layer_index, .k = token_index },
                 // transpose to match kv-cache layout
                 new_v.contiguous(.{ .h, .k, .hd }),
-            ).reuseBuffer(self.v),
+            ),
             .layer_index = self.layer_index,
         };
     }

--- a/examples/llama/llama.zig
+++ b/examples/llama/llama.zig
@@ -367,12 +367,12 @@ pub const KvCache = struct {
                 .{ .layer = self.layer_index, .k = token_index },
                 // transpose to match kv-cache layout
                 new_k.contiguous(.{ .h, .k, .hd }),
-            ),
+            ).reuseBuffer(self.k),
             .v = self.v.dynamicUpdateSlice(
                 .{ .layer = self.layer_index, .k = token_index },
                 // transpose to match kv-cache layout
                 new_v.contiguous(.{ .h, .k, .hd }),
-            ),
+            ).reuseBuffer(self.v),
             .layer_index = self.layer_index,
         };
     }

--- a/examples/llama/main.zig
+++ b/examples/llama/main.zig
@@ -57,10 +57,12 @@ pub fn generateText(
     defer output.deinit();
 
     var tokens = try zml.Buffer.fromSlice(mod.platform(), .{max_seq_len}, token_buffer);
-    var token_index = try zml.Buffer.fromSlice(mod.platform(), .{}, &[_]i32{@intCast(prompt_tok.len - 1)});
+    var prefill_token_index = try zml.Buffer.fromSlice(mod.platform(), .{}, &[_]i32{@intCast(prompt_tok.len - 1)});
+    defer prefill_token_index.deinit();
 
     var rng = try zml.Tensor.Rng.init(mod.platform(), seed);
-    tokens, token_index, var kv_cache, rng = mod_prefill.call(.{ tokens, token_index, null, rng });
+    tokens, var token_index, var kv_cache, rng = mod_prefill.call(.{ tokens, prefill_token_index, null, rng });
+    defer token_index.deinit();
     defer kv_cache.k.deinit();
     defer kv_cache.v.deinit();
     defer kv_cache.layer_index.deinit();
@@ -74,7 +76,9 @@ pub fn generateText(
     for (0..output_tokens_len) |i| {
         //_ = i;
         const frame_id = tracer.frameStart(try std.fmt.bufPrintZ(tracer_buffer, "Generate token {}/{}", .{ i + 1, output_tokens_len }));
-        tokens, token_index, kv_cache, rng = mod.call(.{ tokens, token_index, kv_cache, rng });
+        tokens, const new_token_index, kv_cache, rng = mod.call(.{ tokens, token_index, kv_cache, rng });
+        token_index.deinit();
+        token_index = new_token_index;
         if ((i + 1) % output_freq == 0) {
             const n = output.items.len;
             _ = try tokens.toHost(std.mem.sliceAsBytes(token_buffer));

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -350,9 +350,6 @@ pub const CompilationContext = struct {
     /// Given a list of donations mapping output buffers to input buffers,
     /// generate donation attribute for each `n_args` input argument.
     fn addDonationsAttributes(self: CompilationContext, attributes: []AttributeList, donations: []const Tensor._Donation) void {
-        if (self.target() == .neuron) {
-            return;
-        }
         var n_donations: usize = 0;
         for (donations, 0..) |donation, index| {
             switch (donation) {


### PR DESCRIPTION
Donate verything except the `token_index` buffer as it messes up the output