### PR TITLE
pjrt/cpu: fix compilation without cpu

### DIFF
--- a/runtimes/cpu/BUILD.bazel
+++ b/runtimes/cpu/BUILD.bazel
@@ -20,6 +20,7 @@ config_setting(
 
 cc_library(
     name = "empty",
+    defines = ["ZML_RUNTIME_CPU_DISABLED"],
 )
 
 copy_to_directory(


### PR DESCRIPTION
Zig modules that want to access the "c" module needs to have a non empty CcCompilationContext for now.
So basically depending on an empty cc_library is not enough, it needs to contain something (defines or headers or includes or wathever)