### PR TITLE
zml: emit `func.call` operations

### DIFF
--- a/examples/llama/llama.zig
+++ b/examples/llama/llama.zig
@@ -180,10 +180,8 @@ pub const Llama = struct {
         var updated_kv_cache = kv_cache0;
         for (self.layers, 0..) |layer, i| {
             hidden, updated_kv_cache = zml.call(layer, .forward, .{ hidden, token_index, updated_kv_cache.atLayer(i) });
-            hidden = hidden.withPartialTags(.{ .s, .d });
         }
-        // TODO: tags seem to be lost by `callFunc`.
-        const output = zml.call(self.norm, .forward, .{hidden.withPartialTags(.{ .s, .d })});
+        const output = zml.call(self.norm, .forward, .{hidden});
 
         return .{ output, updated_kv_cache.reuseBuffer(kv_cache0) };
     }

--- a/examples/llama/main.zig
+++ b/examples/llama/main.zig
@@ -21,12 +21,10 @@ const log = std.log.scoped(.llama);
 const show_mlir = true;
 
 pub const std_options = .{
-    .log_level = .err,
+    .log_level = .warn,
     .log_scope_levels = &[_]std.log.ScopeLevel{
-        .{ .scope = .pjrt, .level = if (show_mlir) .debug else .err },
-        .{ .scope = .zml_module, .level = if (show_mlir) .debug else .err },
-        .{ .scope = .zml, .level = if (show_mlir) .debug else .err },
-        .{ .scope = .llama, .level = if (show_mlir) .debug else .info },
+        .{ .scope = .zml_module, .level = if (show_mlir) .debug else .warn },
+        .{ .scope = .llama, .level = .info },
     },
 };
 

--- a/mlir/dialects/func.zig
+++ b/mlir/dialects/func.zig
@@ -13,8 +13,7 @@ pub fn func(
         location: mlir.Location,
     },
 ) mlir.Operation {
-    const AttrTuple = struct { [:0]const u8, mlir.Attribute };
-    var attrs_tuple_buffer = std.BoundedArray(AttrTuple, 4){};
+    var attrs_tuple_buffer = std.BoundedArray(mlir.AttrTuple, 4){};
     attrs_tuple_buffer.appendAssumeCapacity(.{ "sym_name", mlir.StringAttribute.init(ctx, args.sym_name).as(mlir.Attribute).? });
     attrs_tuple_buffer.appendAssumeCapacity(.{ "function_type", mlir.TypeAttribute.init((mlir.FunctionType.init(ctx, args.args, args.results) catch unreachable).as(mlir.Type).?).as(mlir.Attribute).? });
     if (args.arg_attrs.len > 0) {

--- a/mlir/dialects/stablehlo.zig
+++ b/mlir/dialects/stablehlo.zig
@@ -189,7 +189,7 @@ pub fn dot_general(
     },
 ) mlir.Operation {
     const precisions = [1]mlir.Attribute{opts.precision.precisionAttr(ctx)} ** 2;
-    const attributes = [3]mlir.Operation.AttrTuple{
+    const attributes = [3]mlir.AttrTuple{
         .{
             "dot_dimension_numbers", DotDimensionNumbersAttribute.init(ctx, .{
                 .lhs_batching_dimensions = opts.lhs_batching_dimensions,

--- a/mlir/mlir.zig
+++ b/mlir/mlir.zig
@@ -333,6 +333,8 @@ pub const Identifier = struct {
     }
 };
 
+pub const AttrTuple = struct { [:0]const u8, Attribute };
+
 pub const Attribute = struct {
     _inner: c.MlirAttribute,
     pub usingnamespace MlirHelpers(Attribute, .{
@@ -790,8 +792,6 @@ pub const Operation = struct {
             c.mlirOperationCreate(state.innerPtr()),
         ) orelse Error.InvalidMlir;
     }
-
-    pub const AttrTuple = struct { [:0]const u8, Attribute };
 
     pub fn make(ctx: Context, op_name: [:0]const u8, args: struct {
         operands: ?[]const Value = null,

--- a/zml/meta.zig
+++ b/zml/meta.zig
@@ -120,8 +120,6 @@ pub fn mapAlloc(comptime cb: anytype, allocator: std.mem.Allocator, ctx: FnParam
         return;
     }
 
-    const err_msg = "zml.meta.mapAlloc doesn't support type {}, which was found inside {} for callback: {}";
-    const err_args = .{ FromStruct, From, @TypeOf(cb) };
     switch (type_info_to) {
         .Struct => |info| inline for (info.fields) |field| {
             // if (field.is_comptime) continue;
@@ -167,7 +165,7 @@ pub fn mapAlloc(comptime cb: anytype, allocator: std.mem.Allocator, ctx: FnParam
                 }
                 to.* = items;
             },
-            else => stdx.debug.compileError(err_msg, err_args),
+            else => stdx.debug.compileError("zml.meta.mapAlloc doesn't support: {}", .{FromStruct}),
         },
         .Optional => if (from) |f| {
             to.* = @as(@typeInfo(type_info_to_ptr.Pointer.child).Optional.child, undefined);
@@ -176,7 +174,7 @@ pub fn mapAlloc(comptime cb: anytype, allocator: std.mem.Allocator, ctx: FnParam
             to.* = null;
         },
         .Int, .Float, .Enum => to.* = from,
-        else => stdx.debug.compileError(err_msg, err_args),
+        else => stdx.debug.compileError("zml.meta.mapAlloc doesn't support: {}", .{FromStruct}),
     }
 }
 

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -482,6 +482,10 @@ pub const CompilationContext = struct {
             bias: Tensor,
 
             pub fn forward(self: @This(), x: Tensor) Tensor {
+                return zml.ops.call(self, .inner, .{x});
+            }
+
+            pub fn inner(self: @This(), x: Tensor) Tensor {
                 const y = x.add(self.bias);
                 return y.reuseBuffer(x);
             }

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -671,8 +671,11 @@ pub const CompilationContext = struct {
         }.cb, self, &args, donations);
 
         const op = dialect.func.call(self.mlirCtx(), @ptrCast(function.name), values, function.res_types, loc);
+        // Create the result tensor object by combining the operand results,
+        // as well as the registered shapes and donations.
         // Note: this assume res can be stack-allocated.
-        // Ideally we should call Zig code to
+        // Maybe it'd be simpler to just call the Zig function twice to do the shape/donation propagation for us.
+        // But this is blocked on https://github.com/zml/zml/issues/97
         var res: stdx.meta.FnResult(func) = undefined;
         const LocalContext = struct { index: usize = 0, op: mlir.Operation, function: MlirFn, donations: []Tensor._Donation };
         var context: LocalContext = .{ .op = op, .function = function, .donations = donations };

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -49,7 +49,7 @@ const Block = union(BlockKind) {
             .op_result => |parent_op| self.appendOperationRecursive(parent_op),
             .block_argument => |arg| {
                 // Hermetic blocks are not allowed to use arguments from other blocks.
-                stdx.debug.assert(self == .open or self.block().eql(arg.block()), "Can't add {}  from {?x} block to {?x} block", .{ arg, arg.block()._inner.ptr, self.block()._inner.ptr });
+                stdx.debug.assert(self == .open or self.block().eql(arg.block()), "Can't add {} from {?x} block to {?x} block", .{ arg, arg.block()._inner.ptr, self.block()._inner.ptr });
             },
             .null => @panic("InvalidMlir"),
         }

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -30,9 +30,10 @@ test {
 
 /// Generate an MLIR call to the given member function with the given tensors.
 pub fn call(self: anytype, comptime func: stdx.meta.DeclEnum(@TypeOf(self)), args: anytype) @TypeOf(@call(.auto, @field(stdx.meta.UnwrapPtr(@TypeOf(self)), @tagName(func)), .{self} ++ args)) {
-    // TODO: this should use `self.getContext().callFunc(self, args)`
-
-    return @call(.auto, @field(@TypeOf(self), @tagName(func)), .{self} ++ args);
+    const ctx = CompilationContext.current();
+    const name = @typeName(@TypeOf(self)) ++ "." ++ @tagName(func);
+    const actual_fn = @field(@TypeOf(self), @tagName(func));
+    return ctx.callFunc(name, actual_fn, .{self} ++ args);
 }
 
 pub fn while_(

--- a/zml/testing.zig
+++ b/zml/testing.zig
@@ -138,7 +138,7 @@ pub fn compileAndCall(platform: zml.Platform, func: anytype, buffer_args: zml.Bu
         }
     };
     var shape_args: zml.ShapeOf(stdx.meta.FnArgs(func)) = undefined;
-    try meta.mapAlloc(Local.bufferToShape, allocator, {}, buffer_args, &shape_args);
+    try meta.mapAlloc(Local.bufferToShape, arena.allocator(), {}, buffer_args, &shape_args);
 
     const mod = try zml.compileFn(allocator, func, shape_args, platform);
     defer mod.deinit();


### PR DESCRIPTION
Restore the machinery to emit individual functions and calls to them.

this should unblock composites, and generates cleaner MLIR in general

* functions are cached based on the input shapes including tags.
* donations/tags are propagated through function calls

