### PR TITLE
llama: fix dims & dtypes -> fix #170

### DIFF
--- a/examples/llama/main.zig
+++ b/examples/llama/main.zig
@@ -97,7 +97,7 @@ pub fn generateText(
     defer kv_cache.layer_index.deinit();
 
     // Prepare for token-by-token generation
-    var first_token_hostbuffer = [_]u32{@intCast(prompt_tok[prompt_tok.len - 1])}; // start with the prompt's last token
+    var first_token_hostbuffer = [_]u32{prompt_tok[prompt_tok.len - 1]}; // start with the prompt's last token
     var current_token = try zml.Buffer.fromSlice(platform, .{1}, &first_token_hostbuffer);
     defer current_token.deinit();
 

--- a/examples/llama/main.zig
+++ b/examples/llama/main.zig
@@ -85,7 +85,8 @@ pub fn generateText(
     // prepare device buffers for the prefill tokens and the index
     var prefill_tokens = try zml.Buffer.fromSlice(platform, .{max_seq_len}, prefill_buffer);
     defer prefill_tokens.deinit();
-    var prefill_token_index = try zml.Buffer.fromSlice(platform, .{}, &[_]u32{0});
+    var prefill_token_index = try zml.Buffer.constant(platform, zml.Shape.init(.{}, .u32), 0);
+
     defer prefill_token_index.deinit();
 
     // init RNG and prefill
@@ -96,8 +97,8 @@ pub fn generateText(
     defer kv_cache.layer_index.deinit();
 
     // Prepare for token-by-token generation
-    var first_token_hostbuffer = [_]u32{prompt_tok[prompt_tok.len - 1]}; // start with the prompt's last token
-    var current_token = try zml.Buffer.fromSlice(platform, .{}, &first_token_hostbuffer);
+    var first_token_hostbuffer = [_]u32{@intCast(prompt_tok[prompt_tok.len - 1])}; // start with the prompt's last token
+    var current_token = try zml.Buffer.fromSlice(platform, .{1}, &first_token_hostbuffer);
     defer current_token.deinit();
 
     // Here we will copy the generated token from device
@@ -121,6 +122,7 @@ pub fn generateText(
         // current token index needs to go into a zml.Buffer
         const token_index_buffer = &[_]u32{@intCast(prompt_tok.len + i)};
         const token_index = try zml.Buffer.fromSlice(platform, .{}, token_index_buffer);
+    
         defer token_index.deinit();
 
         // call to generate the next token
@@ -256,13 +258,11 @@ pub fn asyncMain() !void {
     const dims = model_instance.model.shape();
     const dtype = model_instance.model.embed_tokens.weight.dtype();
 
-    const batch_size = 1;
+    const tokens_shape_prefill = zml.Shape.init(.{ .s = llama_options.max_seq_len }, .u32);
+    const tokens_shape = zml.Shape.init(.{ .s = 1 }, .u32);
+    const token_idx_shape = zml.Shape.init(.{}, .u32);
 
-    const tokens_shape_prefill = zml.Shape.init(.{ .b = batch_size, .s = llama_options.max_seq_len }, .u32);
-    const tokens_shape = zml.Shape.init(.{ .b = batch_size, .s = 1 }, .u32);
-    const token_idx_shape = zml.Shape.init(.{ .b = batch_size }, .u32);
-
-    const kv_shape = zml.Shape.init(.{ .layer = model_instance.model.layers.len, .b = batch_size, .k = dims.s, .h = dims.nkvh, .hd = dims.hd }, dtype).withSharding(.{.h});
+    const kv_shape = zml.Shape.init(.{ .layer = model_instance.model.layers.len, .k = dims.s, .h = dims.nkvh, .hd = dims.hd }, dtype).withSharding(.{.h});
 
     const kv_cache_shape: zml.ShapeOf(llama.KvCache) = llama.KvCache.initShape(kv_shape);
     const rng_shape = zml.Tensor.Rng.shape();

--- a/examples/llama/main.zig
+++ b/examples/llama/main.zig
@@ -122,7 +122,7 @@ pub fn generateText(
         // current token index needs to go into a zml.Buffer
         const token_index_buffer = &[_]u32{@intCast(prompt_tok.len + i)};
         const token_index = try zml.Buffer.fromSlice(platform, .{}, token_index_buffer);
-    
+
         defer token_index.deinit();
 
         // call to generate the next token


### PR DESCRIPTION
This PR fixes issue #170 , making Llama run again on CUDA and RoCM.

- Latest Llama changes had introduced an unnecessary batching dimension: fixed
- Ops returning indices return i32 yet we now use u32 as token indices -> dtype conversion requred: fixed

Tested on CUDA.