### PR TITLE
zls: Inject BUILD_EXECROOT from tools/zls.sh like bazel 9

### DIFF
--- a/third_party/zls/workspace_printer.zig
+++ b/third_party/zls/workspace_printer.zig
@@ -123,18 +123,9 @@ pub fn main(init: std.process.Init) !void {
     const args = try init.minimal.args.toSlice(arena.allocator());
 
     const build_workspace_directory = init.environ_map.get("BUILD_WORKSPACE_DIRECTORY").?;
-    const execution_root = if (init.environ_map.get("BAZEL_EXECUTION_ROOT")) |value|
-        value
-    else blk: {
-        const output_base_result = try std.process.run(arena.allocator(), init.io, .{
-            .argv = &.{
-                "bazel",
-                "info",
-                "execution_root",
-            },
-            .cwd = .{ .path = build_workspace_directory },
-        });
-        break :blk std.mem.trimEnd(u8, output_base_result.stdout, "\n");
+    const build_execroot = init.environ_map.get("BUILD_EXECROOT") orelse b: {
+        std.debug.print("=== BUILD_EXECROOT environment variable not found, using empty string as fallback ===\n", .{});
+        break :b "";
     };
 
     var output = try readBuildConfig(
@@ -154,8 +145,8 @@ pub fn main(init: std.process.Init) !void {
         u8,
         arena.allocator(),
         output,
-        "@@__BAZEL_EXECUTION_ROOT__@@",
-        execution_root,
+        "@@__BUILD_EXECROOT__@@",
+        build_execroot,
     );
 
     var stdout_buf: [4096]u8 = undefined;

--- a/third_party/zls/workspace_printer_test.zig
+++ b/third_party/zls/workspace_printer_test.zig
@@ -9,21 +9,6 @@ fn requireEnv(name: [:0]const u8) ![]const u8 {
     return std.mem.span(std.c.getenv(name) orelse return error.MissingEnvironmentVariable);
 }
 
-fn workspaceDirFromConfigPath(config_path: []const u8, package_name: []const u8) ![]const u8 {
-    var workspace_dir = std.fs.path.dirname(config_path) orelse
-        return error.InvalidWorkspacePath;
-    if (package_name.len == 0) {
-        return workspace_dir;
-    }
-
-    var it = std.mem.splitScalar(u8, package_name, '/');
-    while (it.next()) |_| {
-        workspace_dir = std.fs.path.dirname(workspace_dir) orelse
-            return error.InvalidWorkspacePath;
-    }
-    return workspace_dir;
-}
-
 test "completion print_build_config emits valid json" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -41,19 +26,16 @@ test "completion print_build_config emits valid json" {
 
     const printer_rpath = try requireEnv("COMPLETION_PRINTER_RLOCATION");
     const config_rpath = try requireEnv("COMPLETION_BUILD_CONFIG_RLOCATION");
-    const package_name = try requireEnv("COMPLETION_PACKAGE");
 
     const printer_path = try r.rlocationAlloc(allocator, printer_rpath) orelse
         return error.RLocationNotFound;
     const config_path = try r.rlocationAlloc(allocator, config_rpath) orelse
         return error.RLocationNotFound;
-    const workspace_dir = try workspaceDirFromConfigPath(config_path, package_name);
-    const execution_root = workspace_dir;
 
     var child_env_map: std.process.Environ.Map = .init(std.testing.allocator);
     defer child_env_map.deinit();
-    try child_env_map.put("BUILD_WORKSPACE_DIRECTORY", workspace_dir);
-    try child_env_map.put("BAZEL_EXECUTION_ROOT", execution_root);
+    try child_env_map.put("BUILD_WORKSPACE_DIRECTORY", "/workspace");
+    try child_env_map.put("BUILD_EXECROOT", "/execroot");
 
     const result = try std.process.run(std.testing.allocator, std.testing.io, .{
         .argv = &.{ printer_path, config_path },

--- a/third_party/zls/zls_write_build_config.bzl
+++ b/third_party/zls/zls_write_build_config.bzl
@@ -55,7 +55,7 @@ zls_construct_zig_module_info = aspect(
 def format_main_file(main):
     prefix = "@@__BUILD_WORKSPACE_DIRECTORY__@@/"
     if (main.startswith("bazel-out/") or main.startswith("external/")):
-        prefix = "@@__BAZEL_EXECUTION_ROOT__@@/"
+        prefix = "@@__BUILD_EXECROOT__@@/"
     return prefix + main
 
 def _zls_write_build_config_impl(ctx):

--- a/tools/zls.sh
+++ b/tools/zls.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+
+set -euo pipefail
+
 cd "$(dirname "${BASH_SOURCE[0]}")"
 cd "$(bazel info workspace)"
+
+# Only provided in Bazel 9
+export BUILD_EXECROOT="$(bazel info execution_root)"
+
 exec bazel run -- @zml//:completion "${@}"


### PR DESCRIPTION
Initially, I thought I had a zls issue with a C dependency. But now that I've made this PR I realize it was something else. `BUILD_EXECROOT` will be provided by Bazel 9 and it feels a bit cleaner to not call bazel from within zig IMHO.