### PR TITLE
async: detect xev most preferable backend to use

### DIFF
--- a/async/async.zig
+++ b/async/async.zig
@@ -177,6 +177,7 @@ pub const AsyncThread = struct {
     }
 
     pub fn main(allocator: std.mem.Allocator, comptime mainFunc: fn () anyerror!void) !void {
+        try xev.detect();
         var thread_pool = XevThreadPool.init(.{});
         defer {
             thread_pool.shutdown();


### PR DESCRIPTION
Since change allow use to leverage io_uring instead of xev if the backend is supported.