### PR TITLE
zml: rewrite simple transpose

### DIFF
--- a/examples/llama/llama.zig
+++ b/examples/llama/llama.zig
@@ -194,7 +194,7 @@ pub const Llama = struct {
 
     pub fn embed(embed_tokens_: zml.nn.TokenEmbedding, tokens_: Tensor, token_index: ?Tensor) Tensor {
         const tokens = if (token_index) |idx|
-            tokens_.dynamicSlice1d(-1, 1, idx)
+            tokens_.dynamicSlice1d(-1, .{ .start = idx, .len = 1 })
         else
             tokens_;
         return zml.call(embed_tokens_, .forward, .{tokens}).withPartialTags(.{ .s, .d });

--- a/mlir/mlir.zig
+++ b/mlir/mlir.zig
@@ -619,7 +619,7 @@ pub const DenseElementsAttributeTypes = enum {
 
 pub fn DenseIntOrFPElementsAttribute(comptime dt: DenseElementsAttributeTypes) type {
     const ZigInDataType, const ZigOutDataType, const initFn, const getValue = switch (dt) {
-        .bool => .{ i32, bool, c.mlirDenseElementsAttrBoolGet, c.mlirDenseElementsAttrGetBoolValue },
+        .bool => .{ bool, bool, c.mlirDenseElementsAttrBoolGet, c.mlirDenseElementsAttrGetBoolValue },
         .i8 => .{ i8, i8, c.mlirDenseElementsAttrInt8Get, c.mlirDenseElementsAttrGetInt8Value },
         .i16 => .{ i16, i16, c.mlirDenseElementsAttrInt16Get, c.mlirDenseElementsAttrGetInt16Value },
         .i32 => .{ i32, i32, c.mlirDenseElementsAttrInt32Get, c.mlirDenseElementsAttrGetInt32Value },

--- a/pjrt/profiler.zig
+++ b/pjrt/profiler.zig
@@ -135,7 +135,7 @@ pub const Profiler = struct {
             return;
         }
 
-        var converter = try TraceContainer.init(allocator, profile_data.items(), null);
+        var converter = try TraceContainer.init(allocator, profile_data.items(), 1_000_000);
         defer converter.deinit();
 
         var output_file = try dir.createFile(file_name, .{});

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -177,6 +177,10 @@ pub const CompilationContext = struct {
         return self._mlir_ctx;
     }
 
+    pub fn location(self: *const CompilationContext, src: std.builtin.SourceLocation, comptime name: [:0]const u8, args: anytype) mlir.Location {
+        return self._mlir_ctx.location(src).namedFmt(self._mlir_ctx, name, args);
+    }
+
     /// Compiles the given function with the given arguments.
     /// This is the untyped API and is not meant to be use directly.
     ///
@@ -883,10 +887,12 @@ fn compileModuleToPjrtExecutable(arena: std.mem.Allocator, platform: Platform, m
     try options.env_option_overrides.ensureUnusedCapacity(arena, 16);
     if (xla_dump_to_ orelse platform.compilation_options.xla_dump_to) |xla_dump_to| {
         setFlag(&options, "xla_dump_to", xla_dump_to);
+        setFlag(&options, "xla_dump_hlo_as_dot", true);
         if (platform.compilation_options.xla_dump_fusion_visualization) {
-            setFlag(&options, "xla_dump_hlo_as_html", true);
-            setFlag(&options, "xla_dump_hlo_as_dot", true);
             setFlag(&options, "xla_dump_fusion_visualization", true);
+        }
+        if (platform.compilation_options.xla_dump_hlo_pass_re) |re| {
+            setFlag(&options, "xla_dump_hlo_pass_re", re);
         }
     }
     switch (platform.target) {

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -17,6 +17,7 @@ pub const available_targets = std.enums.values(Target);
 pub const CompilationOptions = struct {
     xla_dump_to: ?[]const u8 = null,
     xla_dump_fusion_visualization: bool = false,
+    xla_dump_hlo_pass_re: ?[]const u8 = null,
     sharding_enabled: bool = false,
     sharding_axes: std.BoundedArray([*:0]const u8, 8) = .{},
 };

--- a/zml/shape.zig
+++ b/zml/shape.zig
@@ -391,20 +391,23 @@ pub const Shape = struct {
         const bare_fmt = fmt.len == 1 and fmt[0] == '_';
         _ = try writer.write(if (bare_fmt) "{" else "Shape({");
 
+        var need_comma = false;
         for (self.dims(), 0..) |d, i| {
-            const prefix = if (i == 0) "" else ",";
+            if (need_comma) try writer.writeByte(',');
             const t = self.tag(i);
             if (t != TagUnknown) {
-                try writer.print("{s}.{s}={d}", .{ prefix, t, d });
+                try writer.print("{s}={d}", .{ t, d });
             } else {
-                try writer.print("{s}{d}", .{ prefix, d });
+                try writer.print("{d}", .{d});
             }
             if (self._sharding_info[i]) {
                 try writer.writeByte('!');
             }
+            need_comma = true;
         }
-        _ = try writer.print("}}, dtype=.{s}", .{@tagName(self.dtype())});
-        if (!bare_fmt) _ = try writer.write(")");
+        if (need_comma) try writer.writeByte(',');
+        _ = try writer.write(@tagName(self.dtype()));
+        _ = try writer.write(if (bare_fmt) "}" else "})");
     }
 
     pub fn reshape(self: Shape, new_shape_: anytype) Shape {

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1372,7 +1372,6 @@ pub const Tensor = struct {
 
         const res_shape = self._shape.transpose(permutation);
         if (transposeIsJustAReshape(self.shape(), permutation)) {
-            scoped_log.warn("Rewriting transpose({}, {d}) as a reshape({}, {})", .{ self, permutation, self, res_shape });
             return self.reshape(res_shape);
         }
 

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -127,8 +127,8 @@ pub const Tensor = struct {
     /// Returns the dimension of axis 'axis_'.
     ///
     /// 'axis_' can be an integer or a tag.
-    pub fn dim(self: Tensor, axis_: anytype) u63 {
-        return @intCast(self._shape.dim(axis_));
+    pub fn dim(self: Tensor, axis_: anytype) i64 {
+        return self._shape.dim(axis_);
     }
 
     /// Returns the dimensions of a Tensor as a slice.

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1776,7 +1776,7 @@ pub const Tensor = struct {
         const dt: DataType = if (sh.dim(a) <= std.math.maxInt(i32)) .i32 else .i64;
         const res_shape = sh.withDtype(dt);
         const mlir_ctx = CompilationContext.current().mlirCtx();
-        const loc = mlir_ctx.location(@src()).namedFmt(mlir_ctx, "iota({_}, {})", .{ res_shape, axis_ });
+        const loc = mlir_ctx.location(@src()).namedFmt(mlir_ctx, "iota({_}, {})", .{ res_shape, a });
 
         var op = dialect.stablehlo.iota(mlir_ctx, a, mlir.ext.RankedTensorType.fromShape(mlir_ctx, res_shape).asType(), loc);
         return _result(res_shape, op.result(0));

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1818,6 +1818,22 @@ pub const Tensor = struct {
         return Tensor.constant(.{}, Data.init(dt, val));
     }
 
+    test scalar {
+        const zml = @import("zml.zig");
+        const platform = zml.testing.env();
+
+        const Local = struct {
+            pub fn _fwd() [6]Tensor {
+                var res: [6]Tensor = undefined;
+                const dtypes = .{ .bool, .u8, .i32, .f32, .bf16, .u64 };
+                inline for (0..6) |i| res[i] = scalar(0, dtypes[i]);
+                return res;
+            }
+        };
+
+        _ = try zml.testing.compileAndCall(platform, Local._fwd, .{});
+    }
+
     /// Returns a constant Tensor with the given value.
     pub fn constant(dimz: anytype, val: Data) Tensor {
         const sh = Shape.init(dimz, val.dtype());

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -3990,7 +3990,7 @@ fn transposeIsJustAReshape(x: Shape, permutation: []const i64) bool {
     if (permutation.len > x.rank()) return false;
     for (permutation) |ax| {
         const squeezable = x.dim(ax) == 1;
-        perm.appendAssumeCapacity(.{@intCast(ax), squeezable});
+        perm.appendAssumeCapacity(.{ @intCast(ax), squeezable });
     }
 
     var effective_ax: u8 = 0;
@@ -4013,15 +4013,14 @@ fn transposeIsJustAReshape(x: Shape, permutation: []const i64) bool {
     return true;
 }
 
-
 test transposeIsJustAReshape {
-    try std.testing.expect(transposeIsJustAReshape(Shape.init(.{ 5, 1, 3}, .i32), &.{0, 1, 2}));
-    try std.testing.expect(transposeIsJustAReshape(Shape.init(.{ 5, 1, 3}, .i32), &.{1, 0, 2}));
-    try std.testing.expect(!transposeIsJustAReshape(Shape.init(.{ 5, 1, 3}, .i32), &.{2, 1, 0}));
-    try std.testing.expect(transposeIsJustAReshape(Shape.init(.{64,8,1,128},.bf16), &.{0,2,1,3}));
-    try std.testing.expect(!transposeIsJustAReshape(Shape.init(.{64,8,155,128},.bf16), &.{0,2,1,3}));
-    try std.testing.expect(transposeIsJustAReshape(Shape.init(.{64,1,1,128},.bf16), &.{1,2,0,3}));
-    try std.testing.expect(!transposeIsJustAReshape(Shape.init(.{.b=1,.h=10,.q=155,.hd=1},.f32), &.{0,2,1,3}));
-    try std.testing.expect(!transposeIsJustAReshape(Shape.init(.{1,10,155,1},.f32), &.{0,2,3,1}));
-    try std.testing.expect(transposeIsJustAReshape(Shape.init(.{1,10,155,1},.f32), &.{0,1,3,2}));
+    try std.testing.expect(transposeIsJustAReshape(Shape.init(.{ 5, 1, 3 }, .i32), &.{ 0, 1, 2 }));
+    try std.testing.expect(transposeIsJustAReshape(Shape.init(.{ 5, 1, 3 }, .i32), &.{ 1, 0, 2 }));
+    try std.testing.expect(!transposeIsJustAReshape(Shape.init(.{ 5, 1, 3 }, .i32), &.{ 2, 1, 0 }));
+    try std.testing.expect(transposeIsJustAReshape(Shape.init(.{ 64, 8, 1, 128 }, .bf16), &.{ 0, 2, 1, 3 }));
+    try std.testing.expect(!transposeIsJustAReshape(Shape.init(.{ 64, 8, 155, 128 }, .bf16), &.{ 0, 2, 1, 3 }));
+    try std.testing.expect(transposeIsJustAReshape(Shape.init(.{ 64, 1, 1, 128 }, .bf16), &.{ 1, 2, 0, 3 }));
+    try std.testing.expect(!transposeIsJustAReshape(Shape.init(.{ .b = 1, .h = 10, .q = 155, .hd = 1 }, .f32), &.{ 0, 2, 1, 3 }));
+    try std.testing.expect(!transposeIsJustAReshape(Shape.init(.{ 1, 10, 155, 1 }, .f32), &.{ 0, 2, 3, 1 }));
+    try std.testing.expect(transposeIsJustAReshape(Shape.init(.{ 1, 10, 155, 1 }, .f32), &.{ 0, 1, 3, 2 }));
 }


### PR DESCRIPTION
Rewrite trivial transpose into reshapes.
Transpose over a 1-d axis are effectively no-op.
Normally the backend can detect this, but we observe that some backend can get confused. So avoiding those extra transpose can help.

I also changed the default profiler size to 1_000_000 events because above that the perfetto ui can't load the generated file anyway