### PR TITLE
async: async mutex on log and fixes on ResetCondition

### DIFF
--- a/async/async.zig
+++ b/async/async.zig
@@ -145,7 +145,9 @@ pub const threading = struct {
                 .waiting = &waiter,
             };
             if (self.waiter.cmpxchgStrong(&State.unset_state, &new_state, .monotonic, .monotonic) == null) {
-                coro.xsuspend();
+                while (self.isSet() == false) {
+                    coro.xsuspend();
+                }
             }
         }
     };


### PR DESCRIPTION
Stop using a real mutex for the `logFn` and use an `Mutex` and allow for a fallback logger if outside a coroutine.