### PR TITLE
zml/buffer: various improvements

### DIFF
--- a/examples/benchmark/main.zig
+++ b/examples/benchmark/main.zig
@@ -123,5 +123,5 @@ fn createRandomBuffer(allocator: std.mem.Allocator, platform: zml.Platform, shap
 
     var host_buffer = zml.HostBuffer.fromBytes(shape, data);
     errdefer host_buffer.deinit(allocator);
-    return zml.Buffer.from(platform, host_buffer);
+    return zml.Buffer.from(platform, host_buffer, .{});
 }

--- a/examples/loader/main.zig
+++ b/examples/loader/main.zig
@@ -54,7 +54,7 @@ pub fn asyncMain() !void {
         const host_buffer = entry.value_ptr.*;
         total_bytes += host_buffer.shape().byteSize();
         std.debug.print("Buffer: {s} ({any} / {any})\n", .{ entry.key_ptr.*, i + 1, buffer_store.buffers.count() });
-        buffers[i] = try zml.Buffer.from(platform, host_buffer);
+        buffers[i] = try zml.Buffer.from(platform, host_buffer, .{});
     }
 
     const stop = timer.read();

--- a/examples/mnist/mnist.zig
+++ b/examples/mnist/mnist.zig
@@ -101,7 +101,7 @@ pub fn asyncMain() !void {
         const idx = rng.random().intRangeAtMost(u64, 0, 10000 - 1);
         var sample: [28 * 28]u8 align(16) = undefined;
         _ = try dataset.pread(&sample, 16 + (idx * 28 * 28));
-        var input = try zml.Buffer.from(platform, zml.HostBuffer.fromBytes(zml.Shape.init(.{ 28, 28 }, .u8), &sample));
+        var input = try zml.Buffer.from(platform, zml.HostBuffer.fromBytes(zml.Shape.init(.{ 28, 28 }, .u8), &sample), .{});
         defer input.deinit();
 
         printDigit(sample);

--- a/examples/simple_layer/main.zig
+++ b/examples/simple_layer/main.zig
@@ -82,7 +82,7 @@ pub fn asyncMain() !void {
     // with a specific shape from an array.
     // For situations where e.g. you have an [4]f16 array but need a .{2, 2} input shape.
     var input = [4]f16{ 5.0, 5.0, 5.0, 5.0 };
-    var input_buffer = try zml.Buffer.from(platform, zml.HostBuffer.fromSlice(input_shape, &input));
+    var input_buffer = try zml.Buffer.from(platform, zml.HostBuffer.fromSlice(input_shape, &input), .{});
     defer input_buffer.deinit();
 
     // call our executable module

--- a/pjrt/pjrt.zig
+++ b/pjrt/pjrt.zig
@@ -932,8 +932,8 @@ pub const Memory = opaque {
 
     pub fn kind(self: *const Memory, api: *const Api) Kind {
         const ret = api.call(.PJRT_Memory_Kind, .{ .memory = self.inner() }) catch unreachable;
-        const kind_ = ret.kind orelse unreachable[0..ret.kind_size];
-        return std.meta.stringToEnum(Kind, kind_) orelse unreachable;
+        const kind_ = ret.kind orelse unreachable;
+        return std.meta.stringToEnum(Kind, kind_[0..ret.kind_size]) orelse unreachable;
     }
 
     pub fn kindId(self: *const Memory, api: *const Api) u32 {

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -160,7 +160,7 @@ pub const Buffer = struct {
     /// return a Buffer using the array shape.
     pub fn fromArray(platform: Platform, arr: anytype) !Buffer {
         const host_buffer = HostBuffer.fromArray(&arr);
-        return try from(platform, host_buffer, .{});
+        return try from(platform, host_buffer, .{ .wait = true });
     }
 
     /// Copies the given Zig slice to the accelerator memory and
@@ -195,7 +195,7 @@ pub const Buffer = struct {
     pub fn scalar(platform: Platform, val: anytype, dtype_: DataType) !Buffer {
         const x = dtype_.constant(val);
         const host_buffer = HostBuffer.fromBytes(Shape.init(.{}, dtype_), x.constSlice());
-        return try from(platform, host_buffer, .{});
+        return try from(platform, host_buffer, .{ .wait = true });
     }
 
     /// Creates a Buffer with a single element repeated manytime.
@@ -221,7 +221,7 @@ pub const Buffer = struct {
                 ._strides = @splat(0),
                 ._data = x.constSlice().ptr,
             };
-            return try from(platform, host_buffer, .{});
+            return try from(platform, host_buffer, .{ .wait = true });
         }
 
         // To speed up copies, duplicate the scalar value into a vector,
@@ -244,7 +244,7 @@ pub const Buffer = struct {
             else => unreachable,
         }
         const host_buffer: HostBuffer = .{ ._shape = shape_, ._strides = strides, ._data = &bytes };
-        return try from(platform, host_buffer, .{});
+        return try from(platform, host_buffer, .{ .wait = true });
     }
 
     test constant {

--- a/zml/hostbuffer.zig
+++ b/zml/hostbuffer.zig
@@ -158,7 +158,12 @@ pub const HostBuffer = struct {
 
     /// Copies this HostBuffer to the given accelerator.
     pub fn toDevice(self: HostBuffer, platform_: Platform) !Buffer {
-        return try Buffer.from(platform_, self, .{});
+        return try self.toDeviceOpts(platform_, .{});
+    }
+
+    /// Copies this HostBuffer to the given accelerator (with options).
+    pub fn toDeviceOpts(self: HostBuffer, platform_: Platform, opts: Buffer.FromOptions) !Buffer {
+        return try Buffer.from(platform_, self, opts);
     }
 
     /// Interpret the underlying data as a contiguous slice.

--- a/zml/hostbuffer.zig
+++ b/zml/hostbuffer.zig
@@ -158,7 +158,7 @@ pub const HostBuffer = struct {
 
     /// Copies this HostBuffer to the given accelerator.
     pub fn toDevice(self: HostBuffer, platform_: Platform) !Buffer {
-        return try Buffer.from(platform_, self);
+        return try Buffer.from(platform_, self, .{});
     }
 
     /// Interpret the underlying data as a contiguous slice.

--- a/zml/pjrtx.zig
+++ b/zml/pjrtx.zig
@@ -57,13 +57,9 @@ pub const Client = opaque {
     }
 
     pub const BufferFromHostBufferArgs = pjrt.Client.BufferFromHostBufferArgs;
-    pub fn bufferFromHostBuffer(self: *const Client, api: *const Api, args: BufferFromHostBufferArgs) ApiError!*Buffer {
-        const buffer, const event_ = try asynk.callBlocking(pjrt.Client.bufferFromHostBuffer, .{ self.inner(), api, args });
-        if (event_) |event__| {
-            const event: *Event = @ptrCast(event__);
-            try event.await_(api);
-        }
-        return @ptrCast(buffer);
+    pub fn bufferFromHostBuffer(self: *const Client, api: *const Api, args: BufferFromHostBufferArgs) ApiError!struct { *Buffer, ?*Event } {
+        const buffer, const event_ = try self.inner().bufferFromHostBuffer(api, args);
+        return .{ @ptrCast(buffer), @ptrCast(event_) };
     }
 
     pub fn deserializeAndLoad(self: *const Client, api: *const Api, bytes: []const u8) ApiError!*LoadedExecutable {
@@ -182,7 +178,7 @@ pub const Buffer = opaque {
     }
 
     pub fn copyToMemory(self: *const Buffer, api: *const Api, memory_: *const Memory) ApiError!*Buffer {
-        return @ptrCast(self.inner().copyToMemory(api, memory_));
+        return @ptrCast(try self.inner().copyToMemory(api, memory_));
     }
 
     pub fn getReadyEvent(self: *const Buffer, api: *const Api) ?*Event {

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -2675,7 +2675,7 @@ pub const Tensor = struct {
         // Test with actual values, no batching.
         {
             const a_host = try zml.HostBuffer.arange(std.testing.allocator, .{ .end = 9 }, .i32);
-            const a = (try zml.Buffer.from(platform, a_host.reshape(.{ 3, 3 }))).withTags(.{ .a, .b });
+            const a = (try zml.Buffer.from(platform, a_host.reshape(.{ 3, 3 }), .{})).withTags(.{ .a, .b });
             defer a.deinit();
             a_host.deinit(std.testing.allocator);
 
@@ -2694,7 +2694,7 @@ pub const Tensor = struct {
         // Test with setting individual values (no batching)
         {
             const a_host = try zml.HostBuffer.arange(std.testing.allocator, .{ .end = 9 }, .i32);
-            const a = try zml.Buffer.from(platform, a_host);
+            const a = try zml.Buffer.from(platform, a_host, .{});
             defer a.deinit();
             a_host.deinit(std.testing.allocator);
 


### PR DESCRIPTION
* `Buffer.from` is blocking by default
* `Buffer.from` takes options to control the loading This includes awaiting for the buffer or to which memory the buffer is copied