### PR TITLE
async: fix async hangs

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -84,7 +84,7 @@ use_repo(zls, "zls_aarch64-macos", "zls_x86_64-linux")
 
 register_toolchains("//third_party/zls:all")
 
-bazel_dep(name = "libxev", version = "20241208.0-db6a52b")
+bazel_dep(name = "libxev", version = "20241208.1-db6a52b")
 bazel_dep(name = "llvm-raw", version = "20250102.0-f739aa4")
 
 llvm = use_extension("@llvm-raw//utils/bazel:extension.bzl", "llvm")

--- a/async/async.zig
+++ b/async/async.zig
@@ -526,6 +526,10 @@ pub fn logFn(
     comptime format: []const u8,
     args: anytype,
 ) void {
+    if (coro.inCoro() == false) {
+        return std.log.defaultLog(message_level, scope, format, args);
+    }
+
     const level_txt = comptime message_level.asText();
     const prefix2 = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
     const stderr = getStdErr().writer();

--- a/async/async.zig
+++ b/async/async.zig
@@ -48,8 +48,8 @@ fn FrameExx(comptime func: anytype, comptime argsT: type, comptime returnT: type
         pub const await_ = awaitt;
         pub fn awaitt(self: *Self) returnT {
             defer {
-                AsyncThread.current.stack_allocator.destroy(&self.inner._frame.stack);
                 self.inner.deinit();
+                AsyncThread.current.stack_allocator.destroy(&self.inner._frame.stack);
                 self.* = undefined;
             }
             return coro.xawait(self.inner);
@@ -145,16 +145,14 @@ pub const threading = struct {
                 .waiting = &waiter,
             };
             if (self.waiter.cmpxchgStrong(&State.unset_state, &new_state, .monotonic, .monotonic) == null) {
-                while (self.isSet() == false) {
-                    coro.xsuspend();
-                }
+                coro.xsuspend();
             }
         }
     };
 };
 
 pub const AsyncThread = struct {
-    threadlocal var current: *const AsyncThread = undefined;
+    threadlocal var current: *AsyncThread = undefined;
 
     executor: *aio.Executor,
     stack_allocator: *stack.StackAllocator,
@@ -167,8 +165,8 @@ pub const AsyncThread = struct {
         self.async_notifier.notify() catch {};
     }
 
-    fn waker_cb(q: ?*threading.WaiterQueue, _: *xev.Loop, _: *xev.Completion, _: xev.Async.WaitError!void) xev.CallbackAction {
-        while (q.?.pop()) |waiter| {
+    fn wakerCallback(self: ?*AsyncThread, _: *xev.Loop, _: *xev.Completion, _: xev.Async.WaitError!void) xev.CallbackAction {
+        while (self.?.waiters_queue.pop()) |waiter| {
             coro.xresume(waiter.frame);
         }
         return .rearm;
@@ -194,13 +192,10 @@ pub const AsyncThread = struct {
         var waiters_queue: threading.WaiterQueue = undefined;
         waiters_queue.init();
 
-        var c: xev.Completion = undefined;
-        async_notifier.wait(&loop, &c, threading.WaiterQueue, &waiters_queue, &waker_cb);
-
         var stack_allocator = stack.StackAllocator.init(allocator);
         defer stack_allocator.deinit();
 
-        AsyncThread.current = &.{
+        var asyncThread: AsyncThread = .{
             .executor = &executor_,
             .stack_allocator = &stack_allocator,
             .loop = &loop,
@@ -208,6 +203,10 @@ pub const AsyncThread = struct {
             .async_notifier = &async_notifier,
             .waiters_queue = &waiters_queue,
         };
+        AsyncThread.current = &asyncThread;
+
+        var c2: xev.Completion = undefined;
+        async_notifier.wait(AsyncThread.current.loop, &c2, AsyncThread, AsyncThread.current, &AsyncThread.wakerCallback);
 
         // allocate the main coroutine stack, on the current thread's stack!
         var mainStackData: stack.Stack.Data = undefined;

--- a/async/asyncio.zig
+++ b/async/asyncio.zig
@@ -52,7 +52,7 @@ pub fn run(
     args: anytype,
     stack: anytype,
 ) !stdx.meta.FnSignature(func, @TypeOf(args)).ReturnPayloadT {
-    stdx.debug.assert(libcoro.inCoro() == false, "Not in a corouine", .{});
+    stdx.debug.assert(libcoro.inCoro() == false, "Not in a coroutine", .{});
     const frame = try xasync(func, args, stack);
     defer frame.deinit();
     try runCoro(exec, frame);
@@ -88,20 +88,20 @@ pub fn sleep(exec: *Executor, ms: u64) !void {
     return data.result;
 }
 
-fn waitForCompletionOutsideCoro(exec: *Executor, c: *xev.Completion) !void {
+pub fn waitForCompletionOutsideCoro(exec: *Executor, c: *xev.Completion) !void {
     @setCold(true);
     while (c.state() != .dead) {
         try exec.tick();
     }
 }
 
-fn waitForCompletionInCoro(c: *xev.Completion) void {
+pub fn waitForCompletionInCoro(c: *xev.Completion) void {
     while (c.state() != .dead) {
         libcoro.xsuspend();
     }
 }
 
-fn waitForCompletion(exec: *Executor, c: *xev.Completion) !void {
+pub fn waitForCompletion(exec: *Executor, c: *xev.Completion) !void {
     if (libcoro.inCoro()) {
         waitForCompletionInCoro(c);
     } else {

--- a/async/coro.zig
+++ b/async/coro.zig
@@ -76,7 +76,7 @@ pub fn xresume(frame: anytype) void {
 /// Must be called from within a coroutine (i.e. not the top level).
 pub fn xsuspend() void {
     xsuspendSafe() catch |e| {
-        log.err("{any}\n", .{e});
+        log.err("{any}", .{e});
         @panic("xsuspend");
     };
 }
@@ -160,10 +160,10 @@ const Coro = struct {
     fn runcoro(from: *base.Coro, this: *base.Coro) callconv(.C) noreturn {
         const from_coro: *Coro = @fieldParentPtr("impl", from);
         const this_coro: *Coro = @fieldParentPtr("impl", this);
-        log.debug("coro start {any}\n", .{this_coro.id});
+        log.debug("coro start {any}", .{this_coro.id});
         @call(.auto, this_coro.func, .{});
         this_coro.status = .Done;
-        log.debug("coro done {any}\n", .{this_coro.id});
+        log.debug("coro done {any}", .{this_coro.id});
         thread_state.switchOut(from_coro);
 
         // Never returns
@@ -258,7 +258,7 @@ const CoroT = struct {
             fn wrapfn() void {
                 const storage = thread_state.currentStorage(InnerStorage);
                 storage.retval = @call(
-                    .always_inline,
+                    .auto,
                     Sig.Func.Value,
                     storage.args,
                 );
@@ -317,7 +317,7 @@ const ThreadState = struct {
 
     /// Called from resume
     fn switchIn(self: *ThreadState, target: Frame) void {
-        log.debug("coro resume {any} from {any}\n", .{ target.id, self.current().id });
+        log.debug("coro resume {any} from {any}", .{ target.id, self.current().id });
 
         // Switch to target, setting this coro as the resumer.
         self.switchTo(target, true);
@@ -332,7 +332,7 @@ const ThreadState = struct {
 
     /// Called from suspend
     fn switchOut(self: *ThreadState, target: Frame) void {
-        log.debug("coro suspend {any} to {any}\n", .{ self.current().id, target.id });
+        log.debug("coro suspend {any} to {any}", .{ self.current().id, target.id });
         self.switchTo(target, false);
     }
 

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -134,7 +134,6 @@ filegroup(
 )
 use_repo(huggingface, "Meta-Llama-3.2-3B-Instruct")
 
-
 # Llama 3.1
 huggingface.model(
     name = "Meta-Llama-3.1-8B-Instruct",

--- a/examples/llama/main.zig
+++ b/examples/llama/main.zig
@@ -28,6 +28,7 @@ pub const std_options = .{
         .{ .scope = .zml_module, .level = if (show_mlir) .debug else .warn },
         .{ .scope = .llama, .level = .info },
     },
+    .logFn = asynk.logFn,
 };
 
 pub fn generateText(

--- a/runtimes/cpu/BUILD.bazel
+++ b/runtimes/cpu/BUILD.bazel
@@ -21,7 +21,10 @@ zig_library(
     deps = [
         "//pjrt",
     ] + select({
-        "//runtimes:cpu.enabled": [":libpjrt_cpu"],
+        "//runtimes:cpu.enabled": [
+            ":libpjrt_cpu",
+            "//async",
+        ],
         "//conditions:default": [":empty"],
     }),
 )

--- a/runtimes/cpu/cpu.zig
+++ b/runtimes/cpu/cpu.zig
@@ -1,6 +1,8 @@
 const builtin = @import("builtin");
-const pjrt = @import("pjrt");
+
+const asynk = @import("async");
 const c = @import("c");
+const pjrt = @import("pjrt");
 
 pub fn isEnabled() bool {
     return @hasDecl(c, "ZML_RUNTIME_CPU");
@@ -16,5 +18,5 @@ pub fn load() !*const pjrt.Api {
         .macos, .ios, .watchos => ".dylib",
         else => ".so",
     };
-    return try pjrt.Api.loadFrom("libpjrt_cpu" ++ ext);
+    return try asynk.callBlocking(pjrt.Api.loadFrom, .{"libpjrt_cpu" ++ ext});
 }

--- a/runtimes/cuda/cuda.zig
+++ b/runtimes/cuda/cuda.zig
@@ -1,8 +1,8 @@
+const builtin = @import("builtin");
 const std = @import("std");
 
 const asynk = @import("async");
 const bazel_builtin = @import("bazel_builtin");
-const builtin = @import("builtin");
 const c = @import("c");
 const pjrt = @import("pjrt");
 const runfiles = @import("runfiles");
@@ -49,5 +49,5 @@ pub fn load() !*const pjrt.Api {
     // See https://github.com/openxla/xla/issues/21428
     try setupXlaGpuCudaDirFlag();
 
-    return try pjrt.Api.loadFrom("libpjrt_cuda.so");
+    return try asynk.callBlocking(pjrt.Api.loadFrom, .{"libpjrt_cuda.so"});
 }

--- a/runtimes/neuron/neuron.zig
+++ b/runtimes/neuron/neuron.zig
@@ -1,11 +1,12 @@
 const builtin = @import("builtin");
-const asynk = @import("async");
-const pjrt = @import("pjrt");
-const c = @import("c");
 const std = @import("std");
-const runfiles = @import("runfiles");
+
+const asynk = @import("async");
 const bazel_builtin = @import("bazel_builtin");
+const c = @import("c");
 const libneuronxla_pyenv = @import("libneuronxla_pyenv");
+const pjrt = @import("pjrt");
+const runfiles = @import("runfiles");
 
 pub fn isEnabled() bool {
     return @hasDecl(c, "ZML_RUNTIME_NEURON");
@@ -136,5 +137,5 @@ pub fn load() !*const pjrt.Api {
 
     setNeuronCCFlags();
     try initialize();
-    return try pjrt.Api.loadFrom("libpjrt_neuron.so");
+    return try asynk.callBlocking(pjrt.Api.loadFrom, .{"libpjrt_neuron.so"});
 }

--- a/runtimes/rocm/rocm.zig
+++ b/runtimes/rocm/rocm.zig
@@ -70,5 +70,5 @@ pub fn load() !*const pjrt.Api {
 
     try setupRocmEnv();
 
-    return try pjrt.Api.loadFrom("libpjrt_rocm.so");
+    return try asynk.callBlocking(pjrt.Api.loadFrom, .{"libpjrt_rocm.so"});
 }

--- a/runtimes/tpu/tpu.zig
+++ b/runtimes/tpu/tpu.zig
@@ -1,8 +1,9 @@
 const builtin = @import("builtin");
+const std = @import("std");
+
 const asynk = @import("async");
 const pjrt = @import("pjrt");
 const c = @import("c");
-const std = @import("std");
 
 pub fn isEnabled() bool {
     return @hasDecl(c, "ZML_RUNTIME_TPU");
@@ -36,5 +37,5 @@ pub fn load() !*const pjrt.Api {
         return error.Unavailable;
     }
 
-    return try pjrt.Api.loadFrom("libpjrt_tpu.so");
+    return try asynk.callBlocking(pjrt.Api.loadFrom, .{"libpjrt_tpu.so"});
 }

--- a/third_party/modules/libxev/20241208.1-db6a52b/MODULE.bazel
+++ b/third_party/modules/libxev/20241208.1-db6a52b/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "libxev",
+    version = "20241208.1-db6a52b",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_zig", version = "20240904.0-010da15")

--- a/third_party/modules/libxev/20241208.1-db6a52b/overlay/BUILD.bazel
+++ b/third_party/modules/libxev/20241208.1-db6a52b/overlay/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_zig//zig:defs.bzl", "zig_library")
+
+zig_library(
+    name = "xev",
+    srcs = glob([
+        "src/*.zig",
+        "src/backend/*.zig",
+        "src/linux/*.zig",
+        "src/watcher/*.zig",
+    ]),
+    main = "main2.zig",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/modules/libxev/20241208.1-db6a52b/overlay/MODULE.bazel
+++ b/third_party/modules/libxev/20241208.1-db6a52b/overlay/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "libxev",
+    version = "20241208.0-db6a52b",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_zig", version = "20240904.0-010da15")

--- a/third_party/modules/libxev/20241208.1-db6a52b/overlay/main2.zig
+++ b/third_party/modules/libxev/20241208.1-db6a52b/overlay/main2.zig
@@ -1,0 +1,22 @@
+const builtin = @import("builtin");
+const root = @import("root");
+
+const main = @import("src/main.zig");
+
+pub const ThreadPool = main.ThreadPool;
+pub const stream = main.stream;
+
+pub const Options = struct {
+    linux_backend: main.Backend = .epoll,
+};
+
+pub const options: Options = if (@hasDecl(root, "xev_options")) root.xev_options else .{};
+
+const default: main.Backend = switch (builtin.os.tag) {
+    .ios, .macos => .kqueue,
+    .linux => options.linux_backend,
+    .wasi => .wasi_poll,
+    .windows => .iocp,
+    else => @compileError("Unsupported OS"),
+};
+pub usingnamespace default.Api();

--- a/third_party/modules/libxev/20241208.1-db6a52b/patches/128.patch
+++ b/third_party/modules/libxev/20241208.1-db6a52b/patches/128.patch
@@ -1,100 +1,7 @@
-From 12fb50bdd4b62c8e111f12eecb171257b6af6038 Mon Sep 17 00:00:00 2001
-From: Mitchell Hashimoto <m@mitchellh.com>
-Date: Mon, 4 Nov 2024 13:30:10 -0800
-Subject: [PATCH 1/8] Revert "Fix potential ThreadPool UAF (#113)"
-
-This reverts commit dbe22910a43e9e8ec9948d3cbd73d8488a074967, reversing
-changes made to 43c7e4b3308f359e5b758db2d824d7c447f4ed3f.
----
- src/ThreadPool.zig | 8 ++++++--
- 1 file changed, 6 insertions(+), 2 deletions(-)
-
-diff --git a/src/ThreadPool.zig b/src/ThreadPool.zig
-index 9e0ff02..1d0123b 100644
---- a/src/ThreadPool.zig
-+++ b/src/ThreadPool.zig
-@@ -335,8 +335,12 @@ fn unregister(noalias self: *ThreadPool, noalias maybe_thread: ?*Thread) void {
- 
- fn join(self: *ThreadPool) void {
-     // Wait for the thread pool to be shutdown() then for all threads to enter a joinable state
--    self.join_event.wait();
--    const sync: Sync = @bitCast(self.sync.load(.monotonic));
-+    var sync: Sync = @bitCast(self.sync.load(.monotonic));
-+    if (!(sync.state == .shutdown and sync.spawned == 0)) {
-+        self.join_event.wait();
-+        sync = @bitCast(self.sync.load(.monotonic));
-+    }
-+
-     assert(sync.state == .shutdown);
-     assert(sync.spawned == 0);
- 
-
-From f6dea8bb85593cca6d4a54d92d4b05fe15b1eb41 Mon Sep 17 00:00:00 2001
-From: Corentin Godeau <corentin.godeau@zml.ai>
-Date: Tue, 10 Sep 2024 11:23:28 +0200
-Subject: [PATCH 2/8] fix: avoid overflow in kqueue backend
-
-When there is more than 256 events, the `events` slice could overflow
-when processing completions.
----
- src/backend/kqueue.zig | 3 +++
- 1 file changed, 3 insertions(+)
-
-diff --git a/src/backend/kqueue.zig b/src/backend/kqueue.zig
-index 834f916..456f64f 100644
---- a/src/backend/kqueue.zig
-+++ b/src/backend/kqueue.zig
-@@ -437,6 +437,9 @@ pub const Loop = struct {
-                     // Only resubmit if we aren't already active (in the queue)
-                     .rearm => if (!c_active) self.submissions.push(c),
-                 }
-+
-+                // If we filled the events slice, we break to avoid overflow.
-+                if (changes == events.len) break;
-             }
- 
-             // Determine our next timeout based on the timers
-
-From 890e2711ff9eb82bbceda2e6229b9c9a8d0b60da Mon Sep 17 00:00:00 2001
-From: David Rubin <daviru007@icloud.com>
-Date: Fri, 6 Dec 2024 20:43:52 -0800
-Subject: [PATCH 3/8] remove race from threadpool
-
----
- src/ThreadPool.zig | 8 +++-----
- 1 file changed, 3 insertions(+), 5 deletions(-)
-
-diff --git a/src/ThreadPool.zig b/src/ThreadPool.zig
-index 1d0123b..aec09d7 100644
---- a/src/ThreadPool.zig
-+++ b/src/ThreadPool.zig
-@@ -291,6 +291,7 @@ pub noinline fn shutdown(self: *ThreadPool) void {
-             // Wake up any threads sleeping on the idle_event.
-             // TODO: I/O polling notification here.
-             if (sync.idle > 0) self.idle_event.shutdown();
-+            if (sync.spawned == 0) self.join_event.notify();
-             return;
-         });
-     }
-@@ -335,11 +336,8 @@ fn unregister(noalias self: *ThreadPool, noalias maybe_thread: ?*Thread) void {
- 
- fn join(self: *ThreadPool) void {
-     // Wait for the thread pool to be shutdown() then for all threads to enter a joinable state
--    var sync: Sync = @bitCast(self.sync.load(.monotonic));
--    if (!(sync.state == .shutdown and sync.spawned == 0)) {
--        self.join_event.wait();
--        sync = @bitCast(self.sync.load(.monotonic));
--    }
-+    self.join_event.wait();
-+    const sync: Sync = @bitCast(self.sync.load(.monotonic));
- 
-     assert(sync.state == .shutdown);
-     assert(sync.spawned == 0);
-
-From d82ee736a1548e6564a296315f33902ae09aa298 Mon Sep 17 00:00:00 2001
+From 8927108937e23ce2ad547a310dabd976ddcaa39d Mon Sep 17 00:00:00 2001
 From: Steeve Morin <steeve@zml.ai>
 Date: Tue, 19 Nov 2024 16:14:14 +0100
-Subject: [PATCH 4/8] backend/epoll: implement eventfd wakeup notification
+Subject: [PATCH 1/5] backend/epoll: implement eventfd wakeup notification
 
 Tries to mimic what happens in backend/kqueue.
 
@@ -211,10 +118,10 @@ index ae4ec7d..f44d326 100644
      task_result: Result = undefined,
  
 
-From 320f1ae9ccc95ce814e246b35ca0f9fd2361f43e Mon Sep 17 00:00:00 2001
+From bf6c19eb1c06d1fb1b3cb5a66ea2ce8f743da5ba Mon Sep 17 00:00:00 2001
 From: Corentin Godeau <corentin@zml.ai>
 Date: Tue, 14 Jan 2025 14:43:54 +0000
-Subject: [PATCH 5/8] backend/epoll: read the wakeup eventfd to avoid being
+Subject: [PATCH 2/5] backend/epoll: read the wakeup eventfd to avoid being
  awaken again
 
 ---
@@ -251,10 +158,10 @@ index f44d326..f84c687 100644
                  const c: *Completion = @ptrFromInt(@as(usize, @intCast(ev.data.ptr)));
  
 
-From 258a64180c901b5e1f9a2c75f1ac77a758411450 Mon Sep 17 00:00:00 2001
+From c0ae753a9874bf78a48bf25b4362b6cca4de1da1 Mon Sep 17 00:00:00 2001
 From: Steeve Morin <steeve@zml.ai>
 Date: Fri, 17 Jan 2025 20:47:42 +0000
-Subject: [PATCH 6/8] epoll: use infinite timeout for epoll_wait
+Subject: [PATCH 3/5] epoll: use infinite timeout for epoll_wait
 
 Since eventfd is now implemented.
 ---
@@ -277,17 +184,16 @@ index f84c687..e3eee20 100644
                  // Determine the time in milliseconds.
                  const ms_now = @as(u64, @intCast(self.cached_now.tv_sec)) * std.time.ms_per_s +
 
-From 9ff535f9b6fac454d454f2799b93863dc9aba7d4 Mon Sep 17 00:00:00 2001
+From 84e75a10ec1c10ea2a13edfcd8a31e582458fc88 Mon Sep 17 00:00:00 2001
 From: Steeve Morin <steeve@zml.ai>
 Date: Fri, 17 Jan 2025 20:48:27 +0000
-Subject: [PATCH 7/8] epoll,kqueue: dispatch close in threadpool
+Subject: [PATCH 4/5] epoll: dispatch close in threadpool
 
 Close might block, so dispatch it inside a threadpool.
 ---
  src/backend/epoll.zig  | 15 +++++++++++++--
- src/backend/kqueue.zig |  6 +++++-
  src/watcher/stream.zig | 16 ++++++++++++++++
- 3 files changed, 34 insertions(+), 3 deletions(-)
+ 2 files changed, 29 insertions(+), 2 deletions(-)
 
 diff --git a/src/backend/epoll.zig b/src/backend/epoll.zig
 index e3eee20..0f4a2ac 100644
@@ -336,30 +242,6 @@ index e3eee20..0f4a2ac 100644
      Unknown,
  };
  
-diff --git a/src/backend/kqueue.zig b/src/backend/kqueue.zig
-index 456f64f..9914309 100644
---- a/src/backend/kqueue.zig
-+++ b/src/backend/kqueue.zig
-@@ -1102,7 +1102,6 @@ pub const Completion = struct {
-     fn perform(self: *Completion, ev_: ?*const Kevent) Result {
-         return switch (self.op) {
-             .cancel,
--            .close,
-             .noop,
-             .timer,
-             .shutdown,
-@@ -1232,6 +1231,11 @@ pub const Completion = struct {
- 
-                 break :res .{ .proc = 0 };
-             },
-+
-+            .close => |*op| res: {
-+                posix.close(op.fd);
-+                break :res .{ .close = {} };
-+            },
-         };
-     }
- 
 diff --git a/src/watcher/stream.zig b/src/watcher/stream.zig
 index 7f5df6f..bc95282 100644
 --- a/src/watcher/stream.zig
@@ -388,10 +270,10 @@ index 7f5df6f..bc95282 100644
          }
      };
 
-From 003416b0b410e70daab0d55ddc48e8e443f4fd09 Mon Sep 17 00:00:00 2001
+From 5bc3ad9f23a03ff3af7a4ec33c8bfa4f3cc6bae9 Mon Sep 17 00:00:00 2001
 From: Steeve Morin <steeve@zml.ai>
 Date: Fri, 17 Jan 2025 20:59:18 +0000
-Subject: [PATCH 8/8] epoll: don't count immediate actions
+Subject: [PATCH 5/5] epoll: don't count immediate actions
 
 If an immediate action is dispatched, the loop might block
 on epoll_wait even though only one action was requested.

--- a/third_party/modules/libxev/20241208.1-db6a52b/source.json
+++ b/third_party/modules/libxev/20241208.1-db6a52b/source.json
@@ -1,0 +1,14 @@
+{
+    "strip_prefix": "libxev-db6a52bafadf00360e675fefa7926e8e6c0e9931",
+    "url": "https://github.com/zml/libxev/archive/db6a52bafadf00360e675fefa7926e8e6c0e9931.tar.gz",
+    "integrity": "sha256-4GT5wkfkZnIjNv20yDiWEzHAhbIiwHHJfS7A4u/LoNQ=",
+    "overlay": {
+        "MODULE.bazel": "",
+        "BUILD.bazel": "",
+        "main2.zig": ""
+    },
+    "patches": {
+        "128.patch": ""
+    },
+    "patch_strip": 1
+}

--- a/zml/aio.zig
+++ b/zml/aio.zig
@@ -116,7 +116,9 @@ pub const BufferStore = struct {
     }
 
     pub fn deinit(self: BufferStore) void {
-        for (self.files) |*file| file.deinit();
+        for (self.files) |*file| {
+            file.deinit();
+        }
         self.arena.deinit();
     }
 


### PR DESCRIPTION
Rework the libxev epoll backend to play nice with zigcoro based scheduler.

In the process, load the PJRT plugins using `callBlocking` because it can a bit slow sometimes.

Should have a slight performance increase, too.