### PR TITLE
zml: custom call v2

### DIFF
--- a/examples/custom_call/BUILD
+++ b/examples/custom_call/BUILD
@@ -1,0 +1,11 @@
+load("@rules_zig//zig:defs.bzl", "zig_binary")
+
+zig_binary(
+    name = "custom_call",
+    copts = ["-freference-trace=30"],
+    main = "main.zig",
+    deps = [
+        "@zml//async",
+        "@zml//zml",
+    ],
+)

--- a/examples/custom_call/main.zig
+++ b/examples/custom_call/main.zig
@@ -145,10 +145,9 @@ pub fn asyncMain() !void {
     defer result.deinit();
 
     const cpu_result = try result.toHostAlloc(arena);
-    _ = cpu_result; // autofix
 
-    // log.warn(
-    //     "\nThe result of {} + {} = {}\n",
-    //     .{ &input_a, &input_b, cpu_result.items(f32) },
-    // );
+    log.warn(
+        "\nThe result of {d} + {d} = {d}\n",
+        .{ input_a[0], input_b[0], cpu_result.items(f32)[0] },
+    );
 }

--- a/examples/custom_call/main.zig
+++ b/examples/custom_call/main.zig
@@ -1,0 +1,154 @@
+const std = @import("std");
+const zml = @import("zml");
+const asynk = @import("async");
+
+const cuda = zml.context.cuda;
+
+pub const std_options: std.Options = .{
+    .log_level = .info,
+    .logFn = asynk.logFn(std.log.defaultLog),
+};
+
+const log = std.log.scoped(.@"examples/custom_call");
+
+fn add_op_host_func(data: *anyopaque) callconv(.c) void {
+    const ctx = @as(*AddOp, @alignCast(@ptrCast(data)));
+
+    const result = std.mem.bytesAsValue(f32, ctx.result.asHostBuffer().mutBytes());
+    result.* = ctx.a.asHostBuffer().item(f32, 0) + ctx.b.asHostBuffer().item(f32, 0);
+}
+
+pub const AddOp = struct {
+    pub var type_id: i64 = undefined;
+    const Self = @This();
+
+    allocator: std.mem.Allocator,
+    platform: zml.Platform,
+
+    a: zml.Buffer,
+    b: zml.Buffer,
+    result: zml.Buffer,
+
+    results: [1]zml.Buffer = undefined,
+    stream: *anyopaque = undefined,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        platform: zml.Platform,
+        io_shape: zml.Shape,
+    ) !AddOp {
+        const host_buffer = try zml.HostBuffer.empty(allocator, io_shape);
+        defer host_buffer.deinit(allocator);
+
+        const a = try zml.Buffer.from(platform, host_buffer, .{ .memory = .host_pinned });
+        const b = try zml.Buffer.from(platform, host_buffer, .{ .memory = .host_pinned });
+        const result = try zml.Buffer.from(platform, host_buffer, .{ .memory = .host_pinned });
+
+        return .{
+            .a = a,
+            .b = b,
+            .result = result,
+            .platform = platform,
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.a.deinit();
+        self.b.deinit();
+        self.result.deinit();
+    }
+
+    pub fn call(self: *Self, a: zml.Buffer, b: zml.Buffer) !void {
+        if (self.platform.target == .cuda) {
+            cuda.memcpyToHostAsync(self.a.asHostBuffer().mutBytes(), a.opaqueDeviceMemoryDataPointer(), self.stream);
+            cuda.memcpyToHostAsync(self.b.asHostBuffer().mutBytes(), b.opaqueDeviceMemoryDataPointer(), self.stream);
+
+            _ = cuda.cuLaunchHostFunc(self.stream, @ptrCast(&add_op_host_func), @ptrCast(self));
+
+            cuda.memcpyToDeviceAsync(self.results[0].opaqueDeviceMemoryDataPointer(), self.result.asHostBuffer().bytes(), self.stream);
+            return;
+        }
+
+        if (self.platform.target == .cpu) {
+            const result = std.mem.bytesAsValue(f32, self.results[0].asHostBuffer().mutBytes());
+            result.* = a.asHostBuffer().item(f32, 0) + b.asHostBuffer().item(f32, 0);
+            return;
+        }
+
+        return error.UnsupportedTarget;
+    }
+};
+
+const Layer = struct {
+    pub fn forward(_: Layer, a: zml.Tensor, b: zml.Tensor) zml.Tensor {
+        const result = zml.custom_call(AddOp, .{ a.print(), b.print() }, &[_]zml.Shape{a.shape()}, .{});
+        return result[0];
+    }
+};
+
+pub fn main() !void {
+    try asynk.AsyncThread.main(std.heap.c_allocator, asyncMain);
+}
+
+pub fn asyncMain() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var arena_state = std.heap.ArenaAllocator.init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var context = try zml.Context.init();
+    defer context.deinit();
+
+    const platform = context.autoPlatform(.{});
+    context.printAvailablePlatforms(platform);
+
+    const shape = zml.Shape.init(.{}, .f32);
+
+    const buffers: zml.aio.BufferStore.Buffers = .{};
+    const buffer_store: zml.aio.BufferStore = .{
+        .arena = arena_state,
+        .buffers = buffers,
+    };
+
+    const model_shapes = try zml.aio.populateModel(Layer, allocator, buffer_store);
+
+    var compilation = try asynk.asyncc(zml.compileModel, .{ allocator, Layer.forward, model_shapes, .{ shape, shape }, platform });
+
+    var model_weights = try zml.aio.loadModelBuffers(Layer, model_shapes, buffer_store, arena, platform);
+    defer zml.aio.unloadBuffers(&model_weights);
+
+    const compiled = try compilation.awaitt();
+
+    var executable = compiled.prepare(model_weights);
+    defer executable.deinit();
+
+    executable = try executable.withExecutionContext();
+
+    try platform.registerFFIType(AddOp);
+    var add_op: AddOp = try .init(allocator, platform, shape);
+    defer add_op.deinit();
+    try executable.bind(AddOp, &add_op);
+
+    var input_a = [1]f32{1.0};
+    var input_buffer_a = try zml.Buffer.from(platform, zml.HostBuffer.fromSlice(shape, &input_a), .{});
+    defer input_buffer_a.deinit();
+
+    var input_b = [1]f32{1.0};
+    var input_buffer_b = try zml.Buffer.from(platform, zml.HostBuffer.fromSlice(shape, &input_b), .{});
+    defer input_buffer_b.deinit();
+
+    var result: zml.Buffer = executable.call(.{ input_buffer_a, input_buffer_b });
+    defer result.deinit();
+
+    const cpu_result = try result.toHostAlloc(arena);
+    _ = cpu_result; // autofix
+
+    // log.warn(
+    //     "\nThe result of {} + {} = {}\n",
+    //     .{ &input_a, &input_b, cpu_result.items(f32) },
+    // );
+}

--- a/pjrt/ffi.zig
+++ b/pjrt/ffi.zig
@@ -169,7 +169,7 @@ pub const ExecutionContext = opaque {
                 const type_id: TypeId = .{ .type_id = T.type_id };
                 var ret = pjrtStruct(c.XLA_FFI_ExecutionContext_Get_Args{
                     .ctx = @constCast(self.inner()),
-                    .type_id = @constCast(&type_id.toCStruct()),
+                    .type_id = @constCast(&type_id),
                 });
                 const result = api.inner().XLA_FFI_ExecutionContext_Get.?(&ret);
 

--- a/pjrt/pjrt.zig
+++ b/pjrt/pjrt.zig
@@ -1293,7 +1293,7 @@ pub const FFI = extern struct {
         }
     };
 
-    pub const RegisterFfiOptions = struct {
+    pub const RegisterOptions = struct {
         traits: RegisterHandlerTraits = @enumFromInt(0),
     };
 
@@ -1305,7 +1305,7 @@ pub const FFI = extern struct {
         target_name: []const u8,
         platform_name: []const u8,
         func: *const ffi.Handler,
-        options: RegisterFfiOptions,
+        options: RegisterOptions,
     ) ApiError!void {
         var ret = pjrtStruct(c.PJRT_FFI_Register_Handler_Args{
             .target_name = target_name.ptr,
@@ -1356,8 +1356,4 @@ pub const FFI = extern struct {
 pub const RegisterHandlerTraits = enum(c.PJRT_FFI_Handler_TraitsBits) {
     command_buffer_compatible = c.PJRT_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE,
     _,
-};
-
-pub const CustomCallRegistry = extern struct {
-    inner: *const c.PJRT_FFI_Register_Handler,
 };

--- a/zml/BUILD.bazel
+++ b/zml/BUILD.bazel
@@ -31,6 +31,7 @@ zig_library(
         "aio/torch/py.zig",
         "buffer.zig",
         "context.zig",
+        "custom_call.zig",
         "dtype.zig",
         "exe.zig",
         "floats.zig",

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -49,7 +49,7 @@ pub const Buffer = struct {
 
     pub const FromOptions = struct {
         wait: bool = true,
-        memory: ?pjrt.Memory.Kind = null,
+        memory: ?Memory = null,
     };
 
     /// Copies the content of the given buffer from host memory to the accelerator memory.
@@ -89,13 +89,13 @@ pub const Buffer = struct {
                 .byte_strides = byte_strides,
                 .host_buffer_semantics = .ImmutableUntilTransferCompletes,
             };
-            if (opts.memory) |memory_kind| {
-                const memories = try devices[i].addressableMemories(platform.pjrt_api);
-                const memory = for (memories) |m| {
+            if (opts.memory) |memory| {
+                const device_memories = try devices[i].addressableMemories(platform.pjrt_api);
+                const selected_memory = for (device_memories) |m| {
                     const kind = m.kind(platform.pjrt_api);
-                    if (kind == memory_kind) break m;
+                    if (kind == memory.toPjrtMemory()) break m;
                 } else return error.NotFound;
-                args.memory = memory;
+                args.memory = selected_memory;
             } else {
                 args.device = devices[i];
             }
@@ -179,10 +179,9 @@ pub const Buffer = struct {
         return try from(platform, host_buffer, opts);
     }
 
-    pub fn asPinnedHostBuffer(self: Buffer) HostBuffer {
-        // TODO restore assert
-        // const memory = self.getMemory().kind(self._api);
-        // stdx.debug.assert(memory == .pinned_host, "asPinnedHostBuffer({}) expects a buffer allocated on host memory, got {}. see `toMemory`", .{ self, memory });
+    pub fn asHostBuffer(self: Buffer) HostBuffer {
+        const memory = self.getMemory().kind(self._api);
+        stdx.debug.assert((memory == .pinned_host) or (memory == .unpinned_host), "asHostBuffer({any}) expects a buffer allocated on host memory, got {any}. see `copyToMemory`", .{ self, memory });
         const ptr: [*]u8 = @ptrCast(self._shards.get(0).getOpaqueDeviceMemoryDataPointer(self._api) catch unreachable);
         return HostBuffer.fromBytes(self._shape, ptr[0..self._shape.byteSize()]);
     }
@@ -299,6 +298,11 @@ pub const Buffer = struct {
         };
     }
 
+    pub fn opaqueDeviceMemoryDataPointer(self: Buffer) *anyopaque {
+        stdx.debug.internalAssert(!self.hasShardedAxis(), "TODO: support sharded Buffer", .{});
+        return self._shards.get(0).getOpaqueDeviceMemoryDataPointer(self._api) catch unreachable;
+    }
+
     /// Fetches the content of the given buffer into a stack variable of the given type.
     pub fn getValue(self: Buffer, T: type) !T {
         stdx.debug.assert(self._shape.byteSize() == @sizeOf(T), "Buffer {f} has {d} bytes of data, can't load it to a {s} with {d} bytes", .{ self, self._shape.byteSize(), @typeName(T), @sizeOf(T) });
@@ -390,11 +394,29 @@ pub const Buffer = struct {
         return @reduce(.Or, self._shape._sharding_info);
     }
 
-    pub fn copyToMemory(self: Buffer, memory: *const pjrt.Memory) !Buffer {
+    pub const CopyToMemoryOpts = struct {
+        wait: bool = true,
+    };
+
+    pub fn copyToMemory(self: Buffer, platform: Platform, memory: Memory, opts: CopyToMemoryOpts) !Buffer {
+        const pjrt_memory = platform.pjrt_client.memoryByKind(self._api, memory.toPjrtMemory());
+        if (pjrt_memory == null) {
+            stdx.debug.panic("Memory destination `{s}` for {any}", .{ memory.pjrtName(), self });
+        }
+
         var new_shards: Buffer.Shards = .{};
         for (self._shards.slice()) |shard| {
-            const new_shard = try shard.copyToMemory(self._api, memory);
+            const new_shard = try shard.copyToMemory(self._api, pjrt_memory.?);
             new_shards.appendAssumeCapacity(new_shard);
+        }
+
+        if (opts.wait) {
+            for (new_shards.constSlice()) |shard| {
+                const event = shard.getReadyEvent(self._api);
+                if (event) |e| {
+                    try e.awaitBlocking(self._api);
+                }
+            }
         }
 
         return Buffer{ ._shape = self._shape, ._shards = new_shards, ._api = self._api };

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -185,8 +185,8 @@ pub const Buffer = struct {
     }
 
     pub fn asHostBuffer(self: Buffer) HostBuffer {
-        const memory = self.getMemory().kind(self._api);
-        stdx.debug.assert((memory == .pinned_host) or (memory == .unpinned_host), "asHostBuffer({any}) expects a buffer allocated on host memory, got {any}. see `copyToMemory`", .{ self, memory });
+        // const memory = self.getMemory().kind(self._api);
+        // stdx.debug.assert((memory == .pinned_host) or (memory == .unpinned_host), "asHostBuffer({any}) expects a buffer allocated on host memory, got {any}. see `copyToMemory`", .{ self, memory });
         const ptr: [*]u8 = @ptrCast(self._shards.get(0).getOpaqueDeviceMemoryDataPointer(self._api) catch unreachable);
         return HostBuffer.fromBytes(self._shape, ptr[0..self._shape.byteSize()]);
     }

--- a/zml/context.zig
+++ b/zml/context.zig
@@ -7,8 +7,6 @@ const runfiles = @import("runfiles");
 const runtimes = @import("runtimes");
 const stdx = @import("stdx");
 
-const DataType = @import("dtype.zig").DataType;
-const HostBuffer = @import("hostbuffer.zig").HostBuffer;
 const pjrt = @import("pjrtx.zig");
 const Platform = @import("platform.zig").Platform;
 const Shape = @import("shape.zig").Shape;

--- a/zml/custom_call.zig
+++ b/zml/custom_call.zig
@@ -1,0 +1,224 @@
+const std = @import("std");
+
+const asynk = @import("async");
+const stdx = @import("stdx");
+
+const dialect = struct {
+    const stablehlo = @import("mlir/dialects").stablehlo;
+};
+const mlir = @import("mlir");
+const mlirx = @import("mlirx.zig");
+const pjrt = @import("pjrt");
+const pjrtx = @import("pjrtx.zig");
+const ffi = pjrtx.ffi;
+const cuda = @import("context.zig").cuda;
+const Buffer = @import("buffer.zig").Buffer;
+const HostBuffer = @import("hostbuffer.zig").HostBuffer;
+const CompilationContext = @import("module.zig").CompilationContext;
+const DataType = @import("dtype.zig").DataType;
+const Platform = @import("platform.zig").Platform;
+const Shape = @import("shape.zig").Shape;
+const Tensor = @import("tensor.zig").Tensor;
+
+const log = std.log.scoped(.@"zml/custom_call");
+
+pub const std_options: std.Options = .{
+    .log_level = .info,
+    .logFn = asynk.logFn(std.log.defaultLog),
+};
+
+pub fn CustomCallInputsType(custom_op: type) type {
+    const ArgsT = stdx.meta.FnArgs(custom_op.call);
+    if (@typeInfo(ArgsT) != .@"struct") {
+        @compileError("Expected struct type");
+    }
+
+    const args = @typeInfo(ArgsT).@"struct".fields;
+
+    for (args[1..args.len]) |field| {
+        if (field.type != Buffer) {
+            @compileError("Expected all arguments in custom call `call` to be of type zml.Buffer");
+        }
+    }
+
+    return [args.len - 1]Tensor;
+}
+
+pub const CustomCallOptions = struct {
+    output_operand_aliases: []const i64 = &.{},
+    copy_inputs_to_host_pinned: bool = false,
+    register_ffi_options: pjrt.FFI.RegisterOptions = .{
+        .traits = @enumFromInt(0),
+    },
+};
+
+pub fn custom_call(
+    comptime custom_op: type,
+    inputs: CustomCallInputsType(custom_op),
+    res_shapes_: []const Shape,
+    comptime opts: CustomCallOptions,
+) []Tensor {
+    stdx.debug.assert(@hasDecl(custom_op, "call"), "custom_op must have a call method", .{});
+    const op_name = @typeName(custom_op);
+
+    const ctx = CompilationContext.current();
+    const allocator = ctx.allocator();
+    const mlir_ctx = ctx.mlirCtx();
+    const platform = ctx._platform;
+    const pjrt_api = platform.pjrt_api;
+    const ffi_ = pjrt_api.ffi();
+
+    if (ffi_ == null) {
+        stdx.debug.panic("Custom calls are not supported for target {s}", .{@tagName(platform.target)});
+    }
+
+    const ffi_func = proxy(custom_op, opts);
+    const target_name = "callback_" ++ op_name;
+
+    ffi_.?.register(pjrt_api, target_name, @tagName(platform.target), &ffi_func, opts.register_ffi_options) catch unreachable;
+    log.info("{s} / Registered custom call with target name \"{s}\" with proxy func {*}", .{ op_name, target_name, &ffi_func });
+
+    const custom_call_inputs = allocator.alloc(mlir.Value, 8) catch unreachable;
+    for (inputs, 0..) |t, i| {
+        custom_call_inputs[i] = t.value();
+    }
+
+    const res_types = allocator.alloc(mlir.Type, 8) catch unreachable;
+    for (res_shapes_, 0..) |sh, i| {
+        res_types[i] = mlirx.tensorType(mlir_ctx, sh);
+    }
+
+    const frontend_attributes: mlir.Attribute = .dict(mlir_ctx, &.{});
+
+    const op = dialect.stablehlo.custom_call(
+        mlir_ctx,
+        custom_call_inputs[0..inputs.len],
+        .{
+            .call_target_name = target_name,
+            .api_version = .typed_ffi,
+            .backend_config = mlir.Attribute.dict(mlir_ctx, &.{}),
+            .additional_attributes = &.{.{ "mhlo.frontend_attributes", frontend_attributes }},
+            .has_side_effect = true,
+            .output_operand_aliases = opts.output_operand_aliases,
+        },
+        res_types[0..res_shapes_.len],
+        mlir_ctx.location(@src()),
+    );
+
+    var custom_call_outputs = allocator.alloc(Tensor, 8) catch unreachable;
+
+    for (custom_call_outputs[0..res_shapes_.len], res_shapes_, 0..) |*t, sh, i| {
+        t.* = Tensor._result(sh, op.result(i));
+    }
+
+    return custom_call_outputs[0..res_shapes_.len];
+}
+
+fn proxy(comptime custom_op: type, opts: CustomCallOptions) ffi.Handler {
+    return struct {
+        const Self = @This();
+
+        pub fn proxy(call_frame: *ffi.CallFrame) callconv(.c) ?*ffi.Error {
+            if (call_frame.registeringHook()) return null;
+            const execution_context = call_frame.ctx;
+            const user_ctx: *custom_op = ffi.ExecutionContext.Context(custom_op).get(execution_context, call_frame.api) catch unreachable;
+            const platform: Platform = user_ctx.platform;
+
+            if (@hasField(custom_op, "stream") and platform.target != .cpu) {
+                const stream = call_frame.api.stream(execution_context);
+                user_ctx.stream = stream;
+            } else {
+                log.info("No stream field provided in container {s} for custom call", .{@typeName(custom_op)});
+            }
+
+            var callback_args: std.meta.ArgsTuple(@TypeOf(custom_op.call)) = undefined;
+            callback_args[0] = user_ctx;
+
+            inline for (1..callback_args.len) |i| {
+                const ffi_buffer = call_frame.args.buffers()[i - 1];
+                const ffi_buffer_shape = getShape(ffi_buffer);
+                var zml_buffer: Buffer = undefined;
+
+                if (platform.target == .cpu) {
+                    zml_buffer = Buffer.asViewOfHostBuffer(platform, HostBuffer.fromBytes(ffi_buffer_shape, ffi_buffer.data[0..ffi_buffer_shape.byteSize()]));
+                } else {
+                    zml_buffer = Buffer.asViewOfDeviceBuffer(platform, getShape(ffi_buffer), null, ffi_buffer.data);
+                }
+                if (opts.copy_inputs_to_host_pinned and platform.target != .cpu) {
+                    zml_buffer = zml_buffer.copyToMemory(platform, .host_pinned, .{ .wait = true }) catch unreachable;
+                }
+                callback_args[i] = zml_buffer;
+            }
+
+            for (0..call_frame.results.len) |i| {
+                const ffi_buffer = call_frame.results.buffers()[i];
+                const ffi_buffer_shape = getShape(ffi_buffer);
+
+                if (platform.target == .cpu) {
+                    user_ctx.results[i] = Buffer.asViewOfHostBuffer(platform, HostBuffer.fromBytes(ffi_buffer_shape, ffi_buffer.data[0..ffi_buffer_shape.byteSize()]));
+                } else {
+                    user_ctx.results[i] = Buffer.asViewOfDeviceBuffer(platform, getShape(ffi_buffer), null, ffi_buffer.data);
+                }
+            }
+
+            @call(.auto, custom_op.call, callback_args) catch |err| {
+                stdx.debug.panic("Error while calling {s} call func: {any}\n", .{ @typeName(custom_op), err });
+            };
+
+            return null;
+        }
+    }.proxy;
+}
+
+pub fn getShape(ffi_buffer: *const ffi.Buffer) Shape {
+    const dt: DataType = switch (ffi_buffer.dtype) {
+        .invalid => stdx.debug.panic("Invalid FFI dtype {any} used by {any}", .{ ffi_buffer.dtype, ffi_buffer }),
+        .pred => .bool,
+        .i8 => .i8,
+        .i16 => .i16,
+        .i32 => .i32,
+        .i64 => .i64,
+        .token, .f8e4m3, .f8e3m4 => stdx.debug.panic("Unsupported FFI dtype {any} used by {any}", .{ ffi_buffer.dtype, ffi_buffer }),
+        inline else => |t| @field(DataType, @tagName(t)),
+    };
+    return Shape.init(ffi_buffer.dims(), dt);
+}
+
+/// Internal custom calls.
+/// These are not meant to be used by users, but rather by the library itself.
+pub const custom_call_internal_types = [_]type{
+    Print,
+};
+
+pub fn registerInternalCustomCalls(
+    platform: Platform,
+) !void {
+    inline for (custom_call_internal_types) |custom_call_type| {
+        try platform.registerFFIType(custom_call_type);
+        log.info("Registered internal custom call {s} with type_id {any}", .{ @typeName(custom_call_type), custom_call_type.type_id });
+    }
+}
+
+pub const Print = struct {
+    pub var type_id: i64 = undefined;
+    const Self = @This();
+
+    allocator: std.mem.Allocator,
+    platform: Platform,
+
+    results: [1]Buffer = undefined,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        platform: Platform,
+    ) !Print {
+        return .{
+            .allocator = allocator,
+            .platform = platform,
+        };
+    }
+
+    pub fn call(_: *Self, input: Buffer) !void {
+        std.log.defaultLog(.info, .zml, "Device buffer: {any}: {any}", .{ input.shape(), input.asHostBuffer().pretty() });
+    }
+};

--- a/zml/custom_call.zig
+++ b/zml/custom_call.zig
@@ -1,25 +1,25 @@
 const std = @import("std");
 
 const asynk = @import("async");
+const mlir = @import("mlir");
+const pjrt = @import("pjrt");
 const stdx = @import("stdx");
 
-const dialect = struct {
-    const stablehlo = @import("mlir/dialects").stablehlo;
-};
-const mlir = @import("mlir");
+const Buffer = @import("buffer.zig").Buffer;
+const CompilationContext = @import("module.zig").CompilationContext;
+const cuda = @import("context.zig").cuda;
+const DataType = @import("dtype.zig").DataType;
+const HostBuffer = @import("hostbuffer.zig").HostBuffer;
 const mlirx = @import("mlirx.zig");
-const pjrt = @import("pjrt");
 const pjrtx = @import("pjrtx.zig");
 const ffi = pjrtx.ffi;
-const cuda = @import("context.zig").cuda;
-const Buffer = @import("buffer.zig").Buffer;
-const HostBuffer = @import("hostbuffer.zig").HostBuffer;
-const CompilationContext = @import("module.zig").CompilationContext;
-const DataType = @import("dtype.zig").DataType;
 const Platform = @import("platform.zig").Platform;
 const Shape = @import("shape.zig").Shape;
 const Tensor = @import("tensor.zig").Tensor;
 
+const dialect = struct {
+    const stablehlo = @import("mlir/dialects").stablehlo;
+};
 const log = std.log.scoped(.@"zml/custom_call");
 
 pub const std_options: std.Options = .{

--- a/zml/exe.zig
+++ b/zml/exe.zig
@@ -250,11 +250,11 @@ pub const BaseExe = struct {
             std.debug.panic("PJRT_LoadedExecutable_Execute failed with: {}", .{err});
         };
 
-        for (events[0..sharding.num_partitions]) |e| {
-            if (e) |ev| {
-                ev.await_(self.platform.pjrt_api) catch unreachable;
-            }
-        }
+        // for (events[0..sharding.num_partitions]) |e| {
+        //     if (e) |ev| {
+        //         ev.await_(self.platform.pjrt_api) catch unreachable;
+        //     }
+        // }
     }
 
     pub fn _unsafeAssignResults(self: BaseExe, T: type, result: *T) void {
@@ -330,7 +330,7 @@ pub const BaseExe = struct {
 
     pub fn clone(self: BaseExe, parent_allocator: std.mem.Allocator) !BaseExe {
         var exe: BaseExe = try .init(parent_allocator, self.platform, self.exe, .{
-            .n_in = self.input_buffer_count,
+            .input_shapes = self.input_shapes,
             .result_shapes = self.result_shapes,
             .n_devices = self.num_devices,
         });

--- a/zml/exe.zig
+++ b/zml/exe.zig
@@ -8,6 +8,7 @@ const Bufferized = @import("tensor.zig").Bufferized;
 const CompilationContext = @import("module.zig").CompilationContext;
 const meta = @import("meta.zig");
 const pjrt = @import("pjrtx.zig");
+const custom_call = @import("custom_call.zig");
 const Platform = @import("platform.zig").Platform;
 const Shape = @import("shape.zig").Shape;
 const ShapeOf = @import("tensor.zig").ShapeOf;
@@ -285,6 +286,21 @@ pub const BaseExe = struct {
         stdx.debug.internalAssert(local_ctx.index == self.result_shapes.len, "Pjrt call returned {} tensors, but the return type {s}, contains {} Buffers. Note that modules need to have a comptime know number of returned tensors.", .{ self.output_per_device.len, @typeName(T), local_ctx.index });
     }
 
+    pub fn bind(self: BaseExe, comptime T: type, value: *T) !void {
+        stdx.debug.assert(self.context != null, "Exe doesn't have an execution context", .{});
+        const pjrt_api = self.platform.pjrt_api;
+
+        if (pjrt_api.ffi()) |ffi| {
+            const type_id = T.type_id;
+            const user_data: *anyopaque = @ptrCast(@constCast(value));
+
+            try ffi.addUserData(pjrt_api, self.context.?, .{ .type_id = type_id, .user_data = user_data });
+            log.info("Bound {s}@{any} with type id {any} on {any}", .{ @typeName(T), user_data, T.type_id, self.context.? });
+        } else {
+            stdx.debug.panic("Custom calls are not supported for target {s}", .{@tagName(self.platform.target)});
+        }
+    }
+
     pub fn serialize(self: BaseExe, writer: anytype) !void {
         var executable = try self.exe.getExecutable(self.platform.pjrt_api);
         var serialize_result = try executable.serialize(self.platform.pjrt_api);
@@ -346,6 +362,28 @@ pub fn Exe(ArgsT: type, ReturnT: type) type {
             var new: Exe(stdx.meta.Tail(ArgsT), ReturnT) = .{ .inner = self.inner };
             new.inner.prepare(first_arg);
             return new;
+        }
+
+        pub fn withExecutionContext(self: Self) !Self {
+            stdx.debug.assert(self.inner.context == null, "Exe already has an execution context", .{});
+            var new: Self = .{ .inner = self.inner };
+            var arena = &new.inner._arena;
+            var allocator = arena.allocator();
+
+            const pjrt_execute_context = try new.inner.platform.pjrt_api.createExecuteContext();
+            new.inner.context = pjrt_execute_context;
+            inline for (custom_call.custom_call_internal_types) |custom_call_internal_type| {
+                const value_ptr = try allocator.create(custom_call_internal_type);
+                value_ptr.* = try .init(allocator, new.platform());
+                try new.inner.bind(custom_call_internal_type, value_ptr);
+            }
+            log.info("Created context execution {*} for {*}", .{ pjrt_execute_context, self.inner.exe });
+
+            return new;
+        }
+
+        pub fn bind(self: Self, comptime T: type, value: *T) !void {
+            try self.inner.bind(T, value);
         }
 
         pub fn serialize(self: Self, writer: anytype) !void {

--- a/zml/hostbuffer.zig
+++ b/zml/hostbuffer.zig
@@ -176,8 +176,18 @@ pub const HostBuffer = struct {
         return ptr[0..self._shape.count()];
     }
 
+    pub fn item(self: HostBuffer, comptime T: type, index: usize) T {
+        stdx.debug.assert(index < self._shape.count(), "index {any} out of bounds for shape {any}", .{ index, self._shape });
+        return self.items(T)[index];
+    }
+
     pub fn mutItems(self: HostBuffer, comptime T: type) []T {
         return @constCast(self.items(T));
+    }
+
+    pub fn mutitem(self: HostBuffer, comptime T: type, index: usize) T {
+        stdx.debug.assert(index < self._shape.count(), "index {any} out of bounds for shape {any}", .{ index, self._shape });
+        return self.mutItems(T)[index];
     }
 
     pub fn bytes(self: HostBuffer) []const u8 {

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -1178,9 +1178,9 @@ pub fn hash(hasher: *std.hash.Wyhash, key: anytype, comptime strat: std.hash.Str
         .@"anyframe", .@"fn" => hash(hasher, @intFromPtr(key), strat),
         .pointer => |info| switch (info.size) {
             .one => switch (strat) {
-                .shallow => hash(hasher, @intFromPtr(key), .Shallow),
-                .deep => hash(hasher, key.*, .Shallow),
-                .deeprecursive => switch (@typeInfo(info.child)) {
+                .Shallow => hash(hasher, @intFromPtr(key), .Shallow),
+                .Deep => hash(hasher, key.*, .Shallow),
+                .DeepRecursive => switch (@typeInfo(info.child)) {
                     .@"opaque", .@"fn" => hash(hasher, @intFromPtr(key), .Shallow),
                     else => hash(hasher, key.*, .DeepRecursive),
                 },
@@ -1196,7 +1196,7 @@ pub fn hash(hasher: *std.hash.Wyhash, key: anytype, comptime strat: std.hash.Str
             .many,
             .c,
             => switch (strat) {
-                .shallow => hash(hasher, @intFromPtr(key), .Shallow),
+                .Shallow => hash(hasher, @intFromPtr(key), .Shallow),
                 else => @compileError(
                     \\ unknown-length pointers and C pointers cannot be hashed deeply.
                     \\ Consider providing your own hash function.

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -764,33 +764,6 @@ pub fn fromMlirOperationWithTags(op: mlir.Operation, base: anytype) @TypeOf(base
     return res;
 }
 
-pub const HostCallbackOpt = struct {
-    has_side_effect: bool = false,
-    output_operand_aliases: []const i64 = &.{},
-};
-
-pub fn addHostCallback(
-    callback: *const Context.HostCallback,
-    blkctx: ?*anyopaque,
-    inputs: []const Tensor,
-    output_shapes: []const Shape,
-    opts: HostCallbackOpt,
-) []Tensor {
-    return customCall(
-        "zmlHostBufferCallback",
-        inputs,
-        output_shapes,
-        .{
-            .callback = @intFromPtr(callback),
-            .user_context = @intFromPtr(blkctx),
-        },
-        .{
-            .has_side_effect = opts.has_side_effect,
-            .output_operand_aliases = opts.output_operand_aliases,
-        },
-    );
-}
-
 pub const TritonOps = struct {
     debug: bool = false,
     name: [:0]const u8,

--- a/zml/pjrtx.zig
+++ b/zml/pjrtx.zig
@@ -207,6 +207,13 @@ pub const Event = opaque {
         return self.inner().getEventError(api);
     }
 
+    pub fn awaitBlocking(self: *Event, api: *const Api) ApiError!void {
+        if (self.isReady(api)) {
+            return;
+        }
+        try self.inner().await_(api);
+    }
+
     pub fn await_(self: *Event, api: *const Api) ApiError!void {
         defer self.deinit(api);
 

--- a/zml/pjrtx.zig
+++ b/zml/pjrtx.zig
@@ -271,14 +271,22 @@ pub const LoadedExecutable = opaque {
     };
 
     pub fn execute(self: *const LoadedExecutable, api: *const Api, args: ExecuteArgs) ExecuteError!void {
-        try asynk.callBlocking(pjrt.LoadedExecutable.execute, .{ self.inner(), api, pjrt.LoadedExecutable.ExecuteArgs{
+        try self.inner().execute(api, pjrt.LoadedExecutable.ExecuteArgs{
             .num_args = args.num_args,
             .arguments = @ptrCast(args.arguments),
             .results = @ptrCast(args.results),
             .events = @ptrCast(args.events),
             .non_donatable_input_indices = args.non_donatable_input_indices,
             .context = args.context,
-        } });
+        });
+        // try asynk.callBlocking(pjrt.LoadedExecutable.execute, .{ self.inner(), api, pjrt.LoadedExecutable.ExecuteArgs{
+        //     .num_args = args.num_args,
+        //     .arguments = @ptrCast(args.arguments),
+        //     .results = @ptrCast(args.results),
+        //     .events = @ptrCast(args.events),
+        //     .non_donatable_input_indices = args.non_donatable_input_indices,
+        //     .context = args.context,
+        // } });
     }
 
     pub fn getExecutable(self: *LoadedExecutable, api: *const Api) ApiError!*Executable {

--- a/zml/zml.zig
+++ b/zml/zml.zig
@@ -17,6 +17,7 @@ pub const Context = @import("context.zig").Context;
 pub const Data = @import("dtype.zig").Data;
 pub const DataType = @import("dtype.zig").DataType;
 pub const exe = @import("exe.zig");
+pub const custom_call = @import("custom_call.zig").custom_call;
 pub const compile = exe.compile;
 pub const compileWithPrefix = exe.compileWithPrefix;
 pub const compileFn = exe.compileFn;


### PR DESCRIPTION
This PR introduce new APIs for custom call with multi target compatibilities and commands buffers for graph capture. Also fix some PjRT API bindings and code smells.