### PR TITLE
zml: HostBuffer.prettyPrint()

### DIFF
--- a/zml/hostbuffer.zig
+++ b/zml/hostbuffer.zig
@@ -262,6 +262,8 @@ pub const HostBuffer = struct {
         try writer.print("HostBuffer(.{_})", .{self._shape});
     }
 
+    /// Formatter for a HostBuffer that also print the values not just the shape.
+    /// Usage: `std.log.info("my buffer: {}", .{buffer.pretty()});`
     pub fn pretty(self: HostBuffer) PrettyPrinter {
         return .{ .x = self };
     }

--- a/zml/hostbuffer.zig
+++ b/zml/hostbuffer.zig
@@ -262,6 +262,20 @@ pub const HostBuffer = struct {
         try writer.print("HostBuffer(.{_})", .{self._shape});
     }
 
+    pub fn pretty(self: HostBuffer) PrettyPrinter {
+        return .{ .x = self };
+    }
+
+    pub const PrettyPrinter = struct {
+        x: HostBuffer,
+
+        pub fn format(self: PrettyPrinter, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
+            _ = fmt;
+            _ = options;
+            try prettyPrint(self.x, writer);
+        }
+    };
+
     pub fn prettyPrint(self: HostBuffer, writer: anytype) !void {
         return self.prettyPrintIndented(4, 0, writer);
     }

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1621,7 +1621,7 @@ pub const Tensor = struct {
 
     /// Repeats a Tensor several times along the given axis.
     ///
-    /// * repeat1d(x, concat(&.{x, x, x, x}, axis);
+    /// * repeat1d(x, axis, 4) = concat(&.{x, x, x, x}, axis);
     /// * repeat1d([0, 1, 2, 3], 0, 2) = [0, 1, 2, 3, 0, 1, 2, 3]
     pub fn repeat1d(self: Tensor, axis_: anytype, n_rep: u63) Tensor {
         if (n_rep == 1) {
@@ -3738,11 +3738,7 @@ pub const Tensor = struct {
     }
 
     fn printCallback(host_buffer: HostBuffer) void {
-        std.debug.lockStdErr();
-        defer std.debug.unlockStdErr();
-        const stderr = std.io.getStdErr().writer();
-        stderr.print("Device buffer: {}:", .{host_buffer.shape()}) catch return;
-        host_buffer.prettyPrint(stderr) catch return;
+        std.debug.print("Device buffer: {}: {}", .{ host_buffer.shape(), host_buffer.pretty() });
     }
 };
 

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1364,7 +1364,7 @@ pub const Tensor = struct {
         else
             toI64(axes__);
 
-        stdx.debug.assert(permutation.len == self.rank(), "transpose expects input tensor rank and 'axes_' length to be equal, got {} and {}", .{ self.rank(), permutation.len });
+        stdx.debug.assert(permutation.len == self.rank(), "transpose expects input tensor rank and 'axes_' length to be equal, got {_} and {d}", .{ self, permutation[0..@min(permutation.len, MAX_RANK + 2)] });
 
         if (std.mem.eql(i64, permutation, no_op[0..self.rank()])) {
             return self;
@@ -3738,13 +3738,11 @@ pub const Tensor = struct {
     }
 
     fn printCallback(host_buffer: HostBuffer) void {
-        switch (host_buffer.dtype()) {
-            inline else => |dt| {
-                const items = host_buffer.items(dt.toZigType());
-                const n = @min(items.len, 1024);
-                std.debug.print("Device buffer: {}: {any}\n", .{ host_buffer.shape(), items[0..n] });
-            },
-        }
+        std.debug.lockStdErr();
+        defer std.debug.unlockStdErr();
+        const stderr = std.io.getStdErr().writer();
+        stderr.print("Device buffer: {}:", .{host_buffer.shape()}) catch return;
+        host_buffer.prettyPrint(stderr) catch return;
     }
 };
 

--- a/zml/testing.zig
+++ b/zml/testing.zig
@@ -53,6 +53,7 @@ pub fn expectClose(left_: anytype, right_: anytype, tolerance: f32) !void {
         if (should_free_left) left.deinit(allocator);
         if (should_free_right) right.deinit(allocator);
     }
+    errdefer log.err("\n--> Left: {}\n--> Right: {}", .{ left.pretty(), right.pretty() });
 
     if (!std.mem.eql(i64, left.shape().dims(), right.shape().dims())) {
         log.err("left.shape() {} != right.shape() {}", .{ left.shape(), right.shape() });

--- a/zml/testing.zig
+++ b/zml/testing.zig
@@ -13,18 +13,16 @@ var _platform: ?zml.Platform = null;
 pub fn env() zml.Platform {
     if (!builtin.is_test) @compileError("Cannot use zml.testing.env outside of a test block");
     if (_platform == null) {
-        _test_compile_opts = .{
-            .sharding_enabled = true,
-        };
-
         var ctx = zml.Context.init() catch unreachable;
-        _platform = ctx.autoPlatform(.{}).withCompilationOptions(_test_compile_opts);
+        _platform = ctx.autoPlatform(.{}).withCompilationOptions(.{
+            .xla_dump_to = "/tmp/zml/tests/",
+            .sharding_enabled = true,
+            .xla_dump_hlo_pass_re = ".*",
+        });
     }
 
     return _platform.?;
 }
-
-var _test_compile_opts: zml.CompilationOptions = .{};
 
 /// In neural network we generally care about the relative precision,
 /// but on a given dimension, if the output is close to 0, then the precision


### PR DESCRIPTION
Add pretty printing of HostBuffer.

This will be leverage by the debug helper `x.print()`
It can also be used like this: `std.log.info("my buffer: {}", .{host_buffer.pretty()})`