### PR TITLE
Add model prefix support

### DIFF
--- a/zml/aio.zig
+++ b/zml/aio.zig
@@ -501,10 +501,31 @@ pub fn loadBuffers(
     allocator: std.mem.Allocator,
     platform: zml.Platform,
 ) !zml.Bufferized(Model) {
+    return loadBuffersWithPrefix(Model, init_args, buffer_store, allocator, platform, "");
+}
+
+/// Creates a bufferized version of a Model from the given BufferStore with a specified prefix.
+/// For details about bufferization, see the documentation of Bufferized(T).
+///
+/// This will represent the weights of the model, loaded on a specific platform.
+/// It can be used with a `module.Exe` (a compiled version of the same Model), to make a
+/// `module.ExeWithWeights` ready to be called.
+///
+/// The `init_args` are used to initialize the non Buffer fields, using `Model.init` function.
+pub fn loadBuffersWithPrefix(
+    comptime Model: type,
+    init_args: anytype,
+    buffer_store: BufferStore,
+    allocator: std.mem.Allocator,
+    platform: zml.Platform,
+    prefix: []const u8,
+) !zml.Bufferized(Model) {
     var arena_state = std.heap.ArenaAllocator.init(allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    var model: Model = try zml.aio.populateModel(Model, arena, buffer_store);
+
+    // Get model structure with tensor shapes from the buffer store with prefix
+    var model: Model = try zml.aio.populateModelWithPrefix(Model, arena, buffer_store, prefix);
 
     // If the Model has a "init" function, call it with the given parameters.
     if (@hasDecl(Model, "init")) {
@@ -513,7 +534,7 @@ pub fn loadBuffers(
         stdx.debug.assertComptime(@TypeOf(init_args) == void or @TypeOf(init_args) == @TypeOf(.{}), "Model of type {} has no init function, so `loadBuffers` should be call with init_args set to {{}} (void)", .{Model});
     }
 
-    return loadModelBuffersWithPrefix(Model, model, buffer_store, allocator, platform, "");
+    return loadModelBuffersWithPrefix(Model, model, buffer_store, allocator, platform, prefix);
 }
 
 /// Creates a bufferized version of a Model from the given BufferStore. For details about

--- a/zml/zml.zig
+++ b/zml/zml.zig
@@ -34,6 +34,7 @@ pub const tokenizer = @import("zml/tokenizer");
 
 pub const call = ops.call;
 pub const compile = exe.compile;
+pub const compileWithPrefix = exe.compileWithPrefix;
 pub const compileFn = exe.compileFn;
 pub const compileModel = exe.compileModel;
 pub const FnExe = exe.FnExe;


### PR DESCRIPTION
## Overview

This PR adds the ability to specify a prefix when loading a model from safetensors file. This is useful when working with models like [ModernBERT](https://huggingface.co/answerdotai/ModernBERT-large/tree/main?show_file_info=model.safetensors) ; the changes enable me to use `ModernBertModel` to generate embeddings instead of the full `ModernBertForMaskedLM` model.

## Test

Changes have been tested with my text embeddings server project : https://github.com/vctrmn/zig-text-embeddings-inference