### PR TITLE
ci: build the examples directory

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -42,3 +42,9 @@ jobs:
         run: |
           export PATH=$PATH:~/bin
           bazel test --remote_cache=grpc://127.0.0.1:15501 //zml:test --test_output=streamed
+
+      - name: Build examples
+        working-directory: examples/
+        run: |
+          export PATH=$PATH:~/bin
+          bazel build --config=debug --remote_cache=grpc://127.0.0.1:15501 //llama

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -48,3 +48,6 @@ jobs:
         run: |
           export PATH=$PATH:~/bin
           bazel build --config=debug --remote_cache=grpc://127.0.0.1:15501 //llama
+          bazel build --config=debug --remote_cache=grpc://127.0.0.1:15501 //mnist
+          bazel build --config=debug --remote_cache=grpc://127.0.0.1:15501 //simple_layer
+          bazel build --config=debug --remote_cache=grpc://127.0.0.1:15501 //loader:safetensors


### PR DESCRIPTION
Run `bazel build //llama` in CI to make sure we don't accidentally break it.
I'm also building all the examples target.

For reference it took 5 minutes to run this CI.