### PR TITLE
Llama3.2: fix tokenizer

### DIFF
--- a/examples/llama/BUILD.bazel
+++ b/examples/llama/BUILD.bazel
@@ -1,7 +1,9 @@
 load("@aspect_bazel_lib//lib:tar.bzl", "mtree_spec", "tar")
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
 load("@zml//bazel:zig.bzl", "zig_cc_binary")
+
 
 zig_cc_binary(
     name = "llama",
@@ -162,6 +164,22 @@ zig_cc_binary(
         "@zml//metax",
         "@zml//zml",
     ],
+)
+
+zig_cc_binary(
+    name = "test_tokenizer",
+    main = "test_tokenizer.zig",
+    deps = [
+        "//third_party/tigerbeetle:flags",
+        "@zml//stdx",
+        "@zml//zml",
+    ],
+    # Note: all Llama-3.x tokenizers are the same,
+    # but using the 3.2-1B version because downloading the tokenizer triggers downloading the model.
+    args = [
+    "--tokenizer=$(location @Meta-Llama-3.2-1B-Instruct//:tokenizer)",
+    ],
+    data = ["@Meta-Llama-3.2-1B-Instruct//:tokenizer"],
 )
 
 mtree_spec(

--- a/examples/llama/test_tokenizer.zig
+++ b/examples/llama/test_tokenizer.zig
@@ -1,0 +1,51 @@
+const std = @import("std");
+const log = std.log.scoped(.@"//llama:test_tokenizer");
+
+const flags = @import("tigerbeetle/flags");
+const zml = @import("zml");
+
+const Flags = struct {
+    tokenizer: []const u8,
+    prompt: []const u8 =
+        \\Examples of titles:
+        \\📉 Stock Market Trends
+        \\🍪 Perfect Chocolate Chip Recipe
+        \\Evolution of Music Streaming
+        \\Remote Work Productivity Tips
+        \\Artificial Intelligence in Healthcare
+        \\🎮 Video Game Development Insights
+        \\
+    ,
+    expected: []const u8 = "128000,41481,315,15671,512,9468,241,231,12937,8152,50730,198,9468,235,103,24118,39520,32013,26371,198,35212,3294,315,10948,45910,198,25732,5664,5761,1968,26788,198,9470,16895,22107,304,39435,198,9468,236,106,8519,4140,11050,73137,198",
+    verbose: bool = false,
+};
+
+pub fn main() !void {
+    var gpa: std.heap.GeneralPurposeAllocator(.{}) = .{};
+    const allocator = gpa.allocator();
+
+    var raw_args = std.process.args();
+    const args = flags.parse(&raw_args, Flags);
+
+    log.info("\tLoading tokenizer from {s}", .{args.tokenizer});
+    var tokenizer = try zml.aio.detectFormatAndLoadTokenizer(allocator, args.tokenizer);
+    log.info("✅\tLoaded tokenizer from {s}", .{args.tokenizer});
+    defer tokenizer.deinit();
+
+    const prompt_tok = try tokenizer.encode(allocator, args.prompt, .{ .debug = args.verbose });
+
+    log.info("Input: {s}\nOutput: {d}", .{ args.prompt, prompt_tok });
+    if (args.expected.len > 0) {
+        var expected = try std.ArrayList(u32).initCapacity(allocator, args.prompt.len);
+        var it = std.mem.splitSequence(u8, args.expected, ",");
+        while (it.next()) |int_token| {
+            const tok = try std.fmt.parseInt(u32, int_token, 10);
+            try expected.append(tok);
+        }
+        if (std.mem.eql(u32, expected.items, prompt_tok)) {
+            log.info("All good !", .{});
+        } else {
+            log.err("Doesn't match expected: {d}", .{expected.items});
+        }
+    }
+}

--- a/zml/aio/tinyllama.zig
+++ b/zml/aio/tinyllama.zig
@@ -112,7 +112,7 @@ fn newBuff(store: *zml.aio.BufferStore, name: []const u8, sh: anytype, offset: u
     const n = shape.byteSize();
     const buff = zml.HostBuffer.fromBytes(shape, store.files[0].data[offset..][0..n]);
     store.buffers.putAssumeCapacityNoClobber(name, buff);
-    zml.log.info("Found {s}: {}", .{ name, shape });
+    zml.log.debug("Found {s}: {}", .{ name, shape });
     return offset + n;
 }
 
@@ -125,7 +125,7 @@ fn splitBuff(store: *zml.aio.BufferStore, comptime fmt: []const u8, sh: anytype,
         const buff = zml.HostBuffer.fromBytes(shape, store.files[0].data[off..][0..n]);
         store.buffers.putAssumeCapacityNoClobber(name, buff);
         off += n;
-        if (i == 0) zml.log.info("Found {s}: {}", .{ name, shape });
+        if (i == 0) zml.log.debug("Found {s}: {}", .{ name, shape });
     }
     return off;
 }

--- a/zml/tokenizer.zig
+++ b/zml/tokenizer.zig
@@ -626,6 +626,13 @@ pub const Normalizer = struct {
                 .lower_case_ascii = false,
                 .split_on_punct_ascii = false,
             }, sentencepiece_space),
+            .llama3 => init(.{
+                .remove_extra_whitespaces = true,
+                .add_dummy_prefix = false,
+                .add_dummy_suffix = false,
+                .lower_case_ascii = false,
+                .split_on_punct_ascii = false,
+            }, null),
             .gpt2 => init(.{
                 .remove_extra_whitespaces = true,
                 .add_dummy_prefix = true,
@@ -722,6 +729,7 @@ pub const Normalizer = struct {
 pub const KnownImplementation = enum(u8) {
     sentencepiece,
     gpt2,
+    llama3,
 };
 
 fn isPunct(unicode_char: []const u8) bool {
@@ -930,7 +938,7 @@ pub fn fromHfJson(allocator: std.mem.Allocator, tokenizer_path: []const u8) !Tok
     const normalizer = if (objectGet(main_object, .object, "normalizer")) |normalizer_config|
         try Normalizer.fromHfJson(normalizer_config)
     else
-        Normalizer.wellKnown(.gpt2);
+        Normalizer.wellKnown(.llama3);
 
     // delay init of special tokens.
     var tokenizer = try Tokenizer.init(allocator, vocab_size, 256, normalizer, undefined, true);
@@ -1015,7 +1023,7 @@ pub fn fromHfJson(allocator: std.mem.Allocator, tokenizer_path: []const u8) !Tok
         if (is_gpt2_vocab) {
             tokenizer.byte_fallback = true;
         } else {
-            log.warn("The given tokenizer can't handle unknown token: no unknown token was set, and byte_fallback is disabled too ! The tokenizer will panic when facing unknown tokens.",.{});
+            log.warn("The given tokenizer can't handle unknown token: no unknown token was set, and byte_fallback is disabled too ! The tokenizer will panic when facing unknown tokens.", .{});
         }
     } else if (byte_fallback) {
         try tokenizer.rewriteByteFallbackTokens();

--- a/zml/tokenizer.zig
+++ b/zml/tokenizer.zig
@@ -991,8 +991,9 @@ pub fn fromHfJson(allocator: std.mem.Allocator, tokenizer_path: []const u8) !Tok
 
     // More tokens, typically added during fine tuning of the model.
     for (added_tokens) |token_obj| {
-        const v = objectGet(token_obj, .string, "content") orelse return error.InvalidFormat;
-        const id: u32 = @intCast(objectGet(token_obj, .integer, "id") orelse return error.InvalidFormat);
+        if (token_obj != .object) return error.InvalidFormat;
+        const v = objectGet(token_obj.object, .string, "content") orelse return error.InvalidFormat;
+        const id: u32 = @intCast(objectGet(token_obj.object, .integer, "id") orelse return error.InvalidFormat);
         const token = try if (is_gpt2_vocab)
             gpt2_decoder.decode(&all_tokens, v)
         else


### PR DESCRIPTION
Fix #134 , superseed #133

Basically the llama3 tokenizer.json has the following config: 

```
  "model": {
    "type": "BPE",
    "dropout": null,
    "unk_token": null,
    "continuing_subword_prefix": null,
    "end_of_word_suffix": null,
    "fuse_unk": false,
    "byte_fallback": false,
    ...
}
```

this it technically invalid because it says the model has no byte fallback and no unknown token either.
This means that unknown emoji can't be converted to bytes nor to the special unknown token.
This ended up in tokenizer.zig using the value of MAX_INT for the UNK token then panicking for out of bound.

So I've added some logic to recognize that in the case of GPT2 encoded vocab (like llama3) that actually contains individual bytes, we should use the "byte_fallback" algorithm even if disabled.

I've also added a Llama3 "well known" normalizer because HF tokenizers doesn't add a dummy prefix for llama3 tokenizer.

Technically this is still not a correct implementation of llama3 tokenizer because we don't do the regex based splitting they do. But even for quite long snippets I tested it now produces exact same tokens.
