### PR TITLE
zml: Reorganize the compilation output folders

### DIFF
--- a/examples/llama/main.zig
+++ b/examples/llama/main.zig
@@ -154,7 +154,6 @@ pub fn asyncMain() !void {
     defer context.deinit();
 
     const compilation_options = zml.CompilationOptions{
-        .cache_location = "/tmp/zml/llama/cache",
         .xla_dump_to = "/tmp/zml/llama",
         .sharding_enabled = true,
     };

--- a/pjrt/BUILD.bazel
+++ b/pjrt/BUILD.bazel
@@ -10,11 +10,13 @@ cc_library(
 
 zig_library(
     name = "pjrt",
-    srcs = ["profiler.zig"],
+    srcs = ["profiler.zig"] + glob(["convert/*.zig"]),
     main = "pjrt.zig",
     visibility = ["//visibility:public"],
     deps = [
         ":profiler_options_proto",
+        ":trace_events_proto",
+        ":xplane_proto",
         "//stdx",
         "@xla//xla/pjrt/c:pjrt_c_api_gpu_extension_hdrs",
         "@xla//xla/pjrt/c:pjrt_c_api_hdrs",

--- a/pjrt/convert/trace_container.zig
+++ b/pjrt/convert/trace_container.zig
@@ -76,7 +76,7 @@ pub const TraceContainer = struct {
         };
     }
 
-    fn xstatValueToString(stat: *const xplane_proto.XStat, plane: *const xplane_visitor.XPlaneVisitor, writer: std.io.AnyWriter) !void {
+    fn xstatValueToString(stat: *const xplane_proto.XStat, plane: *const xplane_visitor.XPlaneVisitor, writer: anytype) !void {
         if (stat.value) |val| {
             switch (val) {
                 inline .int64_value, .uint64_value, .double_value => |v| try writer.print("{d}", .{v}),
@@ -231,7 +231,7 @@ pub const TraceContainer = struct {
         self.events.shrinkRetainingCapacity(max_count);
     }
 
-    pub fn toJson(self: *TraceContainer, writer: std.io.AnyWriter) !void {
+    pub fn toJson(self: *TraceContainer, writer: anytype) !void {
         try writer.writeAll(
             \\{"displayTimeUnit":"ns","metadata":{"highres-ticks":true},"traceEvents":[
         );

--- a/pjrt/pjrt.zig
+++ b/pjrt/pjrt.zig
@@ -359,7 +359,7 @@ pub const Client = opaque {
             }
         }
         log.warn("No profiler found for platform: {}", .{self});
-        return Profiler.init(null, options);
+        return Profiler.init(null, null);
     }
 
     pub fn deserializeAndLoad(self: *const Client, api: *const Api, bytes: []const u8) ApiError!*LoadedExecutable {

--- a/pjrt/profiler.zig
+++ b/pjrt/profiler.zig
@@ -29,16 +29,12 @@ pub const Profiler = struct {
         .repository_path = .Empty,
     };
 
-    pub fn init(api: ?c.PLUGIN_Profiler_Api) Profiler {
-        return initWithOpts(api, default_options);
-    }
-
-    pub fn initWithOpts(api: ?c.PLUGIN_Profiler_Api, options: Options) Profiler {
+    pub fn init(api: ?c.PLUGIN_Profiler_Api, options: ?Options) Profiler {
         if (api == null) {
             return .{ .api = null, .inner = undefined };
         }
-        var options_with_timestamp = options;
-        options_with_timestamp.start_timestamp_ns = @trunc(std.time.nanoTimestamp());
+        var options_with_timestamp = options orelse default_options;
+        options_with_timestamp.start_timestamp_ns = @truncate(@max(0, std.time.nanoTimestamp()));
 
         var buffer: [std.fs.max_path_bytes + @sizeOf(Options) * 4]u8 = undefined;
         var fba = std.heap.FixedBufferAllocator.init(&buffer);

--- a/runtimes/neuron/neuron.zig
+++ b/runtimes/neuron/neuron.zig
@@ -103,6 +103,8 @@ fn comptimeStrJoin(comptime separator: [:0]const u8, comptime slices: []const [:
 }
 
 pub fn setNeuronCCFlags() void {
+    // See neuronxcc reference:
+    // https://awsdocs-neuron.readthedocs-hosted.com/en/latest/compiler/neuronx-cc/api-reference-guide/neuron-compiler-cli-reference-guide.html#neuron-compiler-cli-reference-guide
     _ = c.setenv("NEURON_CC_FLAGS", comptimeStrJoin(" ", &.{
         // 30% faster, no visible speed difference on llama
         "--optlevel=1",

--- a/stdx/meta.zig
+++ b/stdx/meta.zig
@@ -184,3 +184,25 @@ pub fn Tail(Tuple: type) type {
         else => @compileError("Tail works on tuple type"),
     };
 }
+
+pub fn Head(Tuple: type) type {
+    return switch (@typeInfo(Tuple)) {
+        .Struct => |struct_info| {
+            if (struct_info.fields.len == 0) @compileError("Can't tail empty tuple");
+            return struct_info.fields[0].type;
+        },
+        else => @compileError("Head works on tuple type"),
+    };
+}
+
+pub fn Tail(Tuple: type) type {
+    return switch (@typeInfo(Tuple)) {
+        .Struct => |struct_info| {
+            if (struct_info.fields.len == 0) @compileError("Can't tail empty tuple");
+            var types: [struct_info.fields.len - 1]type = undefined;
+            for (struct_info.fields[1..], 0..) |field, i| types[i] = field.type;
+            return std.meta.Tuple(&types);
+        },
+        else => @compileError("Tail works on tuple type"),
+    };
+}

--- a/stdx/meta.zig
+++ b/stdx/meta.zig
@@ -184,25 +184,3 @@ pub fn Tail(Tuple: type) type {
         else => @compileError("Tail works on tuple type"),
     };
 }
-
-pub fn Head(Tuple: type) type {
-    return switch (@typeInfo(Tuple)) {
-        .Struct => |struct_info| {
-            if (struct_info.fields.len == 0) @compileError("Can't tail empty tuple");
-            return struct_info.fields[0].type;
-        },
-        else => @compileError("Head works on tuple type"),
-    };
-}
-
-pub fn Tail(Tuple: type) type {
-    return switch (@typeInfo(Tuple)) {
-        .Struct => |struct_info| {
-            if (struct_info.fields.len == 0) @compileError("Can't tail empty tuple");
-            var types: [struct_info.fields.len - 1]type = undefined;
-            for (struct_info.fields[1..], 0..) |field, i| types[i] = field.type;
-            return std.meta.Tuple(&types);
-        },
-        else => @compileError("Tail works on tuple type"),
-    };
-}

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -207,7 +207,8 @@ pub const CompilationContext = struct {
         var pjrt_location: ?[:0]const u8 = null;
 
         if (self._platform.compilation_options.xla_dump_to) |xla_dump_to| {
-            const module_dir_name = try std.fmt.allocPrint(arena, "{s}{s}{s}_{x}.{s}", .{ xla_dump_to, std.fs.path.sep_str, self._name, module_hash, @tagName(self._platform.target) });
+            const sep = std.fs.path.sep_str;
+            const module_dir_name = try std.fmt.allocPrint(arena, "{s}{s}{s}{s}{s}_{x}", .{ xla_dump_to, sep, @tagName(self._platform.target), sep, self._name, module_hash });
             try std.fs.cwd().makePath(module_dir_name);
             module_dir = try std.fs.cwd().realpathAlloc(arena, module_dir_name);
             const cache_dir = try std.fs.cwd().openDir(module_dir.?, .{});

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -17,7 +17,6 @@ pub const available_targets = std.enums.values(Target);
 pub const CompilationOptions = struct {
     xla_dump_to: ?[]const u8 = null,
     xla_dump_fusion_visualization: bool = false,
-    cache_location: ?[]const u8 = null,
     sharding_enabled: bool = false,
     sharding_axes: std.BoundedArray([*:0]const u8, 8) = .{},
 };

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -81,8 +81,8 @@ pub const Platform = struct {
     /// Returns the Profiler for this API.
     /// Not all platform have a profiling api, for those the profiler object will do nothing.
     /// Platforms with known profiler extensions: cuda, xpu
-    pub fn getProfiler(self: Platform, options: pjrt.Profiler.Options) pjrt.Profiler {
-        return self.pjrt_client.getProfiler(self.pjrt_api, options);
+    pub fn getProfiler(self: Platform, options: ?pjrt.Profiler.Options) pjrt.Profiler {
+        return self.pjrt_client.getProfiler(self.pjrt_api, options orelse pjrt.Profiler.default_options);
     }
 };
 

--- a/zml/testing.zig
+++ b/zml/testing.zig
@@ -13,14 +13,10 @@ var _platform: ?zml.Platform = null;
 pub fn env() zml.Platform {
     if (!builtin.is_test) @compileError("Cannot use zml.testing.env outside of a test block");
     if (_platform == null) {
-        _test_compile_opts = if (initCacheDir())
-            .{
-                .cache_location = "/tmp/zml/tests/cache",
-                .xla_dump_to = "/tmp/zml/tests/",
-                .sharding_enabled = true,
-            }
-        else
-            .{};
+        _test_compile_opts = .{
+            .xla_dump_to = "/tmp/zml/tests/",
+            .sharding_enabled = true,
+        };
 
         var ctx = zml.Context.init() catch unreachable;
         _platform = ctx.autoPlatform(.{}).withCompilationOptions(_test_compile_opts);
@@ -30,12 +26,6 @@ pub fn env() zml.Platform {
 }
 
 var _test_compile_opts: zml.CompilationOptions = .{};
-
-fn initCacheDir() bool {
-    const tmp = std.fs.openDirAbsolute("/tmp", .{}) catch return false;
-    tmp.makePath("zml/tests/cache") catch return false;
-    return true;
-}
 
 /// In neural network we generally care about the relative precision,
 /// but on a given dimension, if the output is close to 0, then the precision


### PR DESCRIPTION
* create one folder per target, then one sub-folder per mlir module.
* pass this folder to `xla_dump_to` so that all the xla files arrive there.
* explicitly save the mlir and the serialized executable there

I'm also exposing James profile conversion tool into ZML as `profiler.dumpDataAsJson(file)`