### PR TITLE
Llama 3.2 (text only models) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,17 +133,17 @@ bazel run -c opt //llama:OpenLLaMA-3B
 bazel run -c opt //llama:OpenLLaMA-3B -- --prompt="Once upon a time,"
 ```
 
-### Meta Llama 3 8B
+### Meta Llama 3.1 8B
 
 This model has restrictions, see
-[here](https://huggingface.co/meta-llama/Meta-Llama-3-8B). It **requires
+[here](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct). It **requires
 approval from Meta on Huggingface**, which can take a few hours to get granted.
 
 While waiting, you can already generate an access token to log into HuggingFace
 from `bazel`; see [here](./docs/huggingface-access-token.md).
 
 Once you've been granted access, you're ready to download a gated model like
-`Meta-Llama-3-8b`!
+`Meta-Llama-3.1-8B-Instruct`!
 
 ```
 # requires token in $HOME/.cache/huggingface/token, as created by the
@@ -153,6 +153,20 @@ bazel run -c opt //llama:Llama-3.1-8B-Instruct
 bazel run -c opt //llama:Llama-3.1-8B-Instruct -- --prompt="Once upon a time,"
 ```
 
+You can also try Llama-3.1-70B-Instruct if you have enough memory.
+
+### Meta Llama 3.2 1B
+
+Like the 8B model above, this model also requires approval. See 
+[here](https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct) for access requirements.
+
+```
+cd examples
+bazel run -c opt //llama:Llama-3.2-1B-Instruct
+bazel run -c opt //llama:Llama-3.2-1B-Instruct -- --prompt="Once upon a time,"
+```
+
+For a larger 3.2 model, you can also try Llama-3.2-3B-Instruct.
 
 ## Running Models on GPU / TPU
 

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -86,6 +86,56 @@ http_file(
     url = "https://github.com/karpathy/llama2.c/raw/c02865df300f3bd9e567ce061000dc23bf785a17/tokenizer.bin",
 )
 
+# Llama 3.2
+huggingface.model(
+    name = "Meta-Llama-3.2-1B-Instruct",
+    build_file_content = """\
+package(default_visibility = ["//visibility:public"])
+filegroup(
+    name = "model",
+    srcs = ["model.safetensors"],
+)
+
+filegroup(
+    name = "tokenizer",
+    srcs = ["tokenizer.json"],
+)
+""",
+    commit = "9213176726f574b556790deb65791e0c5aa438b6",
+    includes = [
+        "model.safetensors",
+        "tokenizer.json",
+    ],
+    model = "meta-llama/Llama-3.2-1B-Instruct",
+)
+use_repo(huggingface, "Meta-Llama-3.2-1B-Instruct")
+
+huggingface.model(
+    name = "Meta-Llama-3.2-3B-Instruct",
+    build_file_content = """\
+package(default_visibility = ["//visibility:public"])
+filegroup(
+    name = "model",
+    srcs = glob(["*.safetensors"]) + ["model.safetensors.index.json"],
+)
+
+filegroup(
+    name = "tokenizer",
+    srcs = ["tokenizer.json"],
+)
+""",
+    commit = "0cb88a4f764b7a12671c53f0838cd831a0843b95",
+    includes = [
+        "*.safetensors",
+        "model.safetensors.index.json",
+        "tokenizer.json",
+    ],
+    model = "meta-llama/Llama-3.2-3B-Instruct",
+)
+use_repo(huggingface, "Meta-Llama-3.2-3B-Instruct")
+
+
+# Llama 3.1
 huggingface.model(
     name = "Meta-Llama-3.1-8B-Instruct",
     build_file_content = """\
@@ -155,6 +205,8 @@ filegroup(
     model = "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
 )
 use_repo(huggingface, "TinyLlama-1.1B-Chat-v1.0")
+
+#OpenLLaMa
 huggingface.model(
     name = "OpenLM-Research-OpenLLaMA-3B",
     build_file_content = """\

--- a/examples/llama/BUILD.bazel
+++ b/examples/llama/BUILD.bazel
@@ -52,6 +52,39 @@ cc_binary(
 )
 
 cc_binary(
+    name = "Llama-3.2-1B-Instruct",
+    args = [
+        "--model=$(location @Meta-Llama-3.2-1B-Instruct//:model.safetensors)",
+        "--tokenizer=$(location @Meta-Llama-3.2-1B-Instruct//:tokenizer)",
+        "--num-heads=32",
+        "--num-kv-heads=8",
+        "--rope-freq-base=500000",
+    ],
+    data = [
+        "@Meta-Llama-3.2-1B-Instruct//:model.safetensors",
+        "@Meta-Llama-3.2-1B-Instruct//:tokenizer",
+    ],
+    deps = [":llama_lib"],
+)
+
+cc_binary(
+    name = "Llama-3.2-3B-Instruct",
+    args = [
+        "--model=$(location @Meta-Llama-3.2-3B-Instruct//:model.safetensors.index.json)",
+        "--tokenizer=$(location @Meta-Llama-3.2-3B-Instruct//:tokenizer)",
+        "--num-heads=24",
+        "--num-kv-heads=8",
+        "--rope-freq-base=500000",
+    ],
+    data = [
+        "@Meta-Llama-3.2-3B-Instruct//:model",
+        "@Meta-Llama-3.2-3B-Instruct//:model.safetensors.index.json",
+        "@Meta-Llama-3.2-3B-Instruct//:tokenizer",
+    ],
+    deps = [":llama_lib"],
+)
+
+cc_binary(
     name = "OpenLLaMA-3B",
     args = [
         "--model=$(location @OpenLM-Research-OpenLLaMA-3B//:model)",

--- a/examples/llama/llama.zig
+++ b/examples/llama/llama.zig
@@ -97,7 +97,7 @@ pub const LlamaLM = struct {
         var logits = if (self.lm_head) |lm_head|
             zml.call(lm_head, .forward, .{next_token_pred})
         else
-            next_token_pred.matmul(self.model.embed_tokens.weight.transpose(.{ -1, -2 })).withTags(.{.d});
+            self.model.embed_tokens.weight.withTags(.{ .voc, .d }).dot(next_token_pred, .{.d});
 
         if (logits.shape().hasTag(.voc) == null)
             logits = logits.rename(.{ .d = .voc });

--- a/examples/llama/main.zig
+++ b/examples/llama/main.zig
@@ -197,7 +197,7 @@ pub fn asyncMain() !void {
     defer tokenizer.deinit();
 
     const dims = llama.model.shape();
-    const dtype = llama.lm_head.weight.dtype();
+    const dtype = llama.model.embed_tokens.weight.dtype();
 
     // Note: we compile the model without a batching dimension.
     // To do so, we would just need to add `.b = batch_size` to `token_shape` and `kv_shape`.


### PR DESCRIPTION
llama 3.2 1B and 3B do not have lm_head. 

I've added transposing over the embed_tokens as a replacement and set lm_head as optional for backward compatibility with the other models. 

I also added both repositories+executions to bazel and updated the README. 

