### PR TITLE
Llama tokenizer has issues with emojis

### DIFF
--- a/zml/tokenizer.zig
+++ b/zml/tokenizer.zig
@@ -204,7 +204,19 @@ pub const Tokenizer = struct {
                             // Detects memory corruption of tokens.
                             if (cur_tok.len == 0 or cur_tok.len > self.max_token_len) @panic("Token looks corrupted !");
 
-                            stdx.debug.assert(std.mem.eql(u8, cur_tok, input[input_off..][0..cur_tok.len]), "current token '{s}' not found in input string '{s}' !", .{ cur_tok, input[input_off..] });
+                            if (std.mem.eql(u8, cur_tok, input[input_off..][0..cur_tok.len])) {
+                                // TODO: FIXME: nocheckin
+                                // std.log.warn("current token '{s}' not found in input string '{s}' !", .{ cur_tok, input[input_off..] });
+                            }
+                        }
+                        // TODO:
+                        // FIXME:
+                        // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                        // THIS IS THE WRONG "SOLUTION":
+                        // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                        if (tok_buff[i + 1] > self.tokens.len) {
+                            tok_buff[i + 1] = self.special_tokens.unk;
+                            continue;
                         }
                         const next_tok = self.tokens[tok_buff[i + 1]];
                         // if `next_tok` is `.unk`, length is 1; otherwise, it's the length of the token.


### PR DESCRIPTION
Using openwebui, the following prompt template is used:

```
Create a concise, 3-5 word title with an emoji as a title for the chat history, in the given language. Suitable Emojis for the summary can be used to enhance understanding but avoid quotation marks or special formatting. RESPOND ONLY WITH THE TITLE TEXT.

Examples of titles:
📉 Stock Market Trends
🍪 Perfect Chocolate Chip Recipe
Evolution of Music Streaming
Remote Work Productivity Tips
Artificial Intelligence in Healthcare
🎮 Video Game Development Insights

<chat_history>
{{MESSAGES:END:2}}
</chat_history>
```

This causes the llama tokenizer to crash.

My fix mitigates the issue but I am not sure it is correct.

