### PR TITLE
examples/llama: switch to `--hf-model-path` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ you, too, to build cool and exciting AI projects.
 
 To give you a glimpse of what you can do with ZML, here is an early demo:
 
-<div align="center"><img src="https://zml.ai/docs-assets/ZML.gif" style="width:75%"></div>
+<div align="center"><img src="https://raw.githubusercontent.com/zml/zml.github.io/refs/heads/main/docs-assets/ZML.gif" style="width:75%"></div>
 
 It shows a prototype running a LLaMA2 model sharded on 1 NVIDIA RTX 4090, 1 AMD
 6800XT, and 1 Google Cloud TPU v2.  All accelerators were hosted in different
@@ -118,18 +118,21 @@ This model has restrictions, see
 [here](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct). It **requires
 approval from Meta on Huggingface**, which can take a few hours to get granted.
 
-While waiting, you can already generate an access token to log into HuggingFace
-from `bazel`; see [here](./docs/huggingface-access-token.md).
-
 Once you've been granted access, you're ready to download a gated model like
-`Meta-Llama-3.1-8B-Instruct`!
+`Llama-3.1-8B-Instruct`!
+
+First, you need to download the model using the [huggingface-cli](https://huggingface.co/docs/huggingface_hub/en/guides/cli).
 
 ```
-# requires token in $HOME/.cache/huggingface/token, as created by the
-# `huggingface-cli login` command, or the `HUGGINGFACE_TOKEN` environment variable.
+huggingface-cli download meta-llama/Llama-3.1-8B-Instruct --local-dir $HOME/Llama-3.1-8B-Instruct
+```
+
+Then, you can run the model.
+
+```
 cd examples
-bazel run --config=release //llama:Llama-3.1-8B-Instruct
-bazel run --config=release //llama:Llama-3.1-8B-Instruct -- --prompt="What is the capital of France?"
+bazel run --config=release //llama -- --hf-model-path=$HOME/Llama-3.1-8B-Instruct
+bazel run --config=release //llama -- --hf-model-path=$HOME/Llama-3.1-8B-Instruct --prompt="What is the capital of France?"
 ```
 
 You can also try `Llama-3.1-70B-Instruct` if you have enough memory.
@@ -140,6 +143,7 @@ Like the 8B model above, this model also requires approval. See
 [here](https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct) for access requirements.
 
 ```
+huggingface-cli download meta-llama/Llama-3.2-1B-Instruct --local-dir $HOME/Llama-3.2-1B-Instruct
 cd examples
 bazel run --config=release //llama:Llama-3.2-1B-Instruct
 bazel run --config=release //llama:Llama-3.2-1B-Instruct -- --prompt="What is the capital of France?"
@@ -160,14 +164,15 @@ following arguments to the command line when compiling / running a model:
 
 The latter, avoiding compilation for CPU, cuts down compilation time.
 
-So, to run the OpenLLama model from above on your host sporting an NVIDIA GPU,
+So, to run the Llama 3.1 8B model from above on your host sporting an NVIDIA GPU,
 run the following:
 
 ```
 cd examples
-bazel run --config=release //llama:Llama-3.2-1B-Instruct             \
-          --@zml//runtimes:cuda=true                       \
-          -- --prompt="What is the capital of France?"
+bazel run --config=release //llama                       \
+          --@zml//runtimes:cuda=true                     \
+          -- --hf-model-path=$HOME/Llama-3.1-8B-Instruct \
+          --prompt="What is the capital of France?"
 ```
 
 

--- a/examples/llama/BUILD.bazel
+++ b/examples/llama/BUILD.bazel
@@ -21,106 +21,6 @@ zig_cc_binary(
     ],
 )
 
-cc_binary(
-    name = "Llama-3.1-8B-Instruct",
-    args = [
-        "--config=$(location @Meta-Llama-3.1-8B-Instruct//:config.json)",
-        "--weights=$(location @Meta-Llama-3.1-8B-Instruct//:model.safetensors.index.json)",
-        "--tokenizer=$(location @Meta-Llama-3.1-8B-Instruct//:tokenizer.json)",
-    ],
-    data = [
-        "@Meta-Llama-3.1-8B-Instruct",
-        "@Meta-Llama-3.1-8B-Instruct//:config.json",
-        "@Meta-Llama-3.1-8B-Instruct//:model.safetensors.index.json",
-        "@Meta-Llama-3.1-8B-Instruct//:tokenizer.json",
-    ],
-    tags = [
-        "manual",
-    ],
-    deps = [":llama_lib"],
-)
-
-cc_binary(
-    name = "Llama-3.1-70B-Instruct",
-    args = [
-        "--config=$(location @Meta-Llama-3.1-70B-Instruct//:config.json)",
-        "--weights=$(location @Meta-Llama-3.1-70B-Instruct//:model.safetensors.index.json)",
-        "--tokenizer=$(location @Meta-Llama-3.1-70B-Instruct//:tokenizer.json)",
-    ],
-    data = [
-        "@Meta-Llama-3.1-70B-Instruct",
-        "@Meta-Llama-3.1-70B-Instruct//:config.json",
-        "@Meta-Llama-3.1-70B-Instruct//:model.safetensors.index.json",
-        "@Meta-Llama-3.1-70B-Instruct//:tokenizer.json",
-    ],
-    tags = [
-        "manual",
-    ],
-    deps = [":llama_lib"],
-)
-
-cc_binary(
-    name = "Llama-3.2-1B-Instruct",
-    args = [
-        "--config=$(location @Meta-Llama-3.2-1B-Instruct//:config.json)",
-        "--weights=$(location @Meta-Llama-3.2-1B-Instruct//:model.safetensors)",
-        "--tokenizer=$(location @Meta-Llama-3.2-1B-Instruct//:tokenizer.json)",
-    ],
-    data = [
-        "@Meta-Llama-3.2-1B-Instruct",
-        "@Meta-Llama-3.2-1B-Instruct//:config.json",
-        "@Meta-Llama-3.2-1B-Instruct//:model.safetensors",
-        "@Meta-Llama-3.2-1B-Instruct//:tokenizer.json",
-    ],
-    tags = [
-        "manual",
-    ],
-    deps = [":llama_lib"],
-)
-
-cc_binary(
-    name = "Llama-3.2-3B-Instruct",
-    args = [
-        "--config=$(location @Meta-Llama-3.2-3B-Instruct//:config.json)",
-        "--weights=$(location @Meta-Llama-3.2-3B-Instruct//:model.safetensors.index.json)",
-        "--tokenizer=$(location @Meta-Llama-3.2-3B-Instruct//:tokenizer.json)",
-    ],
-    data = [
-        "@Meta-Llama-3.2-3B-Instruct",
-        "@Meta-Llama-3.2-3B-Instruct//:config.json",
-        "@Meta-Llama-3.2-3B-Instruct//:model.safetensors.index.json",
-        "@Meta-Llama-3.2-3B-Instruct//:tokenizer.json",
-    ],
-    tags = [
-        "manual",
-    ],
-    deps = [":llama_lib"],
-)
-
-cc_binary(
-    name = "TinyLlama-Stories-15M",
-    args = [
-        "--config=$(location :tinyllama_stories15M_json)",
-        "--weights=$(location @Karpathy-TinyLlama-Stories15M//file)",
-        "--tokenizer=$(location @Karpathy-TinyLlama-Tokenizer//file)",
-        "--prompt='Once upon a time, there was a little girl named Lily.'",
-        "--no-llama3=1",  # don't do template prompt encoding, I'm a simple model
-        "--sharding=false",  # don't shard me, I'm so small
-    ],
-    data = [
-        ":tinyllama_stories15M_json",
-        "@Karpathy-TinyLlama-Stories15M//file",
-        "@Karpathy-TinyLlama-Tokenizer//file",
-    ],
-    deps = [":llama_lib"],
-)
-
-write_file(
-    name = "tinyllama_stories15M_json",
-    out = "config.json",
-    content = ['{"bos_token_id":1,"eos_token_id":2,"hidden_act":"silu","hidden_size":288,"intermediate_size":768,"max_position_embeddings":256,"model_type":"llama","num_attention_heads":6,"num_hidden_layers":6,"num_key_value_heads":6,"rms_norm_eps":1e-05,"hf_rope_impl":false,"rope_scaling":null,"rope_theta":10000.0}'],
-)
-
 zig_cc_binary(
     name = "test-implementation",
     srcs = ["llama.zig"],
@@ -169,7 +69,7 @@ Artificial Intelligence in Healthcare
 
 mtree_spec(
     name = "mtree",
-    srcs = [":Llama-3.2-1B-Instruct"],
+    srcs = [":llama"],
     tags = [
         "manual",
     ],
@@ -177,7 +77,7 @@ mtree_spec(
 
 tar(
     name = "archive",
-    srcs = [":Llama-3.2-1B-Instruct"],
+    srcs = [":llama"],
     args = [
         "--options",
         "zstd:compression-level=9",
@@ -189,36 +89,10 @@ tar(
     ],
 )
 
-expand_template(
-    name = "entrypoint",
-    data = [
-        ":Llama-3.2-1B-Instruct",
-        "@Meta-Llama-3.2-1B-Instruct",
-        "@Meta-Llama-3.2-1B-Instruct//:config.json",
-        "@Meta-Llama-3.2-1B-Instruct//:model.safetensors",
-        "@Meta-Llama-3.2-1B-Instruct//:tokenizer.json",
-    ],
-    substitutions = {
-        ":config": "$(rlocationpath @Meta-Llama-3.2-1B-Instruct//:config.json)",
-        ":weights": "$(rlocationpath @Meta-Llama-3.2-1B-Instruct//:model.safetensors)",
-        ":tokenizer": "$(rlocationpath @Meta-Llama-3.2-1B-Instruct//:tokenizer.json)",
-    },
-    tags = [
-        "manual",
-    ],
-    template = [
-        "./{}/Llama-3.2-1B-Instruct".format(package_name()),
-        "--config=./{}/Llama-3.2-1B-Instruct.runfiles/:config".format(package_name()),
-        "--weights=./{}/Llama-3.2-1B-Instruct.runfiles/:weights".format(package_name()),
-        "--tokenizer=./{}/Llama-3.2-1B-Instruct.runfiles/:tokenizer".format(package_name()),
-    ],
-)
-
 oci_image(
     name = "image_",
     base = "@distroless_cc_debian12_debug",
-    # entrypoint = ["./{}/Llama-3.2-1B-Instruct".format(package_name())],
-    entrypoint = ":entrypoint",
+    entrypoint = ["./{}/llama".format(package_name())],
     tags = [
         "manual",
     ],
@@ -241,7 +115,7 @@ oci_load(
     name = "load",
     image = ":image",
     repo_tags = [
-        "distroless/llama-3.2-1b-instruct:latest",
+        "distroless/llama:latest",
     ],
     tags = [
         "manual",
@@ -252,7 +126,7 @@ oci_push(
     name = "push",
     image = ":image",
     remote_tags = ["latest"],
-    repository = "index.docker.io/steeve/llama-3.2-1b-instruct",
+    repository = "index.docker.io/steeve/llama",
     tags = [
         "manual",
     ],


### PR DESCRIPTION
Instead of giving config, model weights and tokenizer paths, rely on `huggingface-cli` download.