### PR TITLE
workspace: support remote execution

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -115,3 +115,22 @@ common:alldebug --strategy=local
 common:release  --compilation_mode=opt
 common:release  --copt=-Ofast
 common:release  --@rules_zig//zig/settings:mode=release_safe
+
+common:remote --bes_results_url=https://app.buildbuddy.io/invocation/
+common:remote --bes_backend=grpcs://remote.buildbuddy.io
+common:remote --remote_cache=grpcs://remote.buildbuddy.io
+common:remote --remote_download_toplevel
+common:remote --nobuild_runfile_links
+common:remote --remote_timeout=3600
+common:remote --remote_executor=grpcs://remote.buildbuddy.io
+common:remote --noexperimental_throttle_remote_action_building
+common:remote --experimental_remote_execution_keepalive
+common:remote --experimental_remote_cache_compression
+common:remote --grpc_keepalive_time=30s
+common:remote --jobs=800
+common:remote --extra_execution_platforms=//:rbe_platform
+
+# Load from the local configuration file, if it exists. This needs to be the
+# *last* statement in the root configuration file, as the local configuration
+# file should be able to overwrite flags from the root configuration.
+try-import %workspace%/.bazelrc.user

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Bazel symlinks
 bazel-*
 
+# Bazel user config
+.bazelrc.user
+
 # macOS
 .DS_Store
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,3 +10,20 @@ zls_completion(
         "//zml",
     ],
 )
+
+platform(
+    name = "rbe_platform",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+        # ubuntu:22.04 has GNU C Library (Ubuntu GLIBC 2.35-0ubuntu3.10)
+        # But apparently not in this docker://ubuntu:22.04 image?
+        "@toolchains_llvm_bootstrapped//constraints/libc:gnu.2.31",
+        "@bazel_tools//tools/cpp:clang",
+    ],
+    exec_properties = {
+        "container-image": "docker://ubuntu:22.04",
+        "OSFamily": "Linux",
+    },
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Thanks to toolchains_llvm_bootstrapped, we can now remote-exec all targets.

Which means CI will soon follow.

See https://app.buildbuddy.io/invocation/c1c94a4b-0903-4d37-b488-df5f49ee7940 for a successful run.

Requires adding:
```
build:remote --remote_header=x-buildbuddy-api-key=<api-key>
```

which you can create in https://zml.buildbuddy.io