### PR TITLE
pjrt/zml: expose client creation flags

### DIFF
--- a/docs/howtos/howto_torch2zml.md
+++ b/docs/howtos/howto_torch2zml.md
@@ -249,7 +249,7 @@ pub fn asyncMain() !void {
     
     var ctx = try zml.Context.init();
     defer ctx.deinit();
-    const platform = ctx.autoPlatform();
+    const platform = ctx.autoPlatform(.{});
     const mlp_weights = try zml.aio.loadModelBuffers(Mlp, mlp_shape, model_weights, allocator, platform);
 
     zml.testing.testLayer(platform, activations, "model.layers.0.mlp", mlp_shape, mlp_weights, 1e-3);

--- a/docs/tutorials/write_first_model.md
+++ b/docs/tutorials/write_first_model.md
@@ -184,7 +184,7 @@ pub fn asyncMain() !void {
     var context = try zml.Context.init();
     defer context.deinit();
 
-    const platform = context.autoPlatform();
+    const platform = context.autoPlatform(.{});
     ...
 }
 ```
@@ -458,7 +458,7 @@ pub fn asyncMain() !void {
     var context = try zml.Context.init();
     defer context.deinit();
 
-    const platform = context.autoPlatform();
+    const platform = context.autoPlatform(.{});
 
     // Our weights and bias to use
     var weights = [3]f16{ 2.0, 2.0, 2.0 };

--- a/examples/benchmark/main.zig
+++ b/examples/benchmark/main.zig
@@ -34,7 +34,7 @@ pub fn asyncMain() !void {
     defer context.deinit();
 
     // Auto-select platform
-    const platform = context.autoPlatform().withCompilationOptions(.{
+    const platform = context.autoPlatform(.{}).withCompilationOptions(.{
         .sharding_enabled = true,
     });
     context.printAvailablePlatforms(platform);

--- a/examples/llama/main.zig
+++ b/examples/llama/main.zig
@@ -157,7 +157,7 @@ pub fn asyncMain() !void {
         .sharding_enabled = true,
     };
 
-    const platform = context.autoPlatform().withCompilationOptions(compilation_options);
+    const platform = context.autoPlatform(.{}).withCompilationOptions(compilation_options);
     context.printAvailablePlatforms(platform);
 
     var args = std.process.args();

--- a/examples/llama/main.zig
+++ b/examples/llama/main.zig
@@ -140,7 +140,7 @@ pub fn asyncMain() !void {
         prompt: ?[]const u8 = null,
         test_activations: ?[]const u8 = null,
         seed: ?u128 = null,
-        // eg: --create-options='{"cuda":{"allocator":{"bfc": {"memory_fraction": 0.99}}}}'
+        // eg: --create-options='{"cuda":{"allocator":{"bfc":{"memory_fraction": 0.99}}}}'
         create_options: []const u8 = "{}",
     };
 

--- a/examples/llama/test.zig
+++ b/examples/llama/test.zig
@@ -33,7 +33,7 @@ pub fn asyncMain() !void {
     defer context.deinit();
 
     // Select platform
-    const platform = context.autoPlatform();
+    const platform = context.autoPlatform(.{});
 
     // Parse program args
     var args = std.process.args();

--- a/examples/loader/main.zig
+++ b/examples/loader/main.zig
@@ -34,7 +34,7 @@ pub fn asyncMain() !void {
     var context = try zml.Context.init();
     defer context.deinit();
 
-    const platform = context.autoPlatform();
+    const platform = context.autoPlatform(.{});
     context.printAvailablePlatforms(platform);
 
     var buffers = try gpa.allocator().alloc(zml.Buffer, buffer_store.buffers.count());

--- a/examples/mnist/mnist.zig
+++ b/examples/mnist/mnist.zig
@@ -51,7 +51,7 @@ pub fn asyncMain() !void {
     // log.info("\n===========================\n==   ZML MNIST Example   ==\n===========================\n\n", .{});
 
     // // Auto-select platform
-    const platform = context.autoPlatform();
+    const platform = context.autoPlatform(.{});
     context.printAvailablePlatforms(platform);
 
     // Parse program args

--- a/examples/simple_layer/main.zig
+++ b/examples/simple_layer/main.zig
@@ -34,7 +34,7 @@ pub fn asyncMain() !void {
     var context = try zml.Context.init();
     defer context.deinit();
 
-    const platform = context.autoPlatform();
+    const platform = context.autoPlatform(.{});
     context.printAvailablePlatforms(platform);
 
     // Our weights and bias to use

--- a/pjrt/pjrt.zig
+++ b/pjrt/pjrt.zig
@@ -823,7 +823,7 @@ pub const NamedValue = extern struct {
             []i64, []const i64 => fromInt64List(name_, value),
             f32 => fromFloat(name_, value),
             bool => fromBool(name_, value),
-            else => unreachable,
+            else => fromString(name_, @tagName(value)),
         };
     }
 

--- a/zml/context.zig
+++ b/zml/context.zig
@@ -81,35 +81,16 @@ pub const Context = struct {
         Context.apis_once.call();
         Context.mlir_once.call();
 
-        var platforms = PlatformsMap.initFill(null);
         var num_platforms: u8 = 0;
-        var it = Context.apis.iterator();
-        while (it.next()) |entry| {
-            if (entry.value.*) |api| {
-                const target = entry.key;
-                const p = Platform.init(target, api, .{}) catch |err| {
-                    log.err("Failed to load platform .{s}: {}", .{ @tagName(target), err });
-                    continue;
-                };
-                if (p.getDevices().len == 0) {
-                    log.err("No device found for platform {} !", .{target});
-                    continue;
-                }
-                if (target == .cuda) {
-                    try cuda.registerZmlCustomCalls(p);
-                }
-                platforms.set(target, p);
-                num_platforms += 1;
-            }
+        for (Context.apis.values) |api| {
+            if (api != null) num_platforms += 1;
         }
         if (num_platforms == 0) {
             log.err("No platform available", .{});
             return error.NoPlatformAvailable;
         }
 
-        return .{
-            .platforms = platforms,
-        };
+        return .{ .platforms = PlatformsMap.initFill(null) };
     }
 
     fn platformToLibrary(comptime target: Target) []const u8 {
@@ -137,20 +118,71 @@ pub const Context = struct {
         self.* = undefined;
     }
 
+    const prefered_targets = [_]Target{ .tpu, .neuron, .cuda, .rocm, .cpu };
+
     /// Automatically selects the best Platform loaded in the current Context.
     ///
     /// For example, if supported, this will select a platform corresponding to an accelerator (GPU, TPU, ...).
-    pub fn autoPlatform(self: *Context) Platform {
-        // the last platform is the one that with the high enum number, so considered
-        // to be the "best" one
-        var platform_: ?Platform = null;
-        var iterator = self.platforms.iterator();
-        while (iterator.next()) |entry| {
-            if (entry.value.*) |p| {
-                platform_ = p;
-            }
+    pub fn autoPlatform(self: *Context, opts: Platform.CreateOptions) Platform {
+        stdx.debug.assert(prefered_targets.len == apis.values.len, "New target need to be inserted inside `zml.Context.preferred_targets`", .{});
+
+        return self.platformByPreferences(opts, &prefered_targets);
+    }
+
+    /// Given a list of preferred targets to select the best Platform
+    ///
+    /// For example, if supported, this will select a platform corresponding to an accelerator (GPU, TPU, ...).
+    pub fn platformByPreferences(self: *Context, opts: Platform.CreateOptions, prefered: []const Target) Platform {
+        // Try prefered targets.
+        for (prefered) |target| {
+            return self.platform(target, opts) catch |err| {
+                log.err("Failed to load platform .{s}: {}", .{ @tagName(target), err });
+                continue;
+            };
         }
-        return platform_ orelse @panic("No platform found !");
+
+        // Try unlisted targets
+        var it = Context.apis.iterator();
+        while (it.next()) |entry| {
+            const target = entry.key;
+            // CPU should only be use as fallback.
+            if (target == .cpu) continue;
+            if (entry.value.* == null) continue;
+            if (std.mem.indexOfScalar(Target, prefered, target) != null) continue;
+            return self.platform(target, opts) catch |err| {
+                switch (err) {
+                    error.PlatformNotCompiled => {},
+                    else => log.err("Failed to load platform .{s}: {}", .{ @tagName(target), err }),
+                }
+                continue;
+            };
+        }
+
+        // Finally fallback to cpu.
+        return self.platform(.cpu, opts) catch {
+            log.err("No platform available", .{});
+            @panic("No platform available !");
+        };
+    }
+
+    pub fn platform(self: *Context, target: Target, opts: Platform.CreateOptions) !Platform {
+        if (self.platforms.get(target)) |p| {
+            return p;
+        }
+        const api = Context.apis.get(target);
+        if (api == null) return error.PlatformNotCompiled;
+        const p = try Platform.init(target, api.?, opts);
+        if (p.getDevices().len == 0) {
+            log.err("No device found for platform {} !", .{target});
+            return error.NoDevicesFound;
+        }
+        // TODO: should this be moved to platform.zig ?
+        if (target == .cuda) {
+            try cuda.registerZmlCustomCalls(p);
+        }
+
+        self.platforms.set(target, p);
+        return p;
     }
 
     pub fn printAvailablePlatforms(self: Context, selected: Platform) void {

--- a/zml/context.zig
+++ b/zml/context.zig
@@ -87,7 +87,7 @@ pub const Context = struct {
         while (it.next()) |entry| {
             if (entry.value.*) |api| {
                 const target = entry.key;
-                const p = Platform.init(target, api) catch |err| {
+                const p = Platform.init(target, api, .{}) catch |err| {
                     log.err("Failed to load platform .{s}: {}", .{ @tagName(target), err });
                     continue;
                 };

--- a/zml/context.zig
+++ b/zml/context.zig
@@ -135,6 +135,7 @@ pub const Context = struct {
     pub fn platformByPreferences(self: *Context, opts: Platform.CreateOptions, prefered: []const Target) Platform {
         // Try prefered targets.
         for (prefered) |target| {
+            if (apis.get(target) == null) continue;
             return self.platform(target, opts) catch |err| {
                 log.err("Failed to load platform .{s}: {}", .{ @tagName(target), err });
                 continue;
@@ -150,10 +151,7 @@ pub const Context = struct {
             if (entry.value.* == null) continue;
             if (std.mem.indexOfScalar(Target, prefered, target) != null) continue;
             return self.platform(target, opts) catch |err| {
-                switch (err) {
-                    error.PlatformNotCompiled => {},
-                    else => log.err("Failed to load platform .{s}: {}", .{ @tagName(target), err }),
-                }
+                log.err("Failed to load platform .{s}: {}", .{ @tagName(target), err });
                 continue;
             };
         }

--- a/zml/pjrtx.zig
+++ b/zml/pjrtx.zig
@@ -42,39 +42,7 @@ fn InnerMixin(comptime innerT: type) type {
 pub const Client = opaque {
     const inner = InnerMixin(pjrt.Client).inner;
 
-    pub const Allocator = enum {
-        default, // the client chose the best option
-        bfc, // "Best-Fit with Coalescing" algorithm
-        cuda_async, // use cudaMallocAsync
-        platform, // the platform default eg cuMalloc
-    };
-
-    pub const CreateOptions = struct {
-        allocator: Allocator = .default,
-        // preallocate and memory fraction are only used by the bfc allocator
-        preallocate: bool = true,
-        memory_fraction: ?f32 = null,
-        collective_memory_size_mb: ?u16 = null,
-        // TODO support all of https://github.com/openxla/xla/blob/3d31c48c719d331d432132b3e0c2c5ce52650675/xla/pjrt/c/pjrt_c_api_gpu_internal.cc#L76-L86
-    };
-
-    pub fn init(api: *const Api, options: CreateOptions) ClientInitError!*Client {
-        var values: std.BoundedArray(NamedValue, 4) = .{};
-
-        values.appendAssumeCapacity(NamedValue.from("allocator", options.allocator));
-        values.appendAssumeCapacity(NamedValue.from("preallocate", options.preallocate));
-        if (options.memory_fraction) |memory_fraction| {
-            values.appendAssumeCapacity(NamedValue.from("memory_fraction", memory_fraction));
-        }
-        if (options.collective_memory_size_mb) |collective_memory_size_mb| {
-            const collective = @as(i64, collective_memory_size_mb) * 1024 * 1024;
-            values.appendAssumeCapacity(NamedValue.from("collective_memory_size", collective));
-        }
-
-        return initWithOpts(api, values.constSlice());
-    }
-
-    pub fn initWithOpts(api: *const Api, options: []const NamedValue) ClientInitError!*Client {
+    pub fn init(api: *const Api, options: []const NamedValue) ClientInitError!*Client {
         return @ptrCast(try pjrt.Client.init(api, options));
     }
 

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -30,8 +30,8 @@ pub const Platform = struct {
 
     pub const MAX_NUM_DEVICES: u8 = 32;
 
-    pub fn init(target: Target, api: *const pjrt.Api) !Platform {
-        const pjrt_client = try pjrt.Client.init(api, &.{});
+    pub fn init(target: Target, api: *const pjrt.Api, options: pjrt.Client.CreateOptions) !Platform {
+        const pjrt_client = try pjrt.Client.init(api, options);
         const true_num_devices = pjrt_client.getAddressableDevices(api).len;
         if (true_num_devices > MAX_NUM_DEVICES) {
             log.warn("platform {} got {} devices, but ZML only support up to {} devices. Some devices won't be used.", .{ target, true_num_devices, MAX_NUM_DEVICES });

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -29,10 +29,11 @@ pub const Platform = struct {
     compilation_options: CompilationOptions = .{},
 
     pub const MAX_NUM_DEVICES: u8 = 32;
-    pub const CreateOptions = pjrt.Client.CreateOptions;
+    pub const CreateOptions = _CreateOptions;
 
     pub fn init(target: Target, api: *const pjrt.Api, options: CreateOptions) !Platform {
-        const pjrt_client = try pjrt.Client.init(api, options);
+        var named_values_buf: [16]pjrt.NamedValue = undefined;
+        const pjrt_client = try pjrt.Client.init(api, options.toNamedValues(target, &named_values_buf));
         const true_num_devices = pjrt_client.getAddressableDevices(api).len;
         if (true_num_devices > MAX_NUM_DEVICES) {
             log.warn("platform {} got {} devices, but ZML only support up to {} devices. Some devices won't be used.", .{ target, true_num_devices, MAX_NUM_DEVICES });
@@ -85,3 +86,59 @@ pub const Platform = struct {
         return self.pjrt_client.getProfiler(self.pjrt_api, options);
     }
 };
+
+const _CreateOptions = struct {
+    cpu: void = {},
+    cuda: ?Cuda = null,
+    rocm: void = {},
+    tpu: void = {},
+    neuron: void = {},
+
+    pub const Cuda = struct {
+        allocator: Allocator = .default,
+        // preallocate and memory fraction are only used by the bfc allocator
+        preallocate: bool = true,
+        memory_fraction: ?f32 = null,
+        collective_memory_size_mb: ?u16 = null,
+        // TODO support all of https://github.com/openxla/xla/blob/3d31c48c719d331d432132b3e0c2c5ce52650675/xla/pjrt/c/pjrt_c_api_gpu_internal.cc#L76-L86
+
+        pub const Allocator = enum {
+            default, // the client chose the best option
+            bfc, // "Best-Fit with Coalescing" algorithm
+            cuda_async, // use cudaMallocAsync
+            platform, // the platform default eg cuMalloc
+        };
+
+        pub fn writeNamedValues(self: Cuda, values: *std.ArrayListUnmanaged(pjrt.NamedValue)) void {
+            values.appendAssumeCapacity(pjrt.NamedValue.from("allocator", self.allocator));
+            values.appendAssumeCapacity(pjrt.NamedValue.from("preallocate", self.preallocate));
+            if (self.memory_fraction) |memory_fraction| {
+                values.appendAssumeCapacity(pjrt.NamedValue.from("memory_fraction", memory_fraction));
+            }
+            if (self.collective_memory_size_mb) |collective_memory_size_mb| {
+                const collective = @as(i64, collective_memory_size_mb) * 1024 * 1024;
+                values.appendAssumeCapacity(pjrt.NamedValue.from("collective_memory_size", collective));
+            }
+        }
+    };
+
+    pub fn toNamedValues(self: _CreateOptions, target: Target, out: []pjrt.NamedValue) []pjrt.NamedValue {
+        var values = std.ArrayListUnmanaged(pjrt.NamedValue).fromOwnedSlice(out);
+        values.shrinkRetainingCapacity(0);
+        switch (target) {
+            inline else => |t| {
+                const options = @field(self, @tagName(t));
+                if (@TypeOf(options) == void) return &.{};
+
+                if (options) |opt| opt.writeNamedValues(&values);
+            },
+        }
+        return values.items;
+    }
+};
+
+comptime {
+    for (std.meta.fields(Target)) |target_field| {
+        stdx.debug.assertComptime(@hasField(_CreateOptions, target_field.name), "CreateOptions doesn't list target {s}", target_field.name);
+    }
+}

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -141,9 +141,6 @@ const _CreateOptions = struct {
                     }
                 },
             }
-            if (self.visible_devices.len > 0) {
-                values.appendAssumeCapacity(pjrt.NamedValue.from("visible_devices", self.visible_devices));
-            }
         }
     };
 

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -118,7 +118,7 @@ const _CreateOptions = struct {
             /// use cudaMallocAsync
             @"async": Options,
             /// use raw cuMalloc
-            platform: NoOpt,
+            platform,
 
             pub const Options = struct {
                 preallocate: bool = true,

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -29,8 +29,9 @@ pub const Platform = struct {
     compilation_options: CompilationOptions = .{},
 
     pub const MAX_NUM_DEVICES: u8 = 32;
+    pub const CreateOptions = pjrt.Client.CreateOptions;
 
-    pub fn init(target: Target, api: *const pjrt.Api, options: pjrt.Client.CreateOptions) !Platform {
+    pub fn init(target: Target, api: *const pjrt.Api, options: CreateOptions) !Platform {
         const pjrt_client = try pjrt.Client.init(api, options);
         const true_num_devices = pjrt_client.getAddressableDevices(api).len;
         if (true_num_devices > MAX_NUM_DEVICES) {

--- a/zml/testing.zig
+++ b/zml/testing.zig
@@ -8,11 +8,11 @@ const shapesOf = @import("tensor.zig").shapesOf;
 
 const log = std.log.scoped(.@"zml/testing");
 
-var _ctx: ?zml.Context = null;
+var _platform: ?zml.Platform = null;
 
 pub fn env() zml.Platform {
     if (!builtin.is_test) @compileError("Cannot use zml.testing.env outside of a test block");
-    if (_ctx == null) {
+    if (_platform == null) {
         _test_compile_opts = if (initCacheDir())
             .{
                 .cache_location = "/tmp/zml/tests/cache",
@@ -22,10 +22,11 @@ pub fn env() zml.Platform {
         else
             .{};
 
-        _ctx = zml.Context.init() catch unreachable;
+        var ctx = zml.Context.init() catch unreachable;
+        _platform = ctx.autoPlatform(.{}).withCompilationOptions(_test_compile_opts);
     }
 
-    return _ctx.?.autoPlatform().withCompilationOptions(_test_compile_opts);
+    return _platform.?;
 }
 
 var _test_compile_opts: zml.CompilationOptions = .{};


### PR DESCRIPTION
The Pjrt api allows to passe string flags to the plugin on client creation.
Since we don't like working with strings I've converted the strings supported by the cuda plugin into a struct.
For now I've focused on the strings corresponding to the allocator settings following #125 let me know if you think 
that we should expose more from:

https://github.com/openxla/xla/blob/3d31c48c719d331d432132b3e0c2c5ce52650675/xla/pjrt/c/pjrt_c_api_gpu_internal.cc#L76-L86

AFAICT the cpu plugin doesn't read flags at all.

Will need some investigation for TPU and neuron platforms

**Breaking change**: `context.autoPlatform()` -> `context.autoPlatform(.{})` 