### PR TITLE
zml: revisit rope implementation

### DIFF
--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -72,7 +72,9 @@ build           --repo_env HERMETIC_PYTHON_VERSION=3.11
 # Print test errors in the console
 test            --test_output=errors
 
+# --config=debug will used optmized backend, but all the frontend zig code will be compiled in debug mode.
 build:debug     --compilation_mode=opt
+build:debug     --@rules_zig//zig/settings:mode=debug
 build:debug     --strategy=ZigBuildLib=local
 build:debug     --strategy=ZigBuildObj=local
 build:debug     --strategy=ZigBuildTestLib=local

--- a/zml/dtype.zig
+++ b/zml/dtype.zig
@@ -10,6 +10,7 @@ test {
 
 pub const DataType = enum(u8) {
     bool,
+    // Note: the support of the float8 is a bit spotty, f8e4m3b11fnuz seems to be the most supported one on Cuda.
     f8e4m3b11fnuz,
     f8e4m3fn,
     f8e4m3fnuz,

--- a/zml/mlir.zig
+++ b/zml/mlir.zig
@@ -18,7 +18,7 @@ pub const ext = struct {
         return mlir.RankedTensorType.init(sh.dims(), mlir.ext.Type.fromDType(ctx, sh.dtype())).as(mlir.Type).?;
     }
 
-    pub fn denseElementAttrType(dt: dtype.DataType) mlir.DenseElementsAttributeTypes {
+    pub fn denseElementAttrType(dt: dtype.DataType) ?mlir.DenseElementsAttributeTypes {
         return switch (dt) {
             .bool => .bool,
             .i8 => .i8,
@@ -33,7 +33,7 @@ pub const ext = struct {
             .f16 => .f16,
             .f32 => .f32,
             .f64 => .f64,
-            inline else => |tag| @panic("Unsupported data type: " ++ @tagName(tag)),
+            else => null,
         };
     }
 

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -562,6 +562,7 @@ pub const CompilationContext = struct {
         self.extractValues(&args, values[function.n_model..]);
 
         const op = dialect.func.call(self.mlirCtx(), function.name, values, function.res_types, loc);
+        // TODO: tags seem to be lost by `callFunc`.
         var res: stdx.meta.FnResult(func) = undefined;
         assignResults(op, &res, function.res_shapes);
         return res;

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -183,9 +183,7 @@ pub fn rope(x: Tensor, pos_idx: ?Tensor, opts: RopeOpts) Tensor {
     const y_imag = x_real.mul(sin).add(x_imag.mul(cos));
 
     // flatten last dimensions
-    const y = mergeRealImg(y_real, y_imag, opts.impl);
-    log.warn("rope({}, {?}) -> {}", .{ x, pos_idx, y });
-    return y;
+    return mergeRealImg(y_real, y_imag, opts.impl);
 }
 
 pub fn splitRealImg(x: Tensor, impl: RopeOpts.Implementation) [2]Tensor {

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -151,44 +151,41 @@ pub const RopeOpts = struct {
     freq_base: f32 = 10_000,
 };
 
-pub const CosSin = [2]Tensor;
-
 /// Rotary position embedding modify queries and keys tensor before compute Q * K in self attention.
 /// This biases a token to look at token near him.
-/// The nice thing with this solution is that you can cache the modified queries and keys directly.
+/// The nice thing with rope is that you can cache the modified queries and keys directly.
 /// See: https://paperswithcode.com/method/rope
-pub fn rope(x: Tensor, cos_sin_cache: CosSin, opts: RopeOpts) Tensor {
-    const cos, const sin = cos_sin_cache;
-    stdx.debug.assert(x.dim(-1) == 2 * cos.dim(-1), "Couldn't compute rope({}, {}, {})", .{ x, cos, sin });
-    // broadcast cos / sin to .{ batch, .seq, .half_dim }
+///
+/// Expected shapes of tensor:
+/// - x: .{ .s, .hd } where .s is the sequence length and .hd the head dimension
+/// - pos_idx: optional tensor which indicates which positions are needed.
+///   When not set `rope` return all positions from 0 to x.dim(.s) which is the max seq len.
+pub fn rope(x: Tensor, pos_idx: ?Tensor, opts: RopeOpts) Tensor {
+    stdx.debug.assert(@mod(x.dim(.hd), 2) == 0, "rope expects a even head dim (.hd), got {}", .{x});
+
+    const idx = if (pos_idx) |idx| blk: {
+        stdx.debug.assert(x.shape().hasTags(.{.hd}), "rope expects x argument to have .hd axes got: rope(x={}, idx={})", .{ x, idx });
+        break :blk idx;
+    } else blk: {
+        stdx.debug.assert(x.shape().hasTags(.{ .s, .hd }), "rope expects x argument to have both .s and .hd axes got: rope(x={})", .{x});
+        break :blk Tensor.arange(.{ .end = x.dim(.s) }, .f32).withTags(.{.s});
+    };
     const x_real, const x_imag = splitRealImg(x, opts.impl);
-    const has_tags = cos.shape().tag(0) != Shape.TagUnknown;
-    const b_cos = if (has_tags) cos.broad(x_real.shape()) else cos.broadcastLeft(x_real.shape());
-    const b_sin = if (has_tags) sin.broad(x_real.shape()) else sin.broadcastLeft(x_real.shape());
+
+    // compute sin and cos in f32 before downcasting to x type.
+    const inv_freq = invFreq(x.dim(.hd), opts.freq_base, .f32).withTags(.{.hd});
+    const inv_freq_pos = Tensor.outer(idx.convert(.f32), inv_freq);
+    const cos = inv_freq_pos.cos().convert(x.dtype()).broad(x_real.shape());
+    const sin = inv_freq_pos.sin().convert(x.dtype()).broad(x_real.shape());
 
     // apply rotation
-    const y_real = x_real.mul(b_cos).sub(x_imag.mul(b_sin));
-    const y_imag = x_real.mul(b_sin).add(x_imag.mul(b_cos));
+    const y_real = x_real.mul(cos).sub(x_imag.mul(sin));
+    const y_imag = x_real.mul(sin).add(x_imag.mul(cos));
 
     // flatten last dimensions
     const y = mergeRealImg(y_real, y_imag, opts.impl);
-
+    log.warn("rope({}, {?}) -> {}", .{ x, pos_idx, y });
     return y;
-}
-
-pub fn ropeCosSin(sh: anytype, dtype: DataType, opts: RopeOpts) CosSin {
-    const shape = Shape.init(sh, dtype);
-    stdx.debug.assert(shape.rank() == 2, "ropeCosSin({}) shape need to exactly have 2 axes", .{shape});
-    const seq_len, const head_dim = .{ shape.dim(0), shape.dim(1) };
-    stdx.debug.assert(@mod(head_dim, 2) == 0, "ropeCosSin requires an even head_dim, got {}", .{head_dim});
-
-    // compute sin and cos in f32 before downcasting to x type.
-    const inv_freq = invFreq(head_dim, opts.freq_base, .f32);
-    var inv_freq_pos = Tensor.outer(Tensor.arange(.{ .end = seq_len }, .f32), inv_freq).convert(shape.dtype());
-    inv_freq_pos._shape._tags = shape._tags;
-    const cos = inv_freq_pos.cos();
-    const sin = inv_freq_pos.sin();
-    return .{ cos, sin };
 }
 
 pub fn splitRealImg(x: Tensor, impl: RopeOpts.Implementation) [2]Tensor {
@@ -311,16 +308,15 @@ test "real/img" {
 test "rope" {
     const platform = zml.testing.env();
 
-    const TestRope = struct {
-        fn forward(x: Tensor, opts: RopeOpts) Tensor {
+    const Local = struct {
+        fn _fwd1(x: Tensor, opts: RopeOpts) Tensor {
             var input = x;
             {
                 // Convert input to the requested format
                 const real, const imag = splitRealImg(input, .sequential);
                 input = mergeRealImg(real, imag, opts.impl);
             }
-            const cos_sin = ropeCosSin(.{ input.dim(-2), input.dim(-1) }, input.dtype(), opts);
-            var res = rope(input, cos_sin, opts).squeeze(0);
+            var res = rope(input, null, opts).squeeze(0);
 
             {
                 // Convert back to sequential
@@ -329,15 +325,31 @@ test "rope" {
             }
             return res;
         }
+
+        fn _fwd2(x: Tensor, idx: Tensor) [2]Tensor {
+            return .{
+                rope(x, idx, .{ .impl = .interleaved }),
+                rope(x.gatherValues(.s, idx, .{}), null, .{ .impl = .interleaved }).gatherValues(.s, idx, .{}),
+            };
+        }
     };
 
-    // x is made such as the interleaved and sequential reps are the same.
-    // So the two implementations should give the same results.
-    const x = try zml.Buffer.fromSlice(platform, .{ 1, 5, 4 }, &[_]f32{ 1.0, 0.1, -1.0, -0.5 } ** 5);
-    const res1 = try zml.testing.compileAndCall(platform, TestRope.forward, .{ x, RopeOpts{ .impl = .interleaved } });
-    const res2 = try zml.testing.compileAndCall(platform, TestRope.forward, .{ x, RopeOpts{ .impl = .sequential } });
+    {
 
-    try zml.testing.expectClose(res1, res2, 1e-4);
+        // x is made such as the interleaved and sequential reps are the same.
+        // So the two implementations should give the same results.
+        const x = try zml.Buffer.fromSlice(platform, .{ .b = 1, .s = 5, .hd = 4 }, &[_]f32{ 1.0, 0.1, -1.0, -0.5 } ** 5);
+        const res1 = try zml.testing.compileAndCall(platform, Local._fwd1, .{ x, RopeOpts{ .impl = .interleaved } });
+        const res2 = try zml.testing.compileAndCall(platform, Local._fwd1, .{ x, RopeOpts{ .impl = .sequential } });
+        try zml.testing.expectClose(res1, res2, 1e-4);
+    }
+
+    // {
+    //     const x = try zml.Buffer.fromSlice(platform, .{ .b = 2, .hd = 4 }, &[2 * 4]f32{ 1.0, 0.1, -1.0, -0.5, 1.0, 0.1, -1.0, -0.5 });
+    //     const idx = try zml.Buffer.fromSlice(platform, .{ .b = 2 }, &[_]i32{ 2, 4 });
+    //     const res1, const res2 = try zml.testing.compileAndCall(platform, Local._fwd2, .{ x, idx });
+    //     try zml.testing.expectClose(res1, res2, 1e-4);
+    // }
 }
 
 /// In neural network we generally care about the relative precision,

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -303,11 +303,11 @@ test "real/img" {
     try testing.expectEqual(20, d_split_interleaved.getValue(i32));
 }
 
-test "rope" {
+test rope {
     const platform = zml.testing.env();
 
     const Local = struct {
-        fn _fwd1(x: Tensor, opts: RopeOpts) Tensor {
+        fn _fwd(x: Tensor, opts: RopeOpts) Tensor {
             var input = x;
             {
                 // Convert input to the requested format
@@ -323,31 +323,14 @@ test "rope" {
             }
             return res;
         }
-
-        fn _fwd2(x: Tensor, idx: Tensor) [2]Tensor {
-            return .{
-                rope(x, idx, .{ .impl = .interleaved }),
-                rope(x.gatherValues(.s, idx, .{}), null, .{ .impl = .interleaved }).gatherValues(.s, idx, .{}),
-            };
-        }
     };
 
-    {
-
-        // x is made such as the interleaved and sequential reps are the same.
-        // So the two implementations should give the same results.
-        const x = try zml.Buffer.fromSlice(platform, .{ .b = 1, .s = 5, .hd = 4 }, &[_]f32{ 1.0, 0.1, -1.0, -0.5 } ** 5);
-        const res1 = try zml.testing.compileAndCall(platform, Local._fwd1, .{ x, RopeOpts{ .impl = .interleaved } });
-        const res2 = try zml.testing.compileAndCall(platform, Local._fwd1, .{ x, RopeOpts{ .impl = .sequential } });
-        try zml.testing.expectClose(res1, res2, 1e-4);
-    }
-
-    // {
-    //     const x = try zml.Buffer.fromSlice(platform, .{ .b = 2, .hd = 4 }, &[2 * 4]f32{ 1.0, 0.1, -1.0, -0.5, 1.0, 0.1, -1.0, -0.5 });
-    //     const idx = try zml.Buffer.fromSlice(platform, .{ .b = 2 }, &[_]i32{ 2, 4 });
-    //     const res1, const res2 = try zml.testing.compileAndCall(platform, Local._fwd2, .{ x, idx });
-    //     try zml.testing.expectClose(res1, res2, 1e-4);
-    // }
+    // x is made such as the interleaved and sequential reps are the same.
+    // So the two implementations should give the same results.
+    const x = try zml.Buffer.fromSlice(platform, .{ .b = 1, .s = 5, .hd = 4 }, &[_]f32{ 1.0, 0.1, -1.0, -0.5 } ** 5);
+    const res1 = try zml.testing.compileAndCall(platform, Local._fwd, .{ x, RopeOpts{ .impl = .interleaved } });
+    const res2 = try zml.testing.compileAndCall(platform, Local._fwd, .{ x, RopeOpts{ .impl = .sequential } });
+    try zml.testing.expectClose(res1, res2, 1e-4);
 }
 
 /// In neural network we generally care about the relative precision,

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -988,7 +988,7 @@ pub fn sdpaChunk(q_: Tensor, k_: Tensor, v_: Tensor, opts: SdpaOpts) PartialSoft
     var attn_weights = q.dot(k, .{.hd});
     // log.debug("attn_weights : {}", .{attn_weights});
     // log.debug("attn_mask : {?}", .{attn_mask});
-    if (attn_mask) |mask| attn_weights = attn_weights.add(mask.broadcastLeft(attn_weights.shape()));
+    if (attn_mask) |mask| attn_weights = attn_weights.add(mask.broad(attn_weights.shape()));
 
     if (opts.bias) |bias| {
         attn_weights = attn_weights.add(bias);

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -775,7 +775,7 @@ pub fn sdpa(q_: Tensor, k_: Tensor, v_: Tensor, opts: SdpaOpts) Tensor {
     var attn_weights = q.dot(k, .{.hd});
     // log.debug("attn_weights : {}", .{attn_weights});
     // log.debug("attn_mask : {?}", .{attn_mask});
-    if (attn_mask) |mask| attn_weights = attn_weights.add(mask.broadcastLeft(attn_weights.shape()));
+    if (attn_mask) |mask| attn_weights = attn_weights.add(mask.broad(attn_weights.shape()));
 
     attn_weights = attn_weights.convert(.f32);
     if (opts.bias) |bias| {

--- a/zml/nn/cuda.zig
+++ b/zml/nn/cuda.zig
@@ -116,16 +116,16 @@ pub fn sdpa(q_: Tensor, k_: Tensor, v_: Tensor, opts: SdpaOpts) Tensor {
     var bias = Tensor.constant(Shape.init(.{ .b = q.dim(.b), .h = q.dim(.h), .q = q.dim(.q), .k = k.dim(.k) }, q.dtype()), Data.init(q.dtype(), 0));
 
     if (opts.attn_mask) |attn_mask| {
-        const mask = attn_mask.withTags(.{ .q, .k }).broad(bias.shape());
-        bias = bias.add(mask);
+        bias = bias.add(attn_mask.broad(bias.shape()));
     }
     if (opts.bias) |b| {
         bias = bias.add(b);
     }
 
-    const loc = ctx.mlirCtx().location(@src());
+    const mlir_ctx = ctx.mlirCtx();
+    const loc = mlir_ctx.location(@src());
     const op = dialect.stablehlo.custom_call(
-        ctx.mlirCtx(),
+        mlir_ctx,
         &.{ q.value(), k.value(), v.value(), bias.value() },
         .{
             .call_target_name = "__cudnn$fmhaScaleBiasSoftmax",
@@ -135,8 +135,8 @@ pub fn sdpa(q_: Tensor, k_: Tensor, v_: Tensor, opts: SdpaOpts) Tensor {
             .output_operand_aliases = &.{},
         },
         &.{
-            mlir.ext.mlirType(ctx.mlirCtx(), q.shape()),
-            mlir.RankedTensorType.init(&.{0}, mlir.IntegerType(.u8).init(ctx.mlirCtx()).as(mlir.Type).?).as(mlir.Type).?,
+            mlir.ext.mlirType(mlir_ctx, q.shape()),
+            mlir.RankedTensorType.init(&.{0}, mlir.IntegerType(.u8).init(mlir_ctx).as(mlir.Type).?).asType(),
         },
         loc,
     );


### PR DESCRIPTION
The current implementation first compute the full cos/sin matrix for the full sentence,
then slice into it to extract the positions for the current token.
This is generally optimized by the compiler so it's not a performance issue, but it's a readability issue,
because it means calling `rope` requires first a call to `ropeCosSin`.

I rewrote this to directly produce the optimized IR where we only compute rope for given offsets.