### PR TITLE
zml: fix float8 <-> float32 conversions, support for `Tensor.constant(.{}, .{ .f8 = 1.0})` 

### DIFF
--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -72,7 +72,9 @@ build           --repo_env HERMETIC_PYTHON_VERSION=3.11
 # Print test errors in the console
 test            --test_output=errors
 
+# --config=debug will used optmized backend, but all the frontend zig code will be compiled in debug mode.
 build:debug     --compilation_mode=opt
+build:debug     --@rules_zig//zig/settings:mode=debug
 build:debug     --strategy=ZigBuildLib=local
 build:debug     --strategy=ZigBuildObj=local
 build:debug     --strategy=ZigBuildTestLib=local

--- a/zml/dtype.zig
+++ b/zml/dtype.zig
@@ -10,6 +10,7 @@ test {
 
 pub const DataType = enum(u8) {
     bool,
+    // Note: the support of the float8 is a bit spotty, f8e4m3b11fnuz seems to be the most supported one on Cuda.
     f8e4m3b11fnuz,
     f8e4m3fn,
     f8e4m3fnuz,

--- a/zml/mlir.zig
+++ b/zml/mlir.zig
@@ -18,7 +18,7 @@ pub const ext = struct {
         return mlir.RankedTensorType.init(sh.dims(), mlir.ext.Type.fromDType(ctx, sh.dtype())).as(mlir.Type).?;
     }
 
-    pub fn denseElementAttrType(dt: dtype.DataType) mlir.DenseElementsAttributeTypes {
+    pub fn denseElementAttrType(dt: dtype.DataType) ?mlir.DenseElementsAttributeTypes {
         return switch (dt) {
             .bool => .bool,
             .i8 => .i8,
@@ -33,7 +33,7 @@ pub const ext = struct {
             .f16 => .f16,
             .f32 => .f32,
             .f64 => .f64,
-            inline else => |tag| @panic("Unsupported data type: " ++ @tagName(tag)),
+            else => null,
         };
     }
 

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -988,7 +988,7 @@ pub fn sdpaChunk(q_: Tensor, k_: Tensor, v_: Tensor, opts: SdpaOpts) PartialSoft
     var attn_weights = q.dot(k, .{.hd});
     // log.debug("attn_weights : {}", .{attn_weights});
     // log.debug("attn_mask : {?}", .{attn_mask});
-    if (attn_mask) |mask| attn_weights = attn_weights.add(mask.broadcastLeft(attn_weights.shape()));
+    if (attn_mask) |mask| attn_weights = attn_weights.add(mask.broad(attn_weights.shape()));
 
     if (opts.bias) |bias| {
         attn_weights = attn_weights.add(bias);

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -775,7 +775,7 @@ pub fn sdpa(q_: Tensor, k_: Tensor, v_: Tensor, opts: SdpaOpts) Tensor {
     var attn_weights = q.dot(k, .{.hd});
     // log.debug("attn_weights : {}", .{attn_weights});
     // log.debug("attn_mask : {?}", .{attn_mask});
-    if (attn_mask) |mask| attn_weights = attn_weights.add(mask.broadcastLeft(attn_weights.shape()));
+    if (attn_mask) |mask| attn_weights = attn_weights.add(mask.broad(attn_weights.shape()));
 
     attn_weights = attn_weights.convert(.f32);
     if (opts.bias) |bias| {

--- a/zml/nn/cuda.zig
+++ b/zml/nn/cuda.zig
@@ -116,16 +116,16 @@ pub fn sdpa(q_: Tensor, k_: Tensor, v_: Tensor, opts: SdpaOpts) Tensor {
     var bias = Tensor.constant(Shape.init(.{ .b = q.dim(.b), .h = q.dim(.h), .q = q.dim(.q), .k = k.dim(.k) }, q.dtype()), Data.init(q.dtype(), 0));
 
     if (opts.attn_mask) |attn_mask| {
-        const mask = attn_mask.withTags(.{ .q, .k }).broad(bias.shape());
-        bias = bias.add(mask);
+        bias = bias.add(attn_mask.broad(bias.shape()));
     }
     if (opts.bias) |b| {
         bias = bias.add(b);
     }
 
-    const loc = ctx.mlirCtx().location(@src());
+    const mlir_ctx = ctx.mlirCtx();
+    const loc = mlir_ctx.location(@src());
     const op = dialect.stablehlo.custom_call(
-        ctx.mlirCtx(),
+        mlir_ctx,
         &.{ q.value(), k.value(), v.value(), bias.value() },
         .{
             .call_target_name = "__cudnn$fmhaScaleBiasSoftmax",
@@ -135,8 +135,8 @@ pub fn sdpa(q_: Tensor, k_: Tensor, v_: Tensor, opts: SdpaOpts) Tensor {
             .output_operand_aliases = &.{},
         },
         &.{
-            mlir.ext.mlirType(ctx.mlirCtx(), q.shape()),
-            mlir.RankedTensorType.init(&.{0}, mlir.IntegerType(.u8).init(ctx.mlirCtx()).as(mlir.Type).?).as(mlir.Type).?,
+            mlir.ext.mlirType(mlir_ctx, q.shape()),
+            mlir.RankedTensorType.init(&.{0}, mlir.IntegerType(.u8).init(mlir_ctx).as(mlir.Type).?).asType(),
         },
         loc,
     );


### PR DESCRIPTION
Mostly:
* fix float8 <-> float32 conversions
* support for `Tensor.constant(.{}, .{ .f8 = 1.0})` 

Misc:
* fix small inconsistencies between different versions of sdpa
* better error message for broadcast
* bazelrc: --config=debug