### PR TITLE
workspace: fix vscode-zig update

### DIFF
--- a/examples/.vscode/settings.json
+++ b/examples/.vscode/settings.json
@@ -23,7 +23,7 @@
     "C_Cpp.clang_format_style": "Microsoft",
     "zig.formattingProvider": "zls",
     "zig.path": "x",
-    "zig.zls.path": "${workspaceFolder}/tools/zls.sh",
+    "zig.zls.path": "/${workspaceFolder}/tools/zls.sh",
     "[zig]": {
         "editor.suggest.insertMode": "replace",
         "editor.stickyScroll.defaultModel": "foldingProviderModel",


### PR DESCRIPTION
The extension checks that the ZLS path is absolute, else it will run which to find it in the PATH.

Add a heading / so that the path looks absolute. This works because we use ${workspaceFolder}.