### PR TITLE
[WIP] Add ModernBERT implementation in examples

### DIFF
--- a/examples/modernbert/BUILD.bazel
+++ b/examples/modernbert/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@zml//bazel:zig.bzl", "zig_cc_binary")
+
+zig_cc_binary(
+    name = "test-implementation",
+    srcs = ["modernbert.zig"],
+    main = "test.zig",
+    deps = [
+        "@zml//async",
+        "@zml//zml",
+    ],
+)

--- a/examples/modernbert/modernbert.zig
+++ b/examples/modernbert/modernbert.zig
@@ -1,0 +1,234 @@
+const std = @import("std");
+const zml = @import("zml");
+const asynk = @import("async");
+const log = std.log;
+const Tensor = zml.Tensor;
+
+// TODO: I will variablize this later (ModernBertOptions)
+pub const hidden_size = 768;
+pub const intermediate_size = 1152;
+pub const num_attention_heads = 12;
+pub const layer_norm_eps = 1e-05;
+pub const norm_eps = 1e-05;
+pub const local_attention = 128;
+
+pub const ModernBertEmbeddings = struct {
+    tok_embeddings: zml.nn.TokenEmbedding,
+    norm: zml.nn.LayerNorm,
+    drop: void,
+
+    pub fn init(self: *ModernBertEmbeddings) void {
+        self.norm.eps = layer_norm_eps;
+    }
+
+    pub fn forward(self: ModernBertEmbeddings, input_ids: Tensor) Tensor {
+        // Perform tok_embeddings
+        const hidden_states = zml.call(self.tok_embeddings, .forward, .{input_ids});
+
+        // Perform norm
+        return zml.call(self.norm, .forward, .{hidden_states});
+    }
+};
+
+// TODO: Create geglu fn in tensor.zig ?
+/// Switch out the old MLP layers for GeGLU layers, improving on the original BERT’s GeLU activation function.
+///
+/// The GeGLU activation function is a combination of the Gated Linear Unit (GLU) and the Gaussian Error Linear Unit (GeLU).
+///
+/// see: https://paperswithcode.com/method/geglu
+pub const ModernBertMLP = struct {
+    Wi: zml.nn.Linear,
+    Wo: zml.nn.Linear,
+
+    pub fn forward(self: ModernBertMLP, hidden_states: Tensor) Tensor {
+        // Perform Wi
+        const wi_output: Tensor = zml.call(self.Wi, .forward, .{hidden_states});
+
+        // Split into input and gate tensors along the last dimension
+        // input, gate = self.Wi(hidden_states).chunk(2, dim=-1)
+        const input = wi_output.slice1d(-1, .{ .end = intermediate_size });
+        const gate = wi_output.slice1d(-1, .{ .start = intermediate_size });
+
+        // Apply activation function to input and multiply by gate :
+        // self.Wo(self.drop(self.act(input) * gate))
+        const activated_input = input.gelu().mul(gate);
+
+        // Perform Wo
+        return zml.call(self.Wo, .forward, .{activated_input});
+    }
+};
+
+/// Performs multi-headed self attention on a batch of unpadded sequences.
+///
+/// TODO: If Flash Attention 2 is installed, this module uses Flash Attention to improve throughput.
+/// If Flash Attention 2 is not installed, the implementation will use SDPA,
+pub const ModernBertAttention = struct {
+    Wqkv: zml.nn.Linear,
+    Wo: zml.nn.Linear,
+    is_global_attention: bool = false,
+
+    /// sdpa_attention_forward
+    pub fn forward(
+        self: ModernBertAttention,
+        hidden_states: Tensor,
+        attention_mask: Tensor,
+        sliding_window_mask: Tensor,
+        position_ids: Tensor,
+    ) Tensor {
+        const batch_size = hidden_states.shape().dim(0);
+        const seq_length = hidden_states.shape().dim(1);
+        const num_heads = 12; // config.json: num_attention_heads
+        const head_dim = 64; // config.json hidden_size / num_attention_heads = 768 / 12
+
+        if (self.is_global_attention) {
+            log.info("Global attention", .{});
+        } else {
+            log.info("Local attention", .{});
+        }
+
+        // Project to query, key, value - { batch_size, seq_len, 3 * num_heads * head_dim }
+        var qkv: Tensor = zml.call(self.Wqkv, .forward, .{hidden_states}); // Wqkv.out.0
+
+        // Reshape to { batch_size, seq_len, 3, num_heads, head_dim }
+        qkv = qkv.reshape(.{ batch_size, seq_length, 3, num_heads, head_dim });
+        // Transpose for attention computation  { batch_size, seq_len, 3, num_heads, head_dim } -> { batch_size, num_heads, 3, seq_length, head_dim }
+        qkv = qkv.transpose(.{ 0, 3, 2, 1, 4 });
+
+        // Split into query, key, value tensors - each { batch_size, num_heads, seq_length, head_dim }
+        var q = qkv.slice1d(2, .{ .start = 0, .end = 1 }).squeeze(2).withTags(.{ .b, .h, .s, .hd });
+        var k = qkv.slice1d(2, .{ .start = 1, .end = 2 }).squeeze(2).withTags(.{ .b, .h, .s, .hd });
+        var v = qkv.slice1d(2, .{ .start = 2, .end = 3 }).squeeze(2).withTags(.{ .b, .h, .s, .hd });
+
+        // Apply rotary position embeddings (RoPE)
+        // Layer 0, 3, 6, 9, 12 ... use global RoPE
+        // Layer 1, 2, 4, 5, 7, 8, 10, 11 ... use local RoPE
+        const rope_opts = zml.nn.RopeOpts{
+            .impl = .sequential,
+            .freq_base = if (self.is_global_attention) 160_000 else 10_000,
+        };
+        const pos_idx = null; // TODO: This is temporary, need to implement position_ids ?
+        _ = position_ids;
+
+        q = zml.nn.rope(q, pos_idx, rope_opts);
+        k = zml.nn.rope(k, pos_idx, rope_opts);
+
+        // rename dimensions for sdpa
+        q = q.rename(.{ .s = .q });
+        k = k.rename(.{ .s = .k });
+        v = v.rename(.{ .s = .k });
+
+        var mask = attention_mask;
+        if (!self.is_global_attention) mask = sliding_window_mask;
+
+        const sdqa_opts = zml.nn.SdpaOpts{
+            .allow_cudnn = false,
+            .attn_mask = mask,
+        };
+
+        // Scaled dot product attention
+        var attn_output = zml.nn.sdpa(q, k, v, sdqa_opts);
+
+        // { batch, heads, query_seq, head_dim } -> { batch, query_seq, heads * head_dim }
+        attn_output = attn_output.transpose(.{ .b, .q, .h, .hd });
+        const attn = attn_output.merge(.{ .d = .{ .h, .hd } }).rename(.{ .q = .s });
+
+        // Final projection
+        return zml.call(self.Wo, .forward, .{attn});
+    }
+};
+
+pub const ModernBertAttentionLocal = struct {
+    Wqkv: zml.nn.Linear,
+    Wo: zml.nn.Linear,
+
+    pub fn forward(
+        self: ModernBertAttentionLocal,
+        hidden_states: Tensor,
+        attention_mask: Tensor,
+        sliding_window_mask: Tensor,
+        position_ids: Tensor,
+    ) Tensor {
+        const attn = ModernBertAttention{
+            .Wqkv = self.Wqkv,
+            .Wo = self.Wo,
+            .is_global_attention = false,
+        };
+        return attn.forward(hidden_states, attention_mask, sliding_window_mask, position_ids);
+    }
+};
+
+pub const ModernBertAttentionGlobal = struct {
+    Wqkv: zml.nn.Linear,
+    Wo: zml.nn.Linear,
+
+    pub fn forward(
+        self: ModernBertAttentionGlobal,
+        hidden_states: Tensor,
+        attention_mask: Tensor,
+        sliding_window_mask: Tensor,
+        position_ids: Tensor,
+    ) Tensor {
+        const attn = ModernBertAttention{
+            .Wqkv = self.Wqkv,
+            .Wo = self.Wo,
+            .is_global_attention = true,
+        };
+        return attn.forward(hidden_states, attention_mask, sliding_window_mask, position_ids);
+    }
+};
+
+pub const ModernBertEncoderLayer = struct {
+    // TODO: Special case for layer 0 using a union type to handle both "void" and zml.nn.LayerNorm cases
+    attn_norm: zml.nn.LayerNorm,
+    attn: ModernBertAttention,
+    mlp_norm: zml.nn.LayerNorm,
+    mlp: ModernBertMLP,
+
+    pub fn init(self: *ModernBertEncoderLayer) void {
+        self.attn_norm.eps = norm_eps;
+        self.mlp_norm.eps = norm_eps;
+    }
+
+    pub fn forward(
+        self: ModernBertEncoderLayer,
+        hidden_states: Tensor,
+        attention_mask: Tensor,
+        sliding_window_mask: Tensor,
+        position_ids: Tensor,
+    ) Tensor {
+        // TODO: Handle global and local attention
+
+        // Layer norm → Attention → Residual connection
+        const attn_norm_output: Tensor = zml.call(self.attn_norm, .forward, .{hidden_states});
+        const attn_output: Tensor = zml.call(self.attn, .forward, .{
+            attn_norm_output,
+            attention_mask,
+            sliding_window_mask,
+            position_ids,
+        });
+        var output = hidden_states.add(attn_output);
+
+        // Layer norm → MLP → Residual connection
+        const mlp_norm_output: Tensor = zml.call(self.mlp_norm, .forward, .{output});
+        const mlp_output = zml.call(self.mlp, .forward, .{mlp_norm_output});
+        output = output.add(mlp_output);
+
+        return output;
+    }
+};
+
+pub const ModernBertModel = struct {
+    embeddings: ModernBertEmbeddings,
+    // layers: []ModernBertEncoderLayer,
+    final_norm: zml.nn.LayerNorm,
+
+    pub fn init(self: *ModernBertModel) void {
+        self.final_norm.eps = norm_eps;
+    }
+
+    pub fn forward(self: ModernBertModel, input_ids: Tensor, attention_mask: Tensor) Tensor {
+        _ = attention_mask; // autofix
+        _ = self; // autofix
+        return Tensor.constant(input_ids.shape(), input_ids.dtype().zero());
+    }
+};

--- a/examples/modernbert/test.zig
+++ b/examples/modernbert/test.zig
@@ -1,0 +1,309 @@
+const std = @import("std");
+const zml = @import("zml");
+const asynk = @import("async");
+const log = std.log;
+const Tensor = zml.Tensor;
+const modernbert = @import("modernbert.zig");
+const ModernBertEmbeddings = modernbert.ModernBertEmbeddings;
+const ModernBertMLP = modernbert.ModernBertMLP;
+const ModernBertAttentionLocal = modernbert.ModernBertAttentionLocal;
+const ModernBertAttentionGlobal = modernbert.ModernBertAttentionGlobal;
+const ModernBertEncoderLayer = modernbert.ModernBertEncoderLayer;
+
+// ModernBERT
+const ACTIVATIONS_FILE_PATH: []const u8 = "/Users/victor/Documents/development/zml-torch-activation-example/ModernBERT-base.activations.pt";
+const MODEL_WEIGHTS_FILE_PATH: []const u8 = "/Users/victor/.cache/huggingface/hub/models--answerdotai--ModernBERT-base/snapshots/5756c58a31a2478f9e62146021f48295a92c3da5/model.safetensors";
+
+pub fn main() !void {
+    try asynk.AsyncThread.main(std.heap.c_allocator, asyncMain);
+}
+
+// for (0..activations.buffers.count()) |i| {
+//     log.info("activations {d}: {s}", .{ i, activations.buffers.entries.get(i).key });
+// }
+
+pub fn asyncMain() !void {
+    // Short lived allocations
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    // Initialize the ZML context
+    var context = try zml.Context.init();
+    defer context.deinit();
+
+    // Auto-select platform
+    const compute_platform = context.autoPlatform(.{});
+    log.info("Selected platform: {s}", .{@tagName(compute_platform.target)});
+
+    // Create a dedicated memory arena for model-related allocations (dedicated to model shapes and weights)
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const model_arena = arena_state.allocator();
+
+    // Load the model weights file and parse its structure (shape)
+    var weights_file = try zml.aio.detectFormatAndOpen(allocator, MODEL_WEIGHTS_FILE_PATH);
+    defer weights_file.deinit();
+
+    // Log the total number of layers and details of the first layer from weights
+    const first_layer_key = weights_file.buffers.keys()[0];
+    log.info("Model contains {d} layers. Loaded from: {s}", .{ weights_file.buffers.count(), MODEL_WEIGHTS_FILE_PATH });
+    log.info("First layer key: \"{s}\" / First layer buffer: {?}", .{ first_layer_key, weights_file.buffers.get(first_layer_key) });
+
+    // Load the activation data file
+    const activations = try zml.aio.torch.open(model_arena, ACTIVATIONS_FILE_PATH);
+    defer activations.deinit();
+    log.info("Found {} activations in {s}", .{ activations.buffers.count(), ACTIVATIONS_FILE_PATH });
+
+    // model.embeddings.tok_embeddings
+    log.info("\n\nTesting model.embeddings.tok_embeddings layer:", .{});
+
+    const word_embeddings_shape = try zml.aio.populateModelWithPrefix(
+        zml.nn.TokenEmbedding,
+        model_arena,
+        weights_file,
+        "model.embeddings.tok_embeddings",
+    );
+
+    const word_embeddings_weights = try zml.aio.loadModelBuffersWithPrefix(
+        zml.nn.TokenEmbedding,
+        word_embeddings_shape,
+        weights_file,
+        model_arena,
+        compute_platform,
+        "model.embeddings.tok_embeddings",
+    );
+
+    try zml.testing.testLayer(
+        compute_platform,
+        activations,
+        "model.model.embeddings.tok_embeddings",
+        word_embeddings_shape,
+        word_embeddings_weights,
+        1e-6,
+    );
+
+    // model.embeddings.norm
+    log.info("\n\nTesting model.embeddings.norm layer:", .{});
+
+    const norm_shape = try zml.aio.populateModelWithPrefix(
+        zml.nn.LayerNorm,
+        model_arena,
+        weights_file,
+        "model.embeddings.norm",
+    );
+
+    const norm_weights = try zml.aio.loadModelBuffersWithPrefix(
+        zml.nn.LayerNorm,
+        norm_shape,
+        weights_file,
+        model_arena,
+        compute_platform,
+        "model.embeddings.norm",
+    );
+
+    try zml.testing.testLayer(
+        compute_platform,
+        activations,
+        "model.model.embeddings.norm",
+        norm_shape,
+        norm_weights,
+        1e-3,
+    );
+
+    // model.embeddings
+    log.info("\n\nTesting model.embeddings layer:", .{});
+
+    const embeddings_shape = try zml.aio.populateModelWithPrefix(
+        ModernBertEmbeddings,
+        model_arena,
+        weights_file,
+        "model.embeddings",
+    );
+
+    const embeddings_weights = try zml.aio.loadModelBuffersWithPrefix(
+        ModernBertEmbeddings,
+        embeddings_shape,
+        weights_file,
+        model_arena,
+        compute_platform,
+        "model.embeddings",
+    );
+
+    try zml.testing.testLayer(
+        compute_platform,
+        activations,
+        "model.model.embeddings",
+        embeddings_shape,
+        embeddings_weights,
+        1e-3,
+    );
+
+    // model.final_norm
+    log.info("\n\nTesting model.final_norm layer:", .{});
+
+    const final_norm_shape = try zml.aio.populateModelWithPrefix(
+        zml.nn.LayerNorm,
+        model_arena,
+        weights_file,
+        "model.final_norm",
+    );
+
+    const final_norm_weights = try zml.aio.loadModelBuffersWithPrefix(
+        zml.nn.LayerNorm,
+        final_norm_shape,
+        weights_file,
+        model_arena,
+        compute_platform,
+        "model.final_norm",
+    );
+
+    try zml.testing.testLayer(
+        compute_platform,
+        activations,
+        "model.model.final_norm",
+        final_norm_shape,
+        final_norm_weights,
+        1e-5,
+    );
+
+    // model.layers.2.mlp
+    log.info("\n\nTesting model.layers.2.mlp layer:", .{});
+
+    const mlp_shape = try zml.aio.populateModelWithPrefix(
+        ModernBertMLP,
+        model_arena,
+        weights_file,
+        "model.layers.2.mlp",
+    );
+
+    const mlp_weights = try zml.aio.loadModelBuffersWithPrefix(
+        ModernBertMLP,
+        mlp_shape,
+        weights_file,
+        model_arena,
+        compute_platform,
+        "model.layers.2.mlp",
+    );
+
+    try zml.testing.testLayer(
+        compute_platform,
+        activations,
+        "model.model.layers.2.mlp",
+        mlp_shape,
+        mlp_weights,
+        2e-3,
+    );
+
+    // model.layers.0.mlp_norm
+    log.info("\n\nTesting model.layers.2.mlp_norm layer:", .{});
+
+    const mlp_norm_shape = try zml.aio.populateModelWithPrefix(
+        zml.nn.LayerNorm,
+        model_arena,
+        weights_file,
+        "model.layers.2.mlp_norm",
+    );
+
+    const mlp_norm_weights = try zml.aio.loadModelBuffersWithPrefix(
+        zml.nn.LayerNorm,
+        mlp_norm_shape,
+        weights_file,
+        model_arena,
+        compute_platform,
+        "model.layers.2.mlp_norm",
+    );
+
+    try zml.testing.testLayer(
+        compute_platform,
+        activations,
+        "model.model.layers.2.mlp_norm",
+        mlp_norm_shape,
+        mlp_norm_weights,
+        1e-4,
+    );
+
+    // model.layers.2.attn
+    log.info("\n\nTesting model.layers.2.attn layer:", .{});
+
+    const attn_shape = try zml.aio.populateModelWithPrefix(
+        ModernBertAttentionLocal,
+        model_arena,
+        weights_file,
+        "model.layers.2.attn",
+    );
+
+    const attn_weights = try zml.aio.loadModelBuffersWithPrefix(
+        ModernBertAttentionLocal,
+        attn_shape,
+        weights_file,
+        model_arena,
+        compute_platform,
+        "model.layers.2.attn",
+    );
+
+    try zml.testing.testLayer(
+        compute_platform,
+        activations,
+        "model.model.layers.2.attn",
+        attn_shape,
+        attn_weights,
+        1e-6,
+    );
+
+    // model.layers.3.attn
+    log.info("\n\nTesting model.layers.3.attn layer:", .{});
+
+    const attn_global_shape = try zml.aio.populateModelWithPrefix(
+        ModernBertAttentionGlobal,
+        model_arena,
+        weights_file,
+        "model.layers.3.attn",
+    );
+
+    const attn_global_weights = try zml.aio.loadModelBuffersWithPrefix(
+        ModernBertAttentionGlobal,
+        attn_global_shape,
+        weights_file,
+        model_arena,
+        compute_platform,
+        "model.layers.3.attn",
+    );
+
+    try zml.testing.testLayer(
+        compute_platform,
+        activations,
+        "model.model.layers.3.attn",
+        attn_global_shape,
+        attn_global_weights,
+        1e-5,
+    );
+
+    // model.layers.2
+    log.info("\n\nTesting model.layers.2 layer:", .{});
+
+    const layer_shape = try zml.aio.populateModelWithPrefix(
+        ModernBertEncoderLayer,
+        model_arena,
+        weights_file,
+        "model.layers.2",
+    );
+
+    const layer_weights = try zml.aio.loadModelBuffersWithPrefix(
+        ModernBertEncoderLayer,
+        layer_shape,
+        weights_file,
+        model_arena,
+        compute_platform,
+        "model.layers.2",
+    );
+
+    try zml.testing.testLayer(
+        compute_platform,
+        activations,
+        "model.model.layers.2",
+        layer_shape,
+        layer_weights,
+        2e-3,
+    );
+}


### PR DESCRIPTION
# Description

This is a work-in-progress implementation of ModernBERT. ModernBERT is an optimized variant of BERT that includes:
- GeGLU activation function instead of GeLU
- Improved attention mechanism with local and global attention patterns
- RoPE (Rotary Position Embeddings) for better position encoding
- ...

References:
https://huggingface.co/blog/modernbert
https://huggingface.co/docs/transformers/main/en/model_doc/modernbert
https://github.com/AnswerDotAI/ModernBERT
https://github.com/huggingface/transformers/blob/main/src/transformers/models/modernbert/modular_modernbert.py

## TODO

- [x] Embeddings layer with layer normalization
- [x] Attention mechanisms (both local and global variants)
- [x] MLP with GeGLU activation
- [x] Basic test implementation
- [ ] Create ModernBertOptions struct to replace hardcoded constants:
- [ ] Implement Flash Attention 2 optimization for better throughput
- [ ] Create geglu function in tensor.zig
- [ ] Handle layer 0 special case using a union type for both "void" and zml.nn.LayerNorm cases
- [ ] Implement proper position_ids handling (currently using null)
- [ ] Handle global and local attention properly in ModernBertEncoderLayer
- [ ] Complete layers field in ModernBertModel (currently commented out)
- [ ] ... 

## Testing

Basic testing has been implemented for:
- Embeddings layer
- Attention mechanisms (both local and global)
- MLP layer
- Layer normalization
- Full encoder layer (with only local attention mechanism + without handling layer 0)

Current test tolerances range from 1e-6 to 2e-3 depending on the layer.

```bazel run -c opt //modernbert:test-implementation```

__Feedback and suggestions are welcome !__