### PR TITLE
async: detect xev only if the API is dynamic (fix macOS)

### DIFF
--- a/async/async.zig
+++ b/async/async.zig
@@ -177,7 +177,7 @@ pub const AsyncThread = struct {
     }
 
     pub fn main(allocator: std.mem.Allocator, comptime mainFunc: fn () anyerror!void) !void {
-        try xev.detect();
+        if (xev.dynamic) try xev.detect();
         var thread_pool = XevThreadPool.init(.{});
         defer {
             thread_pool.shutdown();


### PR DESCRIPTION
ref: https://github.com/mitchellh/libxev/blob/94ed6af7b2aaaeab987fbf87fcee410063df715b/src/dynamic.zig#L44