### PR TITLE
bin/zml-smi: add prometheus endpoint, json and macos host infos

### DIFF
--- a/bin/zml-smi/BUILD.bazel
+++ b/bin/zml-smi/BUILD.bazel
@@ -1,10 +1,10 @@
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@bazel_lib//tools/release:hashes.bzl", "hashes")
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_library")
 load("@tar.bzl//tar:mtree.bzl", "mtree_spec")
-load("@bazel_lib//tools/release:hashes.bzl", "hashes")
 load("@tar.bzl//tar:tar.bzl", "tar")
 
 # zig libraries
@@ -62,6 +62,19 @@ copy_to_directory(
     },
 )
 
+run_binary(
+    name = "zml-smi.stripped",
+    srcs = [":zml-smi"],
+    outs = ["zml-smi.stripped.bin"],
+    args = [
+        "--strip-all",
+        "-o",
+        "$(location zml-smi.stripped.bin)",
+        "$(location :zml-smi)",
+    ],
+    tool = "@llvm//tools:llvm-strip",
+)
+
 zig_binary(
     name = "zml-smi",
     visibility = ["//visibility:public"],
@@ -95,7 +108,10 @@ zig_binary(
 
 mtree_spec(
     name = "mtree_spec",
-    srcs = [":zml-smi"],
+    srcs = [
+        ":zml-smi",
+        ":zml-smi.stripped",
+    ],
     tags = ["manual"],
 )
 
@@ -104,7 +120,7 @@ genrule(
     name = "mtree",
     srcs = [":mtree_spec"],
     outs = ["mtree.txt"],
-    cmd = """sed -e '/type=dir/d' -e 's#^bin/##g' $< > $@""",
+    cmd = """sed -e '/type=dir/d' -e '/zml-smi\\/zml-smi /d' -e 's#^bin/##g' -e 's#zml-smi\\.stripped\\.bin#zml-smi#' -e '/stamp.c/d' $< > $@""",
     tags = ["manual"],
 )
 
@@ -126,7 +142,10 @@ _RELEASE_PLATFORMS = [
 
 [tar(
     name = "archive_" + os + "_" + arch,
-    srcs = [":zml-smi"],
+    srcs = [
+        ":zml-smi",
+        ":zml-smi.stripped",
+    ],
     out = "zml-smi-" + os + "-" + arch + ".tar.zst",
     args = [
         "--options",

--- a/bin/zml-smi/BUILD.bazel
+++ b/bin/zml-smi/BUILD.bazel
@@ -71,6 +71,7 @@ zig_binary(
         "//bin/zml-smi/csv",
         "//bin/zml-smi/json",
         "//bin/zml-smi/api",
+        "//bin/zml-smi/prometheus",
         "//bin/zml-smi/info",
         "//bin/zml-smi/tui",
         "//stdx",

--- a/bin/zml-smi/BUILD.bazel
+++ b/bin/zml-smi/BUILD.bazel
@@ -69,7 +69,8 @@ zig_binary(
     deps = [
         "//bin/zml-smi/collector",
         "//bin/zml-smi/csv",
-        "//bin/zml-smi/platforms/linux",
+        "//bin/zml-smi/json",
+        "//bin/zml-smi/api",
         "//bin/zml-smi/info",
         "//bin/zml-smi/tui",
         "//stdx",

--- a/bin/zml-smi/BUILD.bazel
+++ b/bin/zml-smi/BUILD.bazel
@@ -65,11 +65,11 @@ copy_to_directory(
 run_binary(
     name = "zml-smi.stripped",
     srcs = [":zml-smi"],
-    outs = ["zml-smi.stripped.bin"],
+    outs = ["zml-smi.stripped"],
     args = [
         "--strip-all",
         "-o",
-        "$(location zml-smi.stripped.bin)",
+        "$(location zml-smi.stripped)",
         "$(location :zml-smi)",
     ],
     tool = "@llvm//tools:llvm-strip",
@@ -120,7 +120,7 @@ genrule(
     name = "mtree",
     srcs = [":mtree_spec"],
     outs = ["mtree.txt"],
-    cmd = """sed -e '/type=dir/d' -e '/zml-smi\\/zml-smi /d' -e 's#^bin/##g' -e 's#zml-smi\\.stripped\\.bin#zml-smi#' -e '/stamp.c/d' $< > $@""",
+    cmd = """sed -e '/type=dir/d' -e '/zml-smi\\/zml-smi /d' -e 's#^bin/##g' -e 's#zml-smi\\.stripped#zml-smi#' -e '/stamp.c/d' $< > $@""",
     tags = ["manual"],
 )
 

--- a/bin/zml-smi/BUILD.bazel
+++ b/bin/zml-smi/BUILD.bazel
@@ -115,18 +115,18 @@ genrule(
 # )
 
 # Release archives, one per platform, correctly named for distribution
-# Build one:  bazel build --config=release //bin/zml-smi:zml-smi-linux-x86_64
+# Build one:  bazel build --config=release //bin/zml-smi:zml-smi-linux-amd64
 # Build all:  bazel build --config=release //bin/zml-smi:release
 
 _RELEASE_PLATFORMS = [
-    ("linux_amd64", "linux", "x86_64"),
-    ("linux_arm64", "linux", "aarch64"),
-    ("macos_amd64", "macos", "x86_64"),
-    ("macos_arm64", "macos", "aarch64"),
+    ("linux", "amd64"),
+    ("linux", "arm64"),
+    ("macos", "amd64"),
+    ("macos", "arm64"),
 ]
 
 [tar(
-    name = "archive_" + plat,
+    name = "archive_" + os + "_" + arch,
     srcs = [":zml-smi"],
     out = "zml-smi-" + os + "-" + arch + ".tar.zst",
     args = [
@@ -139,25 +139,25 @@ _RELEASE_PLATFORMS = [
     compress = "zstd",
     mtree = ":mtree",
     tags = ["manual"],
-) for plat, os, arch in _RELEASE_PLATFORMS]
+) for os, arch in _RELEASE_PLATFORMS]
 
 [platform_transition_filegroup(
     name = "zml-smi-" + os + "-" + arch,
-    srcs = [":archive_" + plat],
-    target_platform = "//platforms:" + plat,
+    srcs = [":archive_" + os + "_" + arch],
+    target_platform = "//platforms:" + os + "_" + arch,
     tags = ["manual"],
-) for plat, os, arch in _RELEASE_PLATFORMS]
+) for os, arch in _RELEASE_PLATFORMS]
 
 [hashes(
     name = "zml-smi-" + os + "-" + arch + ".sha256",
     src = ":zml-smi-" + os + "-" + arch,
     tags = ["manual"],
-) for _, os, arch in _RELEASE_PLATFORMS]
+) for os, arch in _RELEASE_PLATFORMS]
 
 filegroup(
     name = "release",
-    srcs = [":zml-smi-" + os + "-" + arch for _, os, arch in _RELEASE_PLATFORMS] +
-           [":zml-smi-" + os + "-" + arch + ".sha256" for _, os, arch in _RELEASE_PLATFORMS],
+    srcs = [":zml-smi-" + os + "-" + arch for os, arch in _RELEASE_PLATFORMS] +
+           [":zml-smi-" + os + "-" + arch + ".sha256" for os, arch in _RELEASE_PLATFORMS],
     tags = ["manual"],
 )
 

--- a/bin/zml-smi/BUILD.bazel
+++ b/bin/zml-smi/BUILD.bazel
@@ -77,8 +77,9 @@ zig_binary(
         "@libvaxis//:vaxis",
         "@rules_zig//zig/runfiles",
     ] + select({
-        "@platforms//os:macos": [],
+        "@platforms//os:macos": ["//bin/zml-smi/platforms/macos"],
         "//conditions:default": [
+            "//bin/zml-smi/platforms/linux",
             "//bin/zml-smi/platforms/amdsmi",
             "//bin/zml-smi/platforms/neuron",
             "//bin/zml-smi/platforms/nvml",

--- a/bin/zml-smi/BUILD.bazel
+++ b/bin/zml-smi/BUILD.bazel
@@ -116,12 +116,11 @@ genrule(
 
 # Release archives, one per platform, correctly named for distribution
 # Build one:  bazel build --config=release //bin/zml-smi:zml-smi-linux-amd64
-# Build all:  bazel build --config=release //bin/zml-smi:release
+# Build all:  bazel build --config=release //bin/zml-smi:archives
 
 _RELEASE_PLATFORMS = [
     ("linux", "amd64"),
     ("linux", "arm64"),
-    ("macos", "amd64"),
     ("macos", "arm64"),
 ]
 
@@ -154,8 +153,14 @@ _RELEASE_PLATFORMS = [
     tags = ["manual"],
 ) for os, arch in _RELEASE_PLATFORMS]
 
-filegroup(
+sh_binary(
     name = "release",
+    srcs = ["scripts/release.sh"],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "archives",
     srcs = [":zml-smi-" + os + "-" + arch for os, arch in _RELEASE_PLATFORMS] +
            [":zml-smi-" + os + "-" + arch + ".sha256" for os, arch in _RELEASE_PLATFORMS],
     tags = ["manual"],

--- a/bin/zml-smi/BUILD.bazel
+++ b/bin/zml-smi/BUILD.bazel
@@ -4,6 +4,7 @@ load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_library")
 load("@tar.bzl//tar:mtree.bzl", "mtree_spec")
+load("@bazel_lib//tools/release:hashes.bzl", "hashes")
 load("@tar.bzl//tar:tar.bzl", "tar")
 
 # zig libraries
@@ -113,9 +114,21 @@ genrule(
 #     strip_prefix = "bin",
 # )
 
-tar(
-    name = "archive",
+# Release archives, one per platform, correctly named for distribution
+# Build one:  bazel build --config=release //bin/zml-smi:zml-smi-linux-x86_64
+# Build all:  bazel build --config=release //bin/zml-smi:release
+
+_RELEASE_PLATFORMS = [
+    ("linux_amd64", "linux", "x86_64"),
+    ("linux_arm64", "linux", "aarch64"),
+    ("macos_amd64", "macos", "x86_64"),
+    ("macos_arm64", "macos", "aarch64"),
+]
+
+[tar(
+    name = "archive_" + plat,
     srcs = [":zml-smi"],
+    out = "zml-smi-" + os + "-" + arch + ".tar.zst",
     args = [
         "--options",
         ",".join([
@@ -126,6 +139,26 @@ tar(
     compress = "zstd",
     mtree = ":mtree",
     tags = ["manual"],
+) for plat, os, arch in _RELEASE_PLATFORMS]
+
+[platform_transition_filegroup(
+    name = "zml-smi-" + os + "-" + arch,
+    srcs = [":archive_" + plat],
+    target_platform = "//platforms:" + plat,
+    tags = ["manual"],
+) for plat, os, arch in _RELEASE_PLATFORMS]
+
+[hashes(
+    name = "zml-smi-" + os + "-" + arch + ".sha256",
+    src = ":zml-smi-" + os + "-" + arch,
+    tags = ["manual"],
+) for _, os, arch in _RELEASE_PLATFORMS]
+
+filegroup(
+    name = "release",
+    srcs = [":zml-smi-" + os + "-" + arch for _, os, arch in _RELEASE_PLATFORMS] +
+           [":zml-smi-" + os + "-" + arch + ".sha256" for _, os, arch in _RELEASE_PLATFORMS],
+    tags = ["manual"],
 )
 
 oci_image(
@@ -133,7 +166,7 @@ oci_image(
     base = "@distroless_cc_debian12",
     entrypoint = ["/zml-smi/zml-smi"],
     tars = [
-        ":archive",
+        ":archive_linux_amd64",
     ],
     tags = ["manual"],
 )

--- a/bin/zml-smi/api/BUILD.bazel
+++ b/bin/zml-smi/api/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_zig//zig:defs.bzl", "zig_library")
+
+zig_library(
+    name = "api",
+    import_name = "zml-smi/api",
+    main = "api.zig",
+    srcs = [
+        "client.zig",
+        "server.zig",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//bin/zml-smi/collector",
+        "//bin/zml-smi/info",
+        "//bin/zml-smi/json",
+        "//bin/zml-smi/utils:double_buffer",
+    ],
+)

--- a/bin/zml-smi/api/BUILD.bazel
+++ b/bin/zml-smi/api/BUILD.bazel
@@ -14,5 +14,8 @@ zig_library(
         "//bin/zml-smi/info",
         "//bin/zml-smi/json",
         "//bin/zml-smi/utils:double_buffer",
-    ],
+    ] + select({
+        "@platforms//os:macos": ["//bin/zml-smi/platforms/macos"],
+        "//conditions:default": ["//bin/zml-smi/platforms/linux"],
+    }),
 )

--- a/bin/zml-smi/api/api.zig
+++ b/bin/zml-smi/api/api.zig
@@ -1,0 +1,2 @@
+pub const Server = @import("server.zig").Server;
+pub const addRemotes = @import("client.zig").addRemotes;

--- a/bin/zml-smi/api/client.zig
+++ b/bin/zml-smi/api/client.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const smi_info = @import("zml-smi/info");
 const DeviceInfo = smi_info.device_info.DeviceInfo;
+const pi = smi_info.process_info;
+const ProcessDoubleBuffer = @import("zml-smi/double_buffer").DoubleBuffer(std.ArrayList(pi.ProcessInfo));
 const Collector = @import("zml-smi/collector").Collector;
 
 const JsonDeviceInfo = struct {
@@ -11,9 +13,10 @@ const JsonDeviceInfo = struct {
 
         inline for (@typeInfo(DeviceInfo).@"union".fields) |field| {
             if (std.mem.eql(u8, type_str, field.name)) {
-                const val = try std.json.innerParseFromValue(field.type.Value, allocator, source, .{
+                var val = try std.json.innerParseFromValue(field.type.Value, allocator, source, .{
                     .ignore_unknown_fields = true,
                 });
+                val.remote = true;
 
                 return .{ .device = @unionInit(DeviceInfo, field.name, .{ .values = .{ val, val } }) };
             }
@@ -38,10 +41,13 @@ fn addHost(collector: *Collector, host: []const u8) !void {
     const parsed = try std.json.parseFromSlice(std.json.Value, collector.gpa, body, .{});
     defer parsed.deinit();
 
-    const json_items = parsed.value.array.items;
+    const root = parsed.value.object;
+    const json_devices = if (root.get("devices")) |v| v.array.items else &.{};
+
+    const dev_offset: u8 = @intCast(collector.device_infos.items.len);
 
     var devices: std.ArrayList(*DeviceInfo) = .empty;
-    for (json_items) |item| {
+    for (json_devices) |item| {
         const jdi = std.json.parseFromValueLeaky(JsonDeviceInfo, collector.arena, item, .{}) catch continue;
         const info = try collector.addDevice(jdi.device);
         try devices.append(collector.arena, info);
@@ -51,12 +57,26 @@ fn addHost(collector: *Collector, host: []const u8) !void {
         return;
     }
 
+    const processes = try collector.createProcessList();
+    const str_arenas: [2]*std.heap.ArenaAllocator = .{ try collector.createPollArena(), try collector.createPollArena() };
+
+    const json_processes = if (root.get("processes")) |v| v.array.items else &.{};
+    const back_idx: usize = 1 - processes.current.load(.acquire);
+    const back = processes.back();
+    for (json_processes) |item| {
+        var proc = std.json.parseFromValueLeaky(pi.ProcessInfo, str_arenas[back_idx].allocator(), item, .{ .ignore_unknown_fields = true }) catch continue;
+        proc.device_idx +|= dev_offset;
+        proc.remote = true;
+        back.append(collector.gpa, proc) catch continue;
+    }
+    processes.swap();
+
     const url = try collector.arena.dupe(u8, host);
     const poll_arena = try collector.createPollArena();
-    try collector.spawnPoll(pollOnce, .{ poll_arena, collector.gpa, collector.io, url, devices.items });
+    try collector.spawnPoll(pollOnce, .{ poll_arena, collector.gpa, collector.io, url, devices.items, processes, dev_offset, str_arenas });
 }
 
-fn pollOnce(poll_arena: *std.heap.ArenaAllocator, gpa: std.mem.Allocator, io: std.Io, host: []const u8, devices: []const *DeviceInfo) void {
+fn pollOnce(poll_arena: *std.heap.ArenaAllocator, gpa: std.mem.Allocator, io: std.Io, host: []const u8, devices: []const *DeviceInfo, processes: *ProcessDoubleBuffer, dev_offset: u8, str_arenas: [2]*std.heap.ArenaAllocator) void {
     _ = poll_arena.reset(.retain_capacity);
 
     const body = httpGet(gpa, io, host) catch return;
@@ -65,9 +85,10 @@ fn pollOnce(poll_arena: *std.heap.ArenaAllocator, gpa: std.mem.Allocator, io: st
     const parsed = std.json.parseFromSlice(std.json.Value, gpa, body, .{}) catch return;
     defer parsed.deinit();
 
-    const json_items = parsed.value.array.items;
+    const root = parsed.value.object;
+    const json_devices = if (root.get("devices")) |v| v.array.items else &.{};
 
-    for (json_items, 0..) |item, i| {
+    for (json_devices, 0..) |item, i| {
         const jdi = std.json.parseFromValueLeaky(JsonDeviceInfo, poll_arena.allocator(), item, .{}) catch continue;
         if (i >= devices.len) {
             break;
@@ -76,10 +97,25 @@ fn pollOnce(poll_arena: *std.heap.ArenaAllocator, gpa: std.mem.Allocator, io: st
         inline for (@typeInfo(DeviceInfo).@"union".fields) |field| {
             if (devices[i].* == @field(smi_info.device_info.Target, field.name)) {
                 @field(devices[i], field.name).back().* = @field(jdi.device, field.name).front().*;
+                @field(devices[i], field.name).back().remote = true;
                 @field(devices[i], field.name).swap();
             }
         }
     }
+
+    const json_processes = if (root.get("processes")) |v| v.array.items else &.{};
+    const back_idx: usize = 1 - processes.current.load(.acquire);
+    _ = str_arenas[back_idx].reset(.retain_capacity);
+    const alloc = str_arenas[back_idx].allocator();
+    const back = processes.back();
+    back.clearRetainingCapacity();
+    for (json_processes) |item| {
+        var proc = std.json.parseFromValueLeaky(pi.ProcessInfo, alloc, item, .{ .ignore_unknown_fields = true }) catch continue;
+        proc.device_idx +|= dev_offset;
+        proc.remote = true;
+        back.append(gpa, proc) catch continue;
+    }
+    processes.swap();
 }
 
 fn httpGet(allocator: std.mem.Allocator, io: std.Io, host: []const u8) ![]const u8 {

--- a/bin/zml-smi/api/client.zig
+++ b/bin/zml-smi/api/client.zig
@@ -5,25 +5,14 @@ const pi = smi_info.process_info;
 const ProcessDoubleBuffer = @import("zml-smi/double_buffer").DoubleBuffer(std.ArrayList(pi.ProcessInfo));
 const Collector = @import("zml-smi/collector").Collector;
 
-const JsonDeviceInfo = struct {
-    device: DeviceInfo,
-
-    pub fn jsonParseFromValue(allocator: std.mem.Allocator, source: std.json.Value, _: std.json.ParseOptions) !JsonDeviceInfo {
-        const type_str = source.object.get("type").?.string;
-
-        inline for (@typeInfo(DeviceInfo).@"union".fields) |field| {
-            if (std.mem.eql(u8, type_str, field.name)) {
-                var val = try std.json.innerParseFromValue(field.type.Value, allocator, source, .{
-                    .ignore_unknown_fields = true,
-                });
-                val.remote = true;
-
-                return .{ .device = @unionInit(DeviceInfo, field.name, .{ .values = .{ val, val } }) };
-            }
+fn setRemote(device: *DeviceInfo) void {
+    inline for (@typeInfo(DeviceInfo).@"union".fields) |field| {
+        if (device.* == @field(smi_info.device_info.Target, field.name)) {
+            @field(device, field.name).values[0].remote = true;
+            @field(device, field.name).values[1].remote = true;
         }
-        return error.UnexpectedToken;
     }
-};
+}
 
 pub fn addRemotes(collector: *Collector, hosts: []const u8) !void {
     var it = std.mem.splitScalar(u8, hosts, ',');
@@ -48,8 +37,9 @@ fn addHost(collector: *Collector, host: []const u8) !void {
 
     var devices: std.ArrayList(*DeviceInfo) = .empty;
     for (json_devices) |item| {
-        const jdi = std.json.parseFromValueLeaky(JsonDeviceInfo, collector.arena, item, .{}) catch continue;
-        const info = try collector.addDevice(jdi.device);
+        var device = std.json.parseFromValueLeaky(DeviceInfo, collector.arena, item, .{ .ignore_unknown_fields = true }) catch continue;
+        setRemote(&device);
+        const info = try collector.addDevice(device);
         try devices.append(collector.arena, info);
     }
 
@@ -89,16 +79,16 @@ fn pollOnce(poll_arena: *std.heap.ArenaAllocator, gpa: std.mem.Allocator, io: st
     const json_devices = if (root.get("devices")) |v| v.array.items else &.{};
 
     for (json_devices, 0..) |item, i| {
-        const jdi = std.json.parseFromValueLeaky(JsonDeviceInfo, poll_arena.allocator(), item, .{}) catch continue;
         if (i >= devices.len) {
             std.log.warn("{s}: remote has more devices than expected ({d} > {d})", .{ host, json_devices.len, devices.len });
             break;
         }
+        var device = std.json.parseFromValueLeaky(DeviceInfo, poll_arena.allocator(), item, .{ .ignore_unknown_fields = true }) catch continue;
+        setRemote(&device);
 
         inline for (@typeInfo(DeviceInfo).@"union".fields) |field| {
             if (devices[i].* == @field(smi_info.device_info.Target, field.name)) {
-                @field(devices[i], field.name).back().* = @field(jdi.device, field.name).front().*;
-                @field(devices[i], field.name).back().remote = true;
+                @field(devices[i], field.name).back().* = @field(device, field.name).front().*;
                 @field(devices[i], field.name).swap();
             }
         }

--- a/bin/zml-smi/api/client.zig
+++ b/bin/zml-smi/api/client.zig
@@ -1,0 +1,106 @@
+const std = @import("std");
+const smi_info = @import("zml-smi/info");
+const DeviceInfo = smi_info.device_info.DeviceInfo;
+const Collector = @import("zml-smi/collector").Collector;
+
+const JsonDeviceInfo = struct {
+    device: DeviceInfo,
+
+    pub fn jsonParseFromValue(allocator: std.mem.Allocator, source: std.json.Value, _: std.json.ParseOptions) !JsonDeviceInfo {
+        const type_str = source.object.get("type").?.string;
+
+        inline for (@typeInfo(DeviceInfo).@"union".fields) |field| {
+            if (std.mem.eql(u8, type_str, field.name)) {
+                const val = try std.json.innerParseFromValue(field.type.Value, allocator, source, .{
+                    .ignore_unknown_fields = true,
+                });
+
+                return .{ .device = @unionInit(DeviceInfo, field.name, .{ .values = .{ val, val } }) };
+            }
+        }
+        return error.UnexpectedToken;
+    }
+};
+
+pub fn addRemotes(collector: *Collector, hosts: []const u8) !void {
+    var it = std.mem.splitScalar(u8, hosts, ',');
+    while (it.next()) |host| {
+        addHost(collector, host) catch |err| {
+            std.log.err("{s}: {s}", .{ host, @errorName(err) });
+        };
+    }
+}
+
+fn addHost(collector: *Collector, host: []const u8) !void {
+    const body = try httpGet(collector.gpa, collector.io, host);
+    defer collector.gpa.free(body);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, collector.gpa, body, .{});
+    defer parsed.deinit();
+
+    const json_items = parsed.value.array.items;
+
+    var devices: std.ArrayList(*DeviceInfo) = .empty;
+    for (json_items) |item| {
+        const jdi = std.json.parseFromValueLeaky(JsonDeviceInfo, collector.arena, item, .{}) catch continue;
+        const info = try collector.addDevice(jdi.device);
+        try devices.append(collector.arena, info);
+    }
+
+    if (devices.items.len == 0) {
+        return;
+    }
+
+    const url = try collector.arena.dupe(u8, host);
+    const poll_arena = try collector.createPollArena();
+    try collector.spawnPoll(pollOnce, .{ poll_arena, collector.gpa, collector.io, url, devices.items });
+}
+
+fn pollOnce(poll_arena: *std.heap.ArenaAllocator, gpa: std.mem.Allocator, io: std.Io, host: []const u8, devices: []const *DeviceInfo) void {
+    _ = poll_arena.reset(.retain_capacity);
+
+    const body = httpGet(gpa, io, host) catch return;
+    defer gpa.free(body);
+
+    const parsed = std.json.parseFromSlice(std.json.Value, gpa, body, .{}) catch return;
+    defer parsed.deinit();
+
+    const json_items = parsed.value.array.items;
+
+    for (json_items, 0..) |item, i| {
+        const jdi = std.json.parseFromValueLeaky(JsonDeviceInfo, poll_arena.allocator(), item, .{}) catch continue;
+        if (i >= devices.len) {
+            break;
+        }
+
+        inline for (@typeInfo(DeviceInfo).@"union".fields) |field| {
+            if (devices[i].* == @field(smi_info.device_info.Target, field.name)) {
+                @field(devices[i], field.name).back().* = @field(jdi.device, field.name).front().*;
+                @field(devices[i], field.name).swap();
+            }
+        }
+    }
+}
+
+fn httpGet(allocator: std.mem.Allocator, io: std.Io, host: []const u8) ![]const u8 {
+    const url = try std.fmt.allocPrint(allocator, "{s}/metrics", .{host});
+    defer allocator.free(url);
+
+    var client: std.http.Client = .{ .allocator = allocator, .io = io };
+    defer client.deinit();
+
+    var aw: std.Io.Writer.Allocating = .init(allocator);
+    errdefer aw.deinit();
+
+    const result = try client.fetch(.{
+        .location = .{ .url = url },
+        .response_writer = &aw.writer,
+    });
+
+    if (result.status != .ok) {
+        aw.deinit();
+        return error.HttpError;
+    }
+
+    return try aw.toOwnedSlice();
+}

--- a/bin/zml-smi/api/client.zig
+++ b/bin/zml-smi/api/client.zig
@@ -44,7 +44,7 @@ fn addHost(collector: *Collector, host: []const u8) !void {
     const root = parsed.value.object;
     const json_devices = if (root.get("devices")) |v| v.array.items else &.{};
 
-    const dev_offset: u8 = @intCast(collector.device_infos.items.len);
+    const dev_offset: u16 = @intCast(collector.device_infos.items.len);
 
     var devices: std.ArrayList(*DeviceInfo) = .empty;
     for (json_devices) |item| {
@@ -65,7 +65,7 @@ fn addHost(collector: *Collector, host: []const u8) !void {
     const back = processes.back();
     for (json_processes) |item| {
         var proc = std.json.parseFromValueLeaky(pi.ProcessInfo, str_arenas[back_idx].allocator(), item, .{ .ignore_unknown_fields = true }) catch continue;
-        proc.device_idx +|= dev_offset;
+        proc.device_idx += dev_offset;
         proc.remote = true;
         back.append(collector.gpa, proc) catch continue;
     }
@@ -76,7 +76,7 @@ fn addHost(collector: *Collector, host: []const u8) !void {
     try collector.spawnPoll(pollOnce, .{ poll_arena, collector.gpa, collector.io, url, devices.items, processes, dev_offset, str_arenas });
 }
 
-fn pollOnce(poll_arena: *std.heap.ArenaAllocator, gpa: std.mem.Allocator, io: std.Io, host: []const u8, devices: []const *DeviceInfo, processes: *ProcessDoubleBuffer, dev_offset: u8, str_arenas: [2]*std.heap.ArenaAllocator) void {
+fn pollOnce(poll_arena: *std.heap.ArenaAllocator, gpa: std.mem.Allocator, io: std.Io, host: []const u8, devices: []const *DeviceInfo, processes: *ProcessDoubleBuffer, dev_offset: u16, str_arenas: [2]*std.heap.ArenaAllocator) void {
     _ = poll_arena.reset(.retain_capacity);
 
     const body = httpGet(gpa, io, host) catch return;
@@ -91,6 +91,7 @@ fn pollOnce(poll_arena: *std.heap.ArenaAllocator, gpa: std.mem.Allocator, io: st
     for (json_devices, 0..) |item, i| {
         const jdi = std.json.parseFromValueLeaky(JsonDeviceInfo, poll_arena.allocator(), item, .{}) catch continue;
         if (i >= devices.len) {
+            std.log.warn("{s}: remote has more devices than expected ({d} > {d})", .{ host, json_devices.len, devices.len });
             break;
         }
 
@@ -111,7 +112,7 @@ fn pollOnce(poll_arena: *std.heap.ArenaAllocator, gpa: std.mem.Allocator, io: st
     back.clearRetainingCapacity();
     for (json_processes) |item| {
         var proc = std.json.parseFromValueLeaky(pi.ProcessInfo, alloc, item, .{ .ignore_unknown_fields = true }) catch continue;
-        proc.device_idx +|= dev_offset;
+        proc.device_idx += dev_offset;
         proc.remote = true;
         back.append(gpa, proc) catch continue;
     }
@@ -119,6 +120,11 @@ fn pollOnce(poll_arena: *std.heap.ArenaAllocator, gpa: std.mem.Allocator, io: st
 }
 
 fn httpGet(allocator: std.mem.Allocator, io: std.Io, host: []const u8) ![]const u8 {
+    if (!std.mem.startsWith(u8, host, "http://") and !std.mem.startsWith(u8, host, "https://")) {
+        std.log.err("remote host must start with http:// or https://: {s}", .{host});
+        return error.InvalidUrl;
+    }
+
     const url = try std.fmt.allocPrint(allocator, "{s}/metrics", .{host});
     defer allocator.free(url);
 

--- a/bin/zml-smi/api/server.zig
+++ b/bin/zml-smi/api/server.zig
@@ -11,15 +11,15 @@ else
     @import("zml-smi/platforms/linux").process.ProcessEnricher;
 
 pub const Server = struct {
+    allocator: std.mem.Allocator,
     io: std.Io,
-    gpa: std.mem.Allocator,
     devices: []const *DeviceInfo,
     process_lists: []const *const ProcessDoubleBuffer,
     enricher: *ProcessEnricher,
     tcp: std.Io.net.Server,
     connection_group: std.Io.Group = .init,
 
-    pub fn init(io: std.Io, port: u16, devices: []const *DeviceInfo, process_lists: []const *const ProcessDoubleBuffer, gpa: std.mem.Allocator, enricher: *ProcessEnricher) !Server {
+    pub fn init(allocator: std.mem.Allocator, io: std.Io, port: u16, devices: []const *DeviceInfo, process_lists: []const *const ProcessDoubleBuffer, enricher: *ProcessEnricher) !Server {
         const address: std.Io.net.IpAddress = .{ .ip4 = .{
             .bytes = .{ 0, 0, 0, 0 },
             .port = port,
@@ -28,8 +28,8 @@ pub const Server = struct {
         errdefer tcp.deinit(io);
 
         return .{
+            .allocator = allocator,
             .io = io,
-            .gpa = gpa,
             .devices = devices,
             .process_lists = process_lists,
             .enricher = enricher,
@@ -37,8 +37,8 @@ pub const Server = struct {
         };
     }
 
-    pub fn run(io: std.Io, port: u16, devices: []const *DeviceInfo, process_lists: []const *const ProcessDoubleBuffer, gpa: std.mem.Allocator, enricher: *ProcessEnricher) void {
-        var self = init(io, port, devices, process_lists, gpa, enricher) catch |err| {
+    pub fn run(allocator: std.mem.Allocator, io: std.Io, port: u16, devices: []const *DeviceInfo, process_lists: []const *const ProcessDoubleBuffer, enricher: *ProcessEnricher) void {
+        var self = init(allocator, io, port, devices, process_lists, enricher) catch |err| {
             std.log.err("api server failed to start: {s}", .{@errorName(err)});
             return;
         };
@@ -73,7 +73,7 @@ pub const Server = struct {
         var http_server: std.http.Server = .init(&reader.interface, &writer.interface);
 
         var procs: std.ArrayList(ProcessInfo) = .empty;
-        defer procs.deinit(self.gpa);
+        defer procs.deinit(self.allocator);
 
         while (true) {
             var request = http_server.receiveHead() catch |err| switch (err) {
@@ -83,7 +83,7 @@ pub const Server = struct {
 
             procs.clearRetainingCapacity();
             for (self.process_lists) |pl| {
-                procs.appendSlice(self.gpa, pl.front().items) catch {};
+                procs.appendSlice(self.allocator, pl.front().items) catch {};
             }
             self.enricher.enrich(self.io, procs.items);
 

--- a/bin/zml-smi/api/server.zig
+++ b/bin/zml-smi/api/server.zig
@@ -1,0 +1,74 @@
+const std = @import("std");
+const smi_info = @import("zml-smi/info");
+const DeviceInfo = smi_info.device_info.DeviceInfo;
+const json = @import("zml-smi/json");
+
+pub const Server = struct {
+    io: std.Io,
+    devices: []const *DeviceInfo,
+    tcp: std.Io.net.Server,
+    connection_group: std.Io.Group = .init,
+
+    pub fn init(io: std.Io, port: u16, devices: []const *DeviceInfo) !Server {
+        const address: std.Io.net.IpAddress = .{ .ip4 = .{
+            .bytes = .{ 0, 0, 0, 0 },
+            .port = port,
+        } };
+        var tcp = try address.listen(io, .{ .reuse_address = true });
+        errdefer tcp.deinit(io);
+
+        return .{
+            .io = io,
+            .devices = devices,
+            .tcp = tcp,
+        };
+    }
+
+    pub fn deinit(self: *Server) void {
+        self.connection_group.await(self.io) catch {};
+        self.tcp.deinit(self.io);
+    }
+
+    pub fn serve(self: *Server) !void {
+        while (true) {
+            const stream = self.tcp.accept(self.io) catch break;
+            try self.connection_group.concurrent(self.io, Server.onConnection, .{ self, stream });
+        }
+    }
+
+    fn onConnection(self: *Server, stream: std.Io.net.Stream) std.Io.Cancelable!void {
+        defer stream.close(self.io);
+        self.handleConn(stream) catch {};
+    }
+
+    fn handleConn(self: *Server, stream: std.Io.net.Stream) !void {
+        var read_buf: [8192]u8 = undefined;
+        var reader = stream.reader(self.io, &read_buf);
+
+        var write_buf: [4096]u8 = undefined;
+        var writer = stream.writer(self.io, &write_buf);
+
+        var http_server: std.http.Server = .init(&reader.interface, &writer.interface);
+
+        while (true) {
+            var request = http_server.receiveHead() catch |err| switch (err) {
+                error.HttpConnectionClosing => return,
+                else => return err,
+            };
+
+            var body_buf: [4096]u8 = undefined;
+            var body_writer = try request.respondStreaming(&body_buf, .{
+                .respond_options = .{
+                    .status = .ok,
+                    .extra_headers = &.{
+                        .{ .name = "content-type", .value = "application/json" },
+                        .{ .name = "access-control-allow-origin", .value = "*" },
+                    },
+                },
+            });
+
+            try json.write(&body_writer.writer, self.devices);
+            try body_writer.end();
+        }
+    }
+};

--- a/bin/zml-smi/api/server.zig
+++ b/bin/zml-smi/api/server.zig
@@ -1,15 +1,25 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const smi_info = @import("zml-smi/info");
 const DeviceInfo = smi_info.device_info.DeviceInfo;
+const ProcessInfo = smi_info.process_info.ProcessInfo;
+const ProcessDoubleBuffer = @import("zml-smi/double_buffer").DoubleBuffer(std.ArrayList(ProcessInfo));
 const json = @import("zml-smi/json");
+const ProcessEnricher = if (builtin.os.tag == .macos)
+    @import("zml-smi/platforms/macos").process.ProcessEnricher
+else
+    @import("zml-smi/platforms/linux").process.ProcessEnricher;
 
 pub const Server = struct {
     io: std.Io,
+    gpa: std.mem.Allocator,
     devices: []const *DeviceInfo,
+    process_lists: []const *const ProcessDoubleBuffer,
+    enricher: *ProcessEnricher,
     tcp: std.Io.net.Server,
     connection_group: std.Io.Group = .init,
 
-    pub fn init(io: std.Io, port: u16, devices: []const *DeviceInfo) !Server {
+    pub fn init(io: std.Io, port: u16, devices: []const *DeviceInfo, process_lists: []const *const ProcessDoubleBuffer, gpa: std.mem.Allocator, enricher: *ProcessEnricher) !Server {
         const address: std.Io.net.IpAddress = .{ .ip4 = .{
             .bytes = .{ 0, 0, 0, 0 },
             .port = port,
@@ -19,9 +29,21 @@ pub const Server = struct {
 
         return .{
             .io = io,
+            .gpa = gpa,
             .devices = devices,
+            .process_lists = process_lists,
+            .enricher = enricher,
             .tcp = tcp,
         };
+    }
+
+    pub fn run(io: std.Io, port: u16, devices: []const *DeviceInfo, process_lists: []const *const ProcessDoubleBuffer, gpa: std.mem.Allocator, enricher: *ProcessEnricher) void {
+        var self = init(io, port, devices, process_lists, gpa, enricher) catch |err| {
+            std.log.err("api server failed to start: {s}", .{@errorName(err)});
+            return;
+        };
+        defer self.deinit();
+        self.serve();
     }
 
     pub fn deinit(self: *Server) void {
@@ -29,10 +51,10 @@ pub const Server = struct {
         self.tcp.deinit(self.io);
     }
 
-    pub fn serve(self: *Server) !void {
+    pub fn serve(self: *Server) void {
         while (true) {
             const stream = self.tcp.accept(self.io) catch break;
-            try self.connection_group.concurrent(self.io, Server.onConnection, .{ self, stream });
+            self.connection_group.concurrent(self.io, Server.onConnection, .{ self, stream }) catch break;
         }
     }
 
@@ -50,11 +72,20 @@ pub const Server = struct {
 
         var http_server: std.http.Server = .init(&reader.interface, &writer.interface);
 
+        var procs: std.ArrayList(ProcessInfo) = .empty;
+        defer procs.deinit(self.gpa);
+
         while (true) {
             var request = http_server.receiveHead() catch |err| switch (err) {
                 error.HttpConnectionClosing => return,
                 else => return err,
             };
+
+            procs.clearRetainingCapacity();
+            for (self.process_lists) |pl| {
+                procs.appendSlice(self.gpa, pl.front().items) catch {};
+            }
+            self.enricher.enrich(self.io, procs.items);
 
             var body_buf: [4096]u8 = undefined;
             var body_writer = try request.respondStreaming(&body_buf, .{
@@ -67,7 +98,7 @@ pub const Server = struct {
                 },
             });
 
-            try json.write(&body_writer.writer, self.devices);
+            try json.write(&body_writer.writer, self.devices, procs.items);
             try body_writer.end();
         }
     }

--- a/bin/zml-smi/csv/csv.zig
+++ b/bin/zml-smi/csv/csv.zig
@@ -43,4 +43,3 @@ fn writeValue(writer: *std.Io.Writer, field: anytype) !void {
         else => return writer.print("{any}", .{field}),
     }
 }
-

--- a/bin/zml-smi/csv/csv.zig
+++ b/bin/zml-smi/csv/csv.zig
@@ -5,7 +5,6 @@ const DeviceInfo = smi_info.device_info.DeviceInfo;
 pub fn write(writer: *std.Io.Writer, devices: []const *DeviceInfo) !void {
     inline for (@typeInfo(DeviceInfo).@"union".fields) |tp| {
         const tag = @field(smi_info.Target, tp.name);
-        const Inner = resolveType(tp.type);
         var header_printed = false;
 
         for (devices, 0..) |dev, i| {
@@ -13,7 +12,7 @@ pub fn write(writer: *std.Io.Writer, devices: []const *DeviceInfo) !void {
                 tag => |*db| {
                     if (!header_printed) {
                         try writer.writeAll("index,type");
-                        inline for (@typeInfo(Inner).@"struct".fields) |f| {
+                        inline for (@typeInfo(tp.type.Value).@"struct".fields) |f| {
                             try writer.writeAll("," ++ f.name);
                         }
                         try writer.writeAll("\n");
@@ -24,7 +23,7 @@ pub fn write(writer: *std.Io.Writer, devices: []const *DeviceInfo) !void {
                     const val = db.front().*;
 
                     try writer.print("{d},{s}", .{ i, tp.name });
-                    inline for (@typeInfo(Inner).@"struct".fields) |f| {
+                    inline for (@typeInfo(tp.type.Value).@"struct".fields) |f| {
                         try writer.writeAll(",");
                         try writeValue(writer, @field(val, f.name));
                     }
@@ -45,9 +44,3 @@ fn writeValue(writer: *std.Io.Writer, field: anytype) !void {
     }
 }
 
-fn resolveType(comptime DB: type) type {
-    for (@typeInfo(DB).@"struct".fields) |df| {
-        if (std.mem.eql(u8, df.name, "values")) return @typeInfo(df.type).array.child;
-    }
-    unreachable;
-}

--- a/bin/zml-smi/info/device_info.zig
+++ b/bin/zml-smi/info/device_info.zig
@@ -13,9 +13,16 @@ pub const DeviceInfo = union(Target) {
     rocm: DoubleBuffer(GpuInfo),
     neuron: DoubleBuffer(NeuronInfo),
     tpu: DoubleBuffer(TpuInfo),
+
+    pub fn isRemote(self: *const DeviceInfo) bool {
+        switch (self.*) {
+            inline else => |*db| return db.front().remote,
+        }
+    }
 };
 
 pub const GpuInfo = struct {
+    remote: bool = false,
     name: ?[]const u8 = null,
     driver_version: ?[]const u8 = null,
     cuda_driver_version: ?[]const u8 = null,
@@ -54,6 +61,7 @@ pub const GpuInfo = struct {
 };
 
 pub const NeuronInfo = struct {
+    remote: bool = false,
     name: ?[]const u8 = null,
     driver_version: ?[]const u8 = null,
 
@@ -76,6 +84,7 @@ pub const NeuronInfo = struct {
 };
 
 pub const TpuInfo = struct {
+    remote: bool = false,
     name: ?[]const u8 = null,
 
     util_percent: ?u64 = null,

--- a/bin/zml-smi/info/process_info.zig
+++ b/bin/zml-smi/info/process_info.zig
@@ -8,4 +8,5 @@ pub const ProcessInfo = struct {
     comm: []const u8 = "",
     cpu_percent: u16 = 0, // *10, e.g. 125 = 12.5%
     rss_kib: u64 = 0,
+    remote: bool = false,
 };

--- a/bin/zml-smi/info/process_info.zig
+++ b/bin/zml-smi/info/process_info.zig
@@ -1,6 +1,6 @@
 pub const ProcessInfo = struct {
     pid: u32 = 0,
-    device_idx: u8 = 0,
+    device_idx: u16 = 0,
     dev_util_percent: ?u16 = null,
     dev_mem_kib: ?u64 = null,
     uid: u32 = 0,

--- a/bin/zml-smi/json/BUILD.bazel
+++ b/bin/zml-smi/json/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@rules_zig//zig:defs.bzl", "zig_library")
+
+zig_library(
+    name = "json",
+    import_name = "zml-smi/json",
+    main = "json.zig",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//bin/zml-smi/info",
+    ],
+)

--- a/bin/zml-smi/json/json.zig
+++ b/bin/zml-smi/json/json.zig
@@ -1,12 +1,15 @@
 const std = @import("std");
 const smi_info = @import("zml-smi/info");
 const DeviceInfo = smi_info.device_info.DeviceInfo;
+const ProcessInfo = smi_info.process_info.ProcessInfo;
 
-pub fn write(writer: *std.Io.Writer, devices: []const *DeviceInfo) !void {
+pub fn write(writer: *std.Io.Writer, devices: []const *DeviceInfo, processes: []const ProcessInfo) !void {
     var jw: std.json.Stringify = .{ .writer = writer };
 
-    try jw.beginArray();
+    try jw.beginObject();
 
+    try jw.objectField("devices");
+    try jw.beginArray();
     for (devices, 0..) |dev, i| {
         inline for (@typeInfo(DeviceInfo).@"union".fields) |tp| {
             const tag = @field(smi_info.Target, tp.name);
@@ -19,8 +22,16 @@ pub fn write(writer: *std.Io.Writer, devices: []const *DeviceInfo) !void {
             }
         }
     }
-
     try jw.endArray();
+
+    try jw.objectField("processes");
+    try jw.beginArray();
+    for (processes) |proc| {
+        try jw.write(proc);
+    }
+    try jw.endArray();
+
+    try jw.endObject();
     try writer.writeAll("\n");
 }
 

--- a/bin/zml-smi/json/json.zig
+++ b/bin/zml-smi/json/json.zig
@@ -5,56 +5,11 @@ const ProcessInfo = smi_info.process_info.ProcessInfo;
 
 pub fn write(writer: *std.Io.Writer, devices: []const *DeviceInfo, processes: []const ProcessInfo) !void {
     var jw: std.json.Stringify = .{ .writer = writer };
-
-    try jw.beginObject();
-
-    try jw.objectField("devices");
-    try jw.beginArray();
-    for (devices, 0..) |dev, i| {
-        inline for (@typeInfo(DeviceInfo).@"union".fields) |tp| {
-            const tag = @field(smi_info.Target, tp.name);
-
-            switch (dev.*) {
-                tag => |*db| {
-                    try jw.write(Envelope(tp.type.Value){ .index = i, .type = tp.name, .inner = db.front().* });
-                },
-                else => {},
-            }
-        }
-    }
-    try jw.endArray();
-
-    try jw.objectField("processes");
-    try jw.beginArray();
-    for (processes) |proc| {
-        try jw.write(proc);
-    }
-    try jw.endArray();
-
-    try jw.endObject();
+    try jw.write(Response{ .devices = devices, .processes = processes });
     try writer.writeAll("\n");
 }
 
-fn Envelope(comptime Inner: type) type {
-    return struct {
-        index: usize,
-        type: []const u8,
-        inner: Inner,
-
-        pub fn jsonStringify(self: @This(), jw: *std.json.Stringify) !void {
-            try jw.beginObject();
-
-            try jw.objectField("index");
-            try jw.write(self.index);
-            try jw.objectField("type");
-            try jw.write(self.type);
-
-            inline for (@typeInfo(Inner).@"struct".fields) |f| {
-                try jw.objectField(f.name);
-                try jw.write(@field(self.inner, f.name));
-            }
-
-            try jw.endObject();
-        }
-    };
-}
+const Response = struct {
+    devices: []const *DeviceInfo,
+    processes: []const ProcessInfo,
+};

--- a/bin/zml-smi/json/json.zig
+++ b/bin/zml-smi/json/json.zig
@@ -1,0 +1,49 @@
+const std = @import("std");
+const smi_info = @import("zml-smi/info");
+const DeviceInfo = smi_info.device_info.DeviceInfo;
+
+pub fn write(writer: *std.Io.Writer, devices: []const *DeviceInfo) !void {
+    var jw: std.json.Stringify = .{ .writer = writer };
+
+    try jw.beginArray();
+
+    for (devices, 0..) |dev, i| {
+        inline for (@typeInfo(DeviceInfo).@"union".fields) |tp| {
+            const tag = @field(smi_info.Target, tp.name);
+
+            switch (dev.*) {
+                tag => |*db| {
+                    try jw.write(Envelope(tp.name, tp.type.Value){ .index = i, .type = tp.name, .inner = db.front().* });
+                },
+                else => {},
+            }
+        }
+    }
+
+    try jw.endArray();
+    try writer.writeAll("\n");
+}
+
+fn Envelope(comptime _: []const u8, comptime Inner: type) type {
+    return struct {
+        index: usize,
+        type: []const u8,
+        inner: Inner,
+
+        pub fn jsonStringify(self: @This(), jw: *std.json.Stringify) !void {
+            try jw.beginObject();
+
+            try jw.objectField("index");
+            try jw.write(self.index);
+            try jw.objectField("type");
+            try jw.write(self.type);
+
+            inline for (@typeInfo(Inner).@"struct".fields) |f| {
+                try jw.objectField(f.name);
+                try jw.write(@field(self.inner, f.name));
+            }
+
+            try jw.endObject();
+        }
+    };
+}

--- a/bin/zml-smi/json/json.zig
+++ b/bin/zml-smi/json/json.zig
@@ -16,7 +16,7 @@ pub fn write(writer: *std.Io.Writer, devices: []const *DeviceInfo, processes: []
 
             switch (dev.*) {
                 tag => |*db| {
-                    try jw.write(Envelope(tp.name, tp.type.Value){ .index = i, .type = tp.name, .inner = db.front().* });
+                    try jw.write(Envelope(tp.type.Value){ .index = i, .type = tp.name, .inner = db.front().* });
                 },
                 else => {},
             }
@@ -35,7 +35,7 @@ pub fn write(writer: *std.Io.Writer, devices: []const *DeviceInfo, processes: []
     try writer.writeAll("\n");
 }
 
-fn Envelope(comptime _: []const u8, comptime Inner: type) type {
+fn Envelope(comptime Inner: type) type {
     return struct {
         index: usize,
         type: []const u8,

--- a/bin/zml-smi/main.zig
+++ b/bin/zml-smi/main.zig
@@ -17,6 +17,8 @@ const ProcessEnricher = linux.process.ProcessEnricher;
 const host = linux.metrics;
 const c = @import("c");
 const csv = @import("zml-smi/csv");
+const json = @import("zml-smi/json");
+const api = @import("zml-smi/api");
 const smi_tui = @import("zml-smi/tui");
 const tui = smi_tui.top;
 const static_print = smi_tui.print;
@@ -25,14 +27,23 @@ const data = smi_tui.data;
 const CliArgs = struct {
     top: bool = false,
     csv: bool = false,
+    json: bool = false,
+    api: bool = false,
+    port: u16 = 9090,
+    remotes: ?[]const u8 = null,
     tui_refresh_rate: u16 = 100,
     poll_interval: u16 = 500,
 
     pub const help =
-        \\ zml-smi [--top] [--csv] [--tui-refresh-rate MS] [--poll-interval MS]
+        \\ zml-smi [--top] [--csv] [--json] [--api] [--port PORT]
+        \\         [--remotes HOST,...] [--tui-refresh-rate MS] [--poll-interval MS]
         \\
         \\ --top               Interactive TUI mode
         \\ --csv               Output device metrics as CSV
+        \\ --json              Output device metrics as JSON
+        \\ --api               Expose device metrics as HTTP JSON endpoint
+        \\ --port              API server port (default: 9090)
+        \\ --remotes           Add devices from remote hosts (comma-separated URLs)
         \\ --tui-refresh-rate  TUI refresh rate in ms (default: 100)
         \\ --poll-interval     Device polling interval in ms (default: 500)
         \\
@@ -56,7 +67,7 @@ pub fn main(init: std.process.Init) !void {
 
     var collector: Collector = .init(arena, gpa, io, .{
         .poll_interval_ms = args.poll_interval,
-        .poll_only = !args.top,
+        .poll_only = !args.top and !args.api,
     });
     defer collector.deinit();
 
@@ -65,6 +76,8 @@ pub fn main(init: std.process.Init) !void {
 
     var enricher: ProcessEnricher = try .init(gpa, io);
     defer enricher.deinit();
+
+    if (args.api) std.log.info("serving on port {d}", .{args.port});
 
     inline for (device_backends) |entry| {
         const target, const backend = entry;
@@ -75,8 +88,15 @@ pub fn main(init: std.process.Init) !void {
         }
     }
 
+    const num_local_devices = collector.device_infos.items.len;
+
+    if (args.remotes) |hosts| {
+        try api.addRemotes(&collector, hosts);
+    }
+
     var state = try data.SystemState.init(arena, .{
         .devices = collector.device_infos.items,
+        .num_local_devices = num_local_devices,
         .host = &host_info,
         .targets = targets,
         .tui_refresh_rate = args.tui_refresh_rate,
@@ -92,6 +112,17 @@ pub fn main(init: std.process.Init) !void {
 
         try csv.write(&csv_writer.interface, collector.device_infos.items);
         try csv_writer.flush();
+    } else if (args.json) {
+        var json_buf: [4096]u8 = undefined;
+        var json_writer = std.Io.File.stdout().writer(io, &json_buf);
+
+        try json.write(&json_writer.interface, collector.device_infos.items);
+        try json_writer.flush();
+    } else if (args.api) {
+        var server = try api.Server.init(io, args.port, collector.device_infos.items);
+        defer server.deinit();
+
+        try server.serve();
     } else if (args.top) {
         try tui.run(gpa, io, &state);
     } else {

--- a/bin/zml-smi/main.zig
+++ b/bin/zml-smi/main.zig
@@ -12,9 +12,12 @@ pub const std_options: std.Options = .{
 const Collector = @import("zml-smi/collector").Collector;
 const smi_info = @import("zml-smi/info");
 const HostInfo = smi_info.host_info.HostInfo;
-const linux = @import("zml-smi/platforms/linux");
-const ProcessEnricher = linux.process.ProcessEnricher;
-const host = linux.metrics;
+const platform = if (builtin.os.tag == .macos)
+    @import("zml-smi/platforms/macos")
+else
+    @import("zml-smi/platforms/linux");
+const ProcessEnricher = platform.process.ProcessEnricher;
+const host = platform.metrics;
 const c = @import("c");
 const csv = @import("zml-smi/csv");
 const json = @import("zml-smi/json");

--- a/bin/zml-smi/main.zig
+++ b/bin/zml-smi/main.zig
@@ -35,20 +35,18 @@ const CliArgs = struct {
     api: bool = false,
     api_port: u16 = 9090,
     remotes: ?[]const u8 = null,
-    prometheus: bool = false,
-    prometheus_port: u16 = 9835,
+    prometheus_listen: ?[]const u8 = null,
     tui_refresh_rate: u16 = 100,
     poll_interval: u16 = 500,
 
     pub const help =
-        \\ zml-smi [--top] [--csv] [--json] [--prometheus] [--prometheus-port PORT]
+        \\ zml-smi [--top] [--csv] [--json] [--prometheus-listen HOST:PORT]
         \\         [--tui-refresh-rate MS] [--poll-interval MS]
         \\
         \\ --top               Interactive TUI mode
         \\ --csv               Output device metrics as CSV
         \\ --json              Output device metrics as JSON
-        \\ --prometheus        Expose metrics as Prometheus endpoint
-        \\ --prometheus-port   Prometheus server port (default: 9835)
+        \\ --prometheus-listen Expose metrics as Prometheus endpoint on HOST:PORT
         \\ --tui-refresh-rate  TUI refresh rate in ms (default: 100)
         \\ --poll-interval     Device polling interval in ms (default: 500)
         \\
@@ -77,7 +75,7 @@ pub fn main(init: std.process.Init) !void {
 
     var collector: Collector = .init(arena, gpa, io, .{
         .poll_interval_ms = args.poll_interval,
-        .poll_only = !args.top and !args.prometheus and !args.api,
+        .poll_only = !args.top and args.prometheus_listen == null and !args.api,
     });
     defer collector.deinit();
 
@@ -91,8 +89,8 @@ pub fn main(init: std.process.Init) !void {
         std.log.info("serving api metrics on port {d}", .{args.api_port});
     }
 
-    if (args.prometheus) {
-        std.log.info("serving prometheus metrics on port {d}", .{args.prometheus_port});
+    if (args.prometheus_listen) |listen| {
+        std.log.info("serving prometheus metrics on {s}", .{listen});
     }
 
     inline for (device_backends) |entry| {
@@ -121,15 +119,15 @@ pub fn main(init: std.process.Init) !void {
     });
     defer state.deinit(arena);
 
-    if (args.prometheus) {
-        try api_group.concurrent(io, prometheus.Server.run, .{ io, args.prometheus_port, collector.device_infos.items, &host_info });
+    if (args.prometheus_listen) |listen| {
+        try api_group.concurrent(io, prometheus.Server.run, .{ io, listen, collector.device_infos.items, &host_info });
     }
 
     if (args.api) {
         try api_group.concurrent(io, api.Server.run, .{ io, args.api_port, collector.device_infos.items, collector.process_lists.items, gpa, &enricher });
     }
 
-    if (args.prometheus or args.api) {
+    if (args.prometheus_listen != null or args.api) {
         try api_group.await(io);
     } else if (args.csv) {
         var csv_buf: [4096]u8 = undefined;

--- a/bin/zml-smi/main.zig
+++ b/bin/zml-smi/main.zig
@@ -22,6 +22,7 @@ const c = @import("c");
 const csv = @import("zml-smi/csv");
 const json = @import("zml-smi/json");
 const api = @import("zml-smi/api");
+const prometheus = @import("zml-smi/prometheus");
 const smi_tui = @import("zml-smi/tui");
 const tui = smi_tui.top;
 const static_print = smi_tui.print;
@@ -32,20 +33,24 @@ const CliArgs = struct {
     csv: bool = false,
     json: bool = false,
     api: bool = false,
-    port: u16 = 9090,
+    api_port: u16 = 9090,
     remotes: ?[]const u8 = null,
+    prometheus: bool = false,
+    prometheus_port: u16 = 9835,
     tui_refresh_rate: u16 = 100,
     poll_interval: u16 = 500,
 
     pub const help =
-        \\ zml-smi [--top] [--csv] [--json] [--api] [--port PORT]
+        \\ zml-smi [--top] [--csv] [--json] [--api] [--port PORT] [--prometheus] [--prometheus-port PORT]
         \\         [--remotes HOST,...] [--tui-refresh-rate MS] [--poll-interval MS]
         \\
         \\ --top               Interactive TUI mode
         \\ --csv               Output device metrics as CSV
         \\ --json              Output device metrics as JSON
         \\ --api               Expose device metrics as HTTP JSON endpoint
-        \\ --port              API server port (default: 9090)
+        \\ --api-port          API server port (default: 9090)
+        \\ --prometheus        Expose metrics as Prometheus endpoint
+        \\ --prometheus-port   Prometheus server port (default: 9835)
         \\ --remotes           Add devices from remote hosts (comma-separated URLs)
         \\ --tui-refresh-rate  TUI refresh rate in ms (default: 100)
         \\ --poll-interval     Device polling interval in ms (default: 500)
@@ -70,7 +75,7 @@ pub fn main(init: std.process.Init) !void {
 
     var collector: Collector = .init(arena, gpa, io, .{
         .poll_interval_ms = args.poll_interval,
-        .poll_only = !args.top and !args.api,
+        .poll_only = !args.top and !args.prometheus and !args.api,
     });
     defer collector.deinit();
 
@@ -80,7 +85,13 @@ pub fn main(init: std.process.Init) !void {
     var enricher: ProcessEnricher = try .init(gpa, io);
     defer enricher.deinit();
 
-    if (args.api) std.log.info("serving on port {d}", .{args.port});
+    if (args.api) {
+        std.log.info("serving api metricson port {d}", .{args.api_port});
+    }
+
+    if (args.prometheus) {
+        std.log.info("serving prometheus metrics on port {d}", .{args.prometheus_port});
+    }
 
     inline for (device_backends) |entry| {
         const target, const backend = entry;
@@ -90,6 +101,8 @@ pub fn main(init: std.process.Init) !void {
             };
         }
     }
+
+    var api_group: std.Io.Group = .init;
 
     const num_local_devices = collector.device_infos.items.len;
 
@@ -109,7 +122,13 @@ pub fn main(init: std.process.Init) !void {
     });
     defer state.deinit(arena);
 
-    if (args.csv) {
+    if (args.prometheus) {
+        var server = try prometheus.Server.init(io, args.prometheus_port, collector.device_infos.items, &host_info);
+        defer server.deinit();
+
+        try api_group.concurrent(io, prometheus.Server.serve, .{&server});
+        try api_group.await(io);
+    } else if (args.csv) {
         var csv_buf: [4096]u8 = undefined;
         var csv_writer = std.Io.File.stdout().writer(io, &csv_buf);
 
@@ -122,7 +141,7 @@ pub fn main(init: std.process.Init) !void {
         try json.write(&json_writer.interface, collector.device_infos.items);
         try json_writer.flush();
     } else if (args.api) {
-        var server = try api.Server.init(io, args.port, collector.device_infos.items);
+        var server = try api.Server.init(io, args.api_port, collector.device_infos.items);
         defer server.deinit();
 
         try server.serve();

--- a/bin/zml-smi/main.zig
+++ b/bin/zml-smi/main.zig
@@ -41,21 +41,23 @@ const CliArgs = struct {
     poll_interval: u16 = 500,
 
     pub const help =
-        \\ zml-smi [--top] [--csv] [--json] [--api] [--port PORT] [--prometheus] [--prometheus-port PORT]
-        \\         [--remotes HOST,...] [--tui-refresh-rate MS] [--poll-interval MS]
+        \\ zml-smi [--top] [--csv] [--json] [--prometheus] [--prometheus-port PORT]
+        \\         [--tui-refresh-rate MS] [--poll-interval MS]
         \\
         \\ --top               Interactive TUI mode
         \\ --csv               Output device metrics as CSV
         \\ --json              Output device metrics as JSON
-        \\ --api               Expose device metrics as HTTP JSON endpoint
-        \\ --api-port          API server port (default: 9090)
         \\ --prometheus        Expose metrics as Prometheus endpoint
         \\ --prometheus-port   Prometheus server port (default: 9835)
-        \\ --remotes           Add devices from remote hosts (comma-separated URLs)
         \\ --tui-refresh-rate  TUI refresh rate in ms (default: 100)
         \\ --poll-interval     Device polling interval in ms (default: 500)
         \\
     ;
+
+    //  [--api] [--port PORT] [--remotes HOST,...]
+    //  \\ --api               Expose device metrics as HTTP JSON endpoint
+    //  \\ --api-port          API server port (default: 9090)
+    //  \\ --remotes           Add devices from remote hosts (comma-separated URLs)
 };
 
 const device_backends = if (builtin.os.tag != .macos) .{
@@ -86,7 +88,7 @@ pub fn main(init: std.process.Init) !void {
     defer enricher.deinit();
 
     if (args.api) {
-        std.log.info("serving api metricson port {d}", .{args.api_port});
+        std.log.info("serving api metrics on port {d}", .{args.api_port});
     }
 
     if (args.prometheus) {
@@ -104,15 +106,12 @@ pub fn main(init: std.process.Init) !void {
 
     var api_group: std.Io.Group = .init;
 
-    const num_local_devices = collector.device_infos.items.len;
-
     if (args.remotes) |hosts| {
         try api.addRemotes(&collector, hosts);
     }
 
     var state = try data.SystemState.init(arena, .{
         .devices = collector.device_infos.items,
-        .num_local_devices = num_local_devices,
         .host = &host_info,
         .targets = targets,
         .tui_refresh_rate = args.tui_refresh_rate,
@@ -123,10 +122,14 @@ pub fn main(init: std.process.Init) !void {
     defer state.deinit(arena);
 
     if (args.prometheus) {
-        var server = try prometheus.Server.init(io, args.prometheus_port, collector.device_infos.items, &host_info);
-        defer server.deinit();
+        try api_group.concurrent(io, prometheus.Server.run, .{ io, args.prometheus_port, collector.device_infos.items, &host_info });
+    }
 
-        try api_group.concurrent(io, prometheus.Server.serve, .{&server});
+    if (args.api) {
+        try api_group.concurrent(io, api.Server.run, .{ io, args.api_port, collector.device_infos.items, collector.process_lists.items, gpa, &enricher });
+    }
+
+    if (args.prometheus or args.api) {
         try api_group.await(io);
     } else if (args.csv) {
         var csv_buf: [4096]u8 = undefined;
@@ -135,16 +138,18 @@ pub fn main(init: std.process.Init) !void {
         try csv.write(&csv_writer.interface, collector.device_infos.items);
         try csv_writer.flush();
     } else if (args.json) {
+        var procs: std.ArrayList(smi_info.process_info.ProcessInfo) = .empty;
+        defer procs.deinit(gpa);
+        for (collector.process_lists.items) |pl| {
+            try procs.appendSlice(gpa, pl.front().items);
+        }
+        enricher.enrich(io, procs.items);
+
         var json_buf: [4096]u8 = undefined;
         var json_writer = std.Io.File.stdout().writer(io, &json_buf);
 
-        try json.write(&json_writer.interface, collector.device_infos.items);
+        try json.write(&json_writer.interface, collector.device_infos.items, procs.items);
         try json_writer.flush();
-    } else if (args.api) {
-        var server = try api.Server.init(io, args.api_port, collector.device_infos.items);
-        defer server.deinit();
-
-        try server.serve();
     } else if (args.top) {
         try tui.run(gpa, io, &state);
     } else {

--- a/bin/zml-smi/main.zig
+++ b/bin/zml-smi/main.zig
@@ -108,13 +108,15 @@ pub fn main(init: std.process.Init) !void {
         try api.addRemotes(&collector, hosts);
     }
 
-    var state = try data.SystemState.init(arena, .{
+    var state = try data.SystemState.init(.{
         .devices = collector.device_infos.items,
         .host = &host_info,
         .targets = targets,
         .tui_refresh_rate = args.tui_refresh_rate,
         .process_lists = collector.process_lists.items,
         .enricher = &enricher,
+        .gpa = gpa,
+        .arena = arena,
         .io = io,
     });
     defer state.deinit(arena);
@@ -124,7 +126,7 @@ pub fn main(init: std.process.Init) !void {
     }
 
     if (args.api) {
-        try api_group.concurrent(io, api.Server.run, .{ io, args.api_port, collector.device_infos.items, collector.process_lists.items, gpa, &enricher });
+        try api_group.concurrent(io, api.Server.run, .{ gpa, io, args.api_port, collector.device_infos.items, collector.process_lists.items, &enricher });
     }
 
     if (args.prometheus_listen != null or args.api) {

--- a/bin/zml-smi/platforms/amdsmi/metrics.zig
+++ b/bin/zml-smi/platforms/amdsmi/metrics.zig
@@ -13,7 +13,7 @@ pub fn start(collector: *Collector) !void {
     amdsmi.* = try AmdSmi.init(collector.arena);
 
     const count = amdsmi.deviceCount();
-    const dev_offset: u8 = @intCast(collector.device_infos.items.len);
+    const dev_offset: u16 = @intCast(collector.device_infos.items.len);
 
     for (0..count) |i| {
         const dev = Device.open(amdsmi, @intCast(i)) catch continue;

--- a/bin/zml-smi/platforms/amdsmi/process.zig
+++ b/bin/zml-smi/platforms/amdsmi/process.zig
@@ -23,10 +23,10 @@ pub fn init(collector: *Collector, list: *ProcessDoubleBuffer, amdsmi: *const Am
         });
     }
 
-    try collector.spawnPoll(pollOnce, .{ collector.io, collector.gpa, list, amdsmi, dev_offset, device_count, pci_slots });
+    try collector.spawnPoll(pollOnce, .{ collector.gpa, collector.io, list, amdsmi, dev_offset, device_count, pci_slots });
 }
 
-fn pollOnce(io: std.Io, allocator: std.mem.Allocator, list: *ProcessDoubleBuffer, amdsmi: *const AmdSmi, dev_offset: u16, device_count: u32, pci_slots: []?[bdf_len]u8) void {
+fn pollOnce(allocator: std.mem.Allocator, io: std.Io, list: *ProcessDoubleBuffer, amdsmi: *const AmdSmi, dev_offset: u16, device_count: u32, pci_slots: []?[bdf_len]u8) void {
     const back = list.back();
 
     back.clearRetainingCapacity();

--- a/bin/zml-smi/platforms/amdsmi/process.zig
+++ b/bin/zml-smi/platforms/amdsmi/process.zig
@@ -7,7 +7,7 @@ const Collector = @import("zml-smi/collector").Collector;
 
 const bdf_len = "0000:00:00.0".len;
 
-pub fn init(collector: *Collector, list: *ProcessDoubleBuffer, amdsmi: *const AmdSmi, dev_offset: u8) !void {
+pub fn init(collector: *Collector, list: *ProcessDoubleBuffer, amdsmi: *const AmdSmi, dev_offset: u16) !void {
     const device_count = amdsmi.deviceCount();
     const pci_slots = try collector.arena.alloc(?[bdf_len]u8, device_count);
 
@@ -26,7 +26,7 @@ pub fn init(collector: *Collector, list: *ProcessDoubleBuffer, amdsmi: *const Am
     try collector.spawnPoll(pollOnce, .{ collector.io, collector.gpa, list, amdsmi, dev_offset, device_count, pci_slots });
 }
 
-fn pollOnce(io: std.Io, allocator: std.mem.Allocator, list: *ProcessDoubleBuffer, amdsmi: *const AmdSmi, dev_offset: u8, device_count: u32, pci_slots: []?[bdf_len]u8) void {
+fn pollOnce(io: std.Io, allocator: std.mem.Allocator, list: *ProcessDoubleBuffer, amdsmi: *const AmdSmi, dev_offset: u16, device_count: u32, pci_slots: []?[bdf_len]u8) void {
     const back = list.back();
 
     back.clearRetainingCapacity();

--- a/bin/zml-smi/platforms/linux/process.zig
+++ b/bin/zml-smi/platforms/linux/process.zig
@@ -43,6 +43,7 @@ pub const ProcessEnricher = struct {
         curr_ticks.ensureTotalCapacity(self.gpa, @intCast(procs.len)) catch return;
 
         for (procs) |*info| {
+            if (info.remote) continue;
             // Read Uid, VmRSS from /proc/{pid}/status
             const status_path = std.fmt.allocPrint(alloc, "/proc/{d}/status", .{info.pid}) catch continue;
             const uid: u32 = @intCast(sysfs.readFieldInt(alloc, io, status_path, "Uid") catch 0);

--- a/bin/zml-smi/platforms/macos/BUILD.bazel
+++ b/bin/zml-smi/platforms/macos/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_zig//zig:defs.bzl", "zig_library")
+
+zig_library(
+    name = "macos",
+    import_name = "zml-smi/platforms/macos",
+    main = "macos.zig",
+    srcs = [
+        "metrics.zig",
+        "process.zig",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//bin/zml-smi/collector",
+        "//bin/zml-smi/info",
+    ],
+)

--- a/bin/zml-smi/platforms/macos/macos.zig
+++ b/bin/zml-smi/platforms/macos/macos.zig
@@ -1,0 +1,2 @@
+pub const metrics = @import("metrics.zig");
+pub const process = @import("process.zig");

--- a/bin/zml-smi/platforms/macos/metrics.zig
+++ b/bin/zml-smi/platforms/macos/metrics.zig
@@ -1,0 +1,161 @@
+const std = @import("std");
+const host_info = @import("zml-smi/info").host_info;
+const HostInfo = host_info.HostInfo;
+const poll_metrics = @import("zml-smi/info").poll_metrics;
+const Collector = @import("zml-smi/collector").Collector;
+
+const c = std.c;
+
+const vm_statistics64 = extern struct {
+    free_count: c_uint,
+    active_count: c_uint,
+    inactive_count: c_uint,
+    wire_count: c_uint,
+    zero_fill_count: u64,
+    reactivations: u64,
+    pageins: u64,
+    pageouts: u64,
+    faults: u64,
+    cow_faults: u64,
+    lookups: u64,
+    hits: u64,
+    purges: u64,
+    purgeable_count: c_uint,
+    speculative_count: c_uint,
+    decompressions: u64,
+    compressions: u64,
+    swapins: u64,
+    swapouts: u64,
+    compressor_page_count: c_uint,
+    throttled_count: c_uint,
+    external_page_count: c_uint,
+    internal_page_count: c_uint,
+    total_uncompressed_pages_in_compressor: u64,
+};
+
+const HOST_VM_INFO64: c_int = 4;
+const HOST_VM_INFO64_COUNT: c_uint = @sizeOf(vm_statistics64) / @sizeOf(c_int);
+const KERN_SUCCESS: c_int = 0;
+
+extern "c" fn host_statistics64(host: c.mach_port_t, flavor: c_int, info: *anyopaque, count: *c_uint) c.kern_return_t;
+extern "c" fn getloadavg(loadavg: *[3]f64, nelem: c_int) c_int;
+
+pub fn init(collector: *Collector, info: *HostInfo) !void {
+    const poll_arena = try collector.createPollArena();
+    const host: Host = .{};
+
+    var initial = info.front().*;
+    initial.hostname = sysctlString(collector.arena, "kern.hostname") catch null;
+    initial.kernel = sysctlString(collector.arena, "kern.osrelease") catch null;
+    initial.cpu_name = sysctlString(collector.arena, "machdep.cpu.brand_string") catch null;
+    initial.cpu_cores = host.cpuCores() catch null;
+    initial.mem_total_kib = host.memTotal() catch null;
+    info.back().* = initial;
+    info.swap();
+
+    try collector.spawnPoll(pollOnce, .{ poll_arena, info, host });
+}
+
+const pollOnce = poll_metrics.poll(*HostInfo, Host, metrics);
+
+const Host = struct {
+    pub fn cpuCores(_: Host) !u64 {
+        return @intCast(try sysctlU32("hw.logicalcpu"));
+    }
+
+    pub fn memTotal(_: Host) !u64 {
+        return (try sysctlU64("hw.memsize")) / 1024;
+    }
+
+    pub fn memAvailable(_: Host) !u64 {
+        var vm_stat: vm_statistics64 = undefined;
+        var count: c_uint = HOST_VM_INFO64_COUNT;
+
+        if (host_statistics64(c.mach_host_self(), HOST_VM_INFO64, &vm_stat, &count) != KERN_SUCCESS) {
+            return error.HostStatsFailed;
+        }
+
+        var page_size: u64 = 0;
+        if (c._host_page_size(c.mach_host_self(), &page_size) != KERN_SUCCESS) {
+            return error.PageSizeFailed;
+        }
+
+        const available_pages: u64 = @as(u64, vm_stat.free_count) +
+            @as(u64, vm_stat.inactive_count) +
+            @as(u64, vm_stat.purgeable_count);
+
+        return (available_pages * page_size) / 1024;
+    }
+
+    fn loadAvg() ![3]f64 {
+        var avg: [3]f64 = undefined;
+        if (getloadavg(&avg, 3) != 3) {
+            return error.LoadAvgFailed;
+        }
+
+        return avg;
+    }
+
+    pub fn load1(_: Host) !f32 {
+        return @floatCast((try loadAvg())[0]);
+    }
+
+    pub fn load5(_: Host) !f32 {
+        return @floatCast((try loadAvg())[1]);
+    }
+
+    pub fn load15(_: Host) !f32 {
+        return @floatCast((try loadAvg())[2]);
+    }
+
+    pub fn uptime(_: Host) !u64 {
+        var boottime: c.timeval = undefined;
+        var len: usize = @sizeOf(c.timeval);
+        if (c.sysctlbyname("kern.boottime", std.mem.asBytes(&boottime), &len, null, 0) != 0) {
+            return error.SysctlFailed;
+        }
+
+        var now: c.timeval = undefined;
+        _ = c.gettimeofday(&now, null);
+
+        return @intCast(now.sec - boottime.sec);
+    }
+};
+
+fn sysctlString(allocator: std.mem.Allocator, name: [*:0]const u8) ![]const u8 {
+    var buf: [256]u8 = undefined;
+    var len: usize = buf.len;
+    if (c.sysctlbyname(name, &buf, &len, null, 0) != 0) {
+        return error.SysctlFailed;
+    }
+
+    return allocator.dupe(u8, std.mem.span(@as([*:0]const u8, @ptrCast(buf[0..len]))));
+}
+
+fn sysctlU64(name: [*:0]const u8) !u64 {
+    var value: u64 = 0;
+    var len: usize = @sizeOf(u64);
+    if (c.sysctlbyname(name, std.mem.asBytes(&value), &len, null, 0) != 0) {
+        return error.SysctlFailed;
+    }
+
+    return value;
+}
+
+fn sysctlU32(name: [*:0]const u8) !u32 {
+    var value: u32 = 0;
+    var len: usize = @sizeOf(u32);
+    if (c.sysctlbyname(name, std.mem.asBytes(&value), &len, null, 0) != 0) {
+        return error.SysctlFailed;
+    }
+
+    return value;
+}
+
+const metrics = .{
+    .{ .field = "mem_available_kib", .query = Host.memAvailable },
+    .{ .field = "load_1", .query = Host.load1 },
+    .{ .field = "load_5", .query = Host.load5 },
+    .{ .field = "load_15", .query = Host.load15 },
+    .{ .field = "uptime_seconds", .query = Host.uptime },
+};

--- a/bin/zml-smi/platforms/macos/process.zig
+++ b/bin/zml-smi/platforms/macos/process.zig
@@ -1,0 +1,12 @@
+const std = @import("std");
+const pi = @import("zml-smi/info").process_info;
+
+pub const ProcessEnricher = struct {
+    pub fn init(_: std.mem.Allocator, _: std.Io) !ProcessEnricher {
+        return .{};
+    }
+
+    pub fn deinit(_: *ProcessEnricher) void {}
+
+    pub fn enrich(_: *ProcessEnricher, _: std.Io, _: []pi.ProcessInfo) void {}
+};

--- a/bin/zml-smi/platforms/neuron/metrics.zig
+++ b/bin/zml-smi/platforms/neuron/metrics.zig
@@ -30,7 +30,7 @@ pub fn start(collector: *Collector) !void {
 
     const GiB: u64 = 1024 * 1024 * 1024;
     var neuron_infos: std.ArrayList(*DeviceInfo) = .{};
-    const dev_offset: u8 = @intCast(collector.device_infos.items.len);
+    const dev_offset: u16 = @intCast(collector.device_infos.items.len);
 
     var ver_buf: [Nrt.version_buf_len]u8 = undefined;
     const nrt_ver: ?[]const u8 = if (nrt.version(&ver_buf)) |v|

--- a/bin/zml-smi/platforms/neuron/process.zig
+++ b/bin/zml-smi/platforms/neuron/process.zig
@@ -16,7 +16,7 @@ pub fn init(collector: *Collector, list: *ProcessDoubleBuffer, nrt: *const Nrt, 
     if (nrt.handles.len == 0) return;
     const delta_states = try collector.arena.alloc(DeltaState, util_buf.len);
     @memset(delta_states, .{});
-    const args: std.meta.ArgsTuple(@TypeOf(pollOnce)) = .{ collector.io, collector.gpa, list, nrt, nc_per_device, util_buf, dev_offset, delta_states };
+    const args: std.meta.ArgsTuple(@TypeOf(pollOnce)) = .{ collector.gpa, collector.io, list, nrt, nc_per_device, util_buf, dev_offset, delta_states };
     if (warmup) {
         @call(.auto, pollOnce, args);
         collector.io.sleep(.fromMilliseconds(500), .awake) catch {};
@@ -27,7 +27,7 @@ pub fn init(collector: *Collector, list: *ProcessDoubleBuffer, nrt: *const Nrt, 
     try collector.spawnPoll(pollOnce, args);
 }
 
-fn pollOnce(io: std.Io, allocator: std.mem.Allocator, list: *ProcessDoubleBuffer, nrt: *const Nrt, nc_per_device: u32, util_buf: []UtilAtomic, dev_offset: u16, delta_states: []DeltaState) void {
+fn pollOnce(allocator: std.mem.Allocator, io: std.Io, list: *ProcessDoubleBuffer, nrt: *const Nrt, nc_per_device: u32, util_buf: []UtilAtomic, dev_offset: u16, delta_states: []DeltaState) void {
     const back = list.back();
 
     back.clearRetainingCapacity();

--- a/bin/zml-smi/platforms/neuron/process.zig
+++ b/bin/zml-smi/platforms/neuron/process.zig
@@ -12,7 +12,7 @@ const DeltaState = struct {
     prev_timestamp: ?std.Io.Timestamp = null,
 };
 
-pub fn init(collector: *Collector, list: *ProcessDoubleBuffer, nrt: *const Nrt, nc_per_device: u32, util_buf: []UtilAtomic, dev_offset: u8, warmup: bool) !void {
+pub fn init(collector: *Collector, list: *ProcessDoubleBuffer, nrt: *const Nrt, nc_per_device: u32, util_buf: []UtilAtomic, dev_offset: u16, warmup: bool) !void {
     if (nrt.handles.len == 0) return;
     const delta_states = try collector.arena.alloc(DeltaState, util_buf.len);
     @memset(delta_states, .{});
@@ -27,7 +27,7 @@ pub fn init(collector: *Collector, list: *ProcessDoubleBuffer, nrt: *const Nrt, 
     try collector.spawnPoll(pollOnce, args);
 }
 
-fn pollOnce(io: std.Io, allocator: std.mem.Allocator, list: *ProcessDoubleBuffer, nrt: *const Nrt, nc_per_device: u32, util_buf: []UtilAtomic, dev_offset: u8, delta_states: []DeltaState) void {
+fn pollOnce(io: std.Io, allocator: std.mem.Allocator, list: *ProcessDoubleBuffer, nrt: *const Nrt, nc_per_device: u32, util_buf: []UtilAtomic, dev_offset: u16, delta_states: []DeltaState) void {
     const back = list.back();
 
     back.clearRetainingCapacity();

--- a/bin/zml-smi/platforms/nvml/metrics.zig
+++ b/bin/zml-smi/platforms/nvml/metrics.zig
@@ -13,7 +13,7 @@ pub fn start(collector: *Collector) !void {
     nvml.* = try Nvml.init();
 
     const count = try nvml.deviceCount();
-    const dev_offset: u8 = @intCast(collector.device_infos.items.len);
+    const dev_offset: u16 = @intCast(collector.device_infos.items.len);
 
     for (0..count) |i| {
         const dev = Device.open(nvml, @intCast(i)) catch continue;

--- a/bin/zml-smi/platforms/nvml/process.zig
+++ b/bin/zml-smi/platforms/nvml/process.zig
@@ -4,7 +4,7 @@ const pi = @import("zml-smi/info").process_info;
 const ProcessDoubleBuffer = @import("zml-smi/double_buffer").DoubleBuffer(std.ArrayList(pi.ProcessInfo));
 const Collector = @import("zml-smi/collector").Collector;
 
-pub fn init(collector: *Collector, list: *ProcessDoubleBuffer, nvml: *const Nvml, dev_offset: u8) !void {
+pub fn init(collector: *Collector, list: *ProcessDoubleBuffer, nvml: *const Nvml, dev_offset: u16) !void {
     const device_count: u32 = nvml.deviceCount() catch 0;
     const last_seen_ts = try collector.arena.alloc(u64, device_count);
     @memset(last_seen_ts, 0);
@@ -12,39 +12,27 @@ pub fn init(collector: *Collector, list: *ProcessDoubleBuffer, nvml: *const Nvml
     try collector.spawnPoll(pollOnce, .{ collector.gpa, list, nvml, dev_offset, device_count, last_seen_ts });
 }
 
-fn pollOnce(allocator: std.mem.Allocator, list: *ProcessDoubleBuffer, nvml: *const Nvml, dev_offset: u8, device_count: u32, last_seen_ts: []u64) void {
+fn pollOnce(allocator: std.mem.Allocator, list: *ProcessDoubleBuffer, nvml: *const Nvml, dev_offset: u16, device_count: u32, last_seen_ts: []u64) void {
     const back = list.back();
 
     back.clearRetainingCapacity();
 
     for (0..device_count) |dev_idx| {
         const handle = nvml.handleByIndex(@intCast(dev_idx)) catch continue;
-        const idx: u8 = @intCast(dev_idx + dev_offset);
+        const idx: u16 = @intCast(dev_idx + dev_offset);
 
         const compute = nvml.computeRunningProcesses(allocator, handle) catch &.{};
-        defer {
-            if (compute.len > 0) {
-                allocator.free(compute);
-            }
-        }
+        defer if (compute.len > 0) allocator.free(compute);
         collectFromQuery(allocator, back, idx, compute);
 
         const graphics = nvml.graphicsRunningProcesses(allocator, handle) catch &.{};
-        defer {
-            if (graphics.len > 0) {
-                allocator.free(graphics);
-            }
-        }
+        defer if (graphics.len > 0) allocator.free(graphics);
         collectFromQuery(allocator, back, idx, graphics);
 
         // Apply utilization samples
         const last_ts = last_seen_ts[dev_idx];
         const utils = nvml.processUtilization(allocator, handle, last_ts) catch continue;
-        defer {
-            if (utils.len > 0) {
-                allocator.free(utils);
-            }
-        }
+        defer if (utils.len > 0) allocator.free(utils);
 
         for (utils) |sample| {
             if (sample.smUtil > 100 or sample.timeStamp <= last_ts) {
@@ -64,7 +52,7 @@ fn pollOnce(allocator: std.mem.Allocator, list: *ProcessDoubleBuffer, nvml: *con
     list.swap();
 }
 
-fn collectFromQuery(allocator: std.mem.Allocator, back: *std.ArrayList(pi.ProcessInfo), dev_idx: u8, procs: []const Nvml.ProcessInfo_t) void {
+fn collectFromQuery(allocator: std.mem.Allocator, back: *std.ArrayList(pi.ProcessInfo), dev_idx: u16, procs: []const Nvml.ProcessInfo_t) void {
     for (procs) |gp| {
         back.append(allocator, .{
             .pid = gp.pid,

--- a/bin/zml-smi/platforms/tpu/metrics.zig
+++ b/bin/zml-smi/platforms/tpu/metrics.zig
@@ -13,7 +13,7 @@ pub fn start(collector: *Collector) !void {
     const chip = scanPciChips(collector.arena, collector.io) orelse return error.TpuUnavailable;
     const device_count = chip.chip_count * chip.devices_per_chip;
     var tpu_infos: std.ArrayList(*DeviceInfo) = .{};
-    const dev_offset: u8 = @intCast(collector.device_infos.items.len);
+    const dev_offset: u16 = @intCast(collector.device_infos.items.len);
 
     for (0..device_count) |_| {
         const chip_name = try collector.arena.dupe(u8, chip.name);

--- a/bin/zml-smi/platforms/tpu/process.zig
+++ b/bin/zml-smi/platforms/tpu/process.zig
@@ -6,15 +6,15 @@ const DeviceInfo = smi_info.device_info.DeviceInfo;
 const Collector = @import("zml-smi/collector").Collector;
 
 pub fn init(collector: *Collector, devices_per_chip: u32, device_infos: []*DeviceInfo, list: *ProcessDoubleBuffer, dev_offset: u16) !void {
-    try collector.spawnPoll(pollOnce, .{ collector.io, collector.gpa, list, devices_per_chip, device_infos, dev_offset });
+    try collector.spawnPoll(pollOnce, .{ collector.gpa, collector.io, list, devices_per_chip, device_infos, dev_offset });
 }
 
-fn pollOnce(io: std.Io, allocator: std.mem.Allocator, list: *ProcessDoubleBuffer, devices_per_chip: u32, device_infos: []*DeviceInfo, dev_offset: u16) void {
-    scan(io, allocator, list.back(), devices_per_chip, device_infos, dev_offset);
+fn pollOnce(allocator: std.mem.Allocator, io: std.Io, list: *ProcessDoubleBuffer, devices_per_chip: u32, device_infos: []*DeviceInfo, dev_offset: u16) void {
+    scan(allocator, io, list.back(), devices_per_chip, device_infos, dev_offset);
     list.swap();
 }
 
-fn scan(io: std.Io, allocator: std.mem.Allocator, back: *std.ArrayList(pi.ProcessInfo), devices_per_chip: u32, infos: []*DeviceInfo, dev_offset: u16) void {
+fn scan(allocator: std.mem.Allocator, io: std.Io, back: *std.ArrayList(pi.ProcessInfo), devices_per_chip: u32, infos: []*DeviceInfo, dev_offset: u16) void {
     back.clearRetainingCapacity();
 
     var proc_dir = std.Io.Dir.openDirAbsolute(io, "/proc", .{ .iterate = true }) catch return;

--- a/bin/zml-smi/platforms/tpu/process.zig
+++ b/bin/zml-smi/platforms/tpu/process.zig
@@ -5,16 +5,16 @@ const ProcessDoubleBuffer = @import("zml-smi/double_buffer").DoubleBuffer(std.Ar
 const DeviceInfo = smi_info.device_info.DeviceInfo;
 const Collector = @import("zml-smi/collector").Collector;
 
-pub fn init(collector: *Collector, devices_per_chip: u32, device_infos: []*DeviceInfo, list: *ProcessDoubleBuffer, dev_offset: u8) !void {
+pub fn init(collector: *Collector, devices_per_chip: u32, device_infos: []*DeviceInfo, list: *ProcessDoubleBuffer, dev_offset: u16) !void {
     try collector.spawnPoll(pollOnce, .{ collector.io, collector.gpa, list, devices_per_chip, device_infos, dev_offset });
 }
 
-fn pollOnce(io: std.Io, allocator: std.mem.Allocator, list: *ProcessDoubleBuffer, devices_per_chip: u32, device_infos: []*DeviceInfo, dev_offset: u8) void {
+fn pollOnce(io: std.Io, allocator: std.mem.Allocator, list: *ProcessDoubleBuffer, devices_per_chip: u32, device_infos: []*DeviceInfo, dev_offset: u16) void {
     scan(io, allocator, list.back(), devices_per_chip, device_infos, dev_offset);
     list.swap();
 }
 
-fn scan(io: std.Io, allocator: std.mem.Allocator, back: *std.ArrayList(pi.ProcessInfo), devices_per_chip: u32, infos: []*DeviceInfo, dev_offset: u8) void {
+fn scan(io: std.Io, allocator: std.mem.Allocator, back: *std.ArrayList(pi.ProcessInfo), devices_per_chip: u32, infos: []*DeviceInfo, dev_offset: u16) void {
     back.clearRetainingCapacity();
 
     var proc_dir = std.Io.Dir.openDirAbsolute(io, "/proc", .{ .iterate = true }) catch return;
@@ -36,9 +36,9 @@ fn scan(io: std.Io, allocator: std.mem.Allocator, back: *std.ArrayList(pi.Proces
             const target = link_buf[0..len];
 
             if (parseChipIndex(target)) |chip_idx| {
-                const base: u8 = @intCast(chip_idx * devices_per_chip);
+                const base: u16 = @intCast(chip_idx * devices_per_chip);
                 for (0..devices_per_chip) |d| {
-                    const local_idx: u8 = @intCast(base + d);
+                    const local_idx: u16 = @intCast(base + d);
                     var info: pi.ProcessInfo = .{ .pid = pid, .device_idx = local_idx + dev_offset };
 
                     if (local_idx < infos.len) {

--- a/bin/zml-smi/prometheus/BUILD.bazel
+++ b/bin/zml-smi/prometheus/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_zig//zig:defs.bzl", "zig_library")
+
+zig_library(
+    name = "prometheus",
+    import_name = "zml-smi/prometheus",
+    main = "prometheus.zig",
+    srcs = [
+        "server.zig",
+        "exposition.zig",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//bin/zml-smi/info",
+        "//bin/zml-smi/utils:double_buffer",
+    ],
+)

--- a/bin/zml-smi/prometheus/exposition.zig
+++ b/bin/zml-smi/prometheus/exposition.zig
@@ -88,47 +88,47 @@ pub fn write(writer: *std.Io.Writer, devices: []const *DeviceInfo, host: *const 
 
     for (devices, 0..) |dev, i| {
         switch (dev.*) {
-            .cuda => |*db| try writeMetrics(writer, gpu_metrics, db.front().*, .{ i, "cuda" }),
-            .rocm => |*db| try writeMetrics(writer, gpu_metrics, db.front().*, .{ i, "rocm" }),
-            .neuron => |*db| try writeMetrics(writer, neuron_metrics, db.front().*, .{ i, "neuron" }),
-            .tpu => |*db| try writeMetrics(writer, tpu_metrics, db.front().*, .{ i, "tpu" }),
+            .cuda => |*db| try writeDeviceMetrics(writer, gpu_metrics, db.front().*, i, "cuda"),
+            .rocm => |*db| try writeDeviceMetrics(writer, gpu_metrics, db.front().*, i, "rocm"),
+            .neuron => |*db| try writeDeviceMetrics(writer, neuron_metrics, db.front().*, i, "neuron"),
+            .tpu => |*db| try writeDeviceMetrics(writer, tpu_metrics, db.front().*, i, "tpu"),
         }
     }
 
-    try writeMetrics(writer, host_metrics, host.front().*, null);
+    try writeHostMetrics(writer, host.front().*);
 }
 
-fn writeMetrics(
+fn writeDeviceMetrics(
     writer: *std.Io.Writer,
     comptime metrics: anytype,
     val: anytype,
-    device: ?struct { usize, []const u8 },
+    device_idx: usize,
+    device_type: []const u8,
 ) !void {
-    const name_label = if (@hasField(@TypeOf(val), "name")) val.name else null;
-
     inline for (metrics) |m| {
         if (@field(val, m.field)) |raw| {
-            try writer.print("# HELP {s} {s}\n# TYPE {s} gauge\n{s}", .{ m.metric, m.help, m.metric, m.metric });
-
-            if (device) |d| {
-                try writer.print("{{device=\"{d}\",type=\"{s}\"", .{ d[0], d[1] });
-
-                if (name_label) |name| {
-                    try writer.print(",name=\"{s}\"", .{name});
-                }
-
-                try writer.writeAll("}");
-            }
-
-            try writer.writeAll(" ");
-
-            if (@hasField(@TypeOf(m), "fmt")) {
-                try m.fmt(writer, raw);
-            } else {
-                try writeValue(writer, raw);
-            }
+            try writer.print("# HELP {s} {s}\n# TYPE {s} gauge\n{s}{{device=\"{d}\",type=\"{s}\",name=\"{?s}\"}} ", .{ m.metric, m.help, m.metric, m.metric, device_idx, device_type, val.name });
+            try fmtValue(m, writer, raw);
             try writer.writeAll("\n");
         }
+    }
+}
+
+fn writeHostMetrics(writer: *std.Io.Writer, val: anytype) !void {
+    inline for (host_metrics) |m| {
+        if (@field(val, m.field)) |raw| {
+            try writer.print("# HELP {s} {s}\n# TYPE {s} gauge\n{s} ", .{ m.metric, m.help, m.metric, m.metric });
+            try fmtValue(m, writer, raw);
+            try writer.writeAll("\n");
+        }
+    }
+}
+
+fn fmtValue(comptime m: anytype, writer: *std.Io.Writer, raw: anytype) !void {
+    if (@hasField(@TypeOf(m), "fmt")) {
+        try m.fmt(writer, raw);
+    } else {
+        try writeValue(writer, raw);
     }
 }
 

--- a/bin/zml-smi/prometheus/exposition.zig
+++ b/bin/zml-smi/prometheus/exposition.zig
@@ -1,0 +1,153 @@
+const std = @import("std");
+const smi_info = @import("zml-smi/info");
+const DeviceInfo = smi_info.device_info.DeviceInfo;
+const HostInfo = smi_info.host_info.HostInfo;
+
+const gpu_metrics = .{
+    .{ .field = "util_percent", .metric = "zml_device_utilization_percent", .help = "GPU utilization percentage" },
+    .{ .field = "encoder_util_percent", .metric = "zml_device_encoder_utilization_percent", .help = "Encoder utilization percentage" },
+    .{ .field = "decoder_util_percent", .metric = "zml_device_decoder_utilization_percent", .help = "Decoder utilization percentage" },
+    .{ .field = "power_mw", .metric = "zml_device_power_watts", .help = "Power draw in watts", .fmt = fmtMilliwattsAsWatts },
+    .{ .field = "power_limit_mw", .metric = "zml_device_power_limit_watts", .help = "Power limit in watts", .fmt = fmtMilliwattsAsWatts },
+    .{ .field = "temperature", .metric = "zml_device_temperature_celsius", .help = "Device temperature in celsius" },
+    .{ .field = "fan_speed_percent", .metric = "zml_device_fan_speed_percent", .help = "Fan speed percentage" },
+    .{ .field = "clock_graphics_mhz", .metric = "zml_device_clock_graphics_mhz", .help = "Graphics clock frequency in MHz" },
+    .{ .field = "clock_sm_mhz", .metric = "zml_device_clock_sm_mhz", .help = "SM clock frequency in MHz" },
+    .{ .field = "clock_mem_mhz", .metric = "zml_device_clock_memory_mhz", .help = "Memory clock frequency in MHz" },
+    .{ .field = "mem_used_bytes", .metric = "zml_device_memory_used_bytes", .help = "Device memory used in bytes" },
+    .{ .field = "mem_total_bytes", .metric = "zml_device_memory_total_bytes", .help = "Device memory total in bytes" },
+    .{ .field = "pcie_tx_kbps", .metric = "zml_device_pcie_tx_bytes_per_second", .help = "PCIe TX throughput in bytes per second", .fmt = fmtKbpsAsBytesPerSec },
+    .{ .field = "pcie_rx_kbps", .metric = "zml_device_pcie_rx_bytes_per_second", .help = "PCIe RX throughput in bytes per second", .fmt = fmtKbpsAsBytesPerSec },
+};
+
+const neuron_metrics = .{
+    .{ .field = "util_percent", .metric = "zml_device_utilization_percent", .help = "Device utilization percentage" },
+    .{ .field = "mem_used_bytes", .metric = "zml_device_memory_used_bytes", .help = "Device memory used in bytes" },
+    .{ .field = "mem_total_bytes", .metric = "zml_device_memory_total_bytes", .help = "Device memory total in bytes" },
+    .{ .field = "nc_tensors", .metric = "zml_device_neuron_tensors_bytes", .help = "Neuron core tensor memory in bytes" },
+    .{ .field = "nc_constants", .metric = "zml_device_neuron_constants_bytes", .help = "Neuron core constants memory in bytes" },
+    .{ .field = "nc_model_code", .metric = "zml_device_neuron_model_code_bytes", .help = "Neuron core model code memory in bytes" },
+    .{ .field = "nc_shared_scratchpad", .metric = "zml_device_neuron_shared_scratchpad_bytes", .help = "Neuron core shared scratchpad memory in bytes" },
+    .{ .field = "nc_nonshared_scratchpad", .metric = "zml_device_neuron_nonshared_scratchpad_bytes", .help = "Neuron core non-shared scratchpad memory in bytes" },
+    .{ .field = "nc_runtime", .metric = "zml_device_neuron_runtime_bytes", .help = "Neuron core runtime memory in bytes" },
+    .{ .field = "nc_driver", .metric = "zml_device_neuron_driver_bytes", .help = "Neuron core driver memory in bytes" },
+    .{ .field = "nc_dma_rings", .metric = "zml_device_neuron_dma_rings_bytes", .help = "Neuron core DMA rings memory in bytes" },
+    .{ .field = "nc_collectives", .metric = "zml_device_neuron_collectives_bytes", .help = "Neuron core collectives memory in bytes" },
+    .{ .field = "nc_notifications", .metric = "zml_device_neuron_notifications_bytes", .help = "Neuron core notifications memory in bytes" },
+    .{ .field = "nc_uncategorized", .metric = "zml_device_neuron_uncategorized_bytes", .help = "Neuron core uncategorized memory in bytes" },
+};
+
+const tpu_metrics = .{
+    .{ .field = "util_percent", .metric = "zml_device_utilization_percent", .help = "Device utilization percentage" },
+    .{ .field = "mem_used_bytes", .metric = "zml_device_memory_used_bytes", .help = "Device memory used in bytes" },
+    .{ .field = "mem_total_bytes", .metric = "zml_device_memory_total_bytes", .help = "Device memory total in bytes" },
+};
+
+const host_metrics = .{
+    .{ .field = "cpu_cores", .metric = "zml_host_cpu_cores", .help = "Number of CPU cores" },
+    .{ .field = "mem_total_kib", .metric = "zml_host_memory_total_bytes", .help = "Total host memory in bytes", .fmt = fmtKibAsBytes },
+    .{ .field = "mem_available_kib", .metric = "zml_host_memory_available_bytes", .help = "Available host memory in bytes", .fmt = fmtKibAsBytes },
+    .{ .field = "load_1", .metric = "zml_host_load_1", .help = "1-minute load average" },
+    .{ .field = "load_5", .metric = "zml_host_load_5", .help = "5-minute load average" },
+    .{ .field = "load_15", .metric = "zml_host_load_15", .help = "15-minute load average" },
+    .{ .field = "uptime_seconds", .metric = "zml_host_uptime_seconds", .help = "System uptime in seconds" },
+};
+
+pub fn write(writer: *std.Io.Writer, devices: []const *DeviceInfo, host: *const HostInfo) !void {
+    try writer.writeAll("# HELP zml_device_info Device metadata\n");
+    try writer.writeAll("# TYPE zml_device_info gauge\n");
+    for (devices, 0..) |dev, i| {
+        inline for (@typeInfo(DeviceInfo).@"union".fields) |tp| {
+            const tag = @field(smi_info.device_info.Target, tp.name);
+
+            switch (dev.*) {
+                tag => |*db| {
+                    const val = db.front().*;
+
+                    try writer.print("zml_device_info{{device=\"{d}\",type=\"{s}\"", .{ i, tp.name });
+
+                    inline for (.{
+                        .{ "name", "name" },
+                        .{ "driver_version", "driver" },
+                        .{ "cuda_driver_version", "cuda_version" },
+                    }) |label| {
+                        if (@hasField(@TypeOf(val), label[0])) {
+                            if (@field(val, label[0])) |v| {
+                                try writer.print(",{s}=\"{s}\"", .{ label[1], v });
+                            }
+                        }
+                    }
+
+                    try writer.writeAll("} 1\n");
+                },
+                else => {},
+            }
+        }
+    }
+    try writer.writeAll("\n");
+
+    for (devices, 0..) |dev, i| {
+        switch (dev.*) {
+            .cuda => |*db| try writeMetrics(writer, gpu_metrics, db.front().*, .{ i, "cuda" }),
+            .rocm => |*db| try writeMetrics(writer, gpu_metrics, db.front().*, .{ i, "rocm" }),
+            .neuron => |*db| try writeMetrics(writer, neuron_metrics, db.front().*, .{ i, "neuron" }),
+            .tpu => |*db| try writeMetrics(writer, tpu_metrics, db.front().*, .{ i, "tpu" }),
+        }
+    }
+
+    try writeMetrics(writer, host_metrics, host.front().*, null);
+}
+
+fn writeMetrics(
+    writer: *std.Io.Writer,
+    comptime metrics: anytype,
+    val: anytype,
+    device: ?struct { usize, []const u8 },
+) !void {
+    const name_label = if (@hasField(@TypeOf(val), "name")) val.name else null;
+
+    inline for (metrics) |m| {
+        if (@field(val, m.field)) |raw| {
+            try writer.print("# HELP {s} {s}\n# TYPE {s} gauge\n{s}", .{ m.metric, m.help, m.metric, m.metric });
+
+            if (device) |d| {
+                try writer.print("{{device=\"{d}\",type=\"{s}\"", .{ d[0], d[1] });
+
+                if (name_label) |name| {
+                    try writer.print(",name=\"{s}\"", .{name});
+                }
+
+                try writer.writeAll("}");
+            }
+
+            try writer.writeAll(" ");
+
+            if (@hasField(@TypeOf(m), "fmt")) {
+                try m.fmt(writer, raw);
+            } else {
+                try writeValue(writer, raw);
+            }
+            try writer.writeAll("\n");
+        }
+    }
+}
+
+fn writeValue(writer: *std.Io.Writer, val: anytype) std.Io.Writer.Error!void {
+    switch (@typeInfo(@TypeOf(val))) {
+        .float, .comptime_float => try writer.print("{d:.2}", .{val}),
+        .pointer => try writer.writeAll(val),
+        else => try writer.print("{d}", .{val}),
+    }
+}
+
+fn fmtMilliwattsAsWatts(writer: *std.Io.Writer, val: u64) std.Io.Writer.Error!void {
+    try writer.print("{d}.{d:0>3}", .{ val / 1000, val % 1000 });
+}
+
+fn fmtKibAsBytes(writer: *std.Io.Writer, val: u64) std.Io.Writer.Error!void {
+    try writer.print("{d}", .{val * 1024});
+}
+
+fn fmtKbpsAsBytesPerSec(writer: *std.Io.Writer, val: u64) std.Io.Writer.Error!void {
+    try writer.print("{d}", .{val * 128});
+}

--- a/bin/zml-smi/prometheus/exposition.zig
+++ b/bin/zml-smi/prometheus/exposition.zig
@@ -18,8 +18,8 @@ const device_metrics = .{
     .{ .field = "clock_graphics_mhz", .metric = "zml_device_clock_graphics_mhz", .help = "Graphics clock frequency in MHz" },
     .{ .field = "clock_sm_mhz", .metric = "zml_device_clock_sm_mhz", .help = "SM clock frequency in MHz" },
     .{ .field = "clock_mem_mhz", .metric = "zml_device_clock_memory_mhz", .help = "Memory clock frequency in MHz" },
-    .{ .field = "pcie_tx_kbps", .metric = "zml_device_pcie_tx_bytes_per_second", .help = "PCIe TX throughput in bytes per second", .fmt = fmtKbpsAsBytesPerSec },
-    .{ .field = "pcie_rx_kbps", .metric = "zml_device_pcie_rx_bytes_per_second", .help = "PCIe RX throughput in bytes per second", .fmt = fmtKbpsAsBytesPerSec },
+    .{ .field = "pcie_tx_kbps", .metric = "zml_device_pcie_tx_bytes_per_second", .help = "PCIe TX throughput in bytes per second", .fmt = fmtScaled(128) },
+    .{ .field = "pcie_rx_kbps", .metric = "zml_device_pcie_rx_bytes_per_second", .help = "PCIe RX throughput in bytes per second", .fmt = fmtScaled(128) },
     // Neuron
     .{ .field = "nc_tensors", .metric = "zml_device_neuron_tensors_bytes", .help = "Neuron core tensor memory in bytes" },
     .{ .field = "nc_constants", .metric = "zml_device_neuron_constants_bytes", .help = "Neuron core constants memory in bytes" },
@@ -36,8 +36,8 @@ const device_metrics = .{
 
 const host_metrics = .{
     .{ .field = "cpu_cores", .metric = "zml_host_cpu_cores", .help = "Number of CPU cores" },
-    .{ .field = "mem_total_kib", .metric = "zml_host_memory_total_bytes", .help = "Total host memory in bytes", .fmt = fmtKibAsBytes },
-    .{ .field = "mem_available_kib", .metric = "zml_host_memory_available_bytes", .help = "Available host memory in bytes", .fmt = fmtKibAsBytes },
+    .{ .field = "mem_total_kib", .metric = "zml_host_memory_total_bytes", .help = "Total host memory in bytes", .fmt = fmtScaled(1024) },
+    .{ .field = "mem_available_kib", .metric = "zml_host_memory_available_bytes", .help = "Available host memory in bytes", .fmt = fmtScaled(1024) },
     .{ .field = "load_1", .metric = "zml_host_load_1", .help = "1-minute load average" },
     .{ .field = "load_5", .metric = "zml_host_load_5", .help = "5-minute load average" },
     .{ .field = "load_15", .metric = "zml_host_load_15", .help = "15-minute load average" },
@@ -65,7 +65,7 @@ pub fn write(writer: *std.Io.Writer, devices: []const *DeviceInfo, host: *const 
                         if (@hasField(@TypeOf(val), label[0])) {
                             if (@field(val, label[0])) |v| {
                                 try writer.print(",{s}=\"", .{label[1]});
-                                try writeEscapedLabel(writer, v);
+                                try std.zig.stringEscape(v, writer);
                                 try writer.writeAll("\"");
                             }
                         }
@@ -104,7 +104,7 @@ fn writeAllDeviceMetrics(
 
                             const device_type = @tagName(std.meta.activeTag(dev.*));
                             try writer.print("{s}{{device=\"{d}\",type=\"{s}\",name=\"", .{ m.metric, i, device_type });
-                            try writeEscapedLabel(writer, val.name orelse "");
+                            try std.zig.stringEscape(val.name orelse "", writer);
                             try writer.writeAll("\"} ");
                             try fmtValue(m, writer, raw);
                             try writer.writeAll("\n");
@@ -150,21 +150,10 @@ fn fmtMilliwattsAsWatts(writer: *std.Io.Writer, val: u64) std.Io.Writer.Error!vo
     try writer.print("{d}.{d:0>3}", .{ val / 1000, val % 1000 });
 }
 
-fn fmtKibAsBytes(writer: *std.Io.Writer, val: u64) std.Io.Writer.Error!void {
-    try writer.print("{d}", .{val * 1024});
-}
-
-fn fmtKbpsAsBytesPerSec(writer: *std.Io.Writer, val: u64) std.Io.Writer.Error!void {
-    try writer.print("{d}", .{val * 128});
-}
-
-fn writeEscapedLabel(writer: *std.Io.Writer, value: []const u8) std.Io.Writer.Error!void {
-    for (value) |ch| {
-        switch (ch) {
-            '\\' => try writer.writeAll("\\\\"),
-            '"' => try writer.writeAll("\\\""),
-            '\n' => try writer.writeAll("\\n"),
-            else => try writer.writeAll(&.{ch}),
+fn fmtScaled(comptime scale: u64) fn (*std.Io.Writer, u64) std.Io.Writer.Error!void {
+    return struct {
+        fn f(writer: *std.Io.Writer, val: u64) std.Io.Writer.Error!void {
+            try writer.print("{d}", .{val * scale});
         }
-    }
+    }.f;
 }

--- a/bin/zml-smi/prometheus/exposition.zig
+++ b/bin/zml-smi/prometheus/exposition.zig
@@ -3,8 +3,12 @@ const smi_info = @import("zml-smi/info");
 const DeviceInfo = smi_info.device_info.DeviceInfo;
 const HostInfo = smi_info.host_info.HostInfo;
 
-const gpu_metrics = .{
-    .{ .field = "util_percent", .metric = "zml_device_utilization_percent", .help = "GPU utilization percentage" },
+const device_metrics = .{
+    // Shared across all device types
+    .{ .field = "util_percent", .metric = "zml_device_utilization_percent", .help = "Device utilization percentage" },
+    .{ .field = "mem_used_bytes", .metric = "zml_device_memory_used_bytes", .help = "Device memory used in bytes" },
+    .{ .field = "mem_total_bytes", .metric = "zml_device_memory_total_bytes", .help = "Device memory total in bytes" },
+    // GPU (CUDA/ROCm)
     .{ .field = "encoder_util_percent", .metric = "zml_device_encoder_utilization_percent", .help = "Encoder utilization percentage" },
     .{ .field = "decoder_util_percent", .metric = "zml_device_decoder_utilization_percent", .help = "Decoder utilization percentage" },
     .{ .field = "power_mw", .metric = "zml_device_power_watts", .help = "Power draw in watts", .fmt = fmtMilliwattsAsWatts },
@@ -14,16 +18,9 @@ const gpu_metrics = .{
     .{ .field = "clock_graphics_mhz", .metric = "zml_device_clock_graphics_mhz", .help = "Graphics clock frequency in MHz" },
     .{ .field = "clock_sm_mhz", .metric = "zml_device_clock_sm_mhz", .help = "SM clock frequency in MHz" },
     .{ .field = "clock_mem_mhz", .metric = "zml_device_clock_memory_mhz", .help = "Memory clock frequency in MHz" },
-    .{ .field = "mem_used_bytes", .metric = "zml_device_memory_used_bytes", .help = "Device memory used in bytes" },
-    .{ .field = "mem_total_bytes", .metric = "zml_device_memory_total_bytes", .help = "Device memory total in bytes" },
     .{ .field = "pcie_tx_kbps", .metric = "zml_device_pcie_tx_bytes_per_second", .help = "PCIe TX throughput in bytes per second", .fmt = fmtKbpsAsBytesPerSec },
     .{ .field = "pcie_rx_kbps", .metric = "zml_device_pcie_rx_bytes_per_second", .help = "PCIe RX throughput in bytes per second", .fmt = fmtKbpsAsBytesPerSec },
-};
-
-const neuron_metrics = .{
-    .{ .field = "util_percent", .metric = "zml_device_utilization_percent", .help = "Device utilization percentage" },
-    .{ .field = "mem_used_bytes", .metric = "zml_device_memory_used_bytes", .help = "Device memory used in bytes" },
-    .{ .field = "mem_total_bytes", .metric = "zml_device_memory_total_bytes", .help = "Device memory total in bytes" },
+    // Neuron
     .{ .field = "nc_tensors", .metric = "zml_device_neuron_tensors_bytes", .help = "Neuron core tensor memory in bytes" },
     .{ .field = "nc_constants", .metric = "zml_device_neuron_constants_bytes", .help = "Neuron core constants memory in bytes" },
     .{ .field = "nc_model_code", .metric = "zml_device_neuron_model_code_bytes", .help = "Neuron core model code memory in bytes" },
@@ -35,12 +32,6 @@ const neuron_metrics = .{
     .{ .field = "nc_collectives", .metric = "zml_device_neuron_collectives_bytes", .help = "Neuron core collectives memory in bytes" },
     .{ .field = "nc_notifications", .metric = "zml_device_neuron_notifications_bytes", .help = "Neuron core notifications memory in bytes" },
     .{ .field = "nc_uncategorized", .metric = "zml_device_neuron_uncategorized_bytes", .help = "Neuron core uncategorized memory in bytes" },
-};
-
-const tpu_metrics = .{
-    .{ .field = "util_percent", .metric = "zml_device_utilization_percent", .help = "Device utilization percentage" },
-    .{ .field = "mem_used_bytes", .metric = "zml_device_memory_used_bytes", .help = "Device memory used in bytes" },
-    .{ .field = "mem_total_bytes", .metric = "zml_device_memory_total_bytes", .help = "Device memory total in bytes" },
 };
 
 const host_metrics = .{
@@ -73,7 +64,9 @@ pub fn write(writer: *std.Io.Writer, devices: []const *DeviceInfo, host: *const 
                     }) |label| {
                         if (@hasField(@TypeOf(val), label[0])) {
                             if (@field(val, label[0])) |v| {
-                                try writer.print(",{s}=\"{s}\"", .{ label[1], v });
+                                try writer.print(",{s}=\"", .{label[1]});
+                                try writeEscapedLabel(writer, v);
+                                try writer.writeAll("\"");
                             }
                         }
                     }
@@ -86,29 +79,42 @@ pub fn write(writer: *std.Io.Writer, devices: []const *DeviceInfo, host: *const 
     }
     try writer.writeAll("\n");
 
-    for (devices, 0..) |dev, i| {
-        switch (dev.*) {
-            .cuda => |*db| try writeDeviceMetrics(writer, gpu_metrics, db.front().*, i, "cuda"),
-            .rocm => |*db| try writeDeviceMetrics(writer, gpu_metrics, db.front().*, i, "rocm"),
-            .neuron => |*db| try writeDeviceMetrics(writer, neuron_metrics, db.front().*, i, "neuron"),
-            .tpu => |*db| try writeDeviceMetrics(writer, tpu_metrics, db.front().*, i, "tpu"),
-        }
-    }
-
+    try writeAllDeviceMetrics(writer, device_metrics, devices);
     try writeHostMetrics(writer, host.front().*);
 }
 
-fn writeDeviceMetrics(
+fn writeAllDeviceMetrics(
     writer: *std.Io.Writer,
     comptime metrics: anytype,
-    val: anytype,
-    device_idx: usize,
-    device_type: []const u8,
+    devices: []const *DeviceInfo,
 ) !void {
     inline for (metrics) |m| {
-        if (@field(val, m.field)) |raw| {
-            try writer.print("# HELP {s} {s}\n# TYPE {s} gauge\n{s}{{device=\"{d}\",type=\"{s}\",name=\"{?s}\"}} ", .{ m.metric, m.help, m.metric, m.metric, device_idx, device_type, val.name });
-            try fmtValue(m, writer, raw);
+        var header_written = false;
+
+        for (devices, 0..) |dev, i| {
+            switch (dev.*) {
+                inline else => |*db| {
+                    const val = db.front().*;
+                    if (@hasField(@TypeOf(val), m.field)) {
+                        if (@field(val, m.field)) |raw| {
+                            if (!header_written) {
+                                try writer.print("# HELP {s} {s}\n# TYPE {s} gauge\n", .{ m.metric, m.help, m.metric });
+                                header_written = true;
+                            }
+
+                            const device_type = @tagName(std.meta.activeTag(dev.*));
+                            try writer.print("{s}{{device=\"{d}\",type=\"{s}\",name=\"", .{ m.metric, i, device_type });
+                            try writeEscapedLabel(writer, val.name orelse "");
+                            try writer.writeAll("\"} ");
+                            try fmtValue(m, writer, raw);
+                            try writer.writeAll("\n");
+                        }
+                    }
+                },
+            }
+        }
+
+        if (header_written) {
             try writer.writeAll("\n");
         }
     }
@@ -119,7 +125,7 @@ fn writeHostMetrics(writer: *std.Io.Writer, val: anytype) !void {
         if (@field(val, m.field)) |raw| {
             try writer.print("# HELP {s} {s}\n# TYPE {s} gauge\n{s} ", .{ m.metric, m.help, m.metric, m.metric });
             try fmtValue(m, writer, raw);
-            try writer.writeAll("\n");
+            try writer.writeAll("\n\n");
         }
     }
 }
@@ -150,4 +156,15 @@ fn fmtKibAsBytes(writer: *std.Io.Writer, val: u64) std.Io.Writer.Error!void {
 
 fn fmtKbpsAsBytesPerSec(writer: *std.Io.Writer, val: u64) std.Io.Writer.Error!void {
     try writer.print("{d}", .{val * 128});
+}
+
+fn writeEscapedLabel(writer: *std.Io.Writer, value: []const u8) std.Io.Writer.Error!void {
+    for (value) |ch| {
+        switch (ch) {
+            '\\' => try writer.writeAll("\\\\"),
+            '"' => try writer.writeAll("\\\""),
+            '\n' => try writer.writeAll("\\n"),
+            else => try writer.writeAll(&.{ch}),
+        }
+    }
 }

--- a/bin/zml-smi/prometheus/prometheus.zig
+++ b/bin/zml-smi/prometheus/prometheus.zig
@@ -1,0 +1,2 @@
+pub const Server = @import("server.zig").Server;
+pub const exposition = @import("exposition.zig");

--- a/bin/zml-smi/prometheus/server.zig
+++ b/bin/zml-smi/prometheus/server.zig
@@ -1,0 +1,87 @@
+const std = @import("std");
+const smi_info = @import("zml-smi/info");
+const DeviceInfo = smi_info.device_info.DeviceInfo;
+const HostInfo = smi_info.host_info.HostInfo;
+const exposition = @import("exposition.zig");
+
+pub const Server = struct {
+    io: std.Io,
+    devices: []const *DeviceInfo,
+    host: *const HostInfo,
+    tcp: std.Io.net.Server,
+    connection_group: std.Io.Group = .init,
+
+    pub fn init(io: std.Io, port: u16, devices: []const *DeviceInfo, host: *const HostInfo) !Server {
+        const address: std.Io.net.IpAddress = .{ .ip4 = .{
+            .bytes = .{ 0, 0, 0, 0 },
+            .port = port,
+        } };
+        var tcp = try address.listen(io, .{ .reuse_address = true });
+        errdefer tcp.deinit(io);
+
+        return .{
+            .io = io,
+            .devices = devices,
+            .host = host,
+            .tcp = tcp,
+        };
+    }
+
+    pub fn deinit(self: *Server) void {
+        self.connection_group.await(self.io) catch {};
+        self.tcp.deinit(self.io);
+    }
+
+    pub fn serve(self: *Server) !void {
+        while (true) {
+            const stream = self.tcp.accept(self.io) catch break;
+            self.connection_group.concurrent(self.io, Server.onConnection, .{ self, stream }) catch break;
+        }
+    }
+
+    fn onConnection(self: *Server, stream: std.Io.net.Stream) std.Io.Cancelable!void {
+        defer stream.close(self.io);
+        self.handleConn(stream) catch {};
+    }
+
+    fn handleConn(self: *Server, stream: std.Io.net.Stream) !void {
+        var read_buf: [8192]u8 = undefined;
+        var reader = stream.reader(self.io, &read_buf);
+
+        var write_buf: [4096]u8 = undefined;
+        var writer = stream.writer(self.io, &write_buf);
+
+        var http_server: std.http.Server = .init(&reader.interface, &writer.interface);
+
+        while (true) {
+            var request = http_server.receiveHead() catch |err| switch (err) {
+                error.HttpConnectionClosing => return,
+                else => return err,
+            };
+
+            if (request.head.method != .GET) {
+                try request.respond("Method Not Allowed\n", .{ .status = .method_not_allowed });
+                continue;
+            }
+
+            if (std.mem.eql(u8, request.head.target, "/metrics")) {
+                var body_buf: [4096]u8 = undefined;
+                var body_writer = try request.respondStreaming(&body_buf, .{
+                    .respond_options = .{
+                        .status = .ok,
+                        .extra_headers = &.{
+                            .{ .name = "content-type", .value = "text/plain" },
+                        },
+                    },
+                });
+
+                try exposition.write(&body_writer.writer, self.devices, self.host);
+                try body_writer.end();
+            } else if (std.mem.eql(u8, request.head.target, "/")) {
+                try request.respond("OK\n", .{ .status = .ok });
+            } else {
+                try request.respond("Not Found\n", .{ .status = .not_found });
+            }
+        }
+    }
+};

--- a/bin/zml-smi/prometheus/server.zig
+++ b/bin/zml-smi/prometheus/server.zig
@@ -11,11 +11,8 @@ pub const Server = struct {
     tcp: std.Io.net.Server,
     connection_group: std.Io.Group = .init,
 
-    pub fn init(io: std.Io, port: u16, devices: []const *DeviceInfo, host: *const HostInfo) !Server {
-        const address: std.Io.net.IpAddress = .{ .ip4 = .{
-            .bytes = .{ 0, 0, 0, 0 },
-            .port = port,
-        } };
+    pub fn init(io: std.Io, listen: []const u8, devices: []const *DeviceInfo, host: *const HostInfo) !Server {
+        const address = parseListenAddress(listen) orelse return error.InvalidAddress;
         var tcp = try address.listen(io, .{ .reuse_address = true });
         errdefer tcp.deinit(io);
 
@@ -27,8 +24,8 @@ pub const Server = struct {
         };
     }
 
-    pub fn run(io: std.Io, port: u16, devices: []const *DeviceInfo, host_info: *const HostInfo) void {
-        var self = init(io, port, devices, host_info) catch |err| {
+    pub fn run(io: std.Io, listen: []const u8, devices: []const *DeviceInfo, host_info: *const HostInfo) void {
+        var self = init(io, listen, devices, host_info) catch |err| {
             std.log.err("prometheus server failed to start: {s}", .{@errorName(err)});
             return;
         };
@@ -92,5 +89,20 @@ pub const Server = struct {
                 try request.respond("Not Found\n", .{ .status = .not_found });
             }
         }
+    }
+
+    fn parseListenAddress(listen: []const u8) ?std.Io.net.IpAddress {
+        var ttk = std.mem.tokenizeScalar(u8, listen, ':');
+
+        const host_str = ttk.next() orelse return null;
+        const port_str = ttk.next() orelse return null;
+        const port = std.fmt.parseInt(u16, port_str, 10) catch return null;
+
+        const ip_bytes: [4]u8 = if (std.mem.eql(u8, host_str, "localhost"))
+            .{ 127, 0, 0, 1 }
+        else
+            (std.Io.net.IpAddress.parseIp4(host_str, 0) catch return null).ip4.bytes;
+
+        return .{ .ip4 = .{ .bytes = ip_bytes, .port = port } };
     }
 };

--- a/bin/zml-smi/prometheus/server.zig
+++ b/bin/zml-smi/prometheus/server.zig
@@ -27,12 +27,21 @@ pub const Server = struct {
         };
     }
 
+    pub fn run(io: std.Io, port: u16, devices: []const *DeviceInfo, host_info: *const HostInfo) void {
+        var self = init(io, port, devices, host_info) catch |err| {
+            std.log.err("prometheus server failed to start: {s}", .{@errorName(err)});
+            return;
+        };
+        defer self.deinit();
+        self.serve();
+    }
+
     pub fn deinit(self: *Server) void {
         self.connection_group.await(self.io) catch {};
         self.tcp.deinit(self.io);
     }
 
-    pub fn serve(self: *Server) !void {
+    pub fn serve(self: *Server) void {
         while (true) {
             const stream = self.tcp.accept(self.io) catch break;
             self.connection_group.concurrent(self.io, Server.onConnection, .{ self, stream }) catch break;

--- a/bin/zml-smi/prometheus/server.zig
+++ b/bin/zml-smi/prometheus/server.zig
@@ -12,7 +12,7 @@ pub const Server = struct {
     connection_group: std.Io.Group = .init,
 
     pub fn init(io: std.Io, listen: []const u8, devices: []const *DeviceInfo, host: *const HostInfo) !Server {
-        const address = parseListenAddress(listen) orelse return error.InvalidAddress;
+        const address = try std.Io.net.IpAddress.parseLiteral(listen);
         var tcp = try address.listen(io, .{ .reuse_address = true });
         errdefer tcp.deinit(io);
 
@@ -89,20 +89,5 @@ pub const Server = struct {
                 try request.respond("Not Found\n", .{ .status = .not_found });
             }
         }
-    }
-
-    fn parseListenAddress(listen: []const u8) ?std.Io.net.IpAddress {
-        var ttk = std.mem.tokenizeScalar(u8, listen, ':');
-
-        const host_str = ttk.next() orelse return null;
-        const port_str = ttk.next() orelse return null;
-        const port = std.fmt.parseInt(u16, port_str, 10) catch return null;
-
-        const ip_bytes: [4]u8 = if (std.mem.eql(u8, host_str, "localhost"))
-            .{ 127, 0, 0, 1 }
-        else
-            (std.Io.net.IpAddress.parseIp4(host_str, 0) catch return null).ip4.bytes;
-
-        return .{ .ip4 = .{ .bytes = ip_bytes, .port = port } };
     }
 };

--- a/bin/zml-smi/prometheus/server.zig
+++ b/bin/zml-smi/prometheus/server.zig
@@ -70,24 +70,18 @@ pub const Server = struct {
                 continue;
             }
 
-            if (std.mem.eql(u8, request.head.target, "/metrics")) {
-                var body_buf: [4096]u8 = undefined;
-                var body_writer = try request.respondStreaming(&body_buf, .{
-                    .respond_options = .{
-                        .status = .ok,
-                        .extra_headers = &.{
-                            .{ .name = "content-type", .value = "text/plain" },
-                        },
+            var body_buf: [4096]u8 = undefined;
+            var body_writer = try request.respondStreaming(&body_buf, .{
+                .respond_options = .{
+                    .status = .ok,
+                    .extra_headers = &.{
+                        .{ .name = "content-type", .value = "text/plain" },
                     },
-                });
+                },
+            });
 
-                try exposition.write(&body_writer.writer, self.devices, self.host);
-                try body_writer.end();
-            } else if (std.mem.eql(u8, request.head.target, "/")) {
-                try request.respond("OK\n", .{ .status = .ok });
-            } else {
-                try request.respond("Not Found\n", .{ .status = .not_found });
-            }
+            try exposition.write(&body_writer.writer, self.devices, self.host);
+            try body_writer.end();
         }
     }
 };

--- a/bin/zml-smi/scripts/release.sh
+++ b/bin/zml-smi/scripts/release.sh
@@ -85,24 +85,28 @@ changelog() {
   prev_tag="$(git describe --tags --abbrev=0 --match 'zml-smi-v*' 2>/dev/null || true)"
   local range="${prev_tag:+${prev_tag}..HEAD}"
 
-  git log ${range:-HEAD} --pretty=format:"- %s" -- bin/zml-smi/ | grep -vi WIP
+  git log ${range:-HEAD} --pretty=format:"- %s" -- bin/zml-smi/ | grep -vi WIP || true
 }
 
 tag() {
   step "Tagging ${CYAN}${TAG}${WHITE}"
+
+  # Cache changelog before tagging, otherwise the new tag makes the range empty
+  CACHED_CHANGELOG="$(changelog)"
+
+  if [ -z "$CACHED_CHANGELOG" ]; then
+    warn "No changes since last release"
+  fi
 
   if git rev-parse "$TAG" &>/dev/null; then
     warn "Tag ${TAG} already exists, skipping"
     return
   fi
 
-  local log
-  log="$(changelog)"
-
   if [ "$DRY_RUN" = true ]; then
     warn "Dry run — skipping tag creation"
   elif confirm "Create tag ${CYAN}${TAG}${RESET}${WHITE}?"; then
-    git tag -a "$TAG" -m "$(printf '%s\n\n%s' "$TAG" "$log")"
+    git tag -a "$TAG" -m "$(printf '%s\n\n%s' "$TAG" "$CACHED_CHANGELOG")"
     success "Created tag ${CYAN}${TAG}"
   else
     warn "Skipped tagging"
@@ -111,7 +115,7 @@ tag() {
   printf "\n"
 
   printf "${DIM}"
-  echo "$log"
+  echo "$CACHED_CHANGELOG"
   printf "${RESET}"
 }
 
@@ -211,8 +215,7 @@ verify() {
 
 release_notes() {
   local install_url="${BASE_URL}/zml-smi/${VERSION}"
-  local log
-  log="$(changelog)"
+  local log="$CACHED_CHANGELOG"
 
   local downloads=""
   for f in "${FILES[@]}"; do
@@ -278,15 +281,11 @@ github_release() {
     return
   fi
 
-  local assets=()
-  for f in "${FILES[@]}"; do
-    [ -f "$f" ] && assets+=("$f")
-  done
-
+  printf "${DIM}%s${RESET}\n" "────────────────────────────────────────"
   gh release create "$TAG" \
     --title "$TAG" \
-    --notes "$notes" \
-    "${assets[@]}"
+    --notes "$notes"
+  printf "${DIM}%s${RESET}\n" "────────────────────────────────────────"
   success "Created release ${CYAN}${TAG}"
 }
 
@@ -303,7 +302,9 @@ push_tag() {
     return
   fi
 
+  printf "${DIM}%s${RESET}\n" "────────────────────────────────────────"
   git push origin "$TAG"
+  printf "${DIM}%s${RESET}\n" "────────────────────────────────────────"
   success "Pushed ${CYAN}${TAG}${RESET}${GREEN} to origin"
 }
 

--- a/bin/zml-smi/scripts/release.sh
+++ b/bin/zml-smi/scripts/release.sh
@@ -167,8 +167,15 @@ upload() {
     success "${name}"
   done
 
-  rclone copyto "$INSTALL_SCRIPT" "${rclone_remote}:${BUCKET}/zml-smi/install.sh"
-  success "install.sh"
+  rclone copyto "$INSTALL_SCRIPT" "${rclone_remote}:${BUCKET}/zml-smi/${VERSION}/install.sh"
+  success "zml-smi/${VERSION}/install.sh"
+
+  if confirm "Set ${CYAN}${VERSION}${RESET}${WHITE} as the default install version?"; then
+    rclone copyto "$INSTALL_SCRIPT" "${rclone_remote}:${BUCKET}/zml-smi/install.sh"
+    success "zml-smi/install.sh"
+  else
+    warn "Skipped default install script"
+  fi
 }
 
 verify() {
@@ -194,7 +201,7 @@ verify() {
 
   local local_sha remote_sha
   local_sha="$(shasum -a 256 "$INSTALL_SCRIPT" | awk '{print $1}')"
-  remote_sha="$(curl -fsSL "${BASE_URL}/zml-smi/install.sh" | shasum -a 256 | awk '{print $1}')"
+  remote_sha="$(curl -fsSL "${install_url}/install.sh" | shasum -a 256 | awk '{print $1}')"
   if [ "$local_sha" = "$remote_sha" ]; then
     success "install.sh"
   else
@@ -234,6 +241,8 @@ release_notes() {
   done
 
   cat <<EOF
+## Changelog
+
 ${log}
 
 ## Install

--- a/bin/zml-smi/scripts/release.sh
+++ b/bin/zml-smi/scripts/release.sh
@@ -55,6 +55,13 @@ usage() {
     ${CYAN}BASE_URL${RESET}        Public base URL serving the bucket
     ${CYAN}RCLONE_REMOTE${RESET}   Rclone remote name ${DIM}(default: r2)${RESET}
 
+    ${DIM}If rclone is not configured, you can set the remote via env vars:${RESET}
+    ${DIM}  RCLONE_CONFIG_R2_TYPE=s3${RESET}
+    ${DIM}  RCLONE_CONFIG_R2_PROVIDER=Cloudflare${RESET}
+    ${DIM}  RCLONE_CONFIG_R2_ACCESS_KEY_ID=your_access_key${RESET}
+    ${DIM}  RCLONE_CONFIG_R2_SECRET_ACCESS_KEY=your_secret_key${RESET}
+    ${DIM}  RCLONE_CONFIG_R2_ENDPOINT=https://<account_id>.r2.cloudflarestorage.com${RESET}
+
   ${WHITE}Examples${RESET}
     ${DIM}# Interactive, local only${RESET}
     bazel run //bin/zml-smi:release -- 0.4.0

--- a/bin/zml-smi/scripts/release.sh
+++ b/bin/zml-smi/scripts/release.sh
@@ -184,8 +184,10 @@ upload() {
   if confirm "Set ${CYAN}${VERSION}${RESET}${WHITE} as the default install version?"; then
     rclone copyto "$INSTALL_SCRIPT" "${rclone_remote}:${BUCKET}/zml-smi/install.sh"
     success "zml-smi/install.sh"
+    DEFAULT_INSTALL=true
   else
     warn "Skipped default install script"
+    DEFAULT_INSTALL=false
   fi
 }
 
@@ -361,7 +363,7 @@ main() {
   if [ "$VERIFY" = true ] && [ "$DRY_RUN" = false ]; then
     verify
   fi
-  if [ "$PUBLISH" = true ]; then
+  if [ "$PUBLISH" = true ] && [ "${DEFAULT_INSTALL:-true}" = true ]; then
     push_tag
     github_release
   fi
@@ -375,7 +377,11 @@ main() {
   else
     printf "  ${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}\n"
     printf "  ${GREEN}  Release complete!${RESET}\n"
-    printf "  ${DIM}  curl -fsSL ${BASE_URL}/zml-smi/install.sh | sudo bash${RESET}\n"
+    if [ "${DEFAULT_INSTALL:-true}" = true ]; then
+      printf "  ${DIM}  curl -fsSL ${BASE_URL}/zml-smi/install.sh | sudo bash${RESET}\n"
+    else
+      printf "  ${DIM}  curl -fsSL ${BASE_URL}/zml-smi/${VERSION}/install.sh | sudo bash${RESET}\n"
+    fi
     printf "  ${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}\n"
   fi
   printf "\n"

--- a/bin/zml-smi/scripts/release.sh
+++ b/bin/zml-smi/scripts/release.sh
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- UI ---
+
+if [ -t 1 ]; then
+  DIM='\033[2m'
+  RESET='\033[0m'
+  BLUE='\033[1;38;2;140;180;255m'
+  GREEN='\033[1;32m'
+  RED='\033[1;31m'
+  YELLOW='\033[1;33m'
+  CYAN='\033[1;36m'
+  WHITE='\033[1;37m'
+else
+  DIM='' RESET='' BLUE='' GREEN='' RED='' YELLOW='' CYAN='' WHITE=''
+fi
+
+info()    { printf "${BLUE}  │${RESET} %b\n" "$*"; }
+success() { printf "${GREEN}  ✓${RESET} %b\n" "$*"; }
+warn()    { printf "${YELLOW}  !${RESET} %b\n" "$*"; }
+fail()    { printf "${RED}  ✗ %b${RESET}\n" "$*" >&2; exit 1; }
+step()    { printf "\n${WHITE}  ▸ %b${RESET}\n" "$*"; }
+
+confirm() {
+  if [ "$YES" = true ]; then
+    return 0
+  fi
+  printf "${WHITE}  ? %b ${DIM}[y/N]${RESET} " "$*"
+  local answer
+  read -r answer
+  case "$answer" in
+    y|Y|yes|Yes) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+usage() {
+  printf >&2 "
+  ${WHITE}Usage${RESET}
+    bazel run //bin/zml-smi:release -- [flags] <version>
+
+  ${WHITE}Arguments${RESET}
+    ${CYAN}version${RESET}         Semantic version, e.g. ${DIM}1.0.0${RESET} (tagged as ${DIM}zml-smi-v1.0.0${RESET})
+
+  ${WHITE}Flags${RESET}
+    ${CYAN}--dry-run${RESET}       Build only — skip tagging, uploading, and publishing
+    ${CYAN}--verify${RESET}        Verify uploaded files by comparing sha256 against the CDN
+    ${CYAN}--publish${RESET}       Push git tag and create a GitHub release
+    ${CYAN}-y, --yes${RESET}       Skip all confirmation prompts
+    ${CYAN}-h, --help${RESET}      Show this help
+
+  ${WHITE}Environment${RESET}
+    ${CYAN}BUCKET${RESET}          S3-compatible bucket name
+    ${CYAN}BASE_URL${RESET}        Public base URL serving the bucket
+    ${CYAN}RCLONE_REMOTE${RESET}   Rclone remote name ${DIM}(default: r2)${RESET}
+
+  ${WHITE}Examples${RESET}
+    ${DIM}# Interactive, local only${RESET}
+    bazel run //bin/zml-smi:release -- 0.4.0
+
+    ${DIM}# Full release, non-interactive${RESET}
+    bazel run //bin/zml-smi:release -- --publish --verify --yes 0.4.0
+
+"
+  exit 0
+}
+
+# --- Checks ---
+
+check_env() {
+  [ -z "${BUILD_WORKSPACE_DIRECTORY:-}" ] && fail "Must be run via 'bazel run //bin/zml-smi:release -- <version>'"
+  local missing=()
+  [ -z "${BUCKET:-}" ] && missing+=("BUCKET")
+  [ -z "${BASE_URL:-}" ] && missing+=("BASE_URL")
+  if [ ${#missing[@]} -gt 0 ]; then
+    fail "Missing required environment variables: ${CYAN}${missing[*]}"
+  fi
+}
+
+# --- Steps ---
+
+changelog() {
+  local prev_tag
+  prev_tag="$(git describe --tags --abbrev=0 --match 'zml-smi-v*' 2>/dev/null || true)"
+  local range="${prev_tag:+${prev_tag}..HEAD}"
+
+  git log ${range:-HEAD} --pretty=format:"- %s" -- bin/zml-smi/ | grep -vi WIP
+}
+
+tag() {
+  step "Tagging ${CYAN}${TAG}${WHITE}"
+
+  if git rev-parse "$TAG" &>/dev/null; then
+    warn "Tag ${TAG} already exists, skipping"
+    return
+  fi
+
+  local log
+  log="$(changelog)"
+
+  if [ "$DRY_RUN" = true ]; then
+    warn "Dry run — skipping tag creation"
+  elif confirm "Create tag ${CYAN}${TAG}${RESET}${WHITE}?"; then
+    git tag -a "$TAG" -m "$(printf '%s\n\n%s' "$TAG" "$log")"
+    success "Created tag ${CYAN}${TAG}"
+  else
+    warn "Skipped tagging"
+    return
+  fi
+  printf "\n"
+
+  printf "${DIM}"
+  echo "$log"
+  printf "${RESET}"
+}
+
+build() {
+  step "Building release archives"
+
+  if ! confirm "Build all platforms?"; then
+    warn "Skipped build"
+    return 1
+  fi
+
+  printf "${DIM}%s${RESET}\n" "────────────────────────────────────────"
+
+  bazel build --config=release //bin/zml-smi:archives
+
+  printf "${DIM}%s${RESET}\n" "────────────────────────────────────────"
+  mapfile -t FILES < <(bazel cquery --config=release --output=files //bin/zml-smi:archives 2>/dev/null)
+  success "Built ${CYAN}${#FILES[@]}${RESET}${GREEN} artifacts"
+}
+
+upload() {
+  local rclone_remote="${RCLONE_REMOTE:-r2}"
+  local install_url="${BASE_URL}/zml-smi/${VERSION}"
+
+  step "Patching install script"
+
+  INSTALL_SCRIPT="$(mktemp)"
+  sed "s|^BASE_URL=.*|BASE_URL=\"${install_url}\"|" \
+    "${BUILD_WORKSPACE_DIRECTORY}/bin/zml-smi/scripts/remote-install.sh" > "$INSTALL_SCRIPT"
+  success "BASE_URL=${CYAN}${install_url}"
+
+  if [ "$DRY_RUN" = true ]; then
+    step "Uploading to ${CYAN}${rclone_remote}:${BUCKET}"
+    warn "Dry run — skipping upload"
+    return
+  fi
+
+  step "Uploading to ${CYAN}${rclone_remote}:${BUCKET}"
+
+  if ! confirm "Upload artifacts?"; then
+    warn "Skipped upload"
+    return
+  fi
+
+  for f in "${FILES[@]}"; do
+    if [ ! -f "$f" ]; then
+      warn "SKIP $(basename "$f") ${DIM}(not built for this host)${RESET}"
+      continue
+    fi
+    local name
+    name="$(basename "$f")"
+    rclone copyto "$f" "${rclone_remote}:${BUCKET}/zml-smi/${VERSION}/${name}"
+    success "${name}"
+  done
+
+  rclone copyto "$INSTALL_SCRIPT" "${rclone_remote}:${BUCKET}/zml-smi/install.sh"
+  success "install.sh"
+}
+
+verify() {
+  local install_url="${BASE_URL}/zml-smi/${VERSION}"
+
+  step "Verifying uploads"
+
+  for f in "${FILES[@]}"; do
+    if [ ! -f "$f" ]; then
+      continue
+    fi
+    local name
+    name="$(basename "$f")"
+    local local_sha remote_sha
+    local_sha="$(shasum -a 256 "$f" | awk '{print $1}')"
+    remote_sha="$(curl -fsSL "${install_url}/${name}" | shasum -a 256 | awk '{print $1}')"
+    if [ "$local_sha" = "$remote_sha" ]; then
+      success "${name}"
+    else
+      fail "${name} — sha256 mismatch (local: ${local_sha}, remote: ${remote_sha})"
+    fi
+  done
+
+  local local_sha remote_sha
+  local_sha="$(shasum -a 256 "$INSTALL_SCRIPT" | awk '{print $1}')"
+  remote_sha="$(curl -fsSL "${BASE_URL}/zml-smi/install.sh" | shasum -a 256 | awk '{print $1}')"
+  if [ "$local_sha" = "$remote_sha" ]; then
+    success "install.sh"
+  else
+    fail "install.sh — sha256 mismatch (local: ${local_sha}, remote: ${remote_sha})"
+  fi
+}
+
+release_notes() {
+  local install_url="${BASE_URL}/zml-smi/${VERSION}"
+  local log
+  log="$(changelog)"
+
+  local downloads=""
+  for f in "${FILES[@]}"; do
+    [ -f "$f" ] || continue
+    local name
+    name="$(basename "$f")"
+    [[ "$name" == *.sha256 ]] && continue
+    local sha_file=""
+    for sf in "${FILES[@]}"; do
+      if [ "$(basename "$sf")" = "${name}.sha256" ]; then
+        sha_file="$sf"
+        break
+      fi
+    done
+    if [ -z "$sha_file" ] || [ ! -f "$sha_file" ]; then
+      fail "Missing sha256 sidecar for ${name}"
+    fi
+    local sha
+    sha="$(awk '{print $1}' "$sha_file")"
+    local actual
+    actual="$(shasum -a 256 "$f" | awk '{print $1}')"
+    if [ "$sha" != "$actual" ]; then
+      fail "${name} sha256 mismatch — sidecar: ${sha}, actual: ${actual}"
+    fi
+    downloads="${downloads}| [${name}](${install_url}/${name}) | \`${sha}\` |"$'\n'
+  done
+
+  cat <<EOF
+${log}
+
+## Install
+
+\`\`\`
+curl -fsSL ${BASE_URL}/zml-smi/install.sh | sudo bash
+\`\`\`
+
+## Downloads
+
+| Archive | SHA-256 |
+|---------|---------|
+${downloads}
+EOF
+}
+
+github_release() {
+  step "Creating GitHub release"
+
+  local notes
+  notes="$(release_notes)"
+
+  if [ "$DRY_RUN" = true ]; then
+    warn "Dry run — skipping GitHub release"
+    info "Title: ${CYAN}${TAG}"
+    info "Notes:"
+    printf "${DIM}%s${RESET}\n" "$notes"
+    return
+  fi
+
+  if ! confirm "Create GitHub release ${CYAN}${TAG}${RESET}${WHITE}?"; then
+    warn "Skipped GitHub release"
+    return
+  fi
+
+  local assets=()
+  for f in "${FILES[@]}"; do
+    [ -f "$f" ] && assets+=("$f")
+  done
+
+  gh release create "$TAG" \
+    --title "$TAG" \
+    --notes "$notes" \
+    "${assets[@]}"
+  success "Created release ${CYAN}${TAG}"
+}
+
+push_tag() {
+  step "Pushing tag"
+
+  if [ "$DRY_RUN" = true ]; then
+    warn "Dry run — skipping push"
+    return
+  fi
+
+  if ! confirm "Push ${CYAN}${TAG}${RESET}${WHITE} to origin?"; then
+    warn "Skipped push"
+    return
+  fi
+
+  git push origin "$TAG"
+  success "Pushed ${CYAN}${TAG}${RESET}${GREEN} to origin"
+}
+
+# --- Main ---
+
+main() {
+  DRY_RUN=false
+  VERIFY=false
+  PUBLISH=false
+  YES=false
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --dry-run)  DRY_RUN=true; shift ;;
+      --verify)   VERIFY=true; shift ;;
+      --publish)  PUBLISH=true; shift ;;
+      -y|--yes)   YES=true; shift ;;
+      -h|--help)  usage ;;
+      -*)         fail "Unknown flag: $1" ;;
+      *)          break ;;
+    esac
+  done
+
+  VERSION="${1:-}"
+  [ -z "$VERSION" ] && usage
+
+  check_env
+
+  TAG="zml-smi-v${VERSION}"
+
+  local title="zml-smi release ${TAG}"
+  if [ "$DRY_RUN" = true ]; then
+    title="${title} (dry run)"
+  fi
+  local pad
+  pad="$(printf '═%.0s' $(seq 1 $((${#title} + 4))))"
+
+  printf "\n"
+  printf "${BLUE}  ╔${pad}╗${RESET}\n"
+  printf "${BLUE}  ║${RESET}  ${WHITE}${title}${RESET}  ${BLUE}║${RESET}\n"
+  printf "${BLUE}  ╚${pad}╝${RESET}\n"
+
+  cd "$BUILD_WORKSPACE_DIRECTORY"
+  tag
+  build
+  upload
+  if [ "$VERIFY" = true ] && [ "$DRY_RUN" = false ]; then
+    verify
+  fi
+  if [ "$PUBLISH" = true ]; then
+    push_tag
+    github_release
+  fi
+  rm -f "${INSTALL_SCRIPT:-}"
+
+  printf "\n"
+  if [ "$DRY_RUN" = true ]; then
+    printf "  ${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}\n"
+    printf "  ${YELLOW}  Dry run complete - nothing was published${RESET}\n"
+    printf "  ${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}\n"
+  else
+    printf "  ${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}\n"
+    printf "  ${GREEN}  Release complete!${RESET}\n"
+    printf "  ${DIM}  curl -fsSL ${BASE_URL}/zml-smi/install.sh | sudo bash${RESET}\n"
+    printf "  ${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}\n"
+  fi
+  printf "\n"
+}
+
+main "$@"

--- a/bin/zml-smi/scripts/release.sh
+++ b/bin/zml-smi/scripts/release.sh
@@ -150,7 +150,8 @@ upload() {
   step "Patching install script"
 
   INSTALL_SCRIPT="$(mktemp)"
-  sed "s|^BASE_URL=.*|BASE_URL=\"${install_url}\"|" \
+  sed -e "s|^BASE_URL=.*|BASE_URL=\"${install_url}\"|" \
+      -e "s|^VERSION=.*|VERSION=\"${VERSION}\"|" \
     "${BUILD_WORKSPACE_DIRECTORY}/bin/zml-smi/scripts/remote-install.sh" > "$INSTALL_SCRIPT"
   success "BASE_URL=${CYAN}${install_url}"
 
@@ -172,10 +173,11 @@ upload() {
       warn "SKIP $(basename "$f") ${DIM}(not built for this host)${RESET}"
       continue
     fi
-    local name
+    local name remote_name
     name="$(basename "$f")"
-    rclone copyto "$f" "${rclone_remote}:${BUCKET}/zml-smi/${VERSION}/${name}"
-    success "${name}"
+    remote_name="${name/zml-smi-/zml-smi-v${VERSION}-}"
+    rclone copyto "$f" "${rclone_remote}:${BUCKET}/zml-smi/${VERSION}/${remote_name}"
+    success "${remote_name}"
   done
 
   rclone copyto "$INSTALL_SCRIPT" "${rclone_remote}:${BUCKET}/zml-smi/${VERSION}/install.sh"
@@ -200,15 +202,16 @@ verify() {
     if [ ! -f "$f" ]; then
       continue
     fi
-    local name
+    local name remote_name
     name="$(basename "$f")"
+    remote_name="${name/zml-smi-/zml-smi-v${VERSION}-}"
     local local_sha remote_sha
     local_sha="$(shasum -a 256 "$f" | awk '{print $1}')"
-    remote_sha="$(curl -fsSL "${install_url}/${name}" | shasum -a 256 | awk '{print $1}')"
+    remote_sha="$(curl -fsSL "${install_url}/${remote_name}" | shasum -a 256 | awk '{print $1}')"
     if [ "$local_sha" = "$remote_sha" ]; then
-      success "${name}"
+      success "${remote_name}"
     else
-      fail "${name} — sha256 mismatch (local: ${local_sha}, remote: ${remote_sha})"
+      fail "${remote_name} — sha256 mismatch (local: ${local_sha}, remote: ${remote_sha})"
     fi
   done
 
@@ -229,7 +232,7 @@ release_notes() {
   local downloads=""
   for f in "${FILES[@]}"; do
     [ -f "$f" ] || continue
-    local name
+    local name remote_name
     name="$(basename "$f")"
     [[ "$name" == *.sha256 ]] && continue
     local sha_file=""
@@ -249,7 +252,8 @@ release_notes() {
     if [ "$sha" != "$actual" ]; then
       fail "${name} sha256 mismatch — sidecar: ${sha}, actual: ${actual}"
     fi
-    downloads="${downloads}| [${name}](${install_url}/${name}) | \`${sha}\` |"$'\n'
+    remote_name="${name/zml-smi-/zml-smi-v${VERSION}-}"
+    downloads="${downloads}| [${remote_name}](${install_url}/${remote_name}) | \`${sha}\` |"$'\n'
   done
 
   cat <<EOF

--- a/bin/zml-smi/scripts/remote-install.sh
+++ b/bin/zml-smi/scripts/remote-install.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 BASE_URL=""
+VERSION=""
 BINARY_NAME="zml-smi"
 
 resolve_dirs() {
@@ -80,7 +81,7 @@ detect_platform() {
 
   success "${OS_LABEL} ${ARCH_LABEL}"
 
-  DOWNLOAD_URL="${BASE_URL}/${BINARY_NAME}-${OS_LABEL}-${ARCH_LABEL}.tar.zst"
+  DOWNLOAD_URL="${BASE_URL}/${BINARY_NAME}-v${VERSION}-${OS_LABEL}-${ARCH_LABEL}.tar.zst"
 }
 
 check_deps() {

--- a/bin/zml-smi/scripts/remote-install.sh
+++ b/bin/zml-smi/scripts/remote-install.sh
@@ -68,11 +68,15 @@ detect_platform() {
   esac
 
   case "$ARCH" in
-    x86_64|amd64)   ARCH_LABEL="x86_64" ;;
-    aarch64|arm64)   ARCH_LABEL="aarch64" ;;
+    x86_64|amd64)   ARCH_LABEL="amd64" ;;
+    aarch64|arm64)   ARCH_LABEL="arm64" ;;
     *)
       fail "Unsupported architecture: ${ARCH}" ;;
   esac
+
+  if [ "$OS_LABEL" = "macos" ] && [ "$ARCH_LABEL" = "amd64" ]; then
+    fail "macOS x86_64 is not supported. Only Apple Silicon (arm64) is supported."
+  fi
 
   success "${OS_LABEL} ${ARCH_LABEL}"
 

--- a/bin/zml-smi/scripts/remote-install.sh
+++ b/bin/zml-smi/scripts/remote-install.sh
@@ -6,21 +6,21 @@ BINARY_NAME="zml-smi"
 
 resolve_dirs() {
   if [ -n "${ZML_SMI_INSTALL_DIR:-}" ] || [ -n "${ZML_SMI_BIN_DIR:-}" ]; then
-    INSTALL_DIR="${ZML_SMI_INSTALL_DIR:-/usr/lib/zml-smi}"
-    BIN_DIR="${ZML_SMI_BIN_DIR:-/usr/bin}"
+    INSTALL_DIR="${ZML_SMI_INSTALL_DIR:-/opt/zml-smi}"
+    BIN_DIR="${ZML_SMI_BIN_DIR:-/usr/local/bin}"
     return
   fi
 
-  INSTALL_DIR="/usr/lib/zml-smi"
-  BIN_DIR="/usr/bin"
+  INSTALL_DIR="/opt/zml-smi"
+  BIN_DIR="/usr/local/bin"
 
   if mkdir -p "$INSTALL_DIR" 2>/dev/null && [ -w "$INSTALL_DIR" ] &&
      mkdir -p "$BIN_DIR" 2>/dev/null && [ -w "$BIN_DIR" ]; then
     return
   fi
 
-  warn "Cannot write to /usr/lib or /usr/bin — falling back to ~/.local"
-  INSTALL_DIR="${HOME}/.local/lib/zml-smi"
+  warn "Cannot write to /opt or /usr/local/bin — falling back to ~/.local"
+  INSTALL_DIR="${HOME}/.local/zml-smi"
   BIN_DIR="${HOME}/.local/bin"
 }
 

--- a/bin/zml-smi/tui/BUILD.bazel
+++ b/bin/zml-smi/tui/BUILD.bazel
@@ -41,10 +41,12 @@ zig_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//bin/zml-smi/platforms/linux",
         "//bazel/stamp:zig",
         "//bin/zml-smi/info",
         "//bin/zml-smi/utils:double_buffer",
         "@libvaxis//:vaxis",
-    ],
+    ] + select({
+        "@platforms//os:macos": ["//bin/zml-smi/platforms/macos"],
+        "//conditions:default": ["//bin/zml-smi/platforms/linux"],
+    }),
 )

--- a/bin/zml-smi/tui/data.zig
+++ b/bin/zml-smi/tui/data.zig
@@ -91,7 +91,6 @@ pub const SystemState = struct {
     allocator: std.mem.Allocator,
     io: std.Io,
     tui_refresh_rate: u16,
-    num_local_devices: usize,
 
     pub const Config = struct {
         devices: []*DeviceInfo,
@@ -101,7 +100,6 @@ pub const SystemState = struct {
         process_lists: []*ProcessDoubleBuffer,
         enricher: *ProcessEnricher,
         io: std.Io,
-        num_local_devices: ?usize = null,
     };
 
     pub fn init(allocator: std.mem.Allocator, cfg: Config) !SystemState {
@@ -115,12 +113,7 @@ pub const SystemState = struct {
             .enricher = cfg.enricher,
             .allocator = allocator,
             .io = cfg.io,
-            .num_local_devices = cfg.num_local_devices orelse cfg.devices.len,
         };
-    }
-
-    pub fn isRemote(self: *const SystemState, device_id: usize) bool {
-        return device_id >= self.num_local_devices;
     }
 
     pub fn deinit(self: *SystemState, allocator: std.mem.Allocator) void {

--- a/bin/zml-smi/tui/data.zig
+++ b/bin/zml-smi/tui/data.zig
@@ -88,7 +88,8 @@ pub const SystemState = struct {
     targets: Targets,
     process_lists: []*ProcessDoubleBuffer,
     enricher: *ProcessEnricher,
-    allocator: std.mem.Allocator,
+    gpa: std.mem.Allocator,
+    arena: std.mem.Allocator,
     io: std.Io,
     tui_refresh_rate: u16,
 
@@ -99,19 +100,22 @@ pub const SystemState = struct {
         tui_refresh_rate: u16,
         process_lists: []*ProcessDoubleBuffer,
         enricher: *ProcessEnricher,
+        gpa: std.mem.Allocator,
+        arena: std.mem.Allocator,
         io: std.Io,
     };
 
-    pub fn init(allocator: std.mem.Allocator, cfg: Config) !SystemState {
+    pub fn init(cfg: Config) !SystemState {
         return .{
             .devices = cfg.devices,
             .host = cfg.host,
-            .history = try HistoryBuffers.init(allocator, cfg.devices.len),
+            .history = try HistoryBuffers.init(cfg.arena, cfg.devices.len),
             .targets = cfg.targets,
             .tui_refresh_rate = cfg.tui_refresh_rate,
             .process_lists = cfg.process_lists,
             .enricher = cfg.enricher,
-            .allocator = allocator,
+            .gpa = cfg.gpa,
+            .arena = cfg.arena,
             .io = cfg.io,
         };
     }

--- a/bin/zml-smi/tui/data.zig
+++ b/bin/zml-smi/tui/data.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const smi_info = @import("zml-smi/info");
 const di = smi_info.device_info;
 pub const DeviceInfo = di.DeviceInfo;
@@ -12,7 +13,10 @@ pub const HostInfo = hi.HostInfo;
 pub const HostData = hi.HostData;
 pub const pi = smi_info.process_info;
 pub const ProcessDoubleBuffer = @import("zml-smi/double_buffer").DoubleBuffer(std.ArrayList(pi.ProcessInfo));
-pub const ProcessEnricher = @import("zml-smi/platforms/linux").process.ProcessEnricher;
+pub const ProcessEnricher = if (builtin.os.tag == .macos)
+    @import("zml-smi/platforms/macos").process.ProcessEnricher
+else
+    @import("zml-smi/platforms/linux").process.ProcessEnricher;
 
 pub const history_len: usize = 500;
 

--- a/bin/zml-smi/tui/data.zig
+++ b/bin/zml-smi/tui/data.zig
@@ -87,6 +87,7 @@ pub const SystemState = struct {
     allocator: std.mem.Allocator,
     io: std.Io,
     tui_refresh_rate: u16,
+    num_local_devices: usize,
 
     pub const Config = struct {
         devices: []*DeviceInfo,
@@ -96,6 +97,7 @@ pub const SystemState = struct {
         process_lists: []*ProcessDoubleBuffer,
         enricher: *ProcessEnricher,
         io: std.Io,
+        num_local_devices: ?usize = null,
     };
 
     pub fn init(allocator: std.mem.Allocator, cfg: Config) !SystemState {
@@ -109,7 +111,12 @@ pub const SystemState = struct {
             .enricher = cfg.enricher,
             .allocator = allocator,
             .io = cfg.io,
+            .num_local_devices = cfg.num_local_devices orelse cfg.devices.len,
         };
+    }
+
+    pub fn isRemote(self: *const SystemState, device_id: usize) bool {
+        return device_id >= self.num_local_devices;
     }
 
     pub fn deinit(self: *SystemState, allocator: std.mem.Allocator) void {

--- a/bin/zml-smi/tui/pages/detail.zig
+++ b/bin/zml-smi/tui/pages/detail.zig
@@ -11,7 +11,7 @@ const tpu_detail = @import("detail/tpu_detail.zig");
 const Detail = @This();
 
 state: *const data.SystemState,
-device_id: u8,
+device_id: u16,
 process_table: *ProcessTable = undefined,
 
 pub fn draw(self: *const Detail, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {

--- a/bin/zml-smi/tui/pages/detail/detail_common.zig
+++ b/bin/zml-smi/tui/pages/detail/detail_common.zig
@@ -9,7 +9,7 @@ const compose = @import("../../lib/compose.zig");
 const Chart = @import("../../widgets/chart.zig");
 const ColumnLayout = @import("../../widgets/column_layout.zig");
 
-pub fn headerText(arena: std.mem.Allocator, id: u8, name: []const u8) std.mem.Allocator.Error!vxfw.Text {
+pub fn headerText(arena: std.mem.Allocator, id: u16, name: []const u8) std.mem.Allocator.Error!vxfw.Text {
     return .{
         .text = try std.fmt.allocPrint(arena, "Device {d}: {s}", .{ id, name }),
         .style = theme.header_style,
@@ -22,7 +22,7 @@ pub fn headerText(arena: std.mem.Allocator, id: u8, name: []const u8) std.mem.Al
 pub fn historyChart(
     ctx: vxfw.DrawContext,
     state: *const data.SystemState,
-    id: u8,
+    id: u16,
     history: anytype,
     opts: struct {
         title: []const u8,

--- a/bin/zml-smi/tui/pages/detail/gpu_detail.zig
+++ b/bin/zml-smi/tui/pages/detail/gpu_detail.zig
@@ -15,7 +15,7 @@ pub fn draw(
     process_table: *ProcessTable,
     ctx: vxfw.DrawContext,
     w: u16,
-    id: u8,
+    id: u16,
     gpu: data.GpuInfo,
     parent_widget: vxfw.Widget,
 ) std.mem.Allocator.Error!vxfw.Surface {

--- a/bin/zml-smi/tui/pages/detail/neuron_detail.zig
+++ b/bin/zml-smi/tui/pages/detail/neuron_detail.zig
@@ -14,7 +14,7 @@ pub fn draw(
     process_table: *ProcessTable,
     ctx: vxfw.DrawContext,
     w: u16,
-    id: u8,
+    id: u16,
     nc: data.NeuronInfo,
     parent_widget: vxfw.Widget,
 ) std.mem.Allocator.Error!vxfw.Surface {

--- a/bin/zml-smi/tui/pages/detail/tpu_detail.zig
+++ b/bin/zml-smi/tui/pages/detail/tpu_detail.zig
@@ -13,7 +13,7 @@ pub fn draw(
     process_table: *ProcessTable,
     ctx: vxfw.DrawContext,
     w: u16,
-    id: u8,
+    id: u16,
     tp: data.TpuInfo,
     parent_widget: vxfw.Widget,
 ) std.mem.Allocator.Error!vxfw.Surface {

--- a/bin/zml-smi/tui/pages/overview.zig
+++ b/bin/zml-smi/tui/pages/overview.zig
@@ -23,10 +23,10 @@ pub const host_line_width: u16 = (Logo.logo_width + 6) + max_info_width + 2;
 state: *const data.SystemState,
 device_cards: []DeviceCard = &.{},
 process_table: ?*ProcessTable = null, // maybe null if we decide not to print the process table in print mode
-viewing_device: *?u8 = undefined,
+viewing_device: *?u16 = undefined,
 use_braille: bool = false,
 
-pub fn init(allocator: std.mem.Allocator, state: *const data.SystemState, process_table: ?*ProcessTable, viewing_device: *?u8) !Overview {
+pub fn init(allocator: std.mem.Allocator, state: *const data.SystemState, process_table: ?*ProcessTable, viewing_device: *?u16) !Overview {
     const count = state.deviceCount();
     const cards = try allocator.alloc(DeviceCard, count);
     for (cards, 0..) |*card, i| {

--- a/bin/zml-smi/tui/pages/overview.zig
+++ b/bin/zml-smi/tui/pages/overview.zig
@@ -14,7 +14,7 @@ const ProcessTable = @import("../widgets/process_table.zig");
 
 const Overview = @This();
 
-const two_col_breakpoint: u16 = 120;
+const two_col_breakpoint: u16 = 140;
 const narrow_breakpoint: u16 = 80;
 const max_info_width: u16 = 50;
 /// Total width of the wide banner: logo box (incl. left margin) + info lines + right margin.

--- a/bin/zml-smi/tui/print.zig
+++ b/bin/zml-smi/tui/print.zig
@@ -56,7 +56,7 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, state: *data.SystemState) !
 
     const content_w: u16 = @min(@as(u16, @intCast(vx.screen.width)), Overview.host_line_width + 2);
 
-    var viewing_device: ?u8 = null;
+    var viewing_device: ?u16 = null;
     var overview = try Overview.init(allocator, state, null, &viewing_device);
     defer overview.deinit(allocator);
 

--- a/bin/zml-smi/tui/top.zig
+++ b/bin/zml-smi/tui/top.zig
@@ -40,8 +40,8 @@ const ScrollState = struct {
 const Model = struct {
     allocator: std.mem.Allocator,
     state: *data.SystemState,
-    viewing_device: ?u8 = null,
-    prev_viewing_device: ?u8 = null,
+    viewing_device: ?u16 = null,
+    prev_viewing_device: ?u16 = null,
     scroll: ScrollState = .{},
     vx: *vaxis.Vaxis,
     tty: *vaxis.Tty,

--- a/bin/zml-smi/tui/widgets/device_card.zig
+++ b/bin/zml-smi/tui/widgets/device_card.zig
@@ -10,12 +10,12 @@ const MetricCard = @import("metric_card.zig");
 
 const DeviceCard = @This();
 
-device_id: u8 = 0,
+device_id: u16 = 0,
 highlighted: bool = false,
 
 state: *const data.SystemState = undefined,
 use_braille: bool = false,
-viewing_device: *?u8 = undefined,
+viewing_device: *?u16 = undefined,
 
 pub fn handleEvent(self: *DeviceCard, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
     switch (event) {

--- a/bin/zml-smi/tui/widgets/device_card.zig
+++ b/bin/zml-smi/tui/widgets/device_card.zig
@@ -116,7 +116,7 @@ pub fn draw(self: *DeviceCard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vx
             .neuron => "gpu_neuron",
             .tpu => "gpu_tpu",
         }),
-        .title_right = if (self.state.isRemote(i)) "remote" else null,
+        .title_right = if (self.state.devices[i].isRemote()) "remote" else null,
         .cell_size = ctx.cell_size,
         .highlighted = self.highlighted,
     };

--- a/bin/zml-smi/tui/widgets/device_card.zig
+++ b/bin/zml-smi/tui/widgets/device_card.zig
@@ -116,6 +116,7 @@ pub fn draw(self: *DeviceCard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vx
             .neuron => "gpu_neuron",
             .tpu => "gpu_tpu",
         }),
+        .title_right = if (self.state.isRemote(i)) "remote" else null,
         .cell_size = ctx.cell_size,
         .highlighted = self.highlighted,
     };

--- a/bin/zml-smi/tui/widgets/metric_card.zig
+++ b/bin/zml-smi/tui/widgets/metric_card.zig
@@ -12,6 +12,7 @@ const MetricCard = @This();
 
 title: []const u8,
 title_image: ?vaxis.Image = null,
+title_right: ?[]const u8 = null,
 cell_size: vxfw.Size = .{},
 /// Lines of "label: value" pairs to display.
 lines: []const LineEntry = &.{},
@@ -51,6 +52,7 @@ pub fn draw(self: *const MetricCard, ctx: vxfw.DrawContext) std.mem.Allocator.Er
         .child = ui.drawWidget(self, drawContent),
         .title = self.title,
         .title_image = self.title_image,
+        .value_label = self.title_right,
         .cell_size = self.cell_size,
         .border_style = bstyle,
     };

--- a/bin/zml-smi/tui/widgets/process_table.zig
+++ b/bin/zml-smi/tui/widgets/process_table.zig
@@ -37,10 +37,10 @@ pub fn prepare(self: *ProcessTable, state: *data.SystemState, device_id: ?u16) v
                 if (entry.device_idx != did) {
                     continue;
                 }
-                self.merged.append(state.allocator, entry) catch break;
+                self.merged.append(state.gpa, entry) catch break;
             }
         } else {
-            self.merged.appendSlice(state.allocator, pl_items) catch break;
+            self.merged.appendSlice(state.gpa, pl_items) catch break;
         }
     }
 

--- a/bin/zml-smi/tui/widgets/process_table.zig
+++ b/bin/zml-smi/tui/widgets/process_table.zig
@@ -26,7 +26,7 @@ scroll_bars: vxfw.ScrollBars = .{
 },
 merged: std.ArrayList(ProcessInfo) = .{},
 
-pub fn prepare(self: *ProcessTable, state: *data.SystemState, device_id: ?u8) void {
+pub fn prepare(self: *ProcessTable, state: *data.SystemState, device_id: ?u16) void {
     self.scroll_bars.scroll_view.children.builder.userdata = self;
     self.merged.clearRetainingCapacity();
 

--- a/bin/zml-smi/tui/widgets/status_line.zig
+++ b/bin/zml-smi/tui/widgets/status_line.zig
@@ -6,7 +6,7 @@ const ui = @import("../lib/ui.zig");
 
 const StatusLine = @This();
 
-viewing_device: ?u8,
+viewing_device: ?u16,
 use_braille: bool,
 
 const Binding = struct {

--- a/bin/zml-smi/utils/double_buffer.zig
+++ b/bin/zml-smi/utils/double_buffer.zig
@@ -19,5 +19,14 @@ pub fn DoubleBuffer(comptime T: type) type {
         pub fn swap(self: *Self) void {
             self.current.store(1 - self.current.load(.acquire), .release);
         }
+
+        pub fn jsonStringify(self: *const Self, jw: *std.json.Stringify) !void {
+            try jw.write(self.front().*);
+        }
+
+        pub fn jsonParseFromValue(allocator: std.mem.Allocator, source: std.json.Value, options: std.json.ParseOptions) !Self {
+            const val = try std.json.innerParseFromValue(T, allocator, source, options);
+            return .{ .values = .{ val, val } };
+        }
     };
 }

--- a/bin/zml-smi/utils/double_buffer.zig
+++ b/bin/zml-smi/utils/double_buffer.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 pub fn DoubleBuffer(comptime T: type) type {
     return struct {
         const Self = @This();
+        pub const Value = T;
 
         values: [2]T,
         current: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),


### PR DESCRIPTION
This PR introduces:

- Prometheus metrics endpoint through `--prometheus` and optionally `--prometheus-port`
- JSON output mode with `--json`
- macOS arm64 host information
- An install and release script