### PR TITLE
zml: remove compile time fields from zml.Bufferized

### DIFF
--- a/zml/meta.zig
+++ b/zml/meta.zig
@@ -80,6 +80,32 @@ pub fn MapType(From: type, To: type) type {
     };
 }
 
+test MapType {
+    const A = struct { a: u32 };
+    const B = struct { b: u32 };
+
+    const A2B = MapType(A, B);
+
+    const StructA = struct { some: []const A, one: A, maybe: ?A, other: u32 };
+    const struct_b = A2B.map(StructA){
+        .some = &[2]B{ .{ .b = 0 }, .{ .b = 1 } },
+        .maybe = null,
+        .one = .{ .b = 2 },
+        .other = 43,
+    };
+    _ = struct_b;
+
+    // TODO(corendos) fixme, union_b should contains Bs not As.
+    const UnionA = union { some: []const A, one: A, maybe: ?A, other: u32 };
+    const union_b = [_]A2B.map(UnionA){
+        .{ .some = &[2]A{ .{ .a = 0 }, .{ .a = 1 } } },
+        .{ .one = .{ .a = 2 } },
+        .{ .maybe = null },
+        .{ .other = 43 },
+    };
+    _ = union_b;
+}
+
 /// Given a callback: `fn(Ctx, From) To`, recursively visits the given `from` struct
 /// and calls the callback when it finds a `From` element, and writes it to the `to` struct.
 /// The `to` parameter must be passed with mutable pointer, and tensor data need to be mutable if callback needs it.
@@ -258,8 +284,9 @@ pub fn MapRestrict(From: type, To: type) type {
 
             return switch (@typeInfo(T)) {
                 .@"struct" => |struct_infos| {
+                    // We know that at least one of the struct field contains a From.
+                    // We map each field individually. Fields without From and comptime fields are removed.
                     const fields = struct_infos.fields;
-                    var same: bool = true;
                     var num_fields: usize = 0;
 
                     var struct_fields: [fields.len]std.builtin.Type.StructField = undefined;
@@ -274,13 +301,11 @@ pub fn MapRestrict(From: type, To: type) type {
                                     .name = name,
                                     .type = R,
                                     .default_value_ptr = null,
-                                    .is_comptime = field.is_comptime,
+                                    .is_comptime = false,
                                     .alignment = @alignOf(R),
                                 };
-                                same = false;
                                 // Handle the case `field: ?Tensor = null`
-                                // Generic handling of default value is complicated,
-                                // it would require to call the callback at comptime.
+                                // Generic handling of default value is not possible.
                                 if (R == ?To) {
                                     struct_fields[num_fields].default_value_ptr = &@as(R, null);
                                 }
@@ -289,12 +314,30 @@ pub fn MapRestrict(From: type, To: type) type {
                         }
                     }
                     if (num_fields == 0) return void;
-                    if (same) return T;
                     return @Type(.{ .@"struct" = .{
                         .layout = .auto,
                         .fields = struct_fields[0..num_fields],
                         .decls = &.{},
                         .is_tuple = struct_infos.is_tuple,
+                    } });
+                },
+                .@"union" => |union_info| {
+                    // We know that at least one of the union field contains a From.
+                    // We map each field individually. Fields without From, are replaced by "void".
+                    const fields = union_info.fields;
+                    var union_fields: [fields.len]std.builtin.Type.UnionField = undefined;
+                    for (0.., fields) |i, field| {
+                        union_fields[i] = .{
+                            .name = field.name,
+                            .type = map(field.type),
+                            .alignment = 0,
+                        };
+                    }
+                    return @Type(.{ .@"union" = .{
+                        .layout = .auto,
+                        .tag_type = union_info.tag_type,
+                        .fields = union_fields[0..],
+                        .decls = &.{},
                     } });
                 },
                 .array => |arr_info| [arr_info.len]map(arr_info.child),
@@ -321,6 +364,32 @@ pub fn MapRestrict(From: type, To: type) type {
             };
         }
     };
+}
+
+test MapRestrict {
+    const A = struct { a: u32 };
+    const B = struct { b: u32 };
+
+    const A2B = MapRestrict(A, B);
+
+    const StructA = struct { some: []const A, one: A, maybe: ?A, other: u32 };
+    const struct_b = A2B.map(StructA){
+        .some = &[2]B{ .{ .b = 0 }, .{ .b = 1 } },
+        .maybe = null,
+        .one = .{ .b = 2 },
+        // Note how struct_b doesn't even have a .other field now.
+    };
+    _ = struct_b;
+
+    const UnionA = union { some: []const A, one: A, maybe: ?A, other: u32 };
+    const union_b = [_]A2B.map(UnionA){
+        .{ .some = &[2]B{ .{ .b = 0 }, .{ .b = 1 } } },
+        .{ .one = .{ .b = 2 } },
+        .{ .maybe = null },
+        // Note how union_b.other is void now.
+        .{ .other = {} },
+    };
+    _ = union_b;
 }
 
 /// Recursively visit the given struct and calls the callback for each K found.
@@ -643,7 +712,7 @@ pub fn Contains(Haystack: type, T: type) bool {
     return switch (@typeInfo(Haystack)) {
         .@"struct" => |info| {
             inline for (info.fields) |field| {
-                if (Contains(field.type, T))
+                if (!field.is_comptime and Contains(field.type, T))
                     return true;
             }
             return false;

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -1011,21 +1011,21 @@ test FnCache {
         }
     };
 
-    const x = try zml.Buffer.fromSlice(platform, .{2}, &[_]f16{ -1, 1 });
-    const nn: zml.Bufferized(NN) = .{
+    const x = try zml.Buffer.fromArray(platform, [2]f16{ -1, 1 });
+    const nn: zml.testing.BufferizedWithArgs(NN) = .{
         .layers = .{
             .{
-                .w = try zml.Buffer.fromSlice(platform, .{ 2, 2 }, &[_]f16{ 1, -1, 0, 1 }),
-                .b = try zml.Buffer.fromSlice(platform, .{2}, &[_]f16{ 0, 0 }),
+                .w = try .fromArray(platform, [2][2]f16{ .{ 1, -1 }, .{ 0, 1 } }),
+                .b = try .fromArray(platform, [2]f16{ 0, 0 }),
             },
             .{
-                .w = try zml.Buffer.fromSlice(platform, .{ 2, 2 }, &[_]f16{ 1, 2, 1, -1 }),
-                .b = try zml.Buffer.fromSlice(platform, .{2}, &[_]f16{ 10, 10 }),
+                .w = try .fromArray(platform, [2][2]f16{ .{ 1, 2 }, .{ 1, -1 } }),
+                .b = try .fromArray(platform, [2]f16{ 10, 10 }),
             },
             // third layer is different
             .{
-                .w = try zml.Buffer.fromSlice(platform, .{ 3, 2 }, &[_]f16{ 1, 2, 0, 1, -1, 0 }),
-                .b = try zml.Buffer.fromSlice(platform, .{3}, &[_]f16{ -10, -10, -10 }),
+                .w = try .fromArray(platform, [3][2]f16{ .{ 1, 2 }, .{ 0, 1 }, .{ -1, 0 } }),
+                .b = try .fromArray(platform, [3]f16{ -10, -10, -10 }),
             },
         },
     };
@@ -1084,13 +1084,13 @@ test "FnCache with mixed integer/tensor" {
         }
     };
 
-    const x = try zml.Buffer.fromSlice(platform, .{2}, &[_]f16{ -1, 1 });
-    const nn: zml.Bufferized(NN) = .{
+    const x = try zml.Buffer.fromArray(platform, [2]f16{ -1, 1 });
+    const nn: zml.testing.BufferizedWithArgs(NN) = .{
         .layers = .{
-            .{ .w = try zml.Buffer.fromSlice(platform, .{ 2, 2 }, &[_]f16{ 1, -1, 0, 1 }) },
-            .{ .w = try zml.Buffer.fromSlice(platform, .{ 2, 2 }, &[_]f16{ 1, 2, 1, -1 }) },
+            .{ .w = try .fromArray(platform, [2][2]f16{ .{ 1, -1 }, .{ 0, 1 } }) },
+            .{ .w = try .fromArray(platform, [2][2]f16{ .{ 1, 2 }, .{ 1, -1 } }) },
             // third layer has different shape
-            .{ .w = try zml.Buffer.fromSlice(platform, .{ 3, 2 }, &[_]f16{ 1, 2, 0, 1, -1, 0 }) },
+            .{ .w = try .fromArray(platform, [3][2]f16{ .{ 1, 2 }, .{ 0, 1 }, .{ -1, 0 } }) },
         },
     };
     const res = try zml.testing.compileAndCall(platform, NN._fwd, .{ nn, x });

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -108,13 +108,15 @@ test "simple while" {
     const zml = @import("zml.zig");
     const platform = zml.testing.env();
 
-    const init_i = try zml.Buffer.fromSlice(platform, .{}, &[_]i64{0});
-    const init_sum = try zml.Buffer.fromSlice(platform, .{}, &[_]i64{0});
-    const counter: zml.Bufferized(CountInts) = .{
-        .step = try zml.Buffer.fromSlice(platform, .{}, &[_]i64{1}),
-        .end = try zml.Buffer.fromSlice(platform, .{}, &[_]i64{10}),
-    };
-    const res0, const res1 = try zml.testing.compileAndCall(platform, CountInts._fwd, .{ counter, init_i, init_sum });
+    const res0, const res1 = try zml.testing.compileAndCall(
+        platform,
+        CountInts._fwd,
+        .{
+            .{ .step = try .scalar(platform, 1, .i64), .end = try .scalar(platform, 10, .i64) },
+            try .scalar(platform, 0, .i64),
+            try .scalar(platform, 0, .i64),
+        },
+    );
     const last_i = try res0.getValue(i64);
     const sum = try res1.getValue(i64);
 

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -640,19 +640,16 @@ pub const Tensor = struct {
             };
 
             const platform = zml.testing.env();
-            const seed: i128 = 1234;
             // Compute stats over a uniform distribution on [-2, 10].
-            const rand, const stats = try zml.testing.compileAndCall(
+            const rand, const stats = try zml.testing.compileAndCallWithTensors(
                 platform,
                 Stats.uniformStats,
-                .{
-                    .{ ._state = try Buffer.fromBytes(platform, Rng.shape()._state, std.mem.asBytes(&seed)) },
-                    Shape.init(.{1024}, .f32),
-                    .{ .min = -2, .max = 10 },
-                },
+                .{ Rng.shape(), zml.Shape.init(.{1024}, .f32), .{ .min = -2, .max = 10 } },
+                .{try Rng.init(platform, 1234)},
             );
+
             // Check the Rng state has been modified.
-            try std.testing.expect(try rand._state.getValue(i128) != 1234);
+            try std.testing.expect(try rand._state.getValue(u128) != 1234);
 
             // Check the mean and variance are close to theoritical values.
             const mean_ = try stats.mean.getValue(f32);

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -532,7 +532,7 @@ pub const Tensor = struct {
     }
 
     pub const Rng = struct {
-        _state: Tensor,
+        _state: Tensor = .{ ._shape = .init(.{2}, .u64), ._id = .{ .buffer_id = 0 } },
         algorithm: dialect.stablehlo.RngAlgorithm.Type = .DEFAULT,
 
         pub fn shape() ShapeOf(Rng) {
@@ -542,10 +542,8 @@ pub const Tensor = struct {
         }
 
         pub fn init(platform: Platform, seed: u128) !Bufferized(Rng) {
-            const bits: [2]u64 = @bitCast(seed);
             return .{
-                ._state = try Buffer.fromSlice(platform, Shape.init(.{2}, .u64), &bits),
-                .algorithm = undefined,
+                ._state = try Buffer.fromBytes(platform, Rng.shape()._state, std.mem.asBytes(&seed)),
             };
         }
 
@@ -642,12 +640,13 @@ pub const Tensor = struct {
             };
 
             const platform = zml.testing.env();
+            const seed: i128 = 1234;
             // Compute stats over a uniform distribution on [-2, 10].
             const rand, const stats = try zml.testing.compileAndCall(
                 platform,
                 Stats.uniformStats,
                 .{
-                    try Rng.init(platform, 1234),
+                    .{ ._state = try Buffer.fromBytes(platform, Rng.shape()._state, std.mem.asBytes(&seed)) },
                     Shape.init(.{1024}, .f32),
                     .{ .min = -2, .max = 10 },
                 },
@@ -746,9 +745,12 @@ pub const Tensor = struct {
 
             const platform = zml.testing.env();
             const tgt_dist = [_]f32{ 2.0, 1.0, 4.0, 3.0 };
-            const rand, const stats = try zml.testing.compileAndCall(platform, Stats.gumbelStats, .{
-                try Rng.init(platform, 1234), try HostBuffer.fromArray(&tgt_dist).toDevice(platform),
-            });
+            const rand, const stats = try zml.testing.compileAndCallWithTensors(
+                platform,
+                Stats.gumbelStats,
+                .{ Rng.shape(), zml.Shape.init(.{tgt_dist.len}, .f32) },
+                .{ try Rng.init(platform, 1234), try .fromArray(platform, tgt_dist) },
+            );
             // Check the Rng state has been modified.
             try std.testing.expect(try rand._state.getValue(i128) != 1234);
 
@@ -1620,15 +1622,15 @@ pub const Tensor = struct {
         };
 
         {
-            const res = try zml.testing.compileAndCallWithTensors(platform, Local._slice1dAxis, .{ x.shape(), 0, .{ .end = 1 } }, .{ x, 0, .{ .end = 1 } });
+            const res = try zml.testing.compileAndCall(platform, Local._slice1dAxis, .{ x, 0, .{ .end = 1 } });
             try testing.expectEqual([5]f32{ 0, 1, 2, 3, 4 }, try res.getValue([5]f32));
         }
         {
-            const res = try zml.testing.compileAndCallWithTensors(platform, Local._slice1dAxis, .{ x.shape(), 1, .{ .start = 1, .step = 2 } }, .{ x, 0, .{ .start = 1, .step = 2 } });
+            const res = try zml.testing.compileAndCall(platform, Local._slice1dAxis, .{ x, 1, .{ .start = 1, .step = 2 } });
             try testing.expectEqual([4]f32{ 1, 3, 6, 8 }, try res.getValue([4]f32));
         }
         {
-            const res = try zml.testing.compileAndCallWithTensors(platform, Local._slice1dAxis, .{ x.shape(), -1, .{ .start = -2 } }, .{ x, 0, .{ .start = -2 } });
+            const res = try zml.testing.compileAndCall(platform, Local._slice1dAxis, .{ x, -1, .{ .start = -2 } });
             try testing.expectEqual([4]f32{ 3, 4, 8, 9 }, try res.getValue([4]f32));
         }
     }
@@ -3965,13 +3967,12 @@ test "Tensor.maxPool2d" {
     );
 }
 
-/// Returns a mirrored version of T where each Tensor has been replaced by a Buffer.
 pub fn Bufferized(comptime T: type) type {
     // TODO: we should strip out the non-buffer fields.
     // Currently it's confusing cause the Bufferized struct contains field that are never read.
     // Also it will simplify the layout of the Bufferized struct.
     // accelerating the calls to execute.
-    return meta.MapType(Tensor, Buffer).map(T);
+    return meta.MapRestrict(Tensor, Buffer).map(T);
 }
 
 /// Return a clone of a type with Tensors replaced by Shapes.

--- a/zml/testing.zig
+++ b/zml/testing.zig
@@ -156,7 +156,7 @@ pub fn compileAndCall(
     var mod = try zml.compileFn(allocator, func, shape_args, platform);
     defer mod.deinit();
 
-    // Note: we dont't use the type safe API of mod,
+    // Note: we don't use the type safe API of mod,
     // cause mod.call expects a `zml.Bufferized` while we have `BufferizedWithArgs`.
     mod.inner.prepare(buffer_and_args);
     mod.inner._unsafeCall();

--- a/zml/testing.zig
+++ b/zml/testing.zig
@@ -112,13 +112,30 @@ pub fn expectEqualShapes(expected: zml.Shape, actual: zml.Shape) error{TestExpec
     return error.TestExpectedEqual;
 }
 
+/// Returns a mirrored version of T where each Tensor has been replaced by a Buffer.
+/// This is similar to zml.Bufferized,
+/// but also keep every other fields that could be used during compilation.
+///
+/// see `compileAndCall`.
+pub fn BufferizedWithArgs(comptime T: type) type {
+    // TODO: we should strip out the non-buffer fields.
+    // Currently it's confusing cause the Bufferized struct contains field that are never read.
+    // Also it will simplify the layout of the Bufferized struct.
+    // accelerating the calls to execute.
+    return meta.MapType(zml.Tensor, zml.Buffer).map(T);
+}
+
 /// Compile a function and immediatly call it with the given buffers.
 /// The compiled module is discarded after the call.
 /// Useful during testing when a module is typically called only once.
 ///
 /// Note: `func` needs explicit types on all parameters.
 /// To test a function with `anytype` (typically for tagged API), you need to create a specialized version of it with specific types.
-pub fn compileAndCall(platform: zml.Platform, func: anytype, buffer_args: zml.Bufferized(stdx.meta.FnArgs(func))) !zml.Bufferized(stdx.meta.FnResult(func)) {
+pub fn compileAndCall(
+    platform: zml.Platform,
+    func: anytype,
+    buffer_and_args: BufferizedWithArgs(stdx.meta.FnArgs(func)),
+) !zml.Bufferized(stdx.meta.FnResult(func)) {
     // This simplify test API and also ensure this fn isn't used outside of tests.
     const allocator = std.testing.allocator;
     var arena = std.heap.ArenaAllocator.init(allocator);
@@ -128,20 +145,36 @@ pub fn compileAndCall(platform: zml.Platform, func: anytype, buffer_args: zml.Bu
         pub fn bufferToShape(_: void, x: zml.Buffer) zml.Shape {
             return x.shape();
         }
+
+        pub fn justBuffers(_: void, x: zml.Buffer) zml.Buffer {
+            return x;
+        }
     };
     var shape_args: zml.ShapeOf(stdx.meta.FnArgs(func)) = undefined;
-    try meta.mapAlloc(Local.bufferToShape, arena.allocator(), {}, buffer_args, &shape_args);
+    try meta.mapAlloc(Local.bufferToShape, arena.allocator(), {}, buffer_and_args, &shape_args);
 
-    const mod = try zml.compileFn(allocator, func, shape_args, platform);
+    var mod = try zml.compileFn(allocator, func, shape_args, platform);
     defer mod.deinit();
 
-    return mod.call(buffer_args);
+    // Note: we dont't use the type safe API of mod,
+    // cause mod.call expects a `zml.Bufferized` while we have `BufferizedWithArgs`.
+    mod.inner.prepare(buffer_and_args);
+    mod.inner._unsafeCall();
+
+    var result: zml.Bufferized(stdx.meta.FnResult(func)) = undefined;
+    mod.inner._unsafeAssignResults(@TypeOf(result), &result);
+    return result;
 }
 
 /// Compile a function and immediatly call it with the given buffers.
 /// The compiled module is discarded after the call.
 /// Useful during testing when a module is typically called only once.
-pub fn compileAndCallWithTensors(platform: zml.Platform, func: anytype, shape_args: zml.ShapeOf(stdx.meta.FnArgs(func)), buffer_args: zml.Bufferized(stdx.meta.FnArgs(func))) !zml.Bufferized(stdx.meta.FnResult(func)) {
+pub fn compileAndCallWithTensors(
+    platform: zml.Platform,
+    func: anytype,
+    shape_args: zml.ShapeOf(stdx.meta.FnArgs(func)),
+    buffer_args: zml.Bufferized(stdx.meta.FnArgs(func)),
+) !zml.Bufferized(stdx.meta.FnResult(func)) {
     // This simplify test API and also ensure this fn isn't used outside of tests.
     const allocator = std.testing.allocator;
     var arena = std.heap.ArenaAllocator.init(allocator);

--- a/zml/testing.zig
+++ b/zml/testing.zig
@@ -145,10 +145,6 @@ pub fn compileAndCall(
         pub fn bufferToShape(_: void, x: zml.Buffer) zml.Shape {
             return x.shape();
         }
-
-        pub fn justBuffers(_: void, x: zml.Buffer) zml.Buffer {
-            return x;
-        }
     };
     var shape_args: zml.ShapeOf(stdx.meta.FnArgs(func)) = undefined;
     try meta.mapAlloc(Local.bufferToShape, arena.allocator(), {}, buffer_and_args, &shape_args);

--- a/zml/torch.zig
+++ b/zml/torch.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
+
 const stdx = @import("stdx");
 
 const zml = @import("zml.zig");
-
 const Tensor = zml.Tensor;
 
 const log = std.log.scoped(.zml_torch);
@@ -141,16 +141,14 @@ test pixelShuffle {
     const platform = zml.testing.env();
 
     const upscale_factor = 3;
-    var digits: [9 * 4 * 4]i32 = undefined;
-    for (&digits, 0..) |*d, i| d.* = @intCast(i);
-    // TODO should we have tags in buffers ?
-    const input = try zml.Buffer.fromSlice(platform, .{ 1, 9, 4, 4 }, &digits);
-    const output = try zml.testing.compileAndCallWithTensors(
-        platform,
-        pixelShuffle,
-        .{ zml.Shape.init(.{ .batch_size = 1, .c = 9, .h = 4, .w = 4 }, .i32), upscale_factor },
-        .{input},
-    );
+    const shape = zml.Shape.init(.{ .b = 1, .c = 9, .h = 4, .w = 4 }, .i32);
+    const input = input: {
+        var digits: [9 * 4 * 4]i32 = undefined;
+        for (&digits, 0..) |*d, i| d.* = @intCast(i);
+        break :input try zml.Buffer.fromSlice(platform, shape, &digits);
+    };
+
+    const output = try zml.testing.compileAndCall(platform, pixelShuffle, .{ input, upscale_factor });
 
     const exp = zml.HostBuffer.fromArray(&[1][1][12][12]i32{.{.{
         .{ 0, 16, 32, 1, 17, 33, 2, 18, 34, 3, 19, 35 },

--- a/zml/torch.zig
+++ b/zml/torch.zig
@@ -149,7 +149,7 @@ test pixelShuffle {
         platform,
         pixelShuffle,
         .{ zml.Shape.init(.{ .batch_size = 1, .c = 9, .h = 4, .w = 4 }, .i32), upscale_factor },
-        .{ input, upscale_factor },
+        .{input},
     );
 
     const exp = zml.HostBuffer.fromArray(&[1][1][12][12]i32{.{.{


### PR DESCRIPTION
this remove the need to pass `undefined` to `exe.call` when the corresponding `.forward` function expects integer/float arguments that have been inlined in the executable.

This was not needed and could just create confusion.
Now you may end up having to pass void to `exe.call` if the executable doesn't have any runtime argument,
but it's still better than passing `undefined`.

The only place that was using the non-buffer parts of a `zml.Bufferized` object was the infamous `zml.testing.compileAndCall`.
So I had to introduce a `zml.testing.BufferizedWithArgs` which is only used for this function.
I put it under the `zml.testing` namespace to make it clear it's only for this testing utility.
Note that because `compileAndCall` is strongly typed, you generally don't need to explicitly mention `BufferizedWithArgs` 
and the can just write the arguments in place and get help from ZLS.