### PR TITLE
zml: revamp scatterSlices

### DIFF
--- a/zml/meta.zig
+++ b/zml/meta.zig
@@ -392,6 +392,26 @@ test visit {
     }
 }
 
+pub fn count(T: type, value: anytype) u32 {
+    var counter: u32 = 0;
+    visit(struct {
+        pub fn cb(res: *u32, _: *const T) void {
+            res.* += 1;
+        }
+    }.cb, &counter, value);
+    return counter;
+}
+
+pub fn first(T: type, value: anytype) T {
+    var res: ?T = null;
+    visit(struct {
+        pub fn cb(res_ptr: *?T, x: *const T) void {
+            if (res_ptr.* == null) res_ptr.* = x.*;
+        }
+    }.cb, &res, &value);
+    return res.?;
+}
+
 /// Given a `fn([]const T, Args) T` and a slice of values,
 /// will combine all values in one value.
 /// Only T elements of values will be looked at.

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -910,7 +910,8 @@ fn compileModuleToPjrtExecutable(arena: std.mem.Allocator, platform: Platform, m
             //  setFlag(&options, "xla_gpu_fused_attention_use_cudnn_rng", true);
             //  setFlag(&options, "xla_gpu_enable_cudnn_layer_norm", true);
             //  setFlag(&options, "xla_gpu_enable_custom_fusions", true);
-            //  setFlag(&options, "xla_gpu_enable_dynamic_slice_fusion", true);
+            setFlag(&options, "xla_gpu_enable_dynamic_slice_fusion", true);
+            setFlag(&options, "xla_gpu_enable_while_loop_double_buffering", true);
             //  setFlag(&options, "xla_gpu_use_runtime_fusion", true);
             //  setFlag(&options, "xla_gpu_enable_latency_hiding_scheduler", true);
             var r_ = try runfiles.Runfiles.create(.{ .allocator = arena }) orelse {

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -368,7 +368,7 @@ pub const CompilationContext = struct {
         defer arena_state.deinit();
         const arena = arena_state.allocator();
 
-        const tensor_count = countTensors(args);
+        const tensor_count = meta.count(Tensor, args);
 
         const mlir_ctx = self.mlirCtx();
         const loc = mlir_ctx.location(@src());
@@ -798,7 +798,7 @@ pub const CompilationContext = struct {
         };
     }
 
-    fn getValue(self: *const CompilationContext, tensor: Tensor) mlir.Value {
+    pub fn getValue(self: *const CompilationContext, tensor: Tensor) mlir.Value {
         return self.getValueAndDonation(tensor)[0];
     }
 

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -505,13 +505,13 @@ pub const CompilationContext = struct {
         const Local = struct {
             bias: Tensor,
 
-            pub fn forward(self: @This(), x: Tensor, y: Tensor) [2]Tensor {
-                const x1 = zml.ops.call(self, .inner, .{x});
-                const x2 = zml.ops.call(self, .inner, .{x1});
+            pub fn _forward(self: @This(), x: Tensor, y: Tensor) [2]Tensor {
+                const x1 = zml.ops.call(self, ._inner, .{x});
+                const x2 = zml.ops.call(self, ._inner, .{x1});
                 return .{ x1.reuseBuffer(y), x2 };
             }
 
-            pub fn inner(self: @This(), x: Tensor) Tensor {
+            pub fn _inner(self: @This(), x: Tensor) Tensor {
                 const y = x.add(self.bias);
                 return y.reuseBuffer(x);
             }
@@ -524,7 +524,7 @@ pub const CompilationContext = struct {
         var comp = try zml.module.CompilationContext.init(std.testing.allocator, "test", platform);
         defer comp.deinit();
         var tensor_args = .{ model, Tensor{ ._shape = s, ._id = .{ .buffer_id = 1234 } }, Tensor{ ._shape = s, ._id = .{ .buffer_id = 1235 } } };
-        const f = try comp.emitMlir(Local.forward, &tensor_args, .{ .name = "test.emitMlir.Local.forward", .kind = .main });
+        const f = try comp.emitMlir(Local._forward, &tensor_args, .{ .name = "test.emitMlir.Local.forward", .kind = .main });
 
         var mlir_bytecode = std.ArrayList(u8).init(std.testing.allocator);
         defer mlir_bytecode.deinit();
@@ -910,8 +910,8 @@ fn compileModuleToPjrtExecutable(arena: std.mem.Allocator, platform: Platform, m
             //  setFlag(&options, "xla_gpu_fused_attention_use_cudnn_rng", true);
             //  setFlag(&options, "xla_gpu_enable_cudnn_layer_norm", true);
             //  setFlag(&options, "xla_gpu_enable_custom_fusions", true);
-            setFlag(&options, "xla_gpu_enable_dynamic_slice_fusion", true);
-            setFlag(&options, "xla_gpu_enable_while_loop_double_buffering", true);
+            //  setFlag(&options, "xla_gpu_enable_dynamic_slice_fusion", true);
+            //  setFlag(&options, "xla_gpu_enable_while_loop_double_buffering", true);
             //  setFlag(&options, "xla_gpu_use_runtime_fusion", true);
             //  setFlag(&options, "xla_gpu_enable_latency_hiding_scheduler", true);
             var r_ = try runfiles.Runfiles.create(.{ .allocator = arena }) orelse {

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -803,7 +803,7 @@ pub fn scatter(
         indices.rank()
     else blk: {
         const ax = indices._shape.hasTag(.coord) orelse indices._shape.axis(-1);
-        stdx.debug.assert(indices.dim(ax) == coord_axes_.len, "scatter({}, coord_axes={any}, indices, updates) expects 'indices' to be a tensor [..., {}], got {}", .{ self, coord_axes, coord_axes_.len, indices });
+        stdx.debug.assert(indices.dim(ax) == coord_axes_.len, "scatter({_}, coord_axes={any}, indices, updates) expects 'indices' to be a tensor [..., {}], got {_}", .{ self, coord_axes, coord_axes_.len, indices });
 
         break :blk ax;
     };
@@ -818,20 +818,20 @@ pub fn scatter(
             if (self_kind.get(self_ax) == .batching) {
                 up_kind.appendAssumeCapacity(.batching);
             } else {
-                stdx.debug.assert(update.dim(up_ax) <= self.dim(self_ax), "scatter expects the slices described in 'updates' to fit inside 'self', but along axis .{s} it doesn't. Got self={}, updates={}.", .{ t, self, update });
+                stdx.debug.assert(update.dim(up_ax) <= self.dim(self_ax), "scatter expects the slices described in 'updates' to fit inside 'self', but along axis .{s} it doesn't. Got self={_}, updates={_}.", .{ t, self, update });
                 up_kind.appendAssumeCapacity(.update_window);
             }
         } else if (t == Shape.TagUnknown or indices._shape.hasTag(t) != null) {
             up_kind.appendAssumeCapacity(.window_id);
         } else {
-            std.debug.panic("scatter expects 'updates' to be made of axes from self={} and from indices={}, got unknown tag {s} in {}", .{ self, indices, t, update });
+            std.debug.panic("scatter expects 'updates' to be made of axes from self={_} and from indices={_}, got unknown tag {s} in {_}", .{ self, indices, t, update });
         }
     }
     const n_indices_axes = update.rank() - _collectAxes(AxisKind, up_kind, .update_window).len;
     if (single_coord) {
-        stdx.debug.assert(n_indices_axes == indices.rank(), "scatter({}, {any}) expects 'updates' to contain all axes from 'indices', got indices={}, updates={}", .{ self, coord_axes, indices, update });
+        stdx.debug.assert(n_indices_axes == indices.rank(), "scatter({_}, {any}) expects 'updates' to contain all axes from 'indices', got indices={_}, updates={_}", .{ self, coord_axes, indices, update });
     } else {
-        stdx.debug.assert(n_indices_axes == indices.rank() - 1, "scatter({}, {any}) expects 'updates' to contain all-but-last axes from 'indices', got indices={}, updates={}", .{ self, coord_axes, indices, update });
+        stdx.debug.assert(n_indices_axes == indices.rank() - 1, "scatter({_}, {any}) expects 'updates' to contain all-but-last axes from 'indices', got indices={_}, updates={_}", .{ self, coord_axes, indices, update });
     }
 
     const mlir_ctx = ctx.mlirCtx();

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -755,6 +755,15 @@ pub fn addHostCallback(
     return Tensor._result(input.shape(), op.result(0));
 }
 
+/// Generalized version of scatter to many inputs.
+/// See `zml.Tensor.scatterSlices` for documentation on scatter.
+///
+/// This allows to use the same indices to update several tensors at once,
+/// and where the update function is allow to look at elements from the different tensors
+/// to compute the final value.
+///
+/// This sounds nice but in practice XLA doesn't support this well on GPU,
+/// and will generate slow code. In practice stick with `zml.Tensor.scatterSlices`.
 pub fn scatter(
     comptime T: type,
     comptime BlkCtx: type,
@@ -792,6 +801,8 @@ pub fn scatter(
 
     // TODO: validate indices_shape: all tensors should have the same shape
     // TODO: validate coord axes: all coord_axes should exist inside self
+    // TODO: ideally we should catch all possible scatter errors and provide nice error messages.
+    // TODO: simplify writing scatter by transposing updates
 
     var config = scatterConfig(self.shape(), update.shape(), indices_per_axis, coord_axes_);
     const indices = scatterPrepareIndices(&config, self.shape(), update.shape(), &indices_per_axis, &coord_axes_);

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -784,9 +784,8 @@ pub fn scatter(
     log.warn("  * coord_axes_ -> {any}", .{coord_axes_.constSlice()});
 
     if (indices_per_axis.len == 0) return inputs;
-    const indices_shape = indices_per_axis.get(0).shape();
     const tagged_api = coord_axes_.len > 0;
-    if (T == Tensor and indices_per_axis.len == 1 and indices_shape.count() == 1) {
+    if (T == Tensor and indices_per_axis.len == 1 and indices_per_axis.get(0).count() == 1) {
         return self.dynamicUpdateSlice1d(
             updates,
             if (tagged_api) self.axis(coord_axes_.get(0)) else 0,
@@ -797,68 +796,7 @@ pub fn scatter(
     // TODO: validate indices_shape: all tensors should have the same shape
     // TODO: validate coord axes: all coord_axes should exist inside self
 
-    const AxisKind = enum { batching, update_window, inserted_window, window_id };
-
-    var self_kind: std.BoundedArray(AxisKind, Tensor.MAX_RANK) = .{};
-    var up_kind: std.BoundedArray(AxisKind, Tensor.MAX_RANK) = .{};
-    var indices_batch_axes: Shape.DimsArray = .{};
-    var scatter_to_operand_axes: Shape.DimsArray = .{};
-
-    if (tagged_api) {
-        for (coord_axes_.constSlice()) |t| {
-            scatter_to_operand_axes.appendAssumeCapacity(self.axis(t));
-        }
-
-        for (self._shape.tags()) |t| {
-            if (update._shape.hasTag(t)) |_| {
-                if (indices_shape.hasTag(t)) |id_ax| {
-                    if (std.mem.indexOfScalar(Shape.Tag, coord_axes_.constSlice(), t) != null) {
-                        // tag is in indices AND in coords -> it's a batching dim that has been rewritten to a regular insertion dim
-                        self_kind.appendAssumeCapacity(.inserted_window);
-                    } else {
-                        // tag is in self, indices and updates -> it's a batching dim
-                        self_kind.appendAssumeCapacity(.batching);
-                        indices_batch_axes.appendAssumeCapacity(@intCast(id_ax));
-                    }
-                } else {
-                    self_kind.appendAssumeCapacity(.update_window);
-                }
-            } else {
-                self_kind.appendAssumeCapacity(.inserted_window);
-            }
-        }
-
-        // Note: we assume the scatter_dims appear in the same order inside indices and inside self.
-        for (update._shape.tags(), 0..) |t, up_ax| {
-            if (t == Shape.TagUnknown or indices_shape.hasTag(t) != null) {
-                up_kind.appendAssumeCapacity(.window_id);
-            } else if (self._shape.hasTag(t)) |self_ax| {
-                if (self_kind.get(self_ax) == .batching) {
-                    up_kind.appendAssumeCapacity(.batching);
-                } else {
-                    stdx.debug.assert(update.dim(up_ax) <= self.dim(self_ax), "scatter expects the slices described in 'updates' to fit inside 'self', but along axis .{s} it doesn't. Got self={_}, updates={_}.", .{ t, self, update });
-                    up_kind.appendAssumeCapacity(.update_window);
-                }
-            } else {
-                std.debug.panic("scatter expects 'updates' to be made of axes from self={_} and from indices={s}, got unknown tag {s} in {_}", .{ self, coord_axes_.constSlice(), t, update });
-            }
-        }
-    } else {
-        for (0..indices_per_axis.len) |i| {
-            self_kind.appendAssumeCapacity(.inserted_window);
-            scatter_to_operand_axes.appendAssumeCapacity(@intCast(i));
-            up_kind.appendAssumeCapacity(.window_id);
-        }
-        for (indices_per_axis.len..self.rank()) |_| {
-            self_kind.appendAssumeCapacity(.update_window);
-        }
-        for (indices_per_axis.len..updates.rank()) |_| {
-            up_kind.appendAssumeCapacity(.update_window);
-        }
-    }
-    log.warn("  * self_kind -> {any}", .{self_kind.constSlice()});
-    log.warn("  * up_kind -> {any}", .{up_kind.constSlice()});
-
+    const config = scatterConfig(self.shape(), update.shape(), indices_per_axis, coord_axes_);
     // const n_indices_axes = update.rank() - _collectAxes(AxisKind, up_kind, .update_window).len;
     // stdx.debug.assert(n_indices_axes == coord_axes_.len, "scatter({_}, {any}) expects 'updates' to contain all axes from 'indices', got indices={s}, updates={_}", .{ self, index_tensors, coord_axes_.constSlice(), update });
 
@@ -888,14 +826,14 @@ pub fn scatter(
         updates_values.items,
         update_block,
         .{
-            .update_window_dims = _collectAxes(AxisKind, up_kind, .update_window).constSlice(),
-            .inserted_window_dims = _collectAxes(AxisKind, self_kind, .inserted_window).constSlice(),
+            .update_window_dims = _collectAxes(AxisKind, config.up_kind, .update_window).constSlice(),
+            .inserted_window_dims = _collectAxes(AxisKind, config.op_kind, .inserted_window).constSlice(),
             // TODO: the batching_dims is a lie
             // although they are in stablehlo, they aren't handled well by "scatter_simplifier" pass that insert extra transposes when it sees them,
             // while they act as extra coordinates. we should rewrite them
-            .input_batching_dims = _collectAxes(AxisKind, self_kind, .batching).constSlice(),
-            .scatter_indices_batching_dims = indices_batch_axes.constSlice(),
-            .scatter_dims_to_operand_dims = scatter_to_operand_axes.constSlice(),
+            .input_batching_dims = _collectAxes(AxisKind, config.op_kind, .batching).constSlice(),
+            .scatter_indices_batching_dims = config.indices_batch_axes.constSlice(),
+            .scatter_dims_to_operand_dims = config.scatter_to_operand_axes.constSlice(),
             .index_vector_dim = indices.rank() - 1,
             .indices_are_sorted = opts.indices_are_sorted,
             .unique_indices = opts.indices_are_unique,
@@ -918,6 +856,135 @@ pub fn scatter(
     }).cb, &local_context, &res);
     assert(local_context.index == op.numResults());
     return res;
+}
+
+const ScatterConfig = struct {
+    op_kind: std.BoundedArray(AxisKind, Tensor.MAX_RANK) = .{},
+    up_kind: std.BoundedArray(AxisKind, Tensor.MAX_RANK) = .{},
+    indices_batch_axes: Shape.DimsArray = .{},
+    scatter_to_operand_axes: Shape.DimsArray = .{},
+};
+
+const AxisKind = enum { batching, update_window, inserted_window, window_id };
+
+fn scatterConfig(
+    op: Shape,
+    update: Shape,
+    indices_per_axis: std.BoundedArray(Tensor, Tensor.MAX_RANK),
+    coord_axes_: Shape.TagsArray,
+) ScatterConfig {
+    var op_kind: std.BoundedArray(AxisKind, Tensor.MAX_RANK) = .{};
+    var up_kind: std.BoundedArray(AxisKind, Tensor.MAX_RANK) = .{};
+    var indices_batch_axes: Shape.DimsArray = .{};
+    var scatter_to_operand_axes: Shape.DimsArray = .{};
+
+    const tagged_api = coord_axes_.len > 0;
+    const indices = indices_per_axis.get(0).shape();
+
+    if (tagged_api) {
+        for (coord_axes_.constSlice()) |t| {
+            scatter_to_operand_axes.appendAssumeCapacity(op.axis(t));
+        }
+
+        for (op.tags()) |t| {
+            if (update.hasTag(t)) |_| {
+                if (indices.hasTag(t)) |id_ax| {
+                    if (std.mem.indexOfScalar(Shape.Tag, coord_axes_.constSlice(), t) != null) {
+                        // tag is in indices AND in coords -> it's a batching dim that has been rewritten to a regular insertion dim
+                        op_kind.appendAssumeCapacity(.inserted_window);
+                    } else {
+                        // tag is in op, indices and updates -> it's a batching dim
+                        op_kind.appendAssumeCapacity(.batching);
+                        indices_batch_axes.appendAssumeCapacity(@intCast(id_ax));
+                    }
+                } else {
+                    op_kind.appendAssumeCapacity(.update_window);
+                }
+            } else {
+                op_kind.appendAssumeCapacity(.inserted_window);
+            }
+        }
+
+        // Note: we assume the scatter_dims appear in the same order inside indices and inside op.
+        for (update.tags(), 0..) |t, up_ax| {
+            // Handle batch axes right away.
+            if (op.hasTag(t)) |self_ax| {
+                if (op_kind.get(self_ax) == .batching) {
+                    up_kind.appendAssumeCapacity(.batching);
+                    continue;
+                }
+            }
+            if (indices.hasTag(t) != null) {
+                up_kind.appendAssumeCapacity(.window_id);
+            } else if (op.hasTag(t)) |self_ax| {
+                stdx.debug.assert(update.dim(up_ax) <= op.dim(self_ax), "scatter expects the slices described in 'updates' to fit inside 'op', but along axis .{s} it doesn't. Got op={_}, updates={_}.", .{ t, op, update });
+                up_kind.appendAssumeCapacity(.update_window);
+            } else {
+                // TODO: consider accepting untagged update here.
+                std.debug.panic("scatter expects 'updates' to be made of axes from op={_} and from indices={s}, got unknown tag {s} in {_}", .{ op, coord_axes_.constSlice(), t, update });
+            }
+        }
+    } else {
+        for (0..indices_per_axis.len) |i| {
+            op_kind.appendAssumeCapacity(.inserted_window);
+            scatter_to_operand_axes.appendAssumeCapacity(@intCast(i));
+            up_kind.appendAssumeCapacity(.window_id);
+        }
+        for (indices_per_axis.len..op.rank()) |_| {
+            op_kind.appendAssumeCapacity(.update_window);
+        }
+        for (indices_per_axis.len..update.rank()) |_| {
+            up_kind.appendAssumeCapacity(.update_window);
+        }
+    }
+    log.warn("  * op_kind -> {any}", .{op_kind.constSlice()});
+    log.warn("  * up_kind -> {any}", .{up_kind.constSlice()});
+
+    return .{
+        .op_kind = op_kind,
+        .up_kind = up_kind,
+        .indices_batch_axes = indices_batch_axes,
+        .scatter_to_operand_axes = scatter_to_operand_axes,
+    };
+}
+
+test scatterConfig {
+    const zml = @import("zml.zig");
+    const platform = zml.testing.env();
+
+    var comp = try zml.module.CompilationContext.init(std.testing.allocator, "test", platform);
+    defer comp.deinit();
+    comp.activate();
+    defer comp.deactivate();
+
+    const Local = struct {
+        pub fn idx(idx_shape: anytype) Tensor {
+            return Tensor.constant(idx_shape, .{ .i32 = 0 });
+        }
+    };
+
+    const idx = Local.idx;
+    const op = Shape.init(.{ .a = 10, .b = 20 }, .f32);
+
+    // Use .a as a batching axis with .a=10 x .n=8 updates of 2 elements of .b
+    {
+        const indices, const coords_tags = Shape.parseStruct(Tensor, .{ .b = idx(.{ .a = 10, .n = 8 }) });
+        const update = Shape.init(.{ .a = 10, .n = 8, .b = 2 }, .f32);
+
+        const cfg = scatterConfig(op, update, indices, coords_tags);
+        try std.testing.expectEqualSlices(AxisKind, &.{ .batching, .update_window }, cfg.op_kind.constSlice());
+        try std.testing.expectEqualSlices(AxisKind, &.{ .batching, .window_id, .update_window }, cfg.up_kind.constSlice());
+    }
+
+    // similar, but use the normalized form where .a is no longer an explicit batching axis.
+    {
+        const indices, const coords_tags = Shape.parseStruct(Tensor, .{ .a = idx(.{ .a = 10, .n = 8 }), .b = idx(.{ .a = 10, .n = 8 }) });
+        const update = Shape.init(.{ .a = 10, .n = 8, .b = 2 }, .f32);
+
+        const cfg = scatterConfig(op, update, indices, coords_tags);
+        try std.testing.expectEqualSlices(AxisKind, &.{ .inserted_window, .update_window }, cfg.op_kind.constSlice());
+        try std.testing.expectEqualSlices(AxisKind, &.{ .window_id, .window_id, .update_window }, cfg.up_kind.constSlice());
+    }
 }
 
 inline fn toI64(values: anytype) []i64 {

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -2407,6 +2407,9 @@ pub const Tensor = struct {
         /// of the operator which is backend specific.
         update_fn: *const fn (Tensor, Tensor) Tensor = increment,
 
+        allow_double_transpose: bool = false,
+        allow_while_loop: bool = false,
+
         pub fn increment(old_value: Tensor, new_value: Tensor) Tensor {
             return old_value.add(new_value.convert(old_value.dtype()));
         }

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -2470,6 +2470,14 @@ pub const Tensor = struct {
                 );
             }
 
+            pub fn scatterCB(self: Tensor, coords: Tensor, updates: Tensor) Tensor {
+                return self.scatterSlices(
+                    .{ .c = coords.choose1d(.coord, 0), .b = coords.choose1d(.coord, 1) },
+                    updates,
+                    .{ .update_fn = ScatterOpts.increment },
+                );
+            }
+
             pub fn idx(idx_shape: anytype) Tensor {
                 return Tensor.constant(idx_shape, .{ .i32 = 0 });
             }
@@ -2546,49 +2554,49 @@ pub const Tensor = struct {
             try std.testing.expect(a.shape().eql(result.shape()));
             try std.testing.expectEqual(expected, result.getValue(@TypeOf(expected)));
         }
-        // {
-        //     // Test with actual values and batching along axis .a
-        //     const operand = try zml.Buffer.constant(platform, Shape.init(.{ .a = 2, .b = 3, .c = 4, .d = 2 }, .u16), 0);
-        //     defer operand.deinit();
-        //     const start_indices = (try zml.Buffer.fromArray(
-        //         platform,
-        //         [2][2][3][2]i32{
-        //             .{
-        //                 .{ .{ 0, 0 }, .{ 1, 0 }, .{ 2, 1 } },
-        //                 .{ .{ 0, 1 }, .{ 1, 1 }, .{ 0, 9 } },
-        //             },
-        //             .{
-        //                 .{ .{ 0, 0 }, .{ 2, 1 }, .{ 2, 2 } },
-        //                 .{ .{ 1, 2 }, .{ 0, 1 }, .{ 1, 0 } },
-        //             },
-        //         },
-        //     )).withTags(.{ .n, .a, .m, .coord });
-        //     defer start_indices.deinit();
+        {
+            // Test with actual values and batching along axis .a
+            const operand = try zml.Buffer.constant(platform, Shape.init(.{ .a = 2, .b = 3, .c = 4, .d = 2 }, .u16), 0);
+            defer operand.deinit();
+            const start_indices = (try zml.Buffer.fromArray(
+                platform,
+                [2][2][3][2]i32{
+                    .{
+                        .{ .{ 0, 0 }, .{ 1, 0 }, .{ 2, 1 } },
+                        .{ .{ 0, 1 }, .{ 1, 1 }, .{ 0, 9 } },
+                    },
+                    .{
+                        .{ .{ 0, 0 }, .{ 2, 1 }, .{ 2, 2 } },
+                        .{ .{ 1, 2 }, .{ 0, 1 }, .{ 1, 0 } },
+                    },
+                },
+            )).withTags(.{ .n, .a, .m, .coord });
+            defer start_indices.deinit();
 
-        //     const values = try zml.Buffer.constant(
-        //         platform,
-        //         Shape.init(.{ .n = 2, .a = 2, .m = 3, .c = 2, .d = 2 }, .u16),
-        //         1,
-        //     );
-        //     defer values.deinit();
+            const values = try zml.Buffer.constant(
+                platform,
+                Shape.init(.{ .n = 2, .a = 2, .m = 3, .c = 2, .d = 2 }, .u16),
+                1,
+            );
+            defer values.deinit();
 
-        //     const result = try zml.testing.compileAndCall(platform, Local.scatter, .{ operand, operand.shape().axes(.{ .c, .b }), start_indices, values });
+            const result = try zml.testing.compileAndCall(platform, Local.scatterCB, .{ operand, start_indices, values });
 
-        //     const expected = [2][3][4][2]u16{
-        //         .{
-        //             .{ .{ 2, 2 }, .{ 3, 3 }, .{ 1, 1 }, .{ 0, 0 } },
-        //             .{ .{ 0, 0 }, .{ 0, 0 }, .{ 2, 2 }, .{ 2, 2 } },
-        //             .{ .{ 0, 0 }, .{ 0, 0 }, .{ 1, 1 }, .{ 1, 1 } },
-        //         },
-        //         .{
-        //             .{ .{ 0, 0 }, .{ 1, 1 }, .{ 1, 1 }, .{ 0, 0 } },
-        //             .{ .{ 2, 2 }, .{ 3, 3 }, .{ 1, 1 }, .{ 0, 0 } },
-        //             .{ .{ 0, 0 }, .{ 1, 1 }, .{ 1, 1 }, .{ 0, 0 } },
-        //         },
-        //     };
-        //     try std.testing.expect(operand.shape().eql(result.shape()));
-        //     try std.testing.expectEqual(expected, result.getValue(@TypeOf(expected)));
-        // }
+            const expected = [2][3][4][2]u16{
+                .{
+                    .{ .{ 2, 2 }, .{ 3, 3 }, .{ 1, 1 }, .{ 0, 0 } },
+                    .{ .{ 0, 0 }, .{ 0, 0 }, .{ 2, 2 }, .{ 2, 2 } },
+                    .{ .{ 0, 0 }, .{ 0, 0 }, .{ 1, 1 }, .{ 1, 1 } },
+                },
+                .{
+                    .{ .{ 0, 0 }, .{ 1, 1 }, .{ 1, 1 }, .{ 0, 0 } },
+                    .{ .{ 2, 2 }, .{ 3, 3 }, .{ 1, 1 }, .{ 0, 0 } },
+                    .{ .{ 0, 0 }, .{ 1, 1 }, .{ 1, 1 }, .{ 0, 0 } },
+                },
+            };
+            try std.testing.expect(operand.shape().eql(result.shape()));
+            try std.testing.expectEqual(expected, result.getValue(@TypeOf(expected)));
+        }
     }
 
     /// Returns a Tensor containing the maximum over a given axis.

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1565,6 +1565,7 @@ pub const Tensor = struct {
 
     /// Concatenates the input Tensors along the given axis.
     pub fn concatenate(tensors: []const Tensor, axis_: anytype) Tensor {
+        if (tensors.len == 1) return tensors[0];
         stdx.debug.assert(tensors.len <= 32, "concatenate only supports up to 32 tensors, got {}", .{tensors.len});
         var buffer: [32]mlir.Value = undefined;
         std.debug.assert(tensors.len <= buffer.len);

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -2491,6 +2491,7 @@ pub const Tensor = struct {
                 .{ .{ .a = 10, .b = 20 }, .{ .b = idx(.{ .a = 10, .n = 8 }) }, .{ .a = 10, .n = 8, .b = 2 } },
                 // similar, but use the normalized form where a is no longer an explicit batching axis.
                 .{ .{ .a = 10, .b = 20 }, .{ .a = idx(.{ .a2 = 10, .n = 8 }), .b = idx(.{ .a2 = 10, .n = 8 }) }, .{ .a2 = 10, .n = 8, .b = 2 } },
+                .{ .{ .a = 10, .b = 20 }, .{ .a = idx(.{ .a = 10, .n = 8 }), .b = idx(.{ .a = 10, .n = 8 }) }, .{ .a = 10, .n = 8, .b = 2 } },
                 // I'm not sure I like this variant, cause `b` is not mentionned in updates.
                 // So 'stablehlo.scatter' is implicitly broadcasting the updates along `b` axis.
                 // OTOH asking the user to do the broadcasting isn't trivial cause they will need to do shape wrangling and that's annoying.

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -2405,19 +2405,14 @@ pub const Tensor = struct {
         /// then you should make sure the slices don't overlap,
         /// otherwise the result will depend on the runtime scheduling
         /// of the operator which is backend specific.
-        update_fn: *const fn (*const anyopaque, Tensor, Tensor) Tensor = increment,
+        update_fn: *const fn (Tensor, Tensor) Tensor = increment,
 
-        /// Extra data that may be needed for a custom update function.
-        /// `override` and `increment` don't need it, leaving it to undefined works.
-        update_fn_ctx: *const anyopaque = undefined,
-
-        pub fn increment(_: *const anyopaque, old_value: Tensor, new_value: Tensor) Tensor {
-            return old_value.add(new_value);
+        pub fn increment(old_value: Tensor, new_value: Tensor) Tensor {
+            return old_value.add(new_value.convert(old_value.dtype()));
         }
 
-        pub fn override(_: *const anyopaque, old_value: Tensor, new_value: Tensor) Tensor {
-            _ = old_value;
-            return new_value;
+        pub fn override(old_value: Tensor, new_value: Tensor) Tensor {
+            return new_value.convert(old_value.dtype());
         }
     };
 
@@ -2446,91 +2441,17 @@ pub const Tensor = struct {
     /// In particular if you scatter overlapping slices, with `zml.Tensor.ScatterOpts.override`,
     /// then the result will depend on the execution order that you don't control.
     pub fn scatterSlices(self: Tensor, coord_axes: anytype, indices: Tensor, updates: Tensor, opts: ScatterOpts) Tensor {
-        const loc = @src();
         // scoped_log.debug("scatterSlices({}, {any}, {}, {})", .{ self, coord_axes, indices, updates });
 
-        stdx.debug.assert(self.dtype() == updates.dtype(), "scatterSlices expects input and 'updates' tensors to be of the same type, got {} and {}", .{ self.dtype(), updates.dtype() });
+        const UpdateType = @TypeOf(ScatterOpts.increment);
 
-        const single_coord, const coord_axes_ = _parseGatherCoord(self, coord_axes);
-        const AxisKind = enum { batching, update_window, inserted_window, window_id };
-        var self_kind: std.BoundedArray(AxisKind, MAX_RANK) = .{};
-        var indices_batch_axes: Shape.DimsArray = .{};
-        for (self._shape.tags()) |t| {
-            if (updates._shape.hasTag(t)) |_| {
-                if (indices._shape.hasTag(t)) |id_ax| {
-                    // tag is in self, indices and updates -> it's a batching dim
-                    self_kind.appendAssumeCapacity(.batching);
-                    indices_batch_axes.appendAssumeCapacity(id_ax);
-                } else {
-                    self_kind.appendAssumeCapacity(.update_window);
-                }
-            } else {
-                self_kind.appendAssumeCapacity(.inserted_window);
+        const Custom = struct {
+            pub fn inc(custom: *const UpdateType, old_value: Tensor, new_value: Tensor) Tensor {
+                return @call(.auto, custom, .{ old_value, new_value });
             }
-        }
-        // scoped_log.warn(" self_kind -> {any}", .{self_kind.constSlice()});
-
-        const index_coord_axis = if (single_coord)
-            indices.rank()
-        else blk: {
-            const ax = indices._shape.hasTag(.coord) orelse indices._shape.axis(-1);
-            stdx.debug.assert(indices.dim(ax) == coord_axes_.len, "scatterSlices({}, coord_axes={any}, indices, updates) expects 'indices' to be a tensor [..., {}], got {}", .{ self, coord_axes, coord_axes_.len, indices });
-
-            break :blk ax;
         };
-        if (indices.count() == 1 and !single_coord) {
-            return self.dynamicUpdateSlice1d(updates, coord_axes_.get(0), indices.reshape(.{}));
-        }
 
-        var up_kind: std.BoundedArray(AxisKind, MAX_RANK) = .{};
-        // Note: we assume the scatter_dims appear in the same order inside indices and inside self.
-        for (updates._shape.tags(), 0..) |t, up_ax| {
-            if (self._shape.hasTag(t)) |self_ax| {
-                if (self_kind.get(self_ax) == .batching) {
-                    up_kind.appendAssumeCapacity(.batching);
-                } else {
-                    stdx.debug.assert(updates.dim(up_ax) <= self.dim(self_ax), "scatterSlices expects the slices described in 'updates' to fit inside 'self', but along axis .{s} it doesn't. Got self={}, updates={}.", .{ t, self, updates });
-                    up_kind.appendAssumeCapacity(.update_window);
-                }
-            } else if (t == Shape.TagUnknown or indices._shape.hasTag(t) != null) {
-                up_kind.appendAssumeCapacity(.window_id);
-            } else {
-                std.debug.panic("scatterSlices expects 'updates' to be made of axes from 'self={}' and from 'indices={}', got unknown tag {s} in {}", .{ self, indices, t, updates });
-            }
-        }
-        const n_indices_axes = updates.rank() - _collectAxes(AxisKind, up_kind, .update_window).len;
-        if (single_coord) {
-            stdx.debug.assert(n_indices_axes == indices.rank(), "scatterSlices({}, {any}) expects 'updates' to contain all axes from 'indices', got indices={}, updates={}", .{ self, coord_axes, indices, updates });
-        } else {
-            stdx.debug.assert(n_indices_axes == indices.rank() - 1, "scatterSlices({}, {any}) expects 'updates' to contain all-but-last axes from 'indices', got indices={}, updates={}", .{ self, coord_axes, indices, updates });
-        }
-
-        const ctx = self.getContext();
-        const mlir_ctx = ctx.mlirCtx();
-
-        const _scalar: Tensor = .{ ._shape = Shape.init(.{}, self.dtype()), ._id = undefined };
-        const UpdateS = ops.BlockSign(ScatterOpts.increment);
-        const update_block, _ = ctx.makeBlock(.hermetic, UpdateS, opts.update_fn, opts.update_fn_ctx, .{ _scalar, _scalar });
-
-        const op = dialect.stablehlo.scatter(
-            mlir_ctx,
-            &.{self.value()},
-            &.{indices.value()},
-            &.{updates.value()},
-            update_block,
-            .{
-                .update_window_dims = _collectAxes(AxisKind, up_kind, .update_window).constSlice(),
-                .inserted_window_dims = _collectAxes(AxisKind, self_kind, .inserted_window).constSlice(),
-                .input_batching_dims = _collectAxes(AxisKind, self_kind, .batching).constSlice(),
-                .scatter_indices_batching_dims = indices_batch_axes.constSlice(),
-                .scatter_dims_to_operand_dims = toI64(coord_axes_.constSlice()),
-                .index_vector_dim = index_coord_axis,
-                .indices_are_sorted = opts.indices_are_sorted,
-                .unique_indices = opts.indices_are_unique,
-            },
-            mlir_ctx.location(loc),
-        );
-        return _result(self._shape, op.result(0));
+        return ops.scatter(Tensor, *const UpdateType, Custom.inc, self, opts.update_fn, coord_axes, indices, updates, opts);
     }
 
     test scatterSlices {
@@ -3962,7 +3883,7 @@ test shapesOf {
     }
 }
 
-fn _collectAxes(T: type, bounded_array: std.BoundedArray(T, Tensor.MAX_RANK), value: T) std.BoundedArray(i64, Tensor.MAX_RANK) {
+pub fn _collectAxes(T: type, bounded_array: std.BoundedArray(T, Tensor.MAX_RANK), value: T) std.BoundedArray(i64, Tensor.MAX_RANK) {
     var res: std.BoundedArray(i64, Tensor.MAX_RANK) = .{};
     for (bounded_array.constSlice(), 0..) |v, ax| {
         if (v == value) {
@@ -3972,7 +3893,7 @@ fn _collectAxes(T: type, bounded_array: std.BoundedArray(T, Tensor.MAX_RANK), va
     return res;
 }
 
-fn _parseGatherCoord(self: Tensor, axes_: anytype) struct { bool, std.BoundedArray(u3, Tensor.MAX_RANK) } {
+pub fn _parseGatherCoord(self: Tensor, axes_: anytype) struct { bool, std.BoundedArray(u3, Tensor.MAX_RANK) } {
     const AxesT = @TypeOf(axes_);
     const axes_is_scalar = AxesT == EnumLiteral or AxesT == comptime_int or @typeInfo(AxesT) == .Int;
 

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1535,21 +1535,21 @@ pub const Tensor = struct {
 
         // Wrap slice1d to hide the anytype in the signature.
         const Local = struct {
-            pub fn slice1dAxis(input: Tensor, ax: i8, slice_: Tensor.Slice) Tensor {
+            pub fn _slice1dAxis(input: Tensor, ax: i8, slice_: Tensor.Slice) Tensor {
                 return input.slice1d(ax, slice_);
             }
         };
 
         {
-            const res = try zml.testing.compileAndCallWithTensors(platform, Local.slice1dAxis, .{ x.shape(), 0, .{ .end = 1 } }, .{ x, 0, .{ .end = 1 } });
+            const res = try zml.testing.compileAndCallWithTensors(platform, Local._slice1dAxis, .{ x.shape(), 0, .{ .end = 1 } }, .{ x, 0, .{ .end = 1 } });
             try testing.expectEqual([5]f32{ 0, 1, 2, 3, 4 }, try res.getValue([5]f32));
         }
         {
-            const res = try zml.testing.compileAndCallWithTensors(platform, Local.slice1dAxis, .{ x.shape(), 1, .{ .start = 1, .step = 2 } }, .{ x, 0, .{ .start = 1, .step = 2 } });
+            const res = try zml.testing.compileAndCallWithTensors(platform, Local._slice1dAxis, .{ x.shape(), 1, .{ .start = 1, .step = 2 } }, .{ x, 0, .{ .start = 1, .step = 2 } });
             try testing.expectEqual([4]f32{ 1, 3, 6, 8 }, try res.getValue([4]f32));
         }
         {
-            const res = try zml.testing.compileAndCallWithTensors(platform, Local.slice1dAxis, .{ x.shape(), -1, .{ .start = -2 } }, .{ x, 0, .{ .start = -2 } });
+            const res = try zml.testing.compileAndCallWithTensors(platform, Local._slice1dAxis, .{ x.shape(), -1, .{ .start = -2 } }, .{ x, 0, .{ .start = -2 } });
             try testing.expectEqual([4]f32{ 3, 4, 8, 9 }, try res.getValue([4]f32));
         }
     }
@@ -2434,18 +2434,15 @@ pub const Tensor = struct {
     ///
     /// ### Arguments
     ///
-    /// * Return a tensor with same shape than `self`, with updated content.
-    /// * `indices` is a set of Tensor (typically rank 1), representing coordinates into `self`.
+    /// - Return a tensor with same shape than `self`, with updated content.
+    /// - `indices` is a set of Tensor (typically rank 1), representing coordinates into `self`.
     ///   all indices must have the same shape, but scalars are accepted.
-    ///
-    /// * each `indices` entry contains offset along an axes into `self`.
+    /// - each `indices` entry contains offset along an axes into `self`.
     /// Typically axes are identified by their tags, but in the absence of tags on `indices`,
     /// The entry in indices will be assigned to axes of `self` from major to minor axis.
     /// It is recommended to have indices referencing only major axes of `self` for better performance.
-    ///
-    /// * `values` shape is obtained by concatenating the shape of `indices` with the shape of the slices to be extracted.
-    ///
-    /// * `opts`: `zml.Tensor.ScatterOpts` des
+    /// - `values` shape is obtained by concatenating the shape of `indices` with the shape of the slices to be extracted.
+    /// - `opts`: `zml.Tensor.ScatterOpts` des
     ///
     /// ### Sample input/output shapes with corresponding pseudo-code.
     ///
@@ -2524,7 +2521,7 @@ pub const Tensor = struct {
         const platform = zml.testing.env();
 
         const Local = struct {
-            pub fn scatter(self: Tensor, indices: []const Tensor, updates: Tensor) Tensor {
+            pub fn _scatter(self: Tensor, indices: []const Tensor, updates: Tensor) Tensor {
                 return self.scatterSlices(
                     indices,
                     updates,
@@ -2532,7 +2529,7 @@ pub const Tensor = struct {
                 );
             }
 
-            pub fn scatterCB(self: Tensor, coords: Tensor, updates: Tensor) Tensor {
+            pub fn _scatterCB(self: Tensor, coords: Tensor, updates: Tensor) Tensor {
                 return self.scatterSlices(
                     .{ .c = coords.choose1d(.coord, 0), .b = coords.choose1d(.coord, 1) },
                     updates,
@@ -2540,7 +2537,7 @@ pub const Tensor = struct {
                 );
             }
 
-            pub fn idx(idx_shape: anytype) Tensor {
+            pub fn _idx(idx_shape: anytype) Tensor {
                 return Tensor.constant(idx_shape, .{ .i32 = 0 });
             }
         };
@@ -2551,7 +2548,7 @@ pub const Tensor = struct {
             defer comp.deinit();
             comp.activate();
             defer comp.deactivate();
-            const idx = Local.idx;
+            const idx = Local._idx;
 
             inline for (.{
                 // This is equivalent to a dynamic update slice, update 3 values at given offset of axis .a:
@@ -2591,7 +2588,7 @@ pub const Tensor = struct {
             const updates = try zml.Buffer.fromArray(platform, [2][3]i32{ .{ 10, 20, 30 }, .{ 70, 80, 90 } });
 
             const expected = [3][3]i32{ .{ 10, 21, 32 }, .{ 3, 4, 5 }, .{ 76, 87, 98 } };
-            const result = try zml.testing.compileAndCall(platform, Local.scatter, .{
+            const result = try zml.testing.compileAndCall(platform, Local._scatter, .{
                 a,
                 &.{scatter_indices.withTags(.{.n})},
                 updates.withTags(.{ .n, .b }),
@@ -2610,7 +2607,7 @@ pub const Tensor = struct {
             const updates = try zml.Buffer.fromArray(platform, [2]i32{ 20, 70 });
 
             const expected = [9]i32{ 0, 1, 22, 3, 4, 5, 6, 77, 8 };
-            const result = try zml.testing.compileAndCall(platform, Local.scatter, .{
+            const result = try zml.testing.compileAndCall(platform, Local._scatter, .{
                 a,
                 &.{scatter_indices.withTags(.{.n})},
                 updates.withTags(.{.n}),
@@ -2644,7 +2641,7 @@ pub const Tensor = struct {
             );
             defer values.deinit();
 
-            const result = try zml.testing.compileAndCall(platform, Local.scatterCB, .{ operand, start_indices, values });
+            const result = try zml.testing.compileAndCall(platform, Local._scatterCB, .{ operand, start_indices, values });
 
             const expected = [2][3][4][2]u16{
                 .{
@@ -3591,15 +3588,16 @@ pub const Tensor = struct {
 
     /// Given a set of N vectors of lengths A, B, C, D,
     /// returns N tensors of rank N, and shape (A, B, C, D).
-    /// For any coordinate (a, b, c, d),
-    /// we have:
+    /// For any coordinate (a, b, c, d), we have:
+    ///
     /// - res[0][a, b, c, d] == A[a]
     /// - res[1][a, b, c, d] == B[b]
     /// - res[2][a, b, c, d] == C[c]
     /// - res[3][a, b, c, d] == D[d]
+    ///
     /// This is implemented with broadcasting, so typically it won't copy.
     /// In Pytorch/Numpy this is know as `meshgrid` with "ij" mode.
-    /// See torch.meshgrid for the "xy" mode.
+    /// See `zml.torch.meshgrid` for the "xy" mode.
     pub fn cartesianProduct(comptime N: u3, vectors: [N]Tensor) [N]Tensor {
         var out: @TypeOf(vectors) = undefined;
         _cartesianProduct(&vectors, &out);
@@ -3636,13 +3634,13 @@ pub const Tensor = struct {
         const y = try zml.Buffer.fromSlice(client, .{4}, &[_]i32{ 0, 1, 2, 3 });
 
         const Local = struct {
-            pub fn cartesianProduct2(a: Tensor, b: Tensor) [2]Tensor {
+            pub fn _cartesianProduct2(a: Tensor, b: Tensor) [2]Tensor {
                 return cartesianProduct(2, .{ a, b });
             }
         };
 
         {
-            const xs, const ys = try zml.testing.compileAndCall(client, Local.cartesianProduct2, .{ x, y });
+            const xs, const ys = try zml.testing.compileAndCall(client, Local._cartesianProduct2, .{ x, y });
             try std.testing.expectEqualSlices(i64, &.{ 6, 4 }, xs.shape().dims());
             try std.testing.expectEqualSlices(i64, &.{ 6, 4 }, ys.shape().dims());
             try std.testing.expectEqualDeep(
@@ -3672,8 +3670,8 @@ pub const Tensor = struct {
 
     /// Given a set of N vectors of lengths A, B, C, D,
     /// returns 1 tensors of rank N+1, and shape (A, B, C, D, N).
-    /// For any coordinate (a, b, c, d),
-    /// we have:
+    /// For any coordinate (a, b, c, d), we have:
+    ///
     /// - res[a, b, c, d] == (A[a], B[b], C[c], D[d])
     pub fn cartesianProductStacked(vectors: []const Tensor) Tensor {
         var out = std.BoundedArray(Tensor, Tensor.MAX_RANK).init(vectors.len) catch unreachable;
@@ -3689,12 +3687,12 @@ pub const Tensor = struct {
         const y = try zml.Buffer.fromSlice(platform, .{4}, &[_]i32{ 0, 1, 2, 3 });
 
         const Local = struct {
-            pub fn cartesianProduct2(a: Tensor, b: Tensor) Tensor {
+            pub fn _fwd(a: Tensor, b: Tensor) Tensor {
                 return cartesianProductStacked(&.{ a, b });
             }
         };
 
-        const z = try zml.testing.compileAndCall(platform, Local.cartesianProduct2, .{ x, y });
+        const z = try zml.testing.compileAndCall(platform, Local._fwd, .{ x, y });
         try std.testing.expectEqualDeep(
             [6][4][2]i32{
                 .{ .{ 0, 0 }, .{ 0, 1 }, .{ 0, 2 }, .{ 0, 3 } },
@@ -4048,13 +4046,13 @@ test "unused tensor" {
     const platform = zml.testing.env();
 
     const Local = struct {
-        pub fn forward(x: Tensor) Tensor {
+        pub fn _fwd(x: Tensor) Tensor {
             const y = x.addConstant(1);
             _ = y;
             return x;
         }
     };
 
-    const mod = try zml.compileFn(std.testing.allocator, Local.forward, .{Shape.init(.{10}, .f32)}, platform);
+    const mod = try zml.compileFn(std.testing.allocator, Local._fwd, .{Shape.init(.{10}, .f32)}, platform);
     defer mod.deinit();
 }

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -2558,6 +2558,8 @@ pub const Tensor = struct {
                 .{ .{ .a = 10 }, .{ .a = idx(.{}) }, .{ .a = 3 } },
                 // Use .a as a batching axis with .a=10 x .n=8 updates of 2 elements of .b
                 .{ .{ .a = 10, .b = 20 }, .{ .b = idx(.{ .a = 10, .n = 8 }) }, .{ .a = 10, .n = 8, .b = 2 } },
+                // Same but with update transposed
+                .{ .{ .a = 10, .b = 20 }, .{ .b = idx(.{ .a = 10, .n = 8 }) }, .{ .a = 10, .b = 2, .n = 8 } },
                 // similar, but use the normalized form where a is no longer an explicit batching axis.
                 .{ .{ .a = 10, .b = 20 }, .{ .a = idx(.{ .a2 = 10, .n = 8 }), .b = idx(.{ .a2 = 10, .n = 8 }) }, .{ .a2 = 10, .n = 8, .b = 2 } },
                 .{ .{ .a = 10, .b = 20 }, .{ .a = idx(.{ .a = 10, .n = 8 }), .b = idx(.{ .a = 10, .n = 8 }) }, .{ .a = 10, .n = 8, .b = 2 } },

--- a/zml/torch.zig
+++ b/zml/torch.zig
@@ -105,8 +105,8 @@ pub fn unsqueeze(
 }
 
 test unsqueeze {
-    const UnsqueezeTest = struct {
-        pub fn forward(x: Tensor) Tensor {
+    const Local = struct {
+        pub fn _fwd(x: Tensor) Tensor {
             var y = x;
             y = unsqueeze(y, 0);
             y = unsqueeze(y, -1);
@@ -117,7 +117,7 @@ test unsqueeze {
     const platform = zml.testing.env();
 
     const x = try zml.Buffer.fromArray(platform, @as([8]f16, undefined));
-    const res = try zml.testing.compileAndCall(platform, UnsqueezeTest.forward, .{x});
+    const res = try zml.testing.compileAndCall(platform, Local._fwd, .{x});
     try zml.testing.expectEqualShapes(zml.Shape.init(.{ 1, 8, 1, 1 }, .f16), res.shape());
 }
 
@@ -247,7 +247,7 @@ test meshgrid {
     const y = try zml.Buffer.fromSlice(platform, .{4}, &[_]i32{ 0, 1, 2, 3 });
 
     const Local = struct {
-        pub fn meshgrid2(a: Tensor, b: Tensor, indexing: MeshgridIndexing) [2]Tensor {
+        pub fn _meshgrid2(a: Tensor, b: Tensor, indexing: MeshgridIndexing) [2]Tensor {
             return meshgrid(2, .{ a, b }, indexing);
         }
     };
@@ -255,7 +255,7 @@ test meshgrid {
     // Only test .xy mode, sinc .ij is just calling cartesianProduct which
     // got its own tests.
     {
-        const xs, const ys = try zml.testing.compileAndCall(platform, Local.meshgrid2, .{ x, y, .xy });
+        const xs, const ys = try zml.testing.compileAndCall(platform, Local._meshgrid2, .{ x, y, .xy });
         try std.testing.expectEqualSlices(i64, &.{ 4, 6 }, xs.dims());
         try std.testing.expectEqualSlices(i64, &.{ 4, 6 }, ys.dims());
         try std.testing.expectEqualDeep(


### PR DESCRIPTION
Main issue with current `scatter` implementation is that it uses broadcasting dims of `stablehlo.scatter`.
While nice in theory, the optimizer doesn't handle them well and they often are unrolled into while loop.
Here I convert the batching dim to extra iotas indices.