### PR TITLE
mlir,pjrt,zml: expose all missing dtype

### DIFF
--- a/mlir/mlir.zig
+++ b/mlir/mlir.zig
@@ -414,9 +414,9 @@ pub const ArrayAttribute = struct {
 
 pub fn IntegerAttribute(comptime it: IntegerTypes) type {
     const ZigType, const getter = comptime switch (it) {
-        .i1, .i4, .i8, .i16, .i32, .i64 => .{ i64, c.mlirIntegerAttrGetValueInt },
+        .i1, .i2, .i4, .i8, .i16, .i32, .i64 => .{ i64, c.mlirIntegerAttrGetValueInt },
         .si4, .si8, .si16, .si32, .si64 => .{ i64, c.mlirIntegerAttrGetValueSInt },
-        .u4, .u8, .u16, .u32, .u64 => .{ u64, c.mlirIntegerAttrGetValueUInt },
+        .u2, .u4, .u8, .u16, .u32, .u64 => .{ u64, c.mlirIntegerAttrGetValueUInt },
         .unknown => @compileError("IntegerAttribute(unknown)"),
     };
 
@@ -1249,6 +1249,7 @@ pub const IndexType = struct {
 
 pub const IntegerTypes = enum {
     i1,
+    i2,
     i4,
     i8,
     i16,
@@ -1259,6 +1260,7 @@ pub const IntegerTypes = enum {
     si16,
     si32,
     si64,
+    u2,
     u4,
     u8,
     u16,
@@ -1271,6 +1273,7 @@ pub const IntegerTypes = enum {
 pub fn IntegerType(comptime it: IntegerTypes) type {
     const Config = switch (it) {
         .i1 => .{ 1, c.mlirIntegerTypeGet, c.mlirIntegerTypeIsSignless },
+        .i2 => .{ 2, c.mlirIntegerTypeGet, c.mlirIntegerTypeIsSignless },
         .i4 => .{ 4, c.mlirIntegerTypeGet, c.mlirIntegerTypeIsSignless },
         .i8 => .{ 8, c.mlirIntegerTypeGet, c.mlirIntegerTypeIsSignless },
         .i16 => .{ 16, c.mlirIntegerTypeGet, c.mlirIntegerTypeIsSignless },
@@ -1281,6 +1284,7 @@ pub fn IntegerType(comptime it: IntegerTypes) type {
         .si16 => .{ 16, c.mlirIntegerTypeSignedGet, c.mlirIntegerTypeIsSigned },
         .si32 => .{ 32, c.mlirIntegerTypeSignedGet, c.mlirIntegerTypeIsSigned },
         .si64 => .{ 64, c.mlirIntegerTypeSignedGet, c.mlirIntegerTypeIsSigned },
+        .u2 => .{ 2, c.mlirIntegerTypeUnsignedGet, c.mlirIntegerTypeIsUnsigned },
         .u4 => .{ 4, c.mlirIntegerTypeUnsignedGet, c.mlirIntegerTypeIsUnsigned },
         .u8 => .{ 8, c.mlirIntegerTypeUnsignedGet, c.mlirIntegerTypeIsUnsigned },
         .u16 => .{ 16, c.mlirIntegerTypeUnsignedGet, c.mlirIntegerTypeIsUnsigned },
@@ -1320,11 +1324,15 @@ pub fn IntegerType(comptime it: IntegerTypes) type {
 }
 
 pub const FloatTypes = enum {
+    f4e2m1fn,
+    f8e3m4,
+    f8e4m3,
     f8e4m3b11fnuz,
     f8e4m3fn,
     f8e4m3fnuz,
     f8e5m2,
     f8e5m2fnuz,
+    f8e8m0fnu,
     bf16,
     f16,
     f32,
@@ -1338,12 +1346,19 @@ pub const FloatTypes = enum {
 };
 
 pub fn FloatType(comptime ft: FloatTypes) type {
-    const Config = switch (ft) {
+    const Config: struct {
+        *const fn (c.MlirType) callconv(.c) bool,
+        *const fn (c.MlirContext) callconv(.c) c.MlirType,
+    } = switch (ft) {
+        .f4e2m1fn => .{ c.mlirTypeIsAFloat4E2M1FN, c.mlirFloat4E2M1FNTypeGet },
+        .f8e3m4 => .{ c.mlirTypeIsAFloat8E3M4, c.mlirFloat8E3M4TypeGet },
+        .f8e4m3 => .{ c.mlirTypeIsAFloat8E4M3, c.mlirFloat8E4M3TypeGet },
         .f8e4m3b11fnuz => .{ c.mlirTypeIsAFloat8E4M3B11FNUZ, c.mlirFloat8E4M3B11FNUZTypeGet },
         .f8e4m3fn => .{ c.mlirTypeIsAFloat8E4M3FN, c.mlirFloat8E4M3FNTypeGet },
         .f8e4m3fnuz => .{ c.mlirTypeIsAFloat8E4M3FNUZ, c.mlirFloat8E4M3FNUZTypeGet },
         .f8e5m2 => .{ c.mlirTypeIsAFloat8E5M2, c.mlirFloat8E5M2TypeGet },
         .f8e5m2fnuz => .{ c.mlirTypeIsAFloat8E5M2FNUZ, c.mlirFloat8E5M2FNUZTypeGet },
+        .f8e8m0fnu => .{ c.mlirTypeIsAFloat8E8M0FNU, c.mlirFloat8E8M0FNUTypeGet },
         .bf16 => .{ c.mlirTypeIsABF16, c.mlirBF16TypeGet },
         .f16 => .{ c.mlirTypeIsAF16, c.mlirF16TypeGet },
         .f32 => .{ c.mlirTypeIsAF32, c.mlirF32TypeGet },

--- a/pjrt/pjrt.zig
+++ b/pjrt/pjrt.zig
@@ -800,11 +800,13 @@ pub const LoadedExecutable = opaque {
 pub const BufferType = enum(c.PJRT_Buffer_Type) {
     invalid = c.PJRT_Buffer_Type_INVALID,
     bool = c.PJRT_Buffer_Type_PRED,
+    i2 = c.PJRT_Buffer_Type_S2,
     i4 = c.PJRT_Buffer_Type_S4,
     i8 = c.PJRT_Buffer_Type_S8,
     i16 = c.PJRT_Buffer_Type_S16,
     i32 = c.PJRT_Buffer_Type_S32,
     i64 = c.PJRT_Buffer_Type_S64,
+    u2 = c.PJRT_Buffer_Type_U2,
     u4 = c.PJRT_Buffer_Type_U4,
     u8 = c.PJRT_Buffer_Type_U8,
     u16 = c.PJRT_Buffer_Type_U16,
@@ -821,6 +823,10 @@ pub const BufferType = enum(c.PJRT_Buffer_Type) {
     f8e4m3b11fnuz = c.PJRT_Buffer_Type_F8E4M3B11FNUZ,
     f8e5m2fnuz = c.PJRT_Buffer_Type_F8E5M2FNUZ,
     f8e4m3fnuz = c.PJRT_Buffer_Type_F8E4M3FNUZ,
+    f8e4m3 = c.PJRT_Buffer_Type_F8E4M3,
+    f8e3m4 = c.PJRT_Buffer_Type_F8E3M4,
+    f8e8m0 = c.PJRT_Buffer_Type_F8E8M0FNU,
+    f4e2m1 = c.PJRT_Buffer_Type_F4E2M1FN,
 };
 
 pub const MemoryLayoutType = enum(c.PJRT_Buffer_MemoryLayout_Type) {

--- a/zml/floats.zig
+++ b/zml/floats.zig
@@ -129,11 +129,7 @@ pub const Float8E4M3B11FNUZ = packed struct(u8) {
     exponent: u4,
     sign: u1,
 
-    pub const nan: Float8E4M3B11FNUZ = .{
-        .sign = 1,
-        .exponent = 0,
-        .mantissa = 0,
-    };
+    pub const nan: Float8E4M3B11FNUZ = .{ .sign = 1, .exponent = 0, .mantissa = 0 };
 
     pub fn isNan(self: Float8E4M3B11FNUZ) bool {
         return self.sign == 1 and self.exponent == 0 and self.mantissa == 0;
@@ -155,7 +151,7 @@ pub const Float8E4M3FN = packed struct(u8) {
     pub const nan: Float8E4M3FN = .{ .sign = 0, .exponent = std.math.maxInt(u4), .mantissa = std.math.maxInt(u3) };
 
     pub fn isNan(self: Float8E4M3FN) bool {
-        return allBitsOne(self.exponent) and allBitsOne(self.mantissa);
+        return self.exponent == nan.exponent and self.mantissa == nan.mantissa;
     }
     const Helpers = FloatHelpers(@This());
     pub const zero = Helpers.zero;
@@ -170,11 +166,7 @@ pub const Float8E4M3FNUZ = packed struct(u8) {
     exponent: u4,
     sign: u1,
 
-    pub const nan: Float8E4M3FNUZ = .{
-        .sign = 1,
-        .exponent = 0,
-        .mantissa = 0,
-    };
+    pub const nan: Float8E4M3FNUZ = .{ .sign = 1, .exponent = 0, .mantissa = 0 };
 
     pub fn isNan(self: Float8E4M3FNUZ) bool {
         return self.sign == 1 and self.exponent == 0 and self.mantissa == 0;
@@ -209,14 +201,10 @@ pub const Float8E5M2 = packed struct(u8) {
     exponent: u5,
     sign: u1,
 
-    pub const nan: Float8E5M2 = .{
-        .sign = 0,
-        .exponent = std.math.maxInt(u5),
-        .mantissa = 1,
-    };
+    pub const nan: Float8E5M2 = .{ .sign = 0, .exponent = std.math.maxInt(u5), .mantissa = 1 };
 
     pub fn isNan(self: Float8E5M2) bool {
-        return allBitsOne(self.exponent) and self.mantissa != 0;
+        return self.exponent == nan.exponent and self.mantissa != 0;
     }
 
     pub const minus_inf: Float8E5M2 = .{
@@ -232,7 +220,7 @@ pub const Float8E5M2 = packed struct(u8) {
     };
 
     pub fn isInf(self: Float8E5M2) bool {
-        return allBitsOne(self.exponent) and self.mantissa == 0;
+        return self == inf or self == minus_inf;
     }
 
     const Helpers = FloatHelpers(@This());
@@ -332,6 +320,107 @@ test BFloat16 {
         .lossy = &[_]f32{3.02344107628},
     });
 }
+
+pub const Float8E4M3 = packed struct(u8) {
+    mantissa: u3,
+    exponent: u4,
+    sign: u1,
+
+    pub const nan: Float8E4M3 = @bitCast(0xFF);
+
+    pub fn isNan(self: Float8E4M3) bool {
+        return self == nan or self == comptime nan.neg();
+    }
+
+    pub const minus_inf: Float8E4M3 = .{
+        .sign = 1,
+        .exponent = std.math.maxInt(u4),
+        .mantissa = 0,
+    };
+
+    pub const inf: Float8E4M3 = .{
+        .sign = 0,
+        .exponent = std.math.maxInt(u4),
+        .mantissa = 0,
+    };
+
+    const Helpers = FloatHelpers(@This());
+    pub const zero = Helpers.zero;
+    pub const neg = Helpers.neg;
+    pub const fromF32 = Helpers.fromF32;
+    pub const toF32 = Helpers.toF32;
+    pub const formatNumber = Helpers.formatNumber;
+};
+
+pub const Float8E3M4 = packed struct(u8) {
+    mantissa: u4,
+    exponent: u3,
+    sign: u1,
+
+    pub const nan: Float8E3M4 = @bitCast(0xFF);
+
+    pub fn isNan(self: Float8E3M4) bool {
+        return self == nan or self == comptime nan.neg();
+    }
+
+    pub const minus_inf: Float8E3M4 = .{
+        .sign = 1,
+        .exponent = std.math.maxInt(u3),
+        .mantissa = 0,
+    };
+
+    pub const inf: Float8E3M4 = .{
+        .sign = 0,
+        .exponent = std.math.maxInt(u3),
+        .mantissa = 0,
+    };
+
+    const Helpers = FloatHelpers(@This());
+    pub const zero = Helpers.zero;
+    pub const neg = Helpers.neg;
+    pub const fromF32 = Helpers.fromF32;
+    pub const toF32 = Helpers.toF32;
+    pub const formatNumber = Helpers.formatNumber;
+};
+
+pub const Float8E8M0 = packed struct(u8) {
+    mantissa: u0,
+    exponent: u8,
+    sign: u0,
+
+    /// Lossy conversion from f32, similar to @floatCast
+    pub fn fromF32(f: f32) Float8E8M0 {
+        const vf32: Float32 = @bitCast(f);
+        return .{ .mantissa = 0, .exponent = @intCast(vf32.exponent), .sign = 0 };
+    }
+
+    /// Lossless conversion to f32.
+    pub fn toF32(x: Float8E8M0) f32 {
+        const vf32: Float32 = .{
+            .sign = 1,
+            .exponent = x.exponent,
+            .mantissa = 0,
+        };
+        return @bitCast(vf32);
+    }
+
+    const Helpers = FloatHelpers(@This());
+    pub const formatNumber = Helpers.formatNumber;
+};
+
+pub const Float4E2M1 = packed struct(u4) {
+    mantissa: u1,
+    exponent: u2,
+    sign: u1,
+
+    pub const nan: Float4E2M1 = @bitCast(@as(u4, 0xF));
+    const Helpers = FloatHelpers(@This());
+    pub const zero = Helpers.zero;
+    pub const neg = Helpers.neg;
+    pub const fromF32 = Helpers.fromF32;
+    pub const toF32 = Helpers.toF32;
+    pub const formatNumber = Helpers.formatNumber;
+};
 
 pub fn floatCast(T: type, x: anytype) T {
     return switch (@TypeOf(x)) {

--- a/zml/mlirx.zig
+++ b/zml/mlirx.zig
@@ -35,20 +35,26 @@ pub const Type = struct {
     pub fn fromDType(ctx: mlir.Context, dt: dtype.DataType) mlir.Type {
         return switch (dt) {
             .bool => .int(ctx, .i1),
+            .f4e2m1 => .float(ctx, .f4e2m1fn),
+            .f8e3m4 => .float(ctx, .f8e3m4),
+            .f8e4m3 => .float(ctx, .f8e4m3),
             .f8e4m3b11fnuz => .float(ctx, .f8e4m3b11fnuz),
             .f8e4m3fn => .float(ctx, .f8e4m3fn),
             .f8e4m3fnuz => .float(ctx, .f8e4m3fnuz),
             .f8e5m2 => .float(ctx, .f8e5m2),
             .f8e5m2fnuz => .float(ctx, .f8e5m2fnuz),
+            .f8e8m0 => .float(ctx, .f8e8m0fnu),
             .bf16 => .float(ctx, .bf16),
             .f16 => .float(ctx, .f16),
             .f32 => .float(ctx, .f32),
             .f64 => .float(ctx, .f64),
+            .i2 => .int(ctx, .i2),
             .i4 => .int(ctx, .i4),
             .i8 => .int(ctx, .i8),
             .i16 => .int(ctx, .i16),
             .i32 => .int(ctx, .i32),
             .i64 => .int(ctx, .i64),
+            .u2 => .int(ctx, .u2),
             .u4 => .int(ctx, .u4),
             .u8 => .int(ctx, .u8),
             .u16 => .int(ctx, .u16),
@@ -62,23 +68,28 @@ pub const Type = struct {
     pub fn toDType(mlir_type: mlir.Type) dtype.DataType {
         const mapping = .{
             .{ .bool, mlir.IntegerType(.i1) },
-
+            .{ .f4e2m1, mlir.FloatType(.f4e2m1fn) },
+            .{ .f8e3m4, mlir.FloatType(.f8e3m4) },
+            .{ .f8e4m3, mlir.FloatType(.f8e4m3) },
             .{ .f8e4m3b11fnuz, mlir.FloatType(.f8e4m3b11fnuz) },
             .{ .f8e4m3fn, mlir.FloatType(.f8e4m3fn) },
             .{ .f8e4m3fnuz, mlir.FloatType(.f8e4m3fnuz) },
             .{ .f8e5m2, mlir.FloatType(.f8e5m2) },
             .{ .f8e5m2fnuz, mlir.FloatType(.f8e5m2fnuz) },
+            .{ .f8e8m0, mlir.FloatType(.f8e8m0fnu) },
             .{ .bf16, mlir.FloatType(.bf16) },
             .{ .f16, mlir.FloatType(.f16) },
             .{ .f32, mlir.FloatType(.f32) },
             .{ .f64, mlir.FloatType(.f64) },
 
+            .{ .i2, mlir.IntegerType(.i2) },
             .{ .i4, mlir.IntegerType(.i4) },
             .{ .i8, mlir.IntegerType(.i8) },
             .{ .i16, mlir.IntegerType(.i16) },
             .{ .i32, mlir.IntegerType(.i32) },
             .{ .i64, mlir.IntegerType(.i64) },
 
+            .{ .u2, mlir.IntegerType(.u2) },
             .{ .u4, mlir.IntegerType(.u4) },
             .{ .u8, mlir.IntegerType(.u8) },
             .{ .u16, mlir.IntegerType(.u16) },
@@ -89,6 +100,8 @@ pub const Type = struct {
             .{ .c128, mlir.ComplexType(.c128) },
         };
 
+        // TODO: this seems quite slow to have all of those functions calls.
+        // Maybe we should memoize the ptr of a set of mlir types when creating the context.
         inline for (mapping) |entry| {
             const dt, const mlirT = entry;
             if (mlirT.is_a_fn(mlir_type._inner)) {

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1057,13 +1057,13 @@ pub const Tensor = struct {
             const x_f4_xla_d = try zml.testing.compileAndCall(platform, Tensor.convert, .{ x_d, .f4e2m1 });
 
             const x_f4_xla = x_f4_xla_d.getValue(@TypeOf(x_f4));
-            errdefer std.log.warn("convert(.f4e2m1) failed !\nzml.floats computed:\n{any}\nxla computed:\n{any}", .{ x_f4, x_f4_xla });
+            errdefer std.log.warn("convert(.f4e2m1) failed !\ninput f32:\n{e}\nzml.floats computed:\n{any}\nxla computed:\n{any}", .{ stdx.fmt.slice(&x), x_f4, x_f4_xla });
             try std.testing.expectEqualDeep(x_f4, x_f4_xla);
         }
 
         // f8e3m4
         {
-            const x = [_]f32{ 0, 1.0, -2, 1.0 / 64.0, -128, 1 / 128 };
+            const x = [_]f32{ 1.1 / 4.0, 1.1 / 8.0, 1.1 / 16.0, 1.1 / 32.0, 1.1 / 64.0, 1.1 / 128.0 };
             var x_f8e3: [x.len]floats.Float8E3M4 = undefined;
             for (&x_f8e3, &x) |*xi_f8e3, xi| xi_f8e3.* = .fromF32(xi);
 
@@ -1071,7 +1071,7 @@ pub const Tensor = struct {
             const x_f8e3_xla_d = try zml.testing.compileAndCall(platform, Tensor.convert, .{ x_d, .f8e3m4 });
 
             const x_f8e3_xla = x_f8e3_xla_d.getValue(@TypeOf(x_f8e3));
-            errdefer std.log.warn("convert(.f8e3m4) failed !\nzml.floats computed:\n{any}\nxla computed:\n{any}", .{ x_f8e3, x_f8e3_xla });
+            errdefer std.log.warn("convert(.f8e3m4) failed !\ninput f32:\n{e}\nzml.floats computed:\n{any}\nxla computed:\n{any}", .{ stdx.fmt.slice(&x), x_f8e3, x_f8e3_xla });
             try std.testing.expectEqualDeep(x_f8e3, x_f8e3_xla);
         }
     }

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -3844,11 +3844,11 @@ fn getPoolResDims(dt: DataType, in_dims: []const i64, base_dilations: @Vector(Te
 }
 
 fn getComparisonType(ctx: mlir.Context, dtype: DataType) dialect.stablehlo.CompareType {
-    return dialect.stablehlo.CompareType.init(ctx, switch (dtype) {
-        .i4, .i8, .i16, .i32, .i64 => .SIGNED,
-        .bool, .u4, .u8, .u16, .u32, .u64 => .UNSIGNED,
-        .f8e4m3b11fnuz, .f8e4m3fn, .f8e4m3fnuz, .f8e5m2, .f8e5m2fnuz, .bf16, .f16, .f32, .f64 => .FLOAT,
-        .c64, .c128 => @panic("Can't compare complex numbers"),
+    return dialect.stablehlo.CompareType.init(ctx, switch (dtype.class()) {
+        .bool => .UNSIGNED,
+        .integer => if (dtype.isSignedInt()) .SIGNED else .UNSIGNED,
+        .float => .FLOAT,
+        .complex => @panic("Can't compare complex numbers"),
     });
 }
 

--- a/zml/testing.zig
+++ b/zml/testing.zig
@@ -65,11 +65,15 @@ pub fn expectClose(left_: anytype, right_: anytype, tolerance: f32) !void {
         .f16,
         .f32,
         .f64,
+        .f4e2m1,
+        .f8e3m4,
+        .f8e4m3,
         .f8e4m3b11fnuz,
         .f8e4m3fn,
         .f8e4m3fnuz,
         .f8e5m2,
         .f8e5m2fnuz,
+        .f8e8m0,
         => |t| {
             const L = t.toZigType();
             const left_data = left.items(L);
@@ -96,7 +100,7 @@ pub fn expectClose(left_: anytype, right_: anytype, tolerance: f32) !void {
                 else => unreachable,
             }
         },
-        inline .bool, .u4, .u8, .u16, .u32, .u64, .i4, .i8, .i16, .i32, .i64 => |t| {
+        inline .bool, .u2, .u4, .u8, .u16, .u32, .u64, .i2, .i4, .i8, .i16, .i32, .i64 => |t| {
             const T = t.toZigType();
             return std.testing.expectEqualSlices(T, left.items(T), right.items(T));
         },


### PR DESCRIPTION
Adding the following missing data types:

- u2
- i1
- i2
- f4e2m1fn
- f8e3m4
- f8e4m3
- f8e8m0fnu

(ground truth is PJRT)

I've also realized the code in from/to Float32 wasn't correct and was truncating to zero to often.
Hence the rewrite and bug fix.