### PR TITLE
zml: add an arena to the CompilationContext

### DIFF
--- a/stdx/meta.zig
+++ b/stdx/meta.zig
@@ -150,11 +150,17 @@ pub fn FnParam(comptime func: anytype, comptime n: comptime_int) type {
 }
 
 pub fn FnArgs(comptime func: anytype) type {
+    debug.assertComptime(!@typeInfo(@TypeOf(func)).Fn.is_generic, "FnArgs expects non generic function, got: {}", .{@TypeOf(func)});
     return FnSignature(func, null).ArgsT;
 }
 
+pub fn FnArgsWithHint(comptime func: anytype, ArgsT: type) type {
+    debug.assertComptime(@typeInfo(@TypeOf(func)).Fn.is_generic, "FnArgsWithHint expects a generic function, got: {}", .{@TypeOf(func)});
+    return FnSignature(func, ArgsT).ArgsT;
+}
+
 pub fn FnResult(comptime func: anytype) type {
-    return FnSignature(func, null).ReturnT;
+    return @typeInfo(@TypeOf(func)).Fn.return_type orelse @compileError("anytype is not supported");
 }
 
 pub fn Head(Tuple: type) type {

--- a/stdx/signature.zig
+++ b/stdx/signature.zig
@@ -12,7 +12,7 @@ pub fn ArgsTuple(comptime funcT: anytype, comptime ArgsT: ?type) type {
         return std.meta.ArgsTuple(funcT);
     }
 
-    const args = std.meta.fields(ArgsT orelse compileError("generic function requires an explicit ArgsTuple", .{}));
+    const args = std.meta.fields(ArgsT orelse @compileError("generic function requires an explicit ArgsTuple"));
     var tuple_fields: [params.len]std.builtin.Type.StructField = undefined;
     if (params.len != args.len) {
         compileError("function {} expected {} args, got {}", .{ funcT, params.len, args.len });
@@ -23,7 +23,7 @@ pub fn ArgsTuple(comptime funcT: anytype, comptime ArgsT: ?type) type {
             continue;
         }
         const T = param.type.?;
-        var num_buf: [32]u8 = undefined;
+        var num_buf: [8]u8 = undefined;
         tuple_fields[i] = .{
             .name = blk: {
                 const s = std.fmt.formatIntBuf(&num_buf, i, 10, .lower, .{});

--- a/zml/aio.zig
+++ b/zml/aio.zig
@@ -88,7 +88,7 @@ pub fn populateModelWithPrefix(comptime Model: type, allocator: std.mem.Allocato
     try prefix_builder.push(allocator, prefix);
     defer prefix_builder.deinit(allocator);
 
-    const unique_id = zml.Tensor.reserveIdRange(@intCast(store.buffers.count()));
+    const unique_id = zml.Tensor._reserveIdRange(@intCast(store.buffers.count()));
     const ok = _populateStruct(allocator, &prefix_builder, unique_id, store, &model, true) catch |err| {
         std.debug.panic("Can't populate model of type {s}: {s}", .{ @typeName(type), @errorName(err) });
     };

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -145,7 +145,7 @@ pub const CompilationContext = struct {
     }
 
     pub fn deinit(self: *CompilationContext) void {
-        // self._fn_cache.deinit(self.allocator());
+        // No need to deinit self._fn_cache cause it uses our arena
         self._mlir_ctx.deinit();
         self._mlir_registry.deinit();
         self._arena.deinit();

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -631,7 +631,6 @@ pub const CompilationContext = struct {
         const args_hash = hashArgs(args);
         const key: FnCache.Key = .{ .fn_ptr = &func, .input_hash = args_hash };
 
-        log.warn("before compiling {s}: %arg0 ->  {?} (in {})", .{ func_name, self._buffer_to_arg.get(.{ .arg_id = 0 }), self._buffer_to_arg });
         const function = self._fn_cache.getEntry(key) orelse b: {
             const full_name: [:0]const u8 = if (std.mem.eql(u8, "main", func_name))
                 arena.dupeZ(u8, func_name) catch unreachable
@@ -666,8 +665,6 @@ pub const CompilationContext = struct {
         };
 
         const loc = self.mlirCtx().location(@src());
-
-        log.warn("after compiling {s}: %arg0 ->  {?} (in {})", .{ func_name, self._buffer_to_arg.get(.{ .arg_id = 0 }), self._buffer_to_arg });
 
         const values = arena.alloc(mlir.Value, function.num_args) catch unreachable;
         self.extractValues(&args, values);

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -816,8 +816,8 @@ const SdpaMemEfficient = struct {
         const n_q_chunks: u32 = @intCast(@divExact(self.q.dim(.q), self.chunking.q_chunk_size));
 
         const ctx = zml.module.CompilationContext.current();
-        const q_chunks = ctx._allocator.alloc(zml.Tensor, n_q_chunks) catch unreachable;
-        defer ctx._allocator.free(q_chunks);
+        const q_chunks = ctx.allocator().alloc(zml.Tensor, n_q_chunks) catch unreachable;
+        defer ctx.allocator().free(q_chunks);
         for (0..n_q_chunks) |i| {
             const idx: u32 = @intCast(i);
             const q_slice: zml.Tensor.DynSlice = .{

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -316,7 +316,7 @@ pub fn for_(comptime func: anytype, blk_ctx: BlockSign(func).BlkCtx, num_steps_:
     // but because of https://github.com/zml/zml/issues/97 we also reuse it to start the while_ loop.
     const first_step = @call(.auto, func, .{ blk_ctx, Tensor.scalar(0, .i32) });
     log.debug("for_ first_step: {}", .{first_step});
-    const allocator = CompilationContext.current()._allocator;
+    const allocator = CompilationContext.current().allocator();
     // Optimize for small num reps
     if (num_steps == 1) {
         var res = first_step;

--- a/zml/testing.zig
+++ b/zml/testing.zig
@@ -126,6 +126,9 @@ pub fn expectEqualShapes(expected: zml.Shape, actual: zml.Shape) error{TestExpec
 /// Compile a function and immediatly call it with the given buffers.
 /// The compiled module is discarded after the call.
 /// Useful during testing when a module is typically called only once.
+///
+/// Note: `func` needs explicit types on all parameters.
+/// To test a function with `anytype` (typically for tagged API), you need to create a specialized version of it with specific types.
 pub fn compileAndCall(platform: zml.Platform, func: anytype, buffer_args: zml.Bufferized(stdx.meta.FnArgs(func))) !zml.Bufferized(stdx.meta.FnResult(func)) {
     // This simplify test API and also ensure this fn isn't used outside of tests.
     const allocator = std.testing.allocator;


### PR DESCRIPTION
* add an arena to the CompilationContext

There was already an allocator in the CompilationContext, this PR makes it into an arena and expose the arena allocator.
This allows ops that need to allocate to do so without abusing `std.BoundedArray` with arbitrary bounds, and in a safe way.
For now little ops use it, which I believe should stay the case, because most of the time you want to know how many tensor you're working with.
It'll also simplify the life of Zig new-comers

this include some **breaking changes** to `chunkAllowTrailing` and `split` that are allocating

* upgrade a few `axis_: i64` into `axis_: anytype` to handle tags

* add a few TODO for the next version of the Tensor API