### PR TITLE
zml/attention: attnd

### DIFF
--- a/examples/llm/main.zig
+++ b/examples/llm/main.zig
@@ -19,6 +19,7 @@ const Args = struct {
     seqlen: u32 = 2048,
     topk: u32 = 4,
     backend: ?zml.attention.attention.Backend = null,
+    attnd_ip: ?[]const u8 = null,
     single: bool = false,
     profile: bool = false,
 
@@ -32,7 +33,8 @@ const Args = struct {
         \\   --prompt=<string>   Prompt to use for generation (default: none)
         \\   --seqlen=<number>   Sequence length (default: 2048)
         \\   --topk=<number>     Top-k sampling cutoff (default: 4)
-        \\   --backend=<text>    Attention backend to use ([vanilla, cuda_fa2, cuda_fa3], default: auto-selection)
+        \\   --backend=<text>    Attention backend to use ([vanilla, attnd, cuda_fa2, cuda_fa3], default: auto-selection)
+        \\   --attnd-ip=<addr>   Register and prefer the `attnd` backend at the provided `IP:PORT`
         \\   --single            Create a single kernel encompassing all the layers when supported
         \\                       (only used by LFM2 which uses multiple kernels by default)
         \\   --profile           Capture a PJRT profile for non-interactive runs and write a Perfetto trace
@@ -85,11 +87,15 @@ pub fn main(init: std.process.Init) !void {
 
     log.info("\n{f}", .{platform.fmtVerbose()});
 
-    const backend = args.backend orelse b: {
-        const selected = zml.attention.attention.Backend.auto(platform);
-        log.info("Selected backend: {}", .{selected});
-        break :b selected;
-    };
+    const backend = args.backend orelse if (args.attnd_ip) |attnd_ip| b: {
+        try zml.attention.attnd.register(allocator, io, platform, .{
+            .destination = try .parseLiteral(attnd_ip),
+            .mtu = 9000,
+        });
+        break :b zml.attention.attention.Backend.attnd;
+    } else zml.attention.attention.Backend.auto(platform);
+    defer if (args.attnd_ip) |_| zml.attention.attnd.deinit();
+    log.info("Selected backend: {}", .{backend});
 
     //
     // Model initialization

--- a/examples/llm/models/llama/inference.zig
+++ b/examples/llm/models/llama/inference.zig
@@ -15,11 +15,13 @@ pub const CompilationParameters = struct {
     kv_cache: model.KvCache,
     rng: zml.Tensor.Rng,
     attention_metadata: attention.Metadata,
-    attention_parameters: attention.Parameters,
+    prefill_attention_parameters: attention.Parameters,
+    decode_attention_parameters: attention.Parameters,
     seqlen: usize,
     shardings: common.Shardings,
 
     pub fn init(mdl: model.Model, config: model.Config, seqlen: u32, backend: attention.Backend, shardings: common.Shardings) CompilationParameters {
+        const head_dim = config.head_dim orelse @divExact(config.hidden_size, config.num_attention_heads);
         return .{
             .prefill_tokens = .init(.{ .s = seqlen }, .u32),
             .decode_tokens = .init(.{ .s = 1 }, .u32),
@@ -28,11 +30,33 @@ pub const CompilationParameters = struct {
                 .layer = mdl.model.layers.len,
                 .k = seqlen,
                 .h = config.num_key_value_heads,
-                .hd = config.head_dim orelse @divExact(config.hidden_size, config.num_attention_heads),
+                .hd = head_dim,
             }, mdl.model.embed_tokens.weight.dtype())),
             .rng = .init(),
-            .attention_metadata = .init(.fromBackend(backend, @intCast(seqlen), @intCast(config.num_attention_heads))),
-            .attention_parameters = .init(.fromBackend(backend)),
+            .attention_metadata = switch (backend) {
+                .attnd => .{ .attnd = .init() },
+                else => .init(.fromBackend(backend, @intCast(seqlen), @intCast(config.num_attention_heads))),
+            },
+            .prefill_attention_parameters = switch (backend) {
+                .attnd => .{ .attnd = .init(.{
+                    .model_id = .@"llama-3.1-8B",
+                    .head_dim = head_dim,
+                    .num_attention_heads = config.num_attention_heads,
+                    .num_kv_heads = @intCast(config.num_key_value_heads),
+                    .is_prefill = true,
+                }) },
+                else => .init(.fromBackend(backend)),
+            },
+            .decode_attention_parameters = switch (backend) {
+                .attnd => .{ .attnd = .init(.{
+                    .model_id = .@"llama-3.1-8B",
+                    .head_dim = head_dim,
+                    .num_attention_heads = config.num_attention_heads,
+                    .num_kv_heads = @intCast(config.num_key_value_heads),
+                    .is_prefill = false,
+                }) },
+                else => .init(.fromBackend(backend)),
+            },
             .seqlen = seqlen,
             .shardings = shardings,
         };
@@ -107,9 +131,11 @@ fn compileModel(
                     parameters_.kv_cache,
                     parameters_.rng,
                     parameters_.attention_metadata,
-                    parameters_.attention_parameters,
+                    parameters_.prefill_attention_parameters,
                 },
-                .{ .shardings = &shardings_ },
+                .{
+                    .shardings = &shardings_,
+                },
             );
         }
     }.call, .{ allocator, io, platform, llama_model, parameters, all_shardings, progress });
@@ -141,7 +167,7 @@ fn compileModel(
                     parameters_.kv_cache,
                     parameters_.rng,
                     parameters_.attention_metadata,
-                    parameters_.attention_parameters,
+                    parameters_.decode_attention_parameters,
                 },
                 .{ .shardings = shardings_ },
             );

--- a/examples/llm/models/llama/model.zig
+++ b/examples/llm/models/llama/model.zig
@@ -293,11 +293,21 @@ pub const Llama = struct {
         var updated_kv_cache = kv_cache;
 
         for (self.layers, 0..) |layer, i| {
+            const layer_attention_metadata: zml.attention.attention.Metadata = switch (attention_parameters) {
+                .attnd => .{ .attnd = .{
+                    .layer_id = zml.Tensor.scalar(i, .u16),
+                    .conversation_id = attention_metadata.attnd.conversation_id,
+                    .num_tokens = attention_metadata.attnd.num_tokens,
+                } },
+                .vanilla => attention_metadata,
+                .cuda_fa2 => attention_metadata,
+                .cuda_fa3 => attention_metadata,
+            };
             hidden, updated_kv_cache = layer.forward(
                 hidden,
                 token_index,
                 updated_kv_cache.atLayer(i),
-                attention_metadata,
+                layer_attention_metadata,
                 attention_parameters,
             );
         }

--- a/examples/llm/models/llama/session.zig
+++ b/examples/llm/models/llama/session.zig
@@ -18,6 +18,7 @@ pub const Session = struct {
     config: *const model.Config,
     seqlen: u32,
     last_generated_token: u32 = 0,
+    conversation_id: u64,
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -50,6 +51,7 @@ pub const Session = struct {
             .tokenizer = tokenizer,
             .config = &compiled_model.loaded_model.parsed_config.value,
             .seqlen = @intCast(compiled_model.params.seqlen),
+            .conversation_id = @bitCast(std.Io.Clock.now(.real, io).toMicroseconds()),
         };
     }
 
@@ -124,13 +126,22 @@ pub const Session = struct {
         var prefill_token_pos_buffer = try zml.Buffer.scalar(self.io, self.platform, 0, .u32);
         defer prefill_token_pos_buffer.deinit();
 
+        const attention_metadata_buffers: zml.Bufferized(zml.attention.attention.Metadata) = switch (self.compiled_model.params.prefill_attention_parameters) {
+            .attnd => .{ .attnd = .{
+                .conversation_id = try zml.Buffer.scalar(self.io, self.platform, self.conversation_id, .u64),
+                .layer_id = try zml.Buffer.scalar(self.io, self.platform, 0, .u16),
+                .num_tokens = try zml.Buffer.scalar(self.io, self.platform, all_tokens.len, .u32),
+            } },
+            .vanilla, .cuda_fa2, .cuda_fa3 => self.attention_metadata_buffers,
+        };
+
         prefill_args.set(.{
             self.model_buffers,
             prefill_tokens_buffer,
             prefill_token_pos_buffer,
             &self.kv_cache_buffers,
             &self.rng_buffers,
-            &self.attention_metadata_buffers,
+            &attention_metadata_buffers,
         });
         self.compiled_model.prefill_exe.call(prefill_args, &prefill_results);
 
@@ -171,12 +182,21 @@ pub const Session = struct {
             var token_pos_buffer: zml.Buffer = try .scalar(self.io, self.platform, all_tokens.items.len, .u32);
             defer token_pos_buffer.deinit();
 
+            const attention_metadata_buffers: zml.Bufferized(zml.attention.attention.Metadata) = switch (self.compiled_model.params.decode_attention_parameters) {
+                .attnd => .{ .attnd = .{
+                    .conversation_id = try zml.Buffer.scalar(self.io, self.platform, self.conversation_id, .u64),
+                    .layer_id = try zml.Buffer.scalar(self.io, self.platform, 0, .u16),
+                    .num_tokens = try zml.Buffer.scalar(self.io, self.platform, 1, .u32),
+                } },
+                .vanilla, .cuda_fa2, .cuda_fa3 => self.attention_metadata_buffers,
+            };
+
             decode_args.set(.{
                 current_token_buffer,
                 token_pos_buffer,
                 &self.kv_cache_buffers,
                 &self.rng_buffers,
-                &self.attention_metadata_buffers,
+                &attention_metadata_buffers,
             });
             self.compiled_model.decode_exe.call(decode_args, &decode_results);
 

--- a/zml/BUILD.bazel
+++ b/zml/BUILD.bazel
@@ -32,6 +32,7 @@ zig_library(
     srcs = [
         "attention.zig",
         "attention/attention.zig",
+        "attention/attnd.zig",
         "attention/flashattn.zig",
         "attention/mosaic_tpu_kernels/ragged_attention.zig",
         "attention/paged_attention.zig",

--- a/zml/attention.zig
+++ b/zml/attention.zig
@@ -1,4 +1,5 @@
 pub const attention = @import("attention/attention.zig");
+pub const attnd = @import("attention/attnd.zig");
 pub const paged_attention = @import("attention/paged_attention.zig");
 pub const flashattn = @import("attention/flashattn.zig");
 pub const tpu = @import("attention/tpu_attention.zig");

--- a/zml/attention/attention.zig
+++ b/zml/attention/attention.zig
@@ -1,12 +1,14 @@
 const std = @import("std");
 
 const zml = @import("../zml.zig");
+const attnd = @import("attnd.zig");
 const flashattn = @import("flashattn.zig");
 
 const Attention = @This();
 
 pub const Backend = enum {
     vanilla,
+    attnd,
     cuda_fa2,
     cuda_fa3,
 
@@ -31,17 +33,20 @@ pub const Backend = enum {
 
 pub const Parameters = union(Backend) {
     vanilla: void,
+    attnd: attnd.Parameters,
     cuda_fa2: flashattn.fa2.Parameters,
     cuda_fa3: flashattn.fa3.Parameters,
 
     pub const InitOptions = union(Backend) {
         vanilla: void,
+        attnd: void,
         cuda_fa2: flashattn.fa2.Parameters.InitOptions,
         cuda_fa3: flashattn.fa3.Parameters.InitOptions,
 
         pub fn fromBackend(backend: Backend) InitOptions {
             return switch (backend) {
                 .vanilla => .{ .vanilla = {} },
+                .attnd => @panic("Must be initialized manually"),
                 .cuda_fa2 => .{ .cuda_fa2 = .{} },
                 .cuda_fa3 => .{ .cuda_fa3 = .{} },
             };
@@ -51,6 +56,7 @@ pub const Parameters = union(Backend) {
     pub fn init(opts: InitOptions) Parameters {
         return switch (opts) {
             .vanilla => .{ .vanilla = {} },
+            .attnd => @panic("Must be initialized manually"),
             .cuda_fa2 => |v| .{ .cuda_fa2 = .init(v) },
             .cuda_fa3 => |v| .{ .cuda_fa3 = .init(v) },
         };
@@ -59,17 +65,20 @@ pub const Parameters = union(Backend) {
 
 pub const Metadata = union(Backend) {
     vanilla: void,
+    attnd: attnd.Metadata,
     cuda_fa2: flashattn.fa2.Metadata,
     cuda_fa3: flashattn.fa3.Metadata,
 
     pub const InitOptions = union(Backend) {
         vanilla: void,
+        attnd: void,
         cuda_fa2: flashattn.fa2.Metadata.InitOptions,
         cuda_fa3: flashattn.fa3.Metadata.InitOptions,
 
         pub fn fromBackend(backend: Backend, seqlen: i64, num_heads: i64) InitOptions {
             return switch (backend) {
                 .vanilla => .{ .vanilla = {} },
+                .attnd => .{ .attnd = {} },
                 .cuda_fa2 => .{ .cuda_fa2 = .{ .seqlen = seqlen, .num_heads = num_heads } },
                 .cuda_fa3 => .{ .cuda_fa3 = .{ .seqlen = seqlen, .num_heads = num_heads } },
             };
@@ -79,6 +88,7 @@ pub const Metadata = union(Backend) {
     pub fn init(opts: InitOptions) Metadata {
         return switch (opts) {
             .vanilla => .{ .vanilla = {} },
+            .attnd => @panic("Must be initialized manually"),
             .cuda_fa2 => |o| .{ .cuda_fa2 = flashattn.fa2.Metadata.init(o) },
             .cuda_fa3 => |o| .{ .cuda_fa3 = flashattn.fa3.Metadata.init(o) },
         };
@@ -87,6 +97,7 @@ pub const Metadata = union(Backend) {
     pub fn initBuffer(self: Metadata, io: std.Io, platform: *const zml.Platform, sharding: zml.Sharding) !zml.Bufferized(Metadata) {
         return switch (self) {
             .vanilla => .{ .vanilla = {} },
+            .attnd => |v| .{ .attnd = try v.initBuffer(io, platform, sharding) },
             .cuda_fa2 => |v| .{ .cuda_fa2 = try v.initBuffer(io, platform, sharding) },
             .cuda_fa3 => |v| .{ .cuda_fa3 = try v.initBuffer(io, platform, sharding) },
         };
@@ -95,6 +106,7 @@ pub const Metadata = union(Backend) {
     pub fn deinitBuffer(self: *zml.Bufferized(Metadata)) void {
         switch (self.*) {
             .vanilla => {},
+            .attnd => |*v| attnd.Metadata.deinitBuffer(v),
             .cuda_fa2 => |*v| flashattn.fa2.Metadata.deinitBuffer(v),
             .cuda_fa3 => |*v| flashattn.fa3.Metadata.deinitBuffer(v),
         }
@@ -114,6 +126,7 @@ pub fn attention(q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, token_index: zml.T
             const attn_output = zml.nn.sdpa(q, k, v, .{ .attn_mask = attn_mask, .allow_cudnn = true });
             break :b attn_output;
         },
+        .attnd => attnd.causalAttention(q, k, v, token_index, metadata.attnd, parameters.attnd),
         .cuda_fa2 => flashattn.fa2.attention(q, k, v, token_index, metadata.cuda_fa2, parameters.cuda_fa2),
         .cuda_fa3 => flashattn.fa3.attention(q, k, v, token_index, metadata.cuda_fa3, parameters.cuda_fa3),
     };

--- a/zml/attention/attnd.zig
+++ b/zml/attention/attnd.zig
@@ -1,0 +1,501 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+const stdx = @import("stdx");
+
+const zml = @import("../zml.zig");
+
+const log = std.log.scoped(.@"zml/attnd");
+var context: ?*Context = null;
+
+pub const Config = struct {
+    destination: std.Io.net.IpAddress,
+    mtu: u16,
+};
+
+pub const Parameters = struct {
+    model_id: ModelId,
+    head_dim: u32,
+    head_bytes: u32,
+    num_kv_heads: u8,
+    num_q_per_head: u8,
+    num_q_per_packet: u8,
+    is_prefill: bool,
+
+    pub const Init = struct {
+        model_id: ModelId,
+        head_dim: u32,
+        num_attention_heads: u32,
+        num_kv_heads: u8,
+        is_prefill: bool,
+    };
+
+    pub fn init(args: Init) Parameters {
+        const mtu: u32 = if (context) |ctx| @intCast(ctx.mtu) else @panic("attnd wasn't registered yet, use register() first.");
+        const num_q_per_head: u8 = @intCast(@divExact(args.num_attention_heads, args.num_kv_heads));
+        const head_bytes = args.head_dim * @sizeOf(u16); // TODO: Here we assume bf16 or equivalent.
+        const kv_bytes = 2 * head_bytes;
+
+        var max_q_per_packet: u8 = @intCast(std.math.divFloor(u32, mtu - @sizeOf(Header) - kv_bytes, head_bytes) catch unreachable);
+        max_q_per_packet = @min(max_q_per_packet, num_q_per_head);
+
+        const num_packets_per_head: u8 = @intCast(std.math.divCeil(u32, num_q_per_head, max_q_per_packet) catch unreachable);
+        const num_q_per_packet = @divExact(num_q_per_head, num_packets_per_head);
+        if (num_q_per_packet < num_q_per_head) {
+            log.warn("Will split attnd requests in {d} packets of {d} queries", .{ num_packets_per_head, max_q_per_packet });
+        }
+
+        return .{
+            .model_id = args.model_id,
+            .head_dim = args.head_dim,
+            .head_bytes = head_bytes,
+            .num_kv_heads = args.num_kv_heads,
+            .num_q_per_head = num_q_per_head,
+            .num_q_per_packet = num_q_per_packet,
+            .is_prefill = args.is_prefill,
+        };
+    }
+};
+
+pub const Metadata = struct {
+    conversation_id: zml.Tensor,
+    layer_id: zml.Tensor,
+    num_tokens: zml.Tensor,
+
+    pub fn init() Metadata {
+        return .{
+            .conversation_id = .fromShape(.scalar(.u64)),
+            .layer_id = .fromShape(.scalar(.u16)),
+            .num_tokens = .fromShape(.scalar(.u32)),
+        };
+    }
+
+    pub fn initBuffer(
+        self: Metadata,
+        io: std.Io,
+        platform: *const zml.Platform,
+        sharding: zml.Sharding,
+    ) !zml.Bufferized(Metadata) {
+        return .{
+            .conversation_id = try zml.Buffer.scalar(io, platform, 749, .u64),
+            .layer_id = try zml.Buffer.uninitialized(io, platform, self.layer_id.shape(), sharding, .{}),
+            .num_tokens = try zml.Buffer.uninitialized(io, platform, self.num_tokens.shape(), sharding, .{}),
+        };
+    }
+
+    pub fn deinitBuffer(self: *zml.Bufferized(Metadata)) void {
+        self.conversation_id.deinit();
+        self.layer_id.deinit();
+        self.num_tokens.deinit();
+    }
+};
+
+pub fn register(allocator: std.mem.Allocator, io: std.Io, platform: *const zml.Platform, config: Config) !void {
+    var ctx = try allocator.create(Context);
+    errdefer allocator.destroy(ctx);
+
+    try ctx.initialize(io, allocator, platform, config);
+
+    context = ctx;
+
+    try targets.attnd.register(platform);
+}
+
+pub fn deinit() void {
+    if (context) |ctx| {
+        ctx.deinit();
+        context = null;
+    }
+}
+
+const Context = struct {
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    mtu: u16,
+    // One client per device.
+    clients: []Client,
+
+    fn initialize(ctx: *Context, io: std.Io, allocator: std.mem.Allocator, platform: *const zml.Platform, config: Config) !void {
+        ctx.allocator = allocator;
+        ctx.io = io;
+        ctx.mtu = config.mtu;
+        ctx.clients = try allocator.alloc(Client, platform.devices.len);
+        errdefer allocator.free(ctx.clients);
+
+        var c_len: usize = 0;
+        errdefer for (ctx.clients[0..c_len]) |*c| c.deinit(allocator, io);
+        for (ctx.clients) |*c| {
+            try c.initialize(allocator, io, config);
+            c_len += 1;
+        }
+    }
+
+    fn deinit(self: *Context) void {
+        for (self.clients) |*c| {
+            c.deinit(self.allocator, self.io);
+        }
+        self.allocator.free(self.clients);
+        self.allocator.destroy(self);
+    }
+};
+
+pub fn causalAttention(q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, token_offset: zml.Tensor, metadata: Metadata, parameters: Parameters) zml.Tensor {
+    const ctx = zml.module.CompilationContext.current();
+    const num_partitions = ctx.partitioning.numPartitionsForLogicalAxis(q.shape(), .model) catch unreachable;
+
+    const actual_k, const actual_v = if (parameters.is_prefill)
+        .{ k, v }
+    else
+        .{
+            k.dynamicSlice(.{ .k = zml.Tensor.DynSlice{ .start = token_offset, .len = 1 } }),
+            v.dynamicSlice(.{ .k = zml.Tensor.DynSlice{ .start = token_offset, .len = 1 } }),
+        };
+
+    // Concatenate q/k/v and metadata into a single byte buffer on the GPU.
+    // This reduces 7 separate D2H transfers to 1 during host-compute offload.
+    const packed_input = zml.Tensor.concatenate(&.{
+        q.bytes(),
+        actual_k.bytes(),
+        actual_v.bytes(),
+        metadata.conversation_id.bytes(),
+        metadata.layer_id.bytes(),
+        token_offset.bytes(),
+        metadata.num_tokens.bytes(),
+    }, .bytes);
+
+    const out = targets.attnd.call(
+        .{ .mqkv = packed_input },
+        .{
+            .attn = q.shape(),
+        },
+        .{
+            .model_id = parameters.model_id,
+            .head_dim = parameters.head_dim,
+            .head_size_in_bytes = parameters.head_bytes,
+            .num_kv_heads = parameters.num_kv_heads,
+            .num_q_per_head = parameters.num_q_per_head,
+            .num_q_per_packet = parameters.num_q_per_packet,
+            .num_partitions = @intCast(num_partitions),
+            .q_byte_size = @intCast(q.shape().byteSize()),
+            .k_byte_size = @intCast(actual_k.shape().byteSize()),
+            .v_byte_size = @intCast(actual_v.shape().byteSize()),
+        },
+    );
+
+    return out.attn;
+}
+
+pub const targets = struct {
+    const NAME = "attnd";
+
+    pub const attnd = zml.ops.CustomCall(Input, Output, Attributes, attndCall, .{
+        .name = NAME,
+        .sharding_aware = true,
+        .has_side_effect = false,
+        .compute_on_host = true,
+    });
+};
+
+const Input = struct {
+    mqkv: zml.Tensor,
+};
+
+const Output = struct {
+    attn: zml.Shape,
+};
+
+const Attributes = struct {
+    model_id: ModelId,
+    head_dim: u32,
+    head_size_in_bytes: u32,
+    num_kv_heads: u8,
+    num_q_per_head: u8,
+    num_q_per_packet: u8,
+    num_partitions: u32,
+    /// Byte sizes for unpacking the concatenated packed buffer.
+    q_byte_size: u32,
+    k_byte_size: u32,
+    v_byte_size: u32,
+};
+
+fn attndCall(
+    call_frame: *zml.pjrt.ffi.CallFrame,
+    input: zml.pjrtx.TensorToCustomCallBuffer(Input),
+    output: zml.pjrtx.ShapeToCustomCallBuffer(Output),
+    attrs: Attributes,
+) !?*zml.pjrt.ffi.Error {
+    const ctx: *Context = context.?;
+    const device_ordinal: u64 = @intCast(try call_frame.ctx.getDeviceOrdinal(call_frame.api));
+
+    const client = &ctx.clients[device_ordinal];
+    // Unpack the concatenated byte buffer: [q_bytes | k_bytes | v_bytes | conversation_id(8) | layer_id(2) | token_offset(4) | num_tokens(4)]
+    const out_full = output.attn.asHostSlice();
+    const mqkv = input.mqkv.asHostConstSlice();
+    const q_end = attrs.q_byte_size;
+    const k_end = q_end + attrs.k_byte_size;
+    const v_end = k_end + attrs.v_byte_size;
+    const q_full = mqkv[0..q_end];
+    const k_full = mqkv[q_end..k_end];
+    const v_full = mqkv[k_end..v_end];
+    const conversation_id = std.mem.bytesAsValue(u64, mqkv[v_end..][0..@sizeOf(u64)]).*;
+    const layer_id = std.mem.bytesAsValue(u16, mqkv[v_end + @sizeOf(u64) ..][0..@sizeOf(u16)]).*;
+    const token_offset = std.mem.bytesAsValue(u32, mqkv[v_end + @sizeOf(u64) + @sizeOf(u16) ..][0..@sizeOf(u32)]).*;
+    const num_tokens = std.mem.bytesAsValue(u32, mqkv[v_end + @sizeOf(u64) + @sizeOf(u16) + @sizeOf(u32) ..][0..@sizeOf(u32)]).*;
+
+    const q_size_in_bytes = attrs.num_q_per_head * attrs.head_size_in_bytes;
+    const head_size_in_bytes = attrs.head_size_in_bytes;
+    const kv_heads_per_partitions = @divExact(attrs.num_kv_heads, attrs.num_partitions);
+    const kv_head_offset = kv_heads_per_partitions * device_ordinal;
+    for (0..num_tokens) |t| {
+        const q = q_full[t * kv_heads_per_partitions * q_size_in_bytes ..][0 .. kv_heads_per_partitions * q_size_in_bytes];
+        const k = k_full[t * kv_heads_per_partitions * head_size_in_bytes ..][0 .. kv_heads_per_partitions * head_size_in_bytes];
+        const v = v_full[t * kv_heads_per_partitions * head_size_in_bytes ..][0 .. kv_heads_per_partitions * head_size_in_bytes];
+
+        var num_send_messages: usize = 0;
+        for (0..kv_heads_per_partitions) |kv_head_id| {
+            const k_offset = kv_head_id * head_size_in_bytes;
+            const v_offset = kv_head_id * head_size_in_bytes;
+            var q_offset = kv_head_id * head_size_in_bytes * attrs.num_q_per_head;
+            var q_sent: u8 = 0;
+
+            while (q_sent < attrs.num_q_per_head) {
+                const nq = @min(attrs.num_q_per_head - q_sent, attrs.num_q_per_packet);
+                const header: Header = .{
+                    .type = .attn,
+                    .kv_head_id = @intCast(kv_head_offset + kv_head_id),
+                    .conversation_id = conversation_id,
+                    .token_pos = token_offset + @as(u32, @intCast(t)),
+                    .layer_id = layer_id,
+                    .model_id = attrs.model_id,
+                    .first_q_id = q_sent,
+                    .num_queries = nq,
+                };
+                try client.send(
+                    header,
+                    q[q_offset..][0 .. head_size_in_bytes * nq],
+                    k[k_offset..][0..head_size_in_bytes],
+                    v[v_offset..][0..head_size_in_bytes],
+                );
+
+                q_offset += head_size_in_bytes * nq;
+                q_sent += nq;
+                num_send_messages += 1;
+            }
+        }
+
+        var out = out_full[t * kv_heads_per_partitions * q_size_in_bytes ..][0 .. kv_heads_per_partitions * q_size_in_bytes];
+        var recv_q: usize = 0;
+        while (recv_q < kv_heads_per_partitions * attrs.num_q_per_head) {
+            const response = client.receive() catch |err| {
+                log.err("Failed to receive response: {any}", .{err});
+                return err;
+            };
+            const header = response.header;
+            const payload = response.payload;
+
+            std.debug.assert(header.num_queries <= attrs.num_q_per_head);
+            std.debug.assert(header.kv_head_id < attrs.num_kv_heads);
+            std.debug.assert(header.first_q_id + header.num_queries <= attrs.num_q_per_head);
+
+            const n = header.num_queries * attrs.head_size_in_bytes;
+            std.debug.assert(payload.len == n);
+            const kv_head_id = header.kv_head_id - kv_head_offset;
+            const q_offset = (@as(usize, kv_head_id) * attrs.num_q_per_head + header.first_q_id) * attrs.head_size_in_bytes;
+            @memcpy(out[q_offset .. q_offset + n], payload[0..n]);
+            recv_q += header.num_queries;
+            num_send_messages -= 1;
+        }
+        std.debug.assert(num_send_messages == 0);
+    }
+
+    return null;
+}
+
+const MAX_CONCURRENT_PACKETS_PER_CLIENT = 32;
+
+const Client = struct {
+    socket: std.Io.net.Socket,
+    destination: std.Io.net.IpAddress,
+    packet_buffer: []u8,
+    send_addr: std.Io.Threaded.PosixAddress,
+    send_namelen: std.posix.socklen_t,
+
+    fn initialize(self: *Client, allocator: std.mem.Allocator, io: std.Io, config: Config) !void {
+        const src: std.Io.net.IpAddress = .{ .ip4 = .unspecified(0) };
+        const socket = try src.bind(io, .{ .mode = .dgram, .protocol = .udp });
+        errdefer socket.close(io);
+
+        const socket_buffer_size = @as(u32, @intCast(config.mtu)) * MAX_CONCURRENT_PACKETS_PER_CLIENT;
+        try std.posix.setsockopt(socket.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVBUF, @ptrCast(&socket_buffer_size));
+        try std.posix.setsockopt(socket.handle, std.posix.SOL.SOCKET, std.posix.SO.SNDBUF, @ptrCast(&socket_buffer_size));
+
+        // Set the Don't Fragment bit to avoid fragmentation on IPv4
+        switch (builtin.os.tag) {
+            .linux => {
+                // With PMTUDISC_DO the kernel will keep track of the ICMP messages to detect the real MTU.
+                // Best practice [1] seems to be to use IP_PMTUDISC_PROBE and do DPLPMTUD to avoid Blind Performance-Degrading Attack [2]
+                // But we assume to be within an internal network, otherwise attnd is useless anyway.
+                // [1] https://seemann.io/posts/2025-02-19---ip-fragmentation/
+                // [2] https://www.rfc-editor.org/rfc/rfc5927#section-7
+                // TODO: Do we actually try to use the max MTU? If we just assume it to be fine, we could just as well use IP_PMTUDISC_PROBE
+                const mtu_discover: u32 = std.os.linux.IP.PMTUDISC_DO;
+                try std.posix.setsockopt(socket.handle, std.posix.IPPROTO.IP, std.os.linux.IP.MTU_DISCOVER, @ptrCast(&mtu_discover));
+            },
+            .macos => {
+                // We could set IP_DONTFRAG on the socket, but Zig doesn't expose this option (yet).
+            },
+            else => {},
+        }
+
+        const packet_buffer = try allocator.alloc(u8, @as(usize, @intCast(config.mtu)));
+        errdefer allocator.free(packet_buffer);
+
+        self.socket = socket;
+        self.destination = config.destination;
+        self.packet_buffer = packet_buffer;
+        self.send_namelen = std.Io.Threaded.addressToPosix(&self.destination, &self.send_addr);
+    }
+
+    pub fn send(self: *Client, header: Header, q: []const u8, k: []const u8, v: []const u8) !void {
+        const iovecs = [_]std.posix.iovec_const{
+            .{ .base = std.mem.asBytes(&header).ptr, .len = @sizeOf(Header) },
+            .{ .base = q.ptr, .len = q.len },
+            .{ .base = k.ptr, .len = k.len },
+            .{ .base = v.ptr, .len = v.len },
+        };
+        const msg: std.posix.msghdr_const = .{
+            .name = &self.send_addr.any,
+            .namelen = self.send_namelen,
+            .iov = &iovecs,
+            .iovlen = iovecs.len,
+            .control = null,
+            .controllen = 0,
+            .flags = 0,
+        };
+
+        const rc = std.c.sendmsg(self.socket.handle, &msg, std.posix.MSG.DONTWAIT);
+        switch (std.posix.errno(rc)) {
+            .SUCCESS => {
+                std.debug.assert(rc == @sizeOf(Header) + q.len + k.len + v.len);
+            },
+            else => |err| {
+                log.err("Failed to send response: {any}", .{err});
+                @panic("Attnd failed");
+            },
+        }
+    }
+
+    pub fn receive(self: *Client) !Response {
+        var iovecs = [_]std.posix.iovec{
+            .{ .base = self.packet_buffer.ptr, .len = self.packet_buffer.len },
+        };
+        var msg: std.posix.msghdr = .{
+            .name = null,
+            .namelen = 0,
+            .iov = &iovecs,
+            .iovlen = iovecs.len,
+            .control = null,
+            .controllen = 0,
+            .flags = 0,
+        };
+
+        const rc = std.c.recvmsg(
+            self.socket.handle,
+            &msg,
+            0,
+        );
+        switch (std.posix.errno(rc)) {
+            .SUCCESS => {
+                const n: usize = @intCast(rc);
+                return Response.parse(self.packet_buffer[0..n]);
+            },
+            else => |err| {
+                log.err("Failed to receive response: {any}", .{err});
+                @panic("Attnd failed");
+            },
+        }
+    }
+
+    pub fn deinit(self: *Client, allocator: std.mem.Allocator, io: std.Io) void {
+        allocator.free(self.packet_buffer);
+        self.socket.close(io);
+    }
+};
+
+pub const Message = struct {
+    header: *align(1) const Header,
+    payload: []const u8,
+
+    pub fn parse(bytes: []const u8) !Message {
+        const n = @sizeOf(Header);
+        if (bytes.len < n) return error.ShortMessage;
+
+        const msg: Message = .{
+            .header = std.mem.bytesAsValue(Header, bytes[0..n]),
+            .payload = bytes[n..],
+        };
+
+        if (!(msg.header.magic[0] == 'Z' and msg.header.magic[1] == 'M' and msg.header.magic[2] == 'L')) {
+            return error.InvalidHeader;
+        }
+
+        return msg;
+    }
+};
+
+pub const Request = struct {
+    header: *align(1) const Header,
+    q: []const u8,
+    k: []const u8,
+    v: []const u8,
+};
+
+pub const Response = Message;
+
+pub const Header = extern struct {
+    pub const MAGIC: [3]u8 = .{ 'Z', 'M', 'L' }; // 0x5A4D4C
+
+    pub const Type = enum(u8) {
+        // Compute attention
+        attn = 'a',
+        // Starts a conversation
+        start = 's',
+        // Ping: the server answers immediately skipping all compute
+        ping = 'p',
+        _,
+    };
+
+    type: Type,
+    kv_head_id: u8,
+
+    conversation_id: u64 align(1),
+    token_pos: u32 align(1),
+    layer_id: u16 align(1),
+
+    model_id: ModelId,
+    first_q_id: u8,
+    num_queries: u8,
+    magic: [3]u8 align(1) = MAGIC,
+
+    comptime {
+        // destination MAC (6) + source MAC (6) + Ethertype (2) [+ 802.1Q / VLAN tag (4)]
+        // We the optional VLAN, we can only guarantee an alignment of 4 for the payload after the prefix + header.
+        const ETH_HEADER_SIZE = 6 + 6 + 2;
+        const IP_HEADER_SIZE = 20;
+        const UDP_HEADER_SIZE = 8;
+        const PREFIX_SIZE = ETH_HEADER_SIZE + IP_HEADER_SIZE + UDP_HEADER_SIZE;
+        stdx.debug.assertComptime(
+            (PREFIX_SIZE + @sizeOf(Header)) % 4 == 0,
+            "ETH_HEADER_SIZE ({}) + @sizeOf(AttnRequest) ({}) == {d} != k * 4",
+            .{ PREFIX_SIZE, @sizeOf(Header), PREFIX_SIZE + @sizeOf(Header) },
+        );
+    }
+};
+
+pub const ModelId = enum(u8) {
+    @"llama-3.1-8B" = 0,
+    @"llama-3.2-1B" = 1,
+    @"qwen3-14B" = 2,
+    @"qwen3-32B" = 3,
+    _, // Unsupported models
+};

--- a/zml/attention/flashattn.zig
+++ b/zml/attention/flashattn.zig
@@ -170,8 +170,8 @@ pub const fa2 = struct {
 
     fn ffiCall(
         call_frame: *zml.pjrt.ffi.CallFrame,
-        input: zml.ops.TensorToCustomCallBuffer(Input),
-        output: zml.ops.ShapeToCustomCallBuffer(Output),
+        input: zml.pjrtx.TensorToCustomCallBuffer(Input),
+        output: zml.pjrtx.ShapeToCustomCallBuffer(Output),
         attributes: Attributes,
     ) !?*zml.pjrt.ffi.Error {
         const params: flashattn.FA2MhaVarlenFwdParams = .{

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -15,7 +15,9 @@ const meta = @import("meta.zig");
 const mlirx = @import("mlirx.zig");
 const Platform = @import("platform.zig").Platform;
 const Shape = @import("shape.zig").Shape;
+pub const ShapeToCustomCallBuffer = @import("pjrtx.zig").ShapeToCustomCallBuffer;
 const Tensor = @import("tensor.zig").Tensor;
+pub const TensorToCustomCallBuffer = @import("pjrtx.zig").TensorToCustomCallBuffer;
 
 pub const ReduceArgs = struct {
     left: Tensor,
@@ -1052,7 +1054,20 @@ fn CustomCallResultTypeFromOutputSpec(comptime OutputSpecT: type) type {
 pub const CustomCallOptions = struct {
     has_side_effect: bool,
     output_operand_aliases: ?[]const dialects.stablehlo.CustomCallOpts.OutputOperandAlias = null,
+    compute_on_host: bool = false,
 };
+
+fn customCallAdditionalAttributes(ctx: *CompilationContext, opts: CustomCallOptions) []const mlir.NamedAttribute {
+    if (!opts.compute_on_host or ctx.platform.target == .cpu) return &.{};
+
+    const frontend_attributes = mlir.dictionaryAttribute(ctx.mlir_ctx, &.{
+        .named(ctx.mlir_ctx, "_xla_compute_type", mlir.stringAttribute(ctx.mlir_ctx, "host")),
+    });
+
+    const additional_attributes = ctx.arena.allocator().alloc(mlir.NamedAttribute, 1) catch unreachable;
+    additional_attributes[0] = .named(ctx.mlir_ctx, "mhlo.frontend_attributes", frontend_attributes);
+    return additional_attributes;
+}
 
 fn customCallOutputOperandAliases(
     comptime I: type,
@@ -1133,7 +1148,13 @@ pub fn customCall(target_name: [:0]const u8, inputs: anytype, outputs: anytype, 
         else => @compileError("Unsupported type: " ++ @typeName(@TypeOf(outputs))),
     };
 
-    const outputs_flat = customCallInternal(target_name, inputs_, output_shapes, metadata, opts);
+    const outputs_flat = typedCustomCall(
+        target_name,
+        opts,
+        inputs_,
+        output_shapes,
+        metadata,
+    );
     if (comptime CustomCallResultTypeFromOutputSpec(@TypeOf(outputs)) == void) {
         stdx.debug.assert(outputs_flat.len == 0, "customCall expected zero outputs for void return, got {}", .{outputs_flat.len});
         return;
@@ -1530,6 +1551,10 @@ fn metadataFieldToMlirAttribute(mlir_ctx: *mlir.Context, comptime T: type, value
     const type_info = @typeInfo(T);
     return switch (type_info) {
         .comptime_int => mlir.integerAttribute(mlir_ctx, .u64, @as(u64, value)),
+        .@"enum" => |enum_field| switch (@typeInfo(enum_field.tag_type)) {
+            .int => |int_tag| metadataIntegerFieldToMlirAttribute(mlir_ctx, int_tag, @intFromEnum(value)),
+            else => @compileError("Unsupported tag type for enum metadata: " ++ @typeName(enum_field.tag_type)),
+        },
         .int => |int_field| metadataIntegerFieldToMlirAttribute(mlir_ctx, int_field, value),
         .float => |float_field| metadataFloatFieldToMlirAttribute(mlir_ctx, float_field, value),
         .bool => mlir.boolAttribute(mlir_ctx, value),
@@ -1548,77 +1573,6 @@ fn metadataFieldToMlirAttribute(mlir_ctx: *mlir.Context, comptime T: type, value
         } else null,
         else => @compileError("Unsupported metadata type: " ++ @typeName(T)),
     };
-}
-
-fn customCallInternal(target_name: [:0]const u8, inputs: []const Tensor, outputs: []const Shape, metadata: anytype, opts: CustomCallOptions) []Tensor {
-    const ctx = CompilationContext.current();
-    const allocator = ctx.arena.allocator();
-
-    stdx.debug.assert(!opts.has_side_effect or ctx.manual_computation_depth > 0, "side-effect customCall '{s}' must be emitted inside manualComputation", .{target_name});
-
-    const values = allocator.alloc(*const mlir.Value, inputs.len) catch unreachable;
-    const input_shapes = allocator.alloc(Shape, inputs.len) catch unreachable;
-    for (inputs, 0..) |input, i| {
-        values[i] = input.value();
-        input_shapes[i] = input.shape();
-    }
-
-    const result_types = allocator.alloc(*const mlir.Type, outputs.len) catch unreachable;
-    for (outputs, 0..) |shape, i| {
-        result_types[i] = mlir.rankedTensorType(shape.dims(), mlirx.Type.fromDType(ctx.mlir_ctx, shape.dtype()));
-    }
-
-    const metadata_type_info = @typeInfo(@TypeOf(metadata));
-    var metadata_attribute_list = std.ArrayList(mlir.NamedAttribute).initCapacity(allocator, metadata_type_info.@"struct".fields.len + 2) catch unreachable;
-    inline for (metadata_type_info.@"struct".fields) |field| {
-        if (metadataFieldToMlirAttribute(ctx.mlir_ctx, field.type, @field(metadata, field.name))) |attribute| {
-            metadata_attribute_list.appendAssumeCapacity(mlir.NamedAttribute.named(ctx.mlir_ctx, field.name, attribute));
-        }
-    }
-
-    metadata_attribute_list.appendSliceAssumeCapacity(&[_]mlir.NamedAttribute{
-        .named(ctx.mlir_ctx, "pjrt_api", mlir.integerAttribute(ctx.mlir_ctx, .u64, @as(u64, @bitCast(@intFromPtr(ctx.platform.pjrt_api))))),
-        .named(ctx.mlir_ctx, "pjrt_client", mlir.integerAttribute(ctx.mlir_ctx, .u64, @as(u64, @bitCast(@intFromPtr(ctx.platform.pjrt_client))))),
-    });
-
-    const backend_config = mlir.dictionaryAttribute(ctx.mlir_ctx, metadata_attribute_list.items);
-
-    const operand_layouts = allocator.alloc([]const usize, input_shapes.len) catch unreachable;
-    for (input_shapes, 0..) |shape, i| {
-        operand_layouts[i] = allocator.dupe(usize, toUsize(constants.minorToMajor(shape.rank())).constSlice()) catch unreachable;
-    }
-
-    const result_layouts = allocator.alloc([]const usize, outputs.len) catch unreachable;
-    for (outputs, 0..) |shape, i| {
-        result_layouts[i] = allocator.dupe(usize, toUsize(constants.minorToMajor(shape.rank())).constSlice()) catch unreachable;
-    }
-
-    const op = dialects.stablehlo.custom_call(
-        ctx.mlir_ctx,
-        values,
-        result_types,
-        .{
-            .call_target_name = target_name,
-            .backend_config = .{ .typed_ffi = backend_config },
-            .has_side_effect = opts.has_side_effect,
-            .operand_layouts = operand_layouts,
-            .result_layouts = result_layouts,
-            .output_operand_aliases = opts.output_operand_aliases orelse &.{},
-            .additional_attributes = &.{},
-        },
-        .unknown(ctx.mlir_ctx),
-    ).appendTo(ctx.currentScope().block);
-
-    if (ctx.manual_computation_depth > 0 and ctx.partitioning.partitioner == .gspmd) {
-        op.setAttributeByName("mhlo.sharding", mlir.stringAttribute(ctx.mlir_ctx, "{manual}"));
-    }
-
-    const outputs_ = allocator.alloc(Tensor, outputs.len) catch unreachable;
-    for (outputs, 0..) |output_shape, i| {
-        outputs_[i] = Tensor._result(output_shape, op.result(i));
-    }
-
-    return outputs_;
 }
 
 pub fn CustomCall(
@@ -1643,6 +1597,9 @@ pub fn CustomCall(
         /// Similar to reuseBuffer on tensors, tells XLA that the custom call re-uses an input buffer for its output.
         /// Use the input/output field names to express the mapping: `{ .<out field> = .<in field> }`
         output_operand_aliases: ?CustomCallOutputOperandAliases(I, O) = null,
+        /// Request XLA host-compute offload for this custom call on accelerator backends.
+        /// Input/Output buffers will automatically be moved d2h/h2d without the need for an explicit `.toMemory(...)`.
+        compute_on_host: bool = false,
     },
 ) type {
     return struct {
@@ -1654,7 +1611,7 @@ pub fn CustomCall(
         pub fn register(platform: *const Platform) !void {
             try platform.registerFfi(.{
                 .name = params.name,
-                .platform_name = null,
+                .platform_name = if (params.compute_on_host) "Host" else null,
                 .handler = @This().handler,
                 .traits = .{
                     .command_buffer_compatible = true,
@@ -1663,32 +1620,26 @@ pub fn CustomCall(
         }
 
         pub fn call(input_tensors: I, output_shapes: O, attributes: A) ShapeToTensor(O) {
-            const args: CustomCallArgs(I, O, A) = .{
-                .input_tensors = input_tensors,
-                .output_shapes = output_shapes,
-                .attributes = attributes,
-            };
             const opts: CustomCallOptions = .{
                 .has_side_effect = params.has_side_effect,
                 .output_operand_aliases = comptime customCallOutputOperandAliases(I, O, params.output_operand_aliases),
+                .compute_on_host = params.compute_on_host,
             };
             if (params.sharding_aware) {
                 return shardingAwareTypedCustomCall(
-                    I,
-                    O,
-                    A,
                     params.name,
                     opts,
-                    args,
+                    input_tensors,
+                    output_shapes,
+                    attributes,
                 );
             } else {
                 return typedCustomCall(
-                    I,
-                    O,
-                    A,
                     params.name,
                     opts,
-                    args,
+                    input_tensors,
+                    output_shapes,
+                    attributes,
                 );
             }
         }
@@ -1703,171 +1654,137 @@ pub fn CustomCall(
     };
 }
 
-fn CustomCallArgs(I: type, O: type, A: type) type {
-    return struct {
-        input_tensors: I,
-        output_shapes: O,
-        attributes: A,
-    };
-}
-
-pub fn TensorToCustomCallBuffer(T: type) type {
-    return meta.MapRestrict(Tensor, CustomCallBuffer).map(T);
-}
-
-pub fn ShapeToCustomCallBuffer(T: type) type {
-    return meta.MapRestrict(Shape, CustomCallBuffer).map(T);
-}
-
 pub fn ShapeToTensor(T: type) type {
     return meta.MapRestrict(Shape, Tensor).map(T);
 }
 
 pub fn CustomCallOutputOperandAliases(I: type, O: type) type {
-    return meta.MapRestrict(Shape, ?std.meta.FieldEnum(I)).map(O);
+    const output_fields = @typeInfo(O).@"struct".fields;
+    var field_names: [output_fields.len][]const u8 = undefined;
+    inline for (output_fields, 0..) |field, i| {
+        field_names[i] = field.name;
+    }
+    return @Struct(
+        .auto,
+        null,
+        &field_names,
+        &@splat(?std.meta.FieldEnum(I)),
+        &@splat(.{ .default_value_ptr = &@as(?std.meta.FieldEnum(I), null) }),
+    );
 }
 
 pub fn shardingAwareTypedCustomCall(
-    I: type,
-    O: type,
-    A: type,
     comptime target_name: [:0]const u8,
     comptime opts: CustomCallOptions,
-    args: CustomCallArgs(I, O, A),
-) ShapeToTensor(O) {
+    input: anytype,
+    output: anytype,
+    attributes: anytype,
+) ShapeToTensor(@TypeOf(output)) {
+    const Input = @TypeOf(input);
+    const Output = @TypeOf(output);
+    const Attributes = @TypeOf(attributes);
+
     // Convert to slices so that manualComputationInternal can inspect the input/output.
-    var input_tensors: [@typeInfo(@TypeOf(args.input_tensors)).@"struct".fields.len]Tensor = undefined;
-    inline for (@typeInfo(@TypeOf(args.input_tensors)).@"struct".fields, 0..) |field, i| {
-        input_tensors[i] = @field(args.input_tensors, field.name);
+    var input_tensors: [@typeInfo(Input).@"struct".fields.len]Tensor = undefined;
+    inline for (@typeInfo(Input).@"struct".fields, 0..) |field, i| {
+        input_tensors[i] = @field(input, field.name);
     }
 
-    var output_shapes: [@typeInfo(@TypeOf(args.output_shapes)).@"struct".fields.len]Shape = undefined;
-    inline for (@typeInfo(@TypeOf(args.output_shapes)).@"struct".fields, 0..) |field, i| {
-        output_shapes[i] = @field(args.output_shapes, field.name);
+    var output_shapes: [@typeInfo(Output).@"struct".fields.len]Shape = undefined;
+    inline for (@typeInfo(Output).@"struct".fields, 0..) |field, i| {
+        output_shapes[i] = @field(output, field.name);
     }
 
-    const output_tensors = manualComputationInternal(&input_tensors, &output_shapes, args.attributes, (struct {
-        fn body(attributes: A, _: std.mem.Allocator, sharded_input_tensors: []const Tensor, sharded_output_shapes: []const Shape) []const Tensor {
+    const output_tensors = manualComputationInternal(&input_tensors, &output_shapes, attributes, (struct {
+        fn body(attributes_: Attributes, _: std.mem.Allocator, sharded_input_tensors: []const Tensor, sharded_output_shapes: []const Shape) []const Tensor {
             return typedCustomCall(
-                []const Tensor,
-                []const Shape,
-                A,
                 target_name,
                 opts,
-                .{
-                    .input_tensors = sharded_input_tensors,
-                    .output_shapes = sharded_output_shapes,
-                    .attributes = attributes,
-                },
+                sharded_input_tensors,
+                sharded_output_shapes,
+                attributes_,
             );
         }
     }).body);
 
     // Convert the slice back to a struct
-    var out: ShapeToTensor(O) = undefined;
-    inline for (@typeInfo(@TypeOf(args.output_shapes)).@"struct".fields, 0..) |field, i| {
+    var out: ShapeToTensor(Output) = undefined;
+    inline for (@typeInfo(Output).@"struct".fields, 0..) |field, i| {
         @field(out, field.name) = output_tensors[i];
     }
     return out;
 }
 
 pub fn typedCustomCall(
-    I: type,
-    O: type,
-    A: type,
-    comptime target_name: [:0]const u8,
-    comptime opts: CustomCallOptions,
-    args: CustomCallArgs(I, O, A),
-) ShapeToTensor(O) {
+    target_name: [:0]const u8,
+    opts: CustomCallOptions,
+    input: anytype,
+    output: anytype,
+    attributes: anytype,
+) ShapeToTensor(@TypeOf(output)) {
+    const Input = @TypeOf(input);
+    const Output = @TypeOf(output);
+    const Attributes = @TypeOf(attributes);
+
     const ctx = CompilationContext.current();
     const allocator = ctx.arena.allocator();
 
     stdx.debug.assert(!opts.has_side_effect or ctx.manual_computation_depth > 0, "side-effect customCall '{s}' must be emitted inside manualComputation", .{target_name});
 
-    const input_tensors: []const Tensor = switch (@typeInfo(@TypeOf(args.input_tensors))) {
+    const input_tensors: []const Tensor = switch (@typeInfo(Input)) {
         .@"struct" => |struct_info| b: {
             var input_tensors: [struct_info.fields.len]Tensor = undefined;
             inline for (struct_info.fields, 0..) |field, i| {
-                input_tensors[i] = @field(args.input_tensors, field.name);
+                input_tensors[i] = @field(input, field.name);
             }
             break :b &input_tensors;
         },
         // Extra case to support []const Tensor from shardingAwareTypedCustomCall
         .pointer => |pointer_info| b: {
             if (pointer_info.size != .slice) @compileError("Expected input slice");
-            break :b args.input_tensors;
+            break :b input;
         },
-        else => @compileError("Unsupported input type: " ++ @typeName(@TypeOf(args.input_tensor))),
+        else => @compileError("Unsupported input type: " ++ @typeName(Input)),
     };
 
-    const output_shapes: []const Shape = switch (@typeInfo(@TypeOf(args.output_shapes))) {
+    const output_shapes: []const Shape = switch (@typeInfo(Output)) {
         .@"struct" => |struct_info| b: {
             var output_shapes: [struct_info.fields.len]Shape = undefined;
             inline for (struct_info.fields, 0..) |field, i| {
-                output_shapes[i] = @field(args.output_shapes, field.name);
+                output_shapes[i] = @field(output, field.name);
             }
             break :b &output_shapes;
         },
         // Extra case to support []const Shape from shardingAwareTypedCustomCall
         .pointer => |pointer_info| b: {
             if (pointer_info.size != .slice) @compileError("Expected input slice");
-            break :b args.output_shapes;
+            break :b output;
         },
-        else => @compileError("Unsupported input type: " ++ @typeName(@TypeOf(args.input_tensor))),
+        else => @compileError("Unsupported output type: " ++ @typeName(Output)),
     };
 
-    const metadata_attributes =
-        switch (@typeInfo(@TypeOf(args.attributes))) {
-            .@"struct" => |struct_info| b: {
-                var mlir_attributes_array: [struct_info.fields.len]mlir.NamedAttribute = undefined;
-                inline for (struct_info.fields, 0..) |field, i| {
-                    const attribute: *const mlir.Attribute = switch (@typeInfo(field.type)) {
-                        .comptime_int => mlir.integerAttribute(ctx.mlir_ctx, .u64, @as(u64, @field(args.attributes, field.name))),
-                        .int => |int_field| switch (int_field.signedness) {
-                            .signed => switch (int_field.bits) {
-                                8 => mlir.integerAttribute(ctx.mlir_ctx, .i8, @field(args.attributes, field.name)),
-                                16 => mlir.integerAttribute(ctx.mlir_ctx, .i16, @field(args.attributes, field.name)),
-                                32 => mlir.integerAttribute(ctx.mlir_ctx, .i32, @field(args.attributes, field.name)),
-                                64 => mlir.integerAttribute(ctx.mlir_ctx, .i64, @field(args.attributes, field.name)),
-                                else => @panic("Unsupported DataType"),
-                            },
-                            .unsigned => switch (int_field.bits) {
-                                8 => mlir.integerAttribute(ctx.mlir_ctx, .u8, @field(args.attributes, field.name)),
-                                16 => mlir.integerAttribute(ctx.mlir_ctx, .u16, @field(args.attributes, field.name)),
-                                32 => mlir.integerAttribute(ctx.mlir_ctx, .u32, @field(args.attributes, field.name)),
-                                64 => mlir.integerAttribute(ctx.mlir_ctx, .u64, @field(args.attributes, field.name)),
-                                else => @panic("Unsupported DataType"),
-                            },
-                        },
-                        .float => |float_field| switch (float_field.bits) {
-                            16 => mlir.floatAttribute(ctx.mlir_ctx, .f16, @as(f64, @field(args.attributes, field.name))),
-                            32 => mlir.floatAttribute(ctx.mlir_ctx, .f32, @as(f64, @field(args.attributes, field.name))),
-                            64 => mlir.floatAttribute(ctx.mlir_ctx, .f64, @as(f64, @field(args.attributes, field.name))),
-                            else => @panic("Unsupported DataType"),
-                        },
-                        .bool => mlir.boolAttribute(ctx.mlir_ctx, @field(args.attributes, field.name)),
-                        .pointer => |pointer_info| switch (pointer_info.size) {
-                            .slice => if (pointer_info.child == u8)
-                                mlir.stringAttribute(ctx.mlir_ctx, @field(args.attributes, field.name))
-                            else
-                                @panic("Unsupported pointer type in metadata"),
-                            else => @panic("Unsupported pointer type in metadata"),
-                        },
-                        else => @compileError("Unsupported metadata type: " ++ @typeName(field.type)),
-                    };
-                    mlir_attributes_array[i] = mlir.NamedAttribute.named(ctx.mlir_ctx, field.name, attribute);
-                }
-
-                break :b mlir_attributes_array;
-            },
-            else => @compileError("Unsupported type: " ++ @typeName(@TypeOf(args.attributes))),
-        };
+    var metadata_attribute_list = switch (@typeInfo(Attributes)) {
+        .void => std.ArrayList(mlir.NamedAttribute).initCapacity(allocator, 2) catch unreachable,
+        .@"struct" => |struct_info| std.ArrayList(mlir.NamedAttribute).initCapacity(allocator, struct_info.fields.len + 2) catch unreachable,
+        else => @compileError("Unsupported type: " ++ @typeName(Attributes)),
+    };
+    if (@typeInfo(Attributes) == .@"struct") {
+        inline for (@typeInfo(Attributes).@"struct".fields) |field| {
+            if (metadataFieldToMlirAttribute(ctx.mlir_ctx, field.type, @field(attributes, field.name))) |attribute| {
+                metadata_attribute_list.appendAssumeCapacity(mlir.NamedAttribute.named(ctx.mlir_ctx, field.name, attribute));
+            }
+        }
+    }
+    metadata_attribute_list.appendSliceAssumeCapacity(&[_]mlir.NamedAttribute{
+        .named(ctx.mlir_ctx, "pjrt_api", mlir.integerAttribute(ctx.mlir_ctx, .u64, @as(u64, @bitCast(@intFromPtr(ctx.platform.pjrt_api))))),
+        .named(ctx.mlir_ctx, "pjrt_client", mlir.integerAttribute(ctx.mlir_ctx, .u64, @as(u64, @bitCast(@intFromPtr(ctx.platform.pjrt_client))))),
+    });
 
     const values = allocator.alloc(*const mlir.Value, input_tensors.len) catch unreachable;
     const input_shapes = allocator.alloc(Shape, input_tensors.len) catch unreachable;
-    for (input_tensors, 0..) |input, i| {
-        values[i] = input.value();
-        input_shapes[i] = input.shape();
+    for (input_tensors, 0..) |input_tensor, i| {
+        values[i] = input_tensor.value();
+        input_shapes[i] = input_tensor.shape();
     }
 
     const result_types = allocator.alloc(*const mlir.Type, output_shapes.len) catch unreachable;
@@ -1875,10 +1792,7 @@ pub fn typedCustomCall(
         result_types[i] = mlir.rankedTensorType(shape.dims(), mlirx.Type.fromDType(ctx.mlir_ctx, shape.dtype()));
     }
 
-    const backend_config = mlir.dictionaryAttribute(ctx.mlir_ctx, &(metadata_attributes ++ [_]mlir.NamedAttribute{
-        .named(ctx.mlir_ctx, "pjrt_api", mlir.integerAttribute(ctx.mlir_ctx, .u64, @as(u64, @bitCast(@intFromPtr(ctx.platform.pjrt_api))))),
-        .named(ctx.mlir_ctx, "pjrt_client", mlir.integerAttribute(ctx.mlir_ctx, .u64, @as(u64, @bitCast(@intFromPtr(ctx.platform.pjrt_client))))),
-    }));
+    const backend_config = mlir.dictionaryAttribute(ctx.mlir_ctx, metadata_attribute_list.items);
 
     const operand_layouts = allocator.alloc([]const usize, input_shapes.len) catch unreachable;
     for (input_shapes, 0..) |shape, i| {
@@ -1901,7 +1815,7 @@ pub fn typedCustomCall(
             .operand_layouts = operand_layouts,
             .result_layouts = result_layouts,
             .output_operand_aliases = opts.output_operand_aliases orelse &.{},
-            .additional_attributes = &.{},
+            .additional_attributes = customCallAdditionalAttributes(ctx, opts),
         },
         .unknown(ctx.mlir_ctx),
     ).appendTo(ctx.currentScope().block);
@@ -1910,9 +1824,9 @@ pub fn typedCustomCall(
         op.setAttributeByName("mhlo.sharding", mlir.stringAttribute(ctx.mlir_ctx, "{manual}"));
     }
 
-    switch (@typeInfo(@TypeOf(args.output_shapes))) {
+    switch (@typeInfo(Output)) {
         .@"struct" => |struct_info| {
-            var out: ShapeToTensor(O) = undefined;
+            var out: ShapeToTensor(Output) = undefined;
             inline for (output_shapes, struct_info.fields, 0..) |output_shape, field, i| {
                 @field(out, field.name) = Tensor._result(output_shape, op.result(i));
             }
@@ -1921,13 +1835,13 @@ pub fn typedCustomCall(
         // Extra case to support []const Shape from shardingAwareTypedCustomCall
         .pointer => |pointer_info| {
             if (pointer_info.size != .slice) @compileError("Expected input slice");
-            var out: []Tensor = allocator.alloc(Tensor, args.output_shapes.len) catch unreachable;
+            var out: []Tensor = allocator.alloc(Tensor, output_shapes.len) catch unreachable;
             for (output_shapes, 0..) |output_shape, i| {
                 out[i] = Tensor._result(output_shape, op.result(i));
             }
             return out;
         },
-        else => @compileError("Unsupported input type: " ++ @typeName(@TypeOf(args.input_tensor))),
+        else => @compileError("Unsupported output type: " ++ @typeName(Output)),
     }
 }
 
@@ -1948,12 +1862,20 @@ fn customCallArgsFromPjrtCallFrame(I: type, O: type, A: type, call_frame: *pjrt.
         @field(output, field.name) = .fromPjrt(shape_buf);
     }
 
-    var attributes: A = undefined;
-    inline for (@typeInfo(A).@"struct".fields) |field| {
-        const attribute = call_frame.attrs.getByName(.scalar, field.name) orelse
-            @panic("Attribute not found: " ++ field.name);
-        @field(attributes, field.name) = attribute.get(field.type);
-    }
+    const attributes: A = switch (@typeInfo(A)) {
+        .void => {},
+        .@"struct" => blk: {
+            var attrs: A = undefined;
+            inline for (@typeInfo(A).@"struct".fields) |field| {
+                // TODO: Use getByIndex instead?
+                const attribute = call_frame.attrs.getByName(.scalar, field.name) orelse
+                    @panic("Attribute not found: " ++ field.name);
+                @field(attrs, field.name) = attribute.get(field.type);
+            }
+            break :blk attrs;
+        },
+        else => @compileError("Unsupported attributes type: " ++ @typeName(A)),
+    };
 
     return .{ input, output, attributes };
 }

--- a/zml/pjrtx.zig
+++ b/zml/pjrtx.zig
@@ -5,7 +5,9 @@ const mlir = @import("mlir");
 const pjrt = @import("pjrt");
 
 pub const DataType = @import("dtype.zig").DataType;
+const meta = @import("meta.zig");
 const Shape = @import("shape.zig").Shape;
+const Tensor = @import("tensor.zig").Tensor;
 
 const log = std.log.scoped(.@"zml/pjrtx");
 
@@ -43,6 +45,14 @@ pub const Client = opaque {
     }
 };
 
+pub fn TensorToCustomCallBuffer(T: type) type {
+    return meta.MapRestrict(Tensor, CustomCallBuffer).map(T);
+}
+
+pub fn ShapeToCustomCallBuffer(T: type) type {
+    return meta.MapRestrict(Shape, CustomCallBuffer).map(T);
+}
+
 pub const CustomCallBuffer = struct {
     shape: Shape,
     ptr: *anyopaque,
@@ -64,6 +74,24 @@ pub const CustomCallBuffer = struct {
             .ptr = buffer.data,
             .shape = .init(buffer.dims(), dt),
         };
+    }
+
+    // Assumes as host-side buffer
+    pub fn asHostSlice(self: CustomCallBuffer) []u8 {
+        const bytes: [*]u8 = @ptrCast(@alignCast(self.ptr));
+        return bytes[0..self.shape.byteSize()];
+    }
+
+    // Assumes as host-side buffer
+    pub fn asHostConstSlice(self: CustomCallBuffer) []const u8 {
+        const bytes: [*]const u8 = @ptrCast(@alignCast(self.ptr));
+        return bytes[0..self.shape.byteSize()];
+    }
+
+    // Assumes as host-side buffer
+    pub fn asHostScalar(self: CustomCallBuffer, T: type) T {
+        std.debug.assert(self.shape.byteSize() == @sizeOf(T));
+        return std.mem.bytesAsValue(T, self.asHostConstSlice()[0..@sizeOf(T)]).*;
     }
 };
 

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -182,7 +182,7 @@ pub const Tensor = struct {
         return _result(partitioned_shape, op_result);
     }
 
-    pub fn toMemory(self: Tensor, kind: Memory) Tensor {
+    pub fn toMemory(self: Tensor, kind: Memory.Kind) Tensor {
         const ctx = CompilationContext.current();
         if (ctx.platform.target == .cpu) return self;
 


### PR DESCRIPTION
Simple reference implementation of attnd client as a attention backend relying on POSIX. I've tried various things with `sendmmsg`/`recvmmsg` and `io_uring` out of curiosity but they weren't worth the extra code here.

The integration as a attention backend is a bit clunky, we're still allocating a KV cache and there are a few panics here and there because the current initialization mechanism of attention backend doesn't work for attnd, but that's something for later.