### PR TITLE
ci: use large disk on runs-on

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -3,6 +3,7 @@ images:
     platform: "linux"
     arch: "amd64"
     ami: "ami-04a92520784b93e73"
+    disk: large
     preinstall: |
       #!/bin/bash
       wget https://github.com/jbdalido/bazel-remote/releases/download/test/bazel-remote -O /usr/local/bin/bzlcache


### PR DESCRIPTION
With the latests developments the default disk space (40GB) is too small for our new needs so we use large disks (80GB). 