### PR TITLE
runtimes: use cloudflare debian snapshots

### DIFF
--- a/runtimes/common/packages.lock.json
+++ b/runtimes/common/packages.lock.json
@@ -4,19 +4,19 @@
 			"arch": "amd64",
 			"dependencies": [
 				{
-					"key": "libc6_2.36-9-p-deb12u9_amd64",
+					"key": "libc6_2.36-9-p-deb12u10_amd64",
 					"name": "libc6",
-					"version": "2.36-9+deb12u9"
+					"version": "2.36-9+deb12u10"
 				},
 				{
-					"key": "libgcc-s1_12.2.0-14_amd64",
+					"key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
 					"name": "libgcc-s1",
-					"version": "12.2.0-14"
+					"version": "12.2.0-14+deb12u1"
 				},
 				{
-					"key": "gcc-12-base_12.2.0-14_amd64",
+					"key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
 					"name": "gcc-12-base",
-					"version": "12.2.0-14"
+					"version": "12.2.0-14+deb12u1"
 				},
 				{
 					"key": "libdrm-common_2.4.114-1_amd64",
@@ -28,42 +28,42 @@
 			"name": "libdrm2",
 			"sha256": "be18fb670797ba32da9628cf3e8acd83160d8db8c8dd842501dd8e401c3b5371",
 			"urls": [
-				"https://snapshot-cloudflare.debian.org/archive/debian/20241127T143620Z/pool/main/libd/libdrm/libdrm2_2.4.114-1+b1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/libd/libdrm/libdrm2_2.4.114-1+b1_amd64.deb"
 			],
 			"version": "2.4.114-1+b1"
 		},
 		{
 			"arch": "amd64",
 			"dependencies": [],
-			"key": "libc6_2.36-9-p-deb12u9_amd64",
+			"key": "libc6_2.36-9-p-deb12u10_amd64",
 			"name": "libc6",
-			"sha256": "3a043b9dbf1a8c8b5a9e2268253e6dca8c7d431bd7a202fea96364abf374fea9",
+			"sha256": "5dc83256f10ca4d0f2a53dd6583ffd0d0e319af30074ea6c82fb0ae77bd16365",
 			"urls": [
-				"https://snapshot-cloudflare.debian.org/archive/debian/20241127T143620Z/pool/main/g/glibc/libc6_2.36-9+deb12u9_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/g/glibc/libc6_2.36-9+deb12u10_amd64.deb"
 			],
-			"version": "2.36-9+deb12u9"
+			"version": "2.36-9+deb12u10"
 		},
 		{
 			"arch": "amd64",
 			"dependencies": [],
-			"key": "libgcc-s1_12.2.0-14_amd64",
+			"key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
 			"name": "libgcc-s1",
-			"sha256": "f3d1d48c0599aea85b7f2077a01d285badc42998c1a1e7473935d5cf995c8141",
+			"sha256": "3016e62cb4b7cd8038822870601f5ed131befe942774d0f745622cc77d8a88f7",
 			"urls": [
-				"https://snapshot-cloudflare.debian.org/archive/debian/20241127T143620Z/pool/main/g/gcc-12/libgcc-s1_12.2.0-14_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/g/gcc-12/libgcc-s1_12.2.0-14+deb12u1_amd64.deb"
 			],
-			"version": "12.2.0-14"
+			"version": "12.2.0-14+deb12u1"
 		},
 		{
 			"arch": "amd64",
 			"dependencies": [],
-			"key": "gcc-12-base_12.2.0-14_amd64",
+			"key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
 			"name": "gcc-12-base",
-			"sha256": "1a03df5a57833d65b5bb08cfa19d50e76f29088dc9e64fb934af42d9023a0807",
+			"sha256": "1896a2aacf4ad681ff5eacc24a5b0ca4d5d9c9b9c9e4b6de5197bc1e116ea619",
 			"urls": [
-				"https://snapshot-cloudflare.debian.org/archive/debian/20241127T143620Z/pool/main/g/gcc-12/gcc-12-base_12.2.0-14_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/g/gcc-12/gcc-12-base_12.2.0-14+deb12u1_amd64.deb"
 			],
-			"version": "12.2.0-14"
+			"version": "12.2.0-14+deb12u1"
 		},
 		{
 			"arch": "amd64",
@@ -72,7 +72,7 @@
 			"name": "libdrm-common",
 			"sha256": "32f9664138b38b224383c6986457d5ad2ec8efd559b1a0ce7749405f7a451aad",
 			"urls": [
-				"https://snapshot-cloudflare.debian.org/archive/debian/20241127T143620Z/pool/main/libd/libdrm/libdrm-common_2.4.114-1_all.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/libd/libdrm/libdrm-common_2.4.114-1_all.deb"
 			],
 			"version": "2.4.114-1"
 		},
@@ -85,26 +85,26 @@
 					"version": "1:1.2.13.dfsg-1"
 				},
 				{
-					"key": "libc6_2.36-9-p-deb12u9_amd64",
+					"key": "libc6_2.36-9-p-deb12u10_amd64",
 					"name": "libc6",
-					"version": "2.36-9+deb12u9"
+					"version": "2.36-9+deb12u10"
 				},
 				{
-					"key": "libgcc-s1_12.2.0-14_amd64",
+					"key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
 					"name": "libgcc-s1",
-					"version": "12.2.0-14"
+					"version": "12.2.0-14+deb12u1"
 				},
 				{
-					"key": "gcc-12-base_12.2.0-14_amd64",
+					"key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
 					"name": "gcc-12-base",
-					"version": "12.2.0-14"
+					"version": "12.2.0-14+deb12u1"
 				}
 			],
 			"key": "libelf1_0.188-2.1_amd64",
 			"name": "libelf1",
 			"sha256": "619add379c606b3ac6c1a175853b918e6939598a83d8ebadf3bdfd50d10b3c8c",
 			"urls": [
-				"https://snapshot-cloudflare.debian.org/archive/debian/20241127T143620Z/pool/main/e/elfutils/libelf1_0.188-2.1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/e/elfutils/libelf1_0.188-2.1_amd64.deb"
 			],
 			"version": "0.188-2.1"
 		},
@@ -112,26 +112,26 @@
 			"arch": "amd64",
 			"dependencies": [
 				{
-					"key": "libc6_2.36-9-p-deb12u9_amd64",
+					"key": "libc6_2.36-9-p-deb12u10_amd64",
 					"name": "libc6",
-					"version": "2.36-9+deb12u9"
+					"version": "2.36-9+deb12u10"
 				},
 				{
-					"key": "libgcc-s1_12.2.0-14_amd64",
+					"key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
 					"name": "libgcc-s1",
-					"version": "12.2.0-14"
+					"version": "12.2.0-14+deb12u1"
 				},
 				{
-					"key": "gcc-12-base_12.2.0-14_amd64",
+					"key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
 					"name": "gcc-12-base",
-					"version": "12.2.0-14"
+					"version": "12.2.0-14+deb12u1"
 				}
 			],
 			"key": "zlib1g_1-1.2.13.dfsg-1_amd64",
 			"name": "zlib1g",
 			"sha256": "d7dd1d1411fedf27f5e27650a6eff20ef294077b568f4c8c5e51466dc7c08ce4",
 			"urls": [
-				"https://snapshot-cloudflare.debian.org/archive/debian/20241127T143620Z/pool/main/z/zlib/zlib1g_1.2.13.dfsg-1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/z/zlib/zlib1g_1.2.13.dfsg-1_amd64.deb"
 			],
 			"version": "1:1.2.13.dfsg-1"
 		},
@@ -139,26 +139,26 @@
 			"arch": "amd64",
 			"dependencies": [
 				{
-					"key": "libc6_2.36-9-p-deb12u9_amd64",
+					"key": "libc6_2.36-9-p-deb12u10_amd64",
 					"name": "libc6",
-					"version": "2.36-9+deb12u9"
+					"version": "2.36-9+deb12u10"
 				},
 				{
-					"key": "libgcc-s1_12.2.0-14_amd64",
+					"key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
 					"name": "libgcc-s1",
-					"version": "12.2.0-14"
+					"version": "12.2.0-14+deb12u1"
 				},
 				{
-					"key": "gcc-12-base_12.2.0-14_amd64",
+					"key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
 					"name": "gcc-12-base",
-					"version": "12.2.0-14"
+					"version": "12.2.0-14+deb12u1"
 				}
 			],
 			"key": "libnuma1_2.0.16-1_amd64",
 			"name": "libnuma1",
 			"sha256": "639e1ab6bd66ead40db8a22c332d7199679fa22db261cac34444eb8eb4c17dda",
 			"urls": [
-				"https://snapshot-cloudflare.debian.org/archive/debian/20241127T143620Z/pool/main/n/numactl/libnuma1_2.0.16-1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/n/numactl/libnuma1_2.0.16-1_amd64.deb"
 			],
 			"version": "2.0.16-1"
 		},
@@ -166,26 +166,26 @@
 			"arch": "amd64",
 			"dependencies": [
 				{
-					"key": "libc6_2.36-9-p-deb12u9_amd64",
+					"key": "libc6_2.36-9-p-deb12u10_amd64",
 					"name": "libc6",
-					"version": "2.36-9+deb12u9"
+					"version": "2.36-9+deb12u10"
 				},
 				{
-					"key": "libgcc-s1_12.2.0-14_amd64",
+					"key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
 					"name": "libgcc-s1",
-					"version": "12.2.0-14"
+					"version": "12.2.0-14+deb12u1"
 				},
 				{
-					"key": "gcc-12-base_12.2.0-14_amd64",
+					"key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
 					"name": "gcc-12-base",
-					"version": "12.2.0-14"
+					"version": "12.2.0-14+deb12u1"
 				}
 			],
 			"key": "libzstd1_1.5.4-p-dfsg2-5_amd64",
 			"name": "libzstd1",
 			"sha256": "6315b5ac38b724a710fb96bf1042019398cb656718b1522279a5185ed39318fa",
 			"urls": [
-				"https://snapshot-cloudflare.debian.org/archive/debian/20241127T143620Z/pool/main/libz/libzstd/libzstd1_1.5.4+dfsg2-5_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/libz/libzstd/libzstd1_1.5.4+dfsg2-5_amd64.deb"
 			],
 			"version": "1.5.4+dfsg2-5"
 		},
@@ -198,19 +198,19 @@
 					"version": "2.4.114-1+b1"
 				},
 				{
-					"key": "libc6_2.36-9-p-deb12u9_amd64",
+					"key": "libc6_2.36-9-p-deb12u10_amd64",
 					"name": "libc6",
-					"version": "2.36-9+deb12u9"
+					"version": "2.36-9+deb12u10"
 				},
 				{
-					"key": "libgcc-s1_12.2.0-14_amd64",
+					"key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
 					"name": "libgcc-s1",
-					"version": "12.2.0-14"
+					"version": "12.2.0-14+deb12u1"
 				},
 				{
-					"key": "gcc-12-base_12.2.0-14_amd64",
+					"key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
 					"name": "gcc-12-base",
-					"version": "12.2.0-14"
+					"version": "12.2.0-14+deb12u1"
 				},
 				{
 					"key": "libdrm-common_2.4.114-1_amd64",
@@ -222,7 +222,7 @@
 			"name": "libdrm-amdgpu1",
 			"sha256": "b75a71e96f1faac0f131ac657e09efcbe8968eef62cc34b8abfcff2ff9f0cccd",
 			"urls": [
-				"https://snapshot-cloudflare.debian.org/archive/debian/20241127T143620Z/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.114-1+b1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.114-1+b1_amd64.deb"
 			],
 			"version": "2.4.114-1+b1"
 		},
@@ -230,26 +230,26 @@
 			"arch": "amd64",
 			"dependencies": [
 				{
-					"key": "libc6_2.36-9-p-deb12u9_amd64",
+					"key": "libc6_2.36-9-p-deb12u10_amd64",
 					"name": "libc6",
-					"version": "2.36-9+deb12u9"
+					"version": "2.36-9+deb12u10"
 				},
 				{
-					"key": "libgcc-s1_12.2.0-14_amd64",
+					"key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
 					"name": "libgcc-s1",
-					"version": "12.2.0-14"
+					"version": "12.2.0-14+deb12u1"
 				},
 				{
-					"key": "gcc-12-base_12.2.0-14_amd64",
+					"key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
 					"name": "gcc-12-base",
-					"version": "12.2.0-14"
+					"version": "12.2.0-14+deb12u1"
 				}
 			],
 			"key": "libtinfo6_6.4-4_amd64",
 			"name": "libtinfo6",
 			"sha256": "072d908f38f51090ca28ca5afa3b46b2957dc61fe35094c0b851426859a49a51",
 			"urls": [
-				"https://snapshot-cloudflare.debian.org/archive/debian/20241127T143620Z/pool/main/n/ncurses/libtinfo6_6.4-4_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/n/ncurses/libtinfo6_6.4-4_amd64.deb"
 			],
 			"version": "6.4-4"
 		}

--- a/runtimes/common/packages.yaml
+++ b/runtimes/common/packages.yaml
@@ -4,17 +4,17 @@
 version: 1
 
 sources:
-  - channel: bookworm main
-    url: https://snapshot-cloudflare.debian.org/archive/debian/20241127T143620Z/
+    - channel: bookworm main
+      url: https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/
 
 archs:
-  - "amd64"
+    - "amd64"
 
 packages:
-  - "libdrm2"
-  - "libelf1"
-  - "libnuma1"
-  - "libzstd1"
-  - "libdrm-amdgpu1"
-  - "libtinfo6"
-  - "zlib1g"
+    - "libdrm2"
+    - "libelf1"
+    - "libnuma1"
+    - "libzstd1"
+    - "libdrm-amdgpu1"
+    - "libtinfo6"
+    - "zlib1g"

--- a/runtimes/neuron/packages.lock.json
+++ b/runtimes/neuron/packages.lock.json
@@ -43,7 +43,7 @@
 			"name": "bash",
 			"sha256": "23910515e6b8b4fb4a3b50549464ef2efdc149b568150e2aa45115b37b6e6578",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/b/bash/bash_5.2.15-2+b8_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/b/bash/bash_5.2.15-2+b8_amd64.deb"
 			],
 			"version": "5.2.15-2+b8"
 		},
@@ -54,7 +54,7 @@
 			"name": "debianutils",
 			"sha256": "55f951359670eb3236c9e2ccd5fac9ccb3db734f5a22aff21589e7a30aee48c9",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/d/debianutils/debianutils_5.7-0.5~deb12u1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/d/debianutils/debianutils_5.7-0.5~deb12u1_amd64.deb"
 			],
 			"version": "5.7-0.5~deb12u1"
 		},
@@ -65,7 +65,7 @@
 			"name": "libc6",
 			"sha256": "5dc83256f10ca4d0f2a53dd6583ffd0d0e319af30074ea6c82fb0ae77bd16365",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/g/glibc/libc6_2.36-9+deb12u10_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/g/glibc/libc6_2.36-9+deb12u10_amd64.deb"
 			],
 			"version": "2.36-9+deb12u10"
 		},
@@ -76,7 +76,7 @@
 			"name": "libgcc-s1",
 			"sha256": "3016e62cb4b7cd8038822870601f5ed131befe942774d0f745622cc77d8a88f7",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/g/gcc-12/libgcc-s1_12.2.0-14+deb12u1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/g/gcc-12/libgcc-s1_12.2.0-14+deb12u1_amd64.deb"
 			],
 			"version": "12.2.0-14+deb12u1"
 		},
@@ -87,7 +87,7 @@
 			"name": "gcc-12-base",
 			"sha256": "1896a2aacf4ad681ff5eacc24a5b0ca4d5d9c9b9c9e4b6de5197bc1e116ea619",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/g/gcc-12/gcc-12-base_12.2.0-14+deb12u1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/g/gcc-12/gcc-12-base_12.2.0-14+deb12u1_amd64.deb"
 			],
 			"version": "12.2.0-14+deb12u1"
 		},
@@ -98,7 +98,7 @@
 			"name": "base-files",
 			"sha256": "c0b28aa96c88ca2e2f18c44911b6cd07de9335e0de7922fba778886a50061e64",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/b/base-files/base-files_12.4+deb12u11_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/b/base-files/base-files_12.4+deb12u11_amd64.deb"
 			],
 			"version": "12.4+deb12u11"
 		},
@@ -109,7 +109,7 @@
 			"name": "mawk",
 			"sha256": "bcbc83f391854ea9d50ce2a4101aacf330de3b8b71d81a798faadba14a157f78",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/m/mawk/mawk_1.3.4.20200120-3.1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/m/mawk/mawk_1.3.4.20200120-3.1_amd64.deb"
 			],
 			"version": "1.3.4.20200120-3.1"
 		},
@@ -120,7 +120,7 @@
 			"name": "libtinfo6",
 			"sha256": "072d908f38f51090ca28ca5afa3b46b2957dc61fe35094c0b851426859a49a51",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/n/ncurses/libtinfo6_6.4-4_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/n/ncurses/libtinfo6_6.4-4_amd64.deb"
 			],
 			"version": "6.4-4"
 		},
@@ -147,7 +147,7 @@
 			"name": "zlib1g",
 			"sha256": "d7dd1d1411fedf27f5e27650a6eff20ef294077b568f4c8c5e51466dc7c08ce4",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/z/zlib/zlib1g_1.2.13.dfsg-1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/z/zlib/zlib1g_1.2.13.dfsg-1_amd64.deb"
 			],
 			"version": "1:1.2.13.dfsg-1"
 		},
@@ -194,7 +194,7 @@
 			"name": "libxml2",
 			"sha256": "35b76cb7038fc1c940204a4f05f33ffb79d027353ce469397d9adcf8f9b3e1a7",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3~deb12u1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3~deb12u1_amd64.deb"
 			],
 			"version": "2.9.14+dfsg-1.3~deb12u1"
 		},
@@ -205,7 +205,7 @@
 			"name": "liblzma5",
 			"sha256": "d321b9502b16aac534e1c691afbe3dc5e125e5091aa35bea026c59b25ebe82e7",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/x/xz-utils/liblzma5_5.4.1-1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/x/xz-utils/liblzma5_5.4.1-1_amd64.deb"
 			],
 			"version": "5.4.1-1"
 		},
@@ -216,7 +216,7 @@
 			"name": "libicu72",
 			"sha256": "e239c1c9f52bee0ff627f291552d63691b765ec7c5cdf6de7c7ae4dec0275857",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/i/icu/libicu72_72.1-3_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/i/icu/libicu72_72.1-3_amd64.deb"
 			],
 			"version": "72.1-3"
 		},
@@ -227,7 +227,7 @@
 			"name": "libstdc++6",
 			"sha256": "5cd3171216d4ab0fc911cfe9c35509bf2dd8f47761c43b7f6a4296701551a24d",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/g/gcc-12/libstdc++6_12.2.0-14+deb12u1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/g/gcc-12/libstdc++6_12.2.0-14+deb12u1_amd64.deb"
 			],
 			"version": "12.2.0-14+deb12u1"
 		},
@@ -401,7 +401,7 @@
 			"name": "libhwloc-dev",
 			"sha256": "0b12593b41cd3c270548509c680192059c7b124261536db2630252559c865fad",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/h/hwloc/libhwloc-dev_2.9.0-1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/h/hwloc/libhwloc-dev_2.9.0-1_amd64.deb"
 			],
 			"version": "2.9.0-1"
 		},
@@ -412,7 +412,7 @@
 			"name": "libltdl-dev",
 			"sha256": "60ad26b3007d4304a1141649d4e764a27735ff4f1835a62c845d51bd734932b0",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/libt/libtool/libltdl-dev_2.4.7-7~deb12u1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/libt/libtool/libltdl-dev_2.4.7-7~deb12u1_amd64.deb"
 			],
 			"version": "2.4.7-7~deb12u1"
 		},
@@ -423,7 +423,7 @@
 			"name": "libltdl7",
 			"sha256": "8070b550321d4bd1c298f52f75374898d39112b709026d2ea5362ef1277b775a",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/libt/libtool/libltdl7_2.4.7-7~deb12u1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/libt/libtool/libltdl7_2.4.7-7~deb12u1_amd64.deb"
 			],
 			"version": "2.4.7-7~deb12u1"
 		},
@@ -434,7 +434,7 @@
 			"name": "libnuma-dev",
 			"sha256": "5893d10043918ed5d730ac1c6a54dd4e3f781166b809cbd43e43b2e576e4a5db",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/n/numactl/libnuma-dev_2.0.16-1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/n/numactl/libnuma-dev_2.0.16-1_amd64.deb"
 			],
 			"version": "2.0.16-1"
 		},
@@ -445,7 +445,7 @@
 			"name": "libc6-dev",
 			"sha256": "5597f588e682c0d8a02b5445eab3b61e5530c9a32db3527698cb963669b27527",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/g/glibc/libc6-dev_2.36-9+deb12u10_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/g/glibc/libc6-dev_2.36-9+deb12u10_amd64.deb"
 			],
 			"version": "2.36-9+deb12u10"
 		},
@@ -456,7 +456,7 @@
 			"name": "rpcsvc-proto",
 			"sha256": "32ac0692694f8a34cc90c895f4fc739680fb2ef0e2d4870a68833682bf1c81a3",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.3-1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.3-1_amd64.deb"
 			],
 			"version": "1.4.3-1"
 		},
@@ -467,7 +467,7 @@
 			"name": "libnsl-dev",
 			"sha256": "bb81a188c119cd7fdebae723cbc95887b6c549b2fe4fb7e268a9c8846444da99",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/libn/libnsl/libnsl-dev_1.3.0-2_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/libn/libnsl/libnsl-dev_1.3.0-2_amd64.deb"
 			],
 			"version": "1.3.0-2"
 		},
@@ -478,7 +478,7 @@
 			"name": "libtirpc-dev",
 			"sha256": "03326473eed54ffa27efae19aa5d6aeb402930968f869f318445513093691d55",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/libt/libtirpc/libtirpc-dev_1.3.3+ds-1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/libt/libtirpc/libtirpc-dev_1.3.3+ds-1_amd64.deb"
 			],
 			"version": "1.3.3+ds-1"
 		},
@@ -489,7 +489,7 @@
 			"name": "libtirpc3",
 			"sha256": "2a46d5a5e9486da11ffeff5740931740d6deae4f92cd6098df060dc5dff1e1c7",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/libt/libtirpc/libtirpc3_1.3.3+ds-1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/libt/libtirpc/libtirpc3_1.3.3+ds-1_amd64.deb"
 			],
 			"version": "1.3.3+ds-1"
 		},
@@ -500,7 +500,7 @@
 			"name": "libtirpc-common",
 			"sha256": "3e3ef129b4bf61513144236e15e1b4ec57fa5ae3dc8a72137abdbefb7a63af85",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/libt/libtirpc/libtirpc-common_1.3.3+ds-1_all.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/libt/libtirpc/libtirpc-common_1.3.3+ds-1_all.deb"
 			],
 			"version": "1.3.3+ds-1"
 		},
@@ -511,7 +511,7 @@
 			"name": "libgssapi-krb5-2",
 			"sha256": "34a3fcd0e5aeeb01e895b8ce563b06b12b0d763f1b5943b97feffed07a3f56f1",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/k/krb5/libgssapi-krb5-2_1.20.1-2+deb12u3_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/k/krb5/libgssapi-krb5-2_1.20.1-2+deb12u3_amd64.deb"
 			],
 			"version": "1.20.1-2+deb12u3"
 		},
@@ -522,7 +522,7 @@
 			"name": "libkrb5support0",
 			"sha256": "8862ae9677f2361d888fcefb2734e4ddfb2678f82535d21c4c0cc77d8e406e9f",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/k/krb5/libkrb5support0_1.20.1-2+deb12u3_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/k/krb5/libkrb5support0_1.20.1-2+deb12u3_amd64.deb"
 			],
 			"version": "1.20.1-2+deb12u3"
 		},
@@ -533,7 +533,7 @@
 			"name": "libkrb5-3",
 			"sha256": "e3c228ea202bf5a278329f5a96cbe3ca48927e0ed7fea849680b0996fece4879",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/k/krb5/libkrb5-3_1.20.1-2+deb12u3_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/k/krb5/libkrb5-3_1.20.1-2+deb12u3_amd64.deb"
 			],
 			"version": "1.20.1-2+deb12u3"
 		},
@@ -544,7 +544,7 @@
 			"name": "libssl3",
 			"sha256": "eaa2bab2130820f09361dc8186ddeb11d2a18ec5e5e3806f24414d5d8065a57a",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/o/openssl/libssl3_3.0.16-1~deb12u1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/o/openssl/libssl3_3.0.16-1~deb12u1_amd64.deb"
 			],
 			"version": "3.0.16-1~deb12u1"
 		},
@@ -555,7 +555,7 @@
 			"name": "libkeyutils1",
 			"sha256": "cfac89e6a7a54ff3c6a4f843310e25efeddaa771baeae470bd98bd588c373563",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/k/keyutils/libkeyutils1_1.6.3-2_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/k/keyutils/libkeyutils1_1.6.3-2_amd64.deb"
 			],
 			"version": "1.6.3-2"
 		},
@@ -566,7 +566,7 @@
 			"name": "libk5crypto3",
 			"sha256": "6aff44ea189ad062eb7a83b9fac99861f1efa35bf66bc7605c2ade644a08bb94",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/k/krb5/libk5crypto3_1.20.1-2+deb12u3_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/k/krb5/libk5crypto3_1.20.1-2+deb12u3_amd64.deb"
 			],
 			"version": "1.20.1-2+deb12u3"
 		},
@@ -577,7 +577,7 @@
 			"name": "libcom-err2",
 			"sha256": "8010e4285276bb344c05ae780deae2fffb45e237116c3a78481365c5954125ec",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/e/e2fsprogs/libcom-err2_1.47.0-2_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/e/e2fsprogs/libcom-err2_1.47.0-2_amd64.deb"
 			],
 			"version": "1.47.0-2"
 		},
@@ -588,7 +588,7 @@
 			"name": "libnsl2",
 			"sha256": "c0d83437fdb016cb289436f49f28a36be44b3e8f1f2498c7e3a095f709c0d6f8",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/libn/libnsl/libnsl2_1.3.0-2_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/libn/libnsl/libnsl2_1.3.0-2_amd64.deb"
 			],
 			"version": "1.3.0-2"
 		},
@@ -599,7 +599,7 @@
 			"name": "libcrypt-dev",
 			"sha256": "81ccd29130f75a9e3adabc80e61921abff42f76761e1f792fa2d1bb69af7f52f",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/libx/libxcrypt/libcrypt-dev_4.4.33-2_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/libx/libxcrypt/libcrypt-dev_4.4.33-2_amd64.deb"
 			],
 			"version": "1:4.4.33-2"
 		},
@@ -610,7 +610,7 @@
 			"name": "libcrypt1",
 			"sha256": "f5f60a5cdfd4e4eaa9438ade5078a57741a7a78d659fcb0c701204f523e8bd29",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/libx/libxcrypt/libcrypt1_4.4.33-2_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/libx/libxcrypt/libcrypt1_4.4.33-2_amd64.deb"
 			],
 			"version": "1:4.4.33-2"
 		},
@@ -621,7 +621,7 @@
 			"name": "linux-libc-dev",
 			"sha256": "0fc664e6e81677598e8bfa41cf377ebd353a6e50ad2099bc4603b9f66c9b854b",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/l/linux/linux-libc-dev_6.1.137-1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/l/linux/linux-libc-dev_6.1.137-1_amd64.deb"
 			],
 			"version": "6.1.137-1"
 		},
@@ -632,7 +632,7 @@
 			"name": "libc-dev-bin",
 			"sha256": "db898f3f85e19d4d54a277a0ab479b57566be5b902e6e8ebe814410aa3149e72",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/g/glibc/libc-dev-bin_2.36-9+deb12u10_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/g/glibc/libc-dev-bin_2.36-9+deb12u10_amd64.deb"
 			],
 			"version": "2.36-9+deb12u10"
 		},
@@ -643,7 +643,7 @@
 			"name": "libnuma1",
 			"sha256": "639e1ab6bd66ead40db8a22c332d7199679fa22db261cac34444eb8eb4c17dda",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/n/numactl/libnuma1_2.0.16-1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/n/numactl/libnuma1_2.0.16-1_amd64.deb"
 			],
 			"version": "2.0.16-1"
 		},
@@ -654,7 +654,7 @@
 			"name": "libhwloc15",
 			"sha256": "4e7194b5d9adbb1a7d11a9501a4be4a4fa22876b69c73b7998056f552962c0e4",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/h/hwloc/libhwloc15_2.9.0-1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/h/hwloc/libhwloc15_2.9.0-1_amd64.deb"
 			],
 			"version": "2.9.0-1"
 		},
@@ -665,7 +665,7 @@
 			"name": "libudev1",
 			"sha256": "ed03696385df7ba1b18b224175b120083875deae0e2f4369857f260b18533ea2",
 			"urls": [
-				"https://deb.debian.org/debian/pool/main/s/systemd/libudev1_252.36-1~deb12u1_amd64.deb"
+				"https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/pool/main/s/systemd/libudev1_252.36-1~deb12u1_amd64.deb"
 			],
 			"version": "252.36-1~deb12u1"
 		}

--- a/runtimes/neuron/packages.yaml
+++ b/runtimes/neuron/packages.yaml
@@ -10,7 +10,7 @@ version: 1
 
 sources:
     - channel: bookworm main
-      url: https://deb.debian.org/debian
+      url: https://snapshot-cloudflare.debian.org/archive/debian/20250529T205323Z/
     - channel: jammy main
       url: https://apt.repos.neuron.amazonaws.com
 


### PR DESCRIPTION
They are more reliable when pinning dependencies.

Replaces and Closes #111