### PR TITLE
workspace: Update Zig to 0.16.0-dev.3153+d6f43caad

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,7 +49,7 @@ zig = use_extension("@rules_zig//zig:extensions.bzl", "zig")
 zig.index(file = "//bazel:zig_index.json")
 zig.toolchain(
     translate_c = "@translate-c",
-    zig_version = "0.16.0-dev.2722+f16eb18ce",
+    zig_version = "0.16.0-dev.3153+d6f43caad",
 )
 zig.mirrors(urls = [
     "https://pkg.machengine.org/zig",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -478,6 +478,173 @@
         ]
       }
     },
+    "@@googleapis+//:extensions.bzl%switched_rules": {
+      "general": {
+        "bzlTransitiveDigest": "JLpojYeGHLdgnwSUuQWOrtkL9UMygBUUEFJZh7ASlmA=",
+        "usagesDigest": "66rLsrgz6YqDpU0pD+02mTGNxYxhb/of6Fh0ulHzjdE=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_google_googleapis_imports": {
+            "repoRuleId": "@@googleapis+//:repository_rules.bzl%switched_rules",
+            "attributes": {
+              "rules": {
+                "proto_library_with_info": [
+                  "",
+                  ""
+                ],
+                "moved_proto_library": [
+                  "",
+                  ""
+                ],
+                "java_proto_library": [
+                  "",
+                  ""
+                ],
+                "java_grpc_library": [
+                  "",
+                  ""
+                ],
+                "java_gapic_library": [
+                  "",
+                  ""
+                ],
+                "java_gapic_test": [
+                  "",
+                  ""
+                ],
+                "java_gapic_assembly_gradle_pkg": [
+                  "",
+                  ""
+                ],
+                "py_proto_library": [
+                  "",
+                  ""
+                ],
+                "py_grpc_library": [
+                  "",
+                  ""
+                ],
+                "py_gapic_library": [
+                  "",
+                  ""
+                ],
+                "py_test": [
+                  "",
+                  ""
+                ],
+                "py_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "py_import": [
+                  "",
+                  ""
+                ],
+                "go_proto_library": [
+                  "",
+                  ""
+                ],
+                "go_grpc_library": [
+                  "",
+                  ""
+                ],
+                "go_library": [
+                  "",
+                  ""
+                ],
+                "go_test": [
+                  "",
+                  ""
+                ],
+                "go_gapic_library": [
+                  "",
+                  ""
+                ],
+                "go_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "cc_proto_library": [
+                  "",
+                  ""
+                ],
+                "cc_grpc_library": [
+                  "",
+                  ""
+                ],
+                "cc_gapic_library": [
+                  "",
+                  ""
+                ],
+                "php_proto_library": [
+                  "",
+                  "php_proto_library"
+                ],
+                "php_grpc_library": [
+                  "",
+                  "php_grpc_library"
+                ],
+                "php_gapic_library": [
+                  "",
+                  "php_gapic_library"
+                ],
+                "php_gapic_assembly_pkg": [
+                  "",
+                  "php_gapic_assembly_pkg"
+                ],
+                "nodejs_gapic_library": [
+                  "",
+                  "typescript_gapic_library"
+                ],
+                "nodejs_gapic_assembly_pkg": [
+                  "",
+                  "typescript_gapic_assembly_pkg"
+                ],
+                "ruby_proto_library": [
+                  "",
+                  ""
+                ],
+                "ruby_grpc_library": [
+                  "",
+                  ""
+                ],
+                "ruby_ads_gapic_library": [
+                  "",
+                  ""
+                ],
+                "ruby_cloud_gapic_library": [
+                  "",
+                  ""
+                ],
+                "ruby_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "csharp_proto_library": [
+                  "",
+                  ""
+                ],
+                "csharp_grpc_library": [
+                  "",
+                  ""
+                ],
+                "csharp_gapic_library": [
+                  "",
+                  ""
+                ],
+                "csharp_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ]
+              }
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
     "@@rules_foreign_cc+//foreign_cc:extensions.bzl%tools": {
       "general": {
         "bzlTransitiveDigest": "b41JwymKkuHbovxSrZD6eawffiN8+iwKcSQZrLCkvbw=",
@@ -1251,18 +1418,18 @@
     "@@rules_zig+//zig:extensions.bzl%zig": {
       "general": {
         "bzlTransitiveDigest": "r7tCqbjlVKc7XEXV8Hiak2ElFfkjvDdMf8Ym+7zxukU=",
-        "usagesDigest": "lqvJAPUaAfUjthqXXAa4LwhcuZ2d3CNerCqKcLkkNPo=",
+        "usagesDigest": "DObSrV9vF3T1Diz4Mp2HSPgtKmxRPL/y5KPhcX6zjvU=",
         "recordedFileInputs": {
-          "@@//bazel/zig_index.json": "809b545c21f13c11c4587dccbfe81de2b767a292325c25ffb785b03c601bbc2e",
+          "@@//bazel/zig_index.json": "4d85811c879dbd2c11d1d7a40decbe25070abe49d4a1ba704b532999b246ad24",
           "@@rules_zig+//zig/private/versions.json": "6eb85ebaee72c4e6fbc82d8ad73f69e0899d839b70a7e19caa792ab6a5fa0c36"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "zig_0.16.0-dev.2722_Pf16eb18ce_aarch64-linux": {
+          "zig_0.16.0-dev.3153_Pd6f43caad_aarch64-linux": {
             "repoRuleId": "@@rules_zig+//zig/private/repo:zig_repository.bzl%zig_repository",
             "attributes": {
-              "url": "https://ziglang.org/builds/zig-aarch64-linux-0.16.0-dev.2722+f16eb18ce.tar.xz",
+              "url": "https://ziglang.org/builds/zig-aarch64-linux-0.16.0-dev.3153+d6f43caad.tar.xz",
               "mirrors": [
                 "https://pkg.machengine.org/zig",
                 "https://zigmirror.hryx.net/zig",
@@ -1279,16 +1446,16 @@
                 "https://fs.liujiacai.net/zigbuilds",
                 "https://ziglang.org/builds/"
               ],
-              "sha256": "03725d297a2e2a8331d774eb601163af42ec61979b82753d41b2c460eefab1be",
-              "zig_version": "0.16.0-dev.2722+f16eb18ce",
+              "sha256": "e46037f7747492b405a42d40bb9bf3ca3f28c71cf9c1ccdf165a4de74cb484bb",
+              "zig_version": "0.16.0-dev.3153+d6f43caad",
               "platform": "aarch64-linux",
               "translate_c": "@@+non_module_deps+translate-c//:translate-c"
             }
           },
-          "zig_0.16.0-dev.2722_Pf16eb18ce_aarch64-macos": {
+          "zig_0.16.0-dev.3153_Pd6f43caad_aarch64-macos": {
             "repoRuleId": "@@rules_zig+//zig/private/repo:zig_repository.bzl%zig_repository",
             "attributes": {
-              "url": "https://ziglang.org/builds/zig-aarch64-macos-0.16.0-dev.2722+f16eb18ce.tar.xz",
+              "url": "https://ziglang.org/builds/zig-aarch64-macos-0.16.0-dev.3153+d6f43caad.tar.xz",
               "mirrors": [
                 "https://pkg.machengine.org/zig",
                 "https://zigmirror.hryx.net/zig",
@@ -1305,16 +1472,16 @@
                 "https://fs.liujiacai.net/zigbuilds",
                 "https://ziglang.org/builds/"
               ],
-              "sha256": "268aa8342e8ef539693e88e1d0982361b1d5dc4a080949264f2d5a14e5eb83e0",
-              "zig_version": "0.16.0-dev.2722+f16eb18ce",
+              "sha256": "9121e3f03515a3434ef9f362f8c541540968316d33ed6485b2d8a31dc7332fe6",
+              "zig_version": "0.16.0-dev.3153+d6f43caad",
               "platform": "aarch64-macos",
               "translate_c": "@@+non_module_deps+translate-c//:translate-c"
             }
           },
-          "zig_0.16.0-dev.2722_Pf16eb18ce_aarch64-windows": {
+          "zig_0.16.0-dev.3153_Pd6f43caad_aarch64-windows": {
             "repoRuleId": "@@rules_zig+//zig/private/repo:zig_repository.bzl%zig_repository",
             "attributes": {
-              "url": "https://ziglang.org/builds/zig-aarch64-windows-0.16.0-dev.2722+f16eb18ce.zip",
+              "url": "https://ziglang.org/builds/zig-aarch64-windows-0.16.0-dev.3153+d6f43caad.zip",
               "mirrors": [
                 "https://pkg.machengine.org/zig",
                 "https://zigmirror.hryx.net/zig",
@@ -1331,16 +1498,16 @@
                 "https://fs.liujiacai.net/zigbuilds",
                 "https://ziglang.org/builds/"
               ],
-              "sha256": "43daaad311bc3b06a733a8a87d2c3180214d62db2067df1591b921826de453ea",
-              "zig_version": "0.16.0-dev.2722+f16eb18ce",
+              "sha256": "b25c7046c111f5a4e614fae1a1b33c8db73fbc3de4c135acabb5740455a3b6fc",
+              "zig_version": "0.16.0-dev.3153+d6f43caad",
               "platform": "aarch64-windows",
               "translate_c": "@@+non_module_deps+translate-c//:translate-c"
             }
           },
-          "zig_0.16.0-dev.2722_Pf16eb18ce_x86_64-linux": {
+          "zig_0.16.0-dev.3153_Pd6f43caad_x86_64-linux": {
             "repoRuleId": "@@rules_zig+//zig/private/repo:zig_repository.bzl%zig_repository",
             "attributes": {
-              "url": "https://ziglang.org/builds/zig-x86_64-linux-0.16.0-dev.2722+f16eb18ce.tar.xz",
+              "url": "https://ziglang.org/builds/zig-x86_64-linux-0.16.0-dev.3153+d6f43caad.tar.xz",
               "mirrors": [
                 "https://pkg.machengine.org/zig",
                 "https://zigmirror.hryx.net/zig",
@@ -1357,16 +1524,16 @@
                 "https://fs.liujiacai.net/zigbuilds",
                 "https://ziglang.org/builds/"
               ],
-              "sha256": "b0fe8fd996b4974cd80fc0967460b13e3a6e3105c4bec19ea0566bd47d73ad81",
-              "zig_version": "0.16.0-dev.2722+f16eb18ce",
+              "sha256": "afb3016a94a8b5608d364e58ec7b01111af775a020d5f93f69eaebde2053fe77",
+              "zig_version": "0.16.0-dev.3153+d6f43caad",
               "platform": "x86_64-linux",
               "translate_c": "@@+non_module_deps+translate-c//:translate-c"
             }
           },
-          "zig_0.16.0-dev.2722_Pf16eb18ce_x86_64-macos": {
+          "zig_0.16.0-dev.3153_Pd6f43caad_x86_64-macos": {
             "repoRuleId": "@@rules_zig+//zig/private/repo:zig_repository.bzl%zig_repository",
             "attributes": {
-              "url": "https://ziglang.org/builds/zig-x86_64-macos-0.16.0-dev.2722+f16eb18ce.tar.xz",
+              "url": "https://ziglang.org/builds/zig-x86_64-macos-0.16.0-dev.3153+d6f43caad.tar.xz",
               "mirrors": [
                 "https://pkg.machengine.org/zig",
                 "https://zigmirror.hryx.net/zig",
@@ -1383,16 +1550,16 @@
                 "https://fs.liujiacai.net/zigbuilds",
                 "https://ziglang.org/builds/"
               ],
-              "sha256": "8e09fb9e90c0566629dfa52bce433e886f4cf7e2cd9985a358d7b8c473c4e9ce",
-              "zig_version": "0.16.0-dev.2722+f16eb18ce",
+              "sha256": "0251a8414f98513a33a7a7bd1f6cc13fb59f391168a742eee47b8c685e9827a0",
+              "zig_version": "0.16.0-dev.3153+d6f43caad",
               "platform": "x86_64-macos",
               "translate_c": "@@+non_module_deps+translate-c//:translate-c"
             }
           },
-          "zig_0.16.0-dev.2722_Pf16eb18ce_x86_64-windows": {
+          "zig_0.16.0-dev.3153_Pd6f43caad_x86_64-windows": {
             "repoRuleId": "@@rules_zig+//zig/private/repo:zig_repository.bzl%zig_repository",
             "attributes": {
-              "url": "https://ziglang.org/builds/zig-x86_64-windows-0.16.0-dev.2722+f16eb18ce.zip",
+              "url": "https://ziglang.org/builds/zig-x86_64-windows-0.16.0-dev.3153+d6f43caad.zip",
               "mirrors": [
                 "https://pkg.machengine.org/zig",
                 "https://zigmirror.hryx.net/zig",
@@ -1409,8 +1576,8 @@
                 "https://fs.liujiacai.net/zigbuilds",
                 "https://ziglang.org/builds/"
               ],
-              "sha256": "0f92e7234ed1d9608444487ca8fb928bd38da79dea744acf6c7a8fa0c440da6a",
-              "zig_version": "0.16.0-dev.2722+f16eb18ce",
+              "sha256": "ab31039adca06ae87c95c11b3ff8ed82808335866d58bc6e508cd3174d2d7e3d",
+              "zig_version": "0.16.0-dev.3153+d6f43caad",
               "platform": "x86_64-windows",
               "translate_c": "@@+non_module_deps+translate-c//:translate-c"
             }
@@ -1419,28 +1586,28 @@
             "repoRuleId": "@@rules_zig+//zig/private/repo:toolchains_repo.bzl%toolchains_repo",
             "attributes": {
               "names": [
-                "zig_0.16.0-dev.2722_Pf16eb18ce_aarch64-linux",
-                "zig_0.16.0-dev.2722_Pf16eb18ce_aarch64-macos",
-                "zig_0.16.0-dev.2722_Pf16eb18ce_aarch64-windows",
-                "zig_0.16.0-dev.2722_Pf16eb18ce_x86_64-linux",
-                "zig_0.16.0-dev.2722_Pf16eb18ce_x86_64-macos",
-                "zig_0.16.0-dev.2722_Pf16eb18ce_x86_64-windows"
+                "zig_0.16.0-dev.3153_Pd6f43caad_aarch64-linux",
+                "zig_0.16.0-dev.3153_Pd6f43caad_aarch64-macos",
+                "zig_0.16.0-dev.3153_Pd6f43caad_aarch64-windows",
+                "zig_0.16.0-dev.3153_Pd6f43caad_x86_64-linux",
+                "zig_0.16.0-dev.3153_Pd6f43caad_x86_64-macos",
+                "zig_0.16.0-dev.3153_Pd6f43caad_x86_64-windows"
               ],
               "labels": [
-                "@zig_0.16.0-dev.2722_Pf16eb18ce_aarch64-linux//:zig_toolchain",
-                "@zig_0.16.0-dev.2722_Pf16eb18ce_aarch64-macos//:zig_toolchain",
-                "@zig_0.16.0-dev.2722_Pf16eb18ce_aarch64-windows//:zig_toolchain",
-                "@zig_0.16.0-dev.2722_Pf16eb18ce_x86_64-linux//:zig_toolchain",
-                "@zig_0.16.0-dev.2722_Pf16eb18ce_x86_64-macos//:zig_toolchain",
-                "@zig_0.16.0-dev.2722_Pf16eb18ce_x86_64-windows//:zig_toolchain"
+                "@zig_0.16.0-dev.3153_Pd6f43caad_aarch64-linux//:zig_toolchain",
+                "@zig_0.16.0-dev.3153_Pd6f43caad_aarch64-macos//:zig_toolchain",
+                "@zig_0.16.0-dev.3153_Pd6f43caad_aarch64-windows//:zig_toolchain",
+                "@zig_0.16.0-dev.3153_Pd6f43caad_x86_64-linux//:zig_toolchain",
+                "@zig_0.16.0-dev.3153_Pd6f43caad_x86_64-macos//:zig_toolchain",
+                "@zig_0.16.0-dev.3153_Pd6f43caad_x86_64-windows//:zig_toolchain"
               ],
               "zig_versions": [
-                "0.16.0-dev.2722+f16eb18ce",
-                "0.16.0-dev.2722+f16eb18ce",
-                "0.16.0-dev.2722+f16eb18ce",
-                "0.16.0-dev.2722+f16eb18ce",
-                "0.16.0-dev.2722+f16eb18ce",
-                "0.16.0-dev.2722+f16eb18ce"
+                "0.16.0-dev.3153+d6f43caad",
+                "0.16.0-dev.3153+d6f43caad",
+                "0.16.0-dev.3153+d6f43caad",
+                "0.16.0-dev.3153+d6f43caad",
+                "0.16.0-dev.3153+d6f43caad",
+                "0.16.0-dev.3153+d6f43caad"
               ],
               "exec_lengths": [
                 2,

--- a/bazel/zig_index.json
+++ b/bazel/zig_index.json
@@ -1,133 +1,148 @@
 {
   "master": {
-    "version": "0.16.0-dev.2722+f16eb18ce",
-    "date": "2026-03-08",
+    "version": "0.16.0-dev.3153+d6f43caad",
+    "date": "2026-04-12",
     "docs": "https://ziglang.org/documentation/master/",
     "stdDocs": "https://ziglang.org/documentation/master/std/",
     "src": {
-      "tarball": "https://ziglang.org/builds/zig-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "1880ddb5502206d8f7322ca1e0138b67b3928fb88dbab3defff80d1dd8a311bb",
-      "size": "22460744"
+      "tarball": "https://ziglang.org/builds/zig-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "cb598f754d00a71af7586d437f490056b084eb6e54587fc2bb9f55148757fd49",
+      "size": "22477252"
     },
     "bootstrap": {
-      "tarball": "https://ziglang.org/builds/zig-bootstrap-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "4e3f14dfdf73f9448fcb3eb7bf61c4e0b26f4e0949e572824fbd47ea62adf97e",
-      "size": "55225064"
+      "tarball": "https://ziglang.org/builds/zig-bootstrap-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "a2ccc95aaed569b3c25d8693f01187144f09e08a2a9b828bad3e5f2c19a4c2bc",
+      "size": "55240588"
     },
     "x86_64-macos": {
-      "tarball": "https://ziglang.org/builds/zig-x86_64-macos-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "8e09fb9e90c0566629dfa52bce433e886f4cf7e2cd9985a358d7b8c473c4e9ce",
-      "size": "57648992"
+      "tarball": "https://ziglang.org/builds/zig-x86_64-macos-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "0251a8414f98513a33a7a7bd1f6cc13fb59f391168a742eee47b8c685e9827a0",
+      "size": "57381556"
     },
     "aarch64-macos": {
-      "tarball": "https://ziglang.org/builds/zig-aarch64-macos-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "268aa8342e8ef539693e88e1d0982361b1d5dc4a080949264f2d5a14e5eb83e0",
-      "size": "52489044"
+      "tarball": "https://ziglang.org/builds/zig-aarch64-macos-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "9121e3f03515a3434ef9f362f8c541540968316d33ed6485b2d8a31dc7332fe6",
+      "size": "52217412"
     },
     "x86_64-linux": {
-      "tarball": "https://ziglang.org/builds/zig-x86_64-linux-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "b0fe8fd996b4974cd80fc0967460b13e3a6e3105c4bec19ea0566bd47d73ad81",
-      "size": "55512692"
+      "tarball": "https://ziglang.org/builds/zig-x86_64-linux-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "afb3016a94a8b5608d364e58ec7b01111af775a020d5f93f69eaebde2053fe77",
+      "size": "55445192"
     },
     "aarch64-linux": {
-      "tarball": "https://ziglang.org/builds/zig-aarch64-linux-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "03725d297a2e2a8331d774eb601163af42ec61979b82753d41b2c460eefab1be",
-      "size": "51286740"
+      "tarball": "https://ziglang.org/builds/zig-aarch64-linux-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "e46037f7747492b405a42d40bb9bf3ca3f28c71cf9c1ccdf165a4de74cb484bb",
+      "size": "51193908"
     },
     "arm-linux": {
-      "tarball": "https://ziglang.org/builds/zig-arm-linux-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "b4407543ef223d459d5925b2f1b8c700e61da3193a79fae3b6104c5116e092e7",
-      "size": "52149112"
+      "tarball": "https://ziglang.org/builds/zig-arm-linux-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "aec322b170a88c998c1c7b59c731e808543310008960b1654caab569567e7c95",
+      "size": "52093456"
     },
     "riscv64-linux": {
-      "tarball": "https://ziglang.org/builds/zig-riscv64-linux-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "473e13775ef2eefe715b727b933462d2ee84cbdebb606cc8988aa70cb6ae72f1",
-      "size": "55352592"
+      "tarball": "https://ziglang.org/builds/zig-riscv64-linux-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "ad83132048c075edd1031a1e2fc9b29921e342f6b1d58142923e60e203a5b53a",
+      "size": "55303468"
     },
     "powerpc64le-linux": {
-      "tarball": "https://ziglang.org/builds/zig-powerpc64le-linux-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "2382d40afa44218a961dddd935cb5ce1f6800d5c5dd9df39a27a25026e0b09de",
-      "size": "55387192"
+      "tarball": "https://ziglang.org/builds/zig-powerpc64le-linux-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "1866a073fdcd0773397d345b21f98221a20126f7e1cec298c16ff0f4ca3fb78f",
+      "size": "55241328"
     },
     "x86-linux": {
-      "tarball": "https://ziglang.org/builds/zig-x86-linux-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "6cb242bd3e0a709a70c1b0e45a81afe1253b6d8367d411e7e25e464344f815b1",
-      "size": "58228456"
+      "tarball": "https://ziglang.org/builds/zig-x86-linux-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "6572c8768de14c0a0bbaf1a0401e19849681840594744a875ade93e4dc040edd",
+      "size": "58171580"
     },
     "loongarch64-linux": {
-      "tarball": "https://ziglang.org/builds/zig-loongarch64-linux-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "5564d7f8323386df38327e72d0b515834487f72d2e7a34673d5195019b552a4d",
-      "size": "52590788"
+      "tarball": "https://ziglang.org/builds/zig-loongarch64-linux-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "9bdf0f91187ede6b418b898d178521c4ce2065171b8bcfaa68cae0adf1d0a8f0",
+      "size": "52511048"
     },
     "s390x-linux": {
-      "tarball": "https://ziglang.org/builds/zig-s390x-linux-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "c7d74bcbbe8b6edb54e7498281b8efe76e7ddbdde9f7bef7699f39d020045bba",
-      "size": "55040152"
+      "tarball": "https://ziglang.org/builds/zig-s390x-linux-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "c893299d0e486337390262ef480615d4f573da158f73a647eb104e10a2811f0d",
+      "size": "54926720"
     },
     "x86_64-windows": {
-      "tarball": "https://ziglang.org/builds/zig-x86_64-windows-0.16.0-dev.2722+f16eb18ce.zip",
-      "shasum": "0f92e7234ed1d9608444487ca8fb928bd38da79dea744acf6c7a8fa0c440da6a",
-      "size": "98134892"
+      "tarball": "https://ziglang.org/builds/zig-x86_64-windows-0.16.0-dev.3153+d6f43caad.zip",
+      "shasum": "ab31039adca06ae87c95c11b3ff8ed82808335866d58bc6e508cd3174d2d7e3d",
+      "size": "97965399"
     },
     "aarch64-windows": {
-      "tarball": "https://ziglang.org/builds/zig-aarch64-windows-0.16.0-dev.2722+f16eb18ce.zip",
-      "shasum": "43daaad311bc3b06a733a8a87d2c3180214d62db2067df1591b921826de453ea",
-      "size": "94131162"
+      "tarball": "https://ziglang.org/builds/zig-aarch64-windows-0.16.0-dev.3153+d6f43caad.zip",
+      "shasum": "b25c7046c111f5a4e614fae1a1b33c8db73fbc3de4c135acabb5740455a3b6fc",
+      "size": "93857928"
     },
     "x86-windows": {
-      "tarball": "https://ziglang.org/builds/zig-x86-windows-0.16.0-dev.2722+f16eb18ce.zip",
-      "shasum": "3e3c3224040329bdc7120a1d16a68117f82572a26985234cb6e68bd800eed11b",
-      "size": "99937580"
+      "tarball": "https://ziglang.org/builds/zig-x86-windows-0.16.0-dev.3153+d6f43caad.zip",
+      "shasum": "51d579299617bd5fae4d0333d6f2b06a8078c1a6f2f6db2dd08289236fad70d4",
+      "size": "99767726"
     },
     "aarch64-freebsd": {
-      "tarball": "https://ziglang.org/builds/zig-aarch64-freebsd-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "fd84224ef223721ce7ee45d31296ec520c0de34ae97c035a4927370d67e955a1",
-      "size": "51224920"
+      "tarball": "https://ziglang.org/builds/zig-aarch64-freebsd-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "fe2a97ed29641cc214d58fa2c054fb3ad3a7120b7b43241e6b833c0978187bb6",
+      "size": "51125424"
     },
     "arm-freebsd": {
-      "tarball": "https://ziglang.org/builds/zig-arm-freebsd-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "01446e45de800ef17f1e8076a3765a51be91c8aa3630166bf8722104e7bf9db2",
-      "size": "52823280"
-    },
-    "powerpc64-freebsd": {
-      "tarball": "https://ziglang.org/builds/zig-powerpc64-freebsd-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "7b68f44fb289651b09318b45e754413f2473ae5956736307f5b55a6d89745ebf",
-      "size": "53947616"
+      "tarball": "https://ziglang.org/builds/zig-arm-freebsd-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "0aa627f73f0bc9c100394d512a375188afb8d33168409050d07b0c8b87adbc0b",
+      "size": "52702132"
     },
     "powerpc64le-freebsd": {
-      "tarball": "https://ziglang.org/builds/zig-powerpc64le-freebsd-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "a77432752e3f9d2746a99b973563a6439bf1908b512a6ad6b74ed8b0bd02c999",
-      "size": "55402492"
+      "tarball": "https://ziglang.org/builds/zig-powerpc64le-freebsd-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "18500e3b2e742c07541b2d35377e3dc770758ea41e9a3bf09535eacad5266583",
+      "size": "55254720"
     },
     "riscv64-freebsd": {
-      "tarball": "https://ziglang.org/builds/zig-riscv64-freebsd-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "d75e1c261075c64a295ae92c28a4871c6ea13541f2604e9399effb31a1473e3a",
-      "size": "55496140"
+      "tarball": "https://ziglang.org/builds/zig-riscv64-freebsd-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "593c19b8feb76a2e66c6d49f3a96390eed22fc4e2c780a96429d202bf4912afc",
+      "size": "55393696"
     },
     "x86_64-freebsd": {
-      "tarball": "https://ziglang.org/builds/zig-x86_64-freebsd-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "edd6ba3241cc0475f177ac2e4bcba692193259c30d0b5da288a4d76f427e0737",
-      "size": "55622060"
+      "tarball": "https://ziglang.org/builds/zig-x86_64-freebsd-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "b043fa6731e205f208d2e50fa84d1d79c7060e04688a4f5e3bff6dace337d5f8",
+      "size": "55587512"
     },
     "aarch64-netbsd": {
-      "tarball": "https://ziglang.org/builds/zig-aarch64-netbsd-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "0499caf08e5bd91bb4201b4cad68faa71be016edab9dbbd25454721549d61bfb",
-      "size": "51189128"
+      "tarball": "https://ziglang.org/builds/zig-aarch64-netbsd-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "c1625244d6fe4008feb27d8bc7bf49739da98d04bc961295124a4e8732cf3b18",
+      "size": "51092376"
     },
     "arm-netbsd": {
-      "tarball": "https://ziglang.org/builds/zig-arm-netbsd-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "46a90dc70bc59384adf9e5f2d70da6119dd4414c8a7e696309313d3b8f9e3022",
-      "size": "53863744"
+      "tarball": "https://ziglang.org/builds/zig-arm-netbsd-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "582116aeee90ea3d38ede6901f93138e543a07c6dc32d2645bf0b4e6fee813c6",
+      "size": "53732592"
     },
     "x86-netbsd": {
-      "tarball": "https://ziglang.org/builds/zig-x86-netbsd-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "92c420f1291b9f8cd4bb423000cca24403ef6dea03ec9f468e81fc20554d0db3",
-      "size": "58827296"
+      "tarball": "https://ziglang.org/builds/zig-x86-netbsd-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "eba2eb8e8efe0748820fcedb4066233a96406f97c3fa7b326e220f7c3a9e07f3",
+      "size": "58765376"
     },
     "x86_64-netbsd": {
-      "tarball": "https://ziglang.org/builds/zig-x86_64-netbsd-0.16.0-dev.2722+f16eb18ce.tar.xz",
-      "shasum": "5b0940ac45f96718ef697de9f5edcb66bd7985928aad2de91004d807a8bca07a",
-      "size": "55576856"
+      "tarball": "https://ziglang.org/builds/zig-x86_64-netbsd-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "281d172d159326167a75f2bc87fbe18afe4e37a26b5a1440cd65c8eef952626a",
+      "size": "55515836"
+    },
+    "aarch64-openbsd": {
+      "tarball": "https://ziglang.org/builds/zig-aarch64-openbsd-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "1d750bb3ed57ff4a83b1411a07df7e38f86a0a611123fcbede1ed84a48937585",
+      "size": "51551144"
+    },
+    "arm-openbsd": {
+      "tarball": "https://ziglang.org/builds/zig-arm-openbsd-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "2bd936eff1c2fadd5aa842e30f35f8509ee07f980bcb42a407940b1ae8fe5f29",
+      "size": "52270724"
+    },
+    "riscv64-openbsd": {
+      "tarball": "https://ziglang.org/builds/zig-riscv64-openbsd-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "c2067369e07e991f2e1cfe8f657c9185d726487a4ab4cbc1fde9768c8fae363d",
+      "size": "55713660"
+    },
+    "x86_64-openbsd": {
+      "tarball": "https://ziglang.org/builds/zig-x86_64-openbsd-0.16.0-dev.3153+d6f43caad.tar.xz",
+      "shasum": "01122836baaa88627de2e82addf7cdcdcfb3ba104ae9d051d92e36aaad4f4e27",
+      "size": "56927908"
     }
   },
   "0.15.2": {

--- a/bin/zml-smi/platforms/amdsmi/amdsmi.zig
+++ b/bin/zml-smi/platforms/amdsmi/amdsmi.zig
@@ -56,7 +56,7 @@ pub fn init(allocator: std.mem.Allocator) !AmdSmi {
     defer allocator.free(sockets);
     try check(fns.amdsmi_get_socket_handles(&socket_count, @ptrCast(sockets.ptr)));
 
-    var handle_list: std.ArrayList(c.amdsmi_processor_handle) = .{};
+    var handle_list: std.ArrayList(c.amdsmi_processor_handle) = .empty;
     defer handle_list.deinit(allocator);
 
     for (sockets[0..socket_count]) |socket| {

--- a/bin/zml-smi/platforms/neuron/metrics.zig
+++ b/bin/zml-smi/platforms/neuron/metrics.zig
@@ -29,8 +29,8 @@ pub fn start(collector: *Collector) !void {
     for (util_buf) |*u| u.* = .init(0);
 
     const GiB: u64 = 1024 * 1024 * 1024;
-    var neuron_infos: std.ArrayList(*DeviceInfo) = .{};
-    const dev_offset: u16 = @intCast(collector.device_infos.items.len);
+    var neuron_infos: std.ArrayList(*DeviceInfo) = .empty;
+    const dev_offset: u8 = @intCast(collector.device_infos.items.len);
 
     var ver_buf: [Nrt.version_buf_len]u8 = undefined;
     const nrt_ver: ?[]const u8 = if (nrt.version(&ver_buf)) |v|

--- a/bin/zml-smi/platforms/neuron/nrt.zig
+++ b/bin/zml-smi/platforms/neuron/nrt.zig
@@ -65,8 +65,8 @@ pub fn init(allocator: std.mem.Allocator, io: std.Io) !Nrt {
     var dev_index_buf: [c.MAX_NEURON_DEVICE_COUNT]c_int = undefined;
     const count: usize = @intCast(@max(0, private_fns.ndl_available_devices(&dev_index_buf, c.MAX_NEURON_DEVICE_COUNT)));
 
-    var handle_list: std.ArrayList(*c.ndl_device_t) = .{};
-    var index_list: std.ArrayList(c_int) = .{};
+    var handle_list: std.ArrayList(*c.ndl_device_t) = .empty;
+    var index_list: std.ArrayList(c_int) = .empty;
 
     for (dev_index_buf[0..count]) |device_idx| {
         var dev: ?*c.ndl_device_t = null;

--- a/bin/zml-smi/platforms/tpu/metrics.zig
+++ b/bin/zml-smi/platforms/tpu/metrics.zig
@@ -12,8 +12,8 @@ const address = "localhost:8431";
 pub fn start(collector: *Collector) !void {
     const chip = scanPciChips(collector.arena, collector.io) orelse return error.TpuUnavailable;
     const device_count = chip.chip_count * chip.devices_per_chip;
-    var tpu_infos: std.ArrayList(*DeviceInfo) = .{};
-    const dev_offset: u16 = @intCast(collector.device_infos.items.len);
+    var tpu_infos: std.ArrayList(*DeviceInfo) = .empty;
+    const dev_offset: u8 = @intCast(collector.device_infos.items.len);
 
     for (0..device_count) |_| {
         const chip_name = try collector.arena.dupe(u8, chip.name);

--- a/bin/zml-smi/tui/data.zig
+++ b/bin/zml-smi/tui/data.zig
@@ -58,7 +58,7 @@ pub const HistoryBuffers = struct {
     power: []RingBuffer(u64, history_len) = &.{},
 
     pub fn init(allocator: std.mem.Allocator, count: usize) !HistoryBuffers {
-        var h: HistoryBuffers = .{
+        const h: HistoryBuffers = .{
             .util = try allocator.alloc(RingBuffer(u64, history_len), count),
             .mem_util = try allocator.alloc(RingBuffer(u64, history_len), count),
             .temp = try allocator.alloc(RingBuffer(u64, history_len), count),

--- a/bin/zml-smi/tui/widgets/process_table.zig
+++ b/bin/zml-smi/tui/widgets/process_table.zig
@@ -24,7 +24,7 @@ scroll_bars: vxfw.ScrollBars = .{
     },
     .draw_horizontal_scrollbar = false,
 },
-merged: std.ArrayList(ProcessInfo) = .{},
+merged: std.ArrayList(ProcessInfo) = .empty,
 
 pub fn prepare(self: *ProcessTable, state: *data.SystemState, device_id: ?u16) void {
     self.scroll_bars.scroll_view.children.builder.userdata = self;

--- a/bin/zml-smi/tui/widgets/status_line.zig
+++ b/bin/zml-smi/tui/widgets/status_line.zig
@@ -62,7 +62,7 @@ pub fn draw(self: *const StatusLine, ctx: vxfw.DrawContext) std.mem.Allocator.Er
         .softwrap = false,
         .overflow = .clip,
     };
-    var surf = try rich.draw(ui.fixedSize(ctx, w, 1));
+    const surf = try rich.draw(ui.fixedSize(ctx, w, 1));
 
     // Fill background across full width
     if (surf.buffer.len > 0) {

--- a/examples/io/main.zig
+++ b/examples/io/main.zig
@@ -139,7 +139,7 @@ pub fn main(init: std.process.Init) !void {
                 var current = root;
                 var parts = std.mem.tokenizeScalar(u8, name, '.');
                 while (parts.next()) |part| {
-                    const gop = try current.children.getOrPut(part);
+                    const gop = try current.children.getOrPut(current.allocator, part);
                     if (!gop.found_existing) {
                         gop.value_ptr.* = try TensorNode.init(init.arena.allocator(), part);
                     }
@@ -274,15 +274,15 @@ fn printTree(io: std.Io, writer: *std.Io.Writer, dir: std.Io.Dir, prefix: []cons
 
 const TensorNode = struct {
     name: []const u8,
-    children: std.StringArrayHashMap(*TensorNode),
+    children: std.StringArrayHashMapUnmanaged(*TensorNode) = .empty,
+    allocator: std.mem.Allocator,
     tensor: ?zml.safetensors.Tensor = null,
 
     fn init(allocator: std.mem.Allocator, name: []const u8) !*TensorNode {
         const node = try allocator.create(TensorNode);
         node.* = .{
             .name = name,
-            .children = std.StringArrayHashMap(*TensorNode).init(allocator),
-            .tensor = null,
+            .allocator = allocator,
         };
         return node;
     }
@@ -314,7 +314,7 @@ fn printTensorTree(
     is_last: bool,
     is_root: bool,
 ) !void {
-    const allocator = node.children.allocator;
+    const allocator = node.allocator;
 
     if (is_root) {
         const children_nodes = try getSortedChildren(allocator, node);

--- a/platforms/neuron/libpjrt_neuron.zig
+++ b/platforms/neuron/libpjrt_neuron.zig
@@ -8,8 +8,9 @@ const stdx = @import("stdx");
 const log = std.log.scoped(.@"zml/platforms/neuron");
 
 fn findFreeTcpPort(io: std.Io) !u16 {
+    const addr: std.Io.net.IpAddress = .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } };
     var server = try std.Io.net.IpAddress.listen(
-        .{ .ip4 = .{ .bytes = .{ 127, 0, 0, 1 }, .port = 0 } },
+        &addr,
         io,
         .{},
     );

--- a/third_party/arocc/repo.bzl
+++ b/third_party/arocc/repo.bzl
@@ -4,6 +4,6 @@ def repo():
     new_git_repository(
         name = "arocc",
         remote = "https://github.com/Vexu/arocc.git",
-        commit = "a08e2ca4b0e83059c3892b8b3e026754467e0ed1",
+        commit = "5f5a050569a95ecc40a426f0c3666ae7ef987ede",
         build_file = "//third_party/arocc:arocc.bazel",
     )

--- a/third_party/flashattn/repo.bzl
+++ b/third_party/flashattn/repo.bzl
@@ -4,8 +4,8 @@ load("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 def repo():
     http_archive(
         name = "flashattn",
-        url = "https://github.com/zml/flash-attention/releases/download/v0.0.6-rc7/flashattn.tar.gz",
-        sha256 = "6b8195a5ab285404fcb084122c1c32f342ff695040b8652c9144afd2289b71b3",
+        url = "https://github.com/zml/flash-attention/releases/download/v0.0.6-rc8/flashattn.tar.gz",
+        sha256 = "360caace18b84f03779fe7af8aa1cdff64e99b6c17cbe05774be100aaf23b579",
         build_file = "//:third_party/flashattn/flashattention.BUILD.bazel",
     )
 

--- a/third_party/libvaxis/fixes.patch
+++ b/third_party/libvaxis/fixes.patch
@@ -191,6 +191,25 @@ index fc3962f..2661cf4 100644
  const vaxis = @import("../main.zig");
  const vxfw = @import("vxfw.zig");
  
+@@ -36,8 +37,8 @@ fn init(allocator: Allocator, io: std.Io) !App {
+             .kitty_keyboard_flags = .{
+                 .report_events = true,
+             },
+         }),
+-        .timers = std.ArrayList(vxfw.Tick){},
++        .timers = .empty,
+         .wants_focus = null,
+         .io = io,
+     };
+@@ -102,7 +103,7 @@
+     var ctx: vxfw.EventContext = .{
+         .alloc = self.allocator,
+         .phase = .capturing,
+-        .cmds = vxfw.CommandList{},
++        .cmds = .empty,
+         .io = io,
+         .consume_event = false,
+         .redraw = false,
 @@ -123,6 +124,13 @@ pub fn run(self: *App, widget: vxfw.Widget, opts: Options) anyerror!void {
  
          try self.checkTimers(&ctx);
@@ -205,6 +224,33 @@ index fc3962f..2661cf4 100644
          {
              loop.queue.lock();
              defer loop.queue.unlock();
+@@ -342,7 +350,7 @@
+         // For mouse events we store the last frame and use that for hit testing
+         const last_frame = surface;
+ 
+-        var hits = std.ArrayList(vxfw.HitResult){};
++        var hits: std.ArrayList(vxfw.HitResult) = .empty;
+         defer hits.deinit(app.allocator);
+         const sub: vxfw.SubSurface = .{
+             .origin = .{ .row = 0, .col = 0 },
+@@ -405,7 +413,7 @@
+         const last_frame = self.last_frame;
+         self.mouse = mouse;
+ 
+-        var hits = std.ArrayList(vxfw.HitResult){};
++        var hits: std.ArrayList(vxfw.HitResult) = .empty;
+         defer hits.deinit(app.allocator);
+         const sub: vxfw.SubSurface = .{
+             .origin = .{ .row = 0, .col = 0 },
+@@ -524,7 +532,7 @@
+         return .{
+             .root = root,
+             .focused_widget = root,
+-            .path_to_focused = std.ArrayList(Widget){},
++            .path_to_focused = .empty,
+         };
+     }
+ 
 diff --git a/src/vxfw/Padding.zig b/src/vxfw/Padding.zig
 index e60162f..6e5f40b 100644
 --- a/src/vxfw/Padding.zig

--- a/third_party/uucode/build_config.zig
+++ b/third_party/uucode/build_config.zig
@@ -1,18 +1,16 @@
 const config = @import("config.zig");
-const config_x = @import("config.x.zig");
 
-pub const tables = [_]config.Table{
+pub const fields = config.fields;
+pub const build_components = config.build_components;
+pub const get_components = config.get_components;
+
+pub const tables: []const config.Table = &.{
     .{
-        .extensions = &.{},
-        .fields = &config._resolveFields(
-            config_x,
-            &.{
-                "east_asian_width",
-                "grapheme_break",
-                "general_category",
-                "is_emoji_presentation",
-            },
-            &.{},
-        ),
+        .fields = &.{
+            "east_asian_width",
+            "grapheme_break",
+            "general_category",
+            "is_emoji_presentation",
+        },
     },
 };

--- a/third_party/uucode/repo.bzl
+++ b/third_party/uucode/repo.bzl
@@ -19,7 +19,7 @@ _uucode_repo = repository_rule(
 def repo():
     _uucode_repo(
         name = "uucode",
-        commit = "faab8894d753207878283d523add01817e23b805",
+        commit = "f1c687f09174f9f11eda14d3e3ce497d68ab09a6",
         build_config = "//third_party/uucode:build_config.zig",
         build_file = "//third_party/uucode:uucode.bazel",
     )

--- a/third_party/uucode/uucode.bazel
+++ b/third_party/uucode/uucode.bazel
@@ -1,4 +1,3 @@
-load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_library")
 
 # Generator
@@ -7,52 +6,34 @@ zig_library(
     name = "_config_gen",
     import_name = "config.zig",
     main = "src/config.zig",
-    srcs = ["src/quirks.zig"],
-    zigopts = ["--dep", "types.zig=_types_gen"],  # circular: config.zig <-> types.zig
-)
-
-zig_library(
-    name = "_types_gen",
-    import_name = "types.zig",
-    main = "src/types.zig",
-    srcs = ["src/get.zig"],
-    deps = [":_config_gen"],
-)
-
-zig_library(
-    name = "_config_x_gen",
-    import_name = "config.x.zig",
-    main = "src/x/config.x.zig",
     srcs = [
-        "src/x/config_x/grapheme_break.zig",
-        "src/x/config_x/wcwidth.zig",
+        "src/components.zig",
+        "src/fields.zig",
+        "src/multi_slice.zig",
+        "src/quirks.zig",
+        "src/types.zig",
     ],
-    deps = [
-        ":_config_gen",
-        ":_types_gen",
-        ":types_x",
-    ],
+    zigopts = ["--dep", "storage.zig=_storage_gen"],  # circular: config.zig <-> storage.zig
+)
+
+zig_library(
+    name = "_storage_gen",
+    import_name = "storage.zig",
+    main = "src/storage.zig",
+    deps = [":_config_gen"],
 )
 
 zig_library(
     name = "_build_config_gen",
     import_name = "build_config",
     main = "build_config.zig",
-    deps = [
-        ":_config_gen",
-        ":_config_x_gen",
-    ],
+    deps = [":_config_gen", ":_storage_gen"],
 )
 
 zig_binary(
     name = "gen_tables",
-    main = "src/build/tables.zig",
-    srcs = ["src/build/Ucd.zig"],
-    deps = [
-        ":_build_config_gen",
-        ":_config_gen",
-        ":_types_gen",
-    ],
+    main = "src/generate.zig",
+    deps = [":_build_config_gen", ":_config_gen", ":_storage_gen"],
 )
 
 genrule(
@@ -66,73 +47,44 @@ genrule(
 # Library
 
 zig_library(
-    name = "config",
-    import_name = "config.zig",
-    main = "src/config.zig",
-    srcs = ["src/quirks.zig"],
-    zigopts = ["--dep", "types.zig=types"],  # circular: config.zig <-> types.zig
-)
-
-zig_library(
     name = "types",
     import_name = "types.zig",
     main = "src/types.zig",
-    deps = [":config"],
-    zigopts = ["--dep", "get.zig=get"],  # circular: types.zig -> get.zig -> tables -> types.zig
 )
 
 zig_library(
-    name = "types_x",
-    import_name = "types.x.zig",
-    main = "src/x/types.x.zig",
-    srcs = ["src/x/types_x/grapheme.zig"],
-)
-
-zig_library(
-    name = "config_x",
-    import_name = "config.x.zig",
-    main = "src/x/config.x.zig",
+    name = "config",
+    import_name = "config.zig",
+    main = "src/config.zig",
     srcs = [
-        "src/x/config_x/grapheme_break.zig",
-        "src/x/config_x/wcwidth.zig",
+        "src/components.zig",
+        "src/fields.zig",
+        "src/multi_slice.zig",
+        "src/quirks.zig",
     ],
-    deps = [
-        ":config",
-        ":types",
-        ":types_x",
-    ],
+    deps = [":types"],
+    zigopts = ["--dep", "storage.zig=storage"],  # circular: config.zig <-> storage.zig
+)
+
+zig_library(
+    name = "storage",
+    import_name = "storage.zig",
+    main = "src/storage.zig",
+    deps = [":config"],
 )
 
 zig_library(
     name = "build_config",
     import_name = "build_config",
     main = "build_config.zig",
-    deps = [
-        ":config",
-        ":config_x",
-    ],
+    deps = [":config", ":storage"],
 )
 
 zig_library(
     name = "tables_lib",
     import_name = "tables",
     main = ":tables",
-    deps = [
-        ":build_config",
-        ":config",
-        ":types",
-        ":types_x",
-    ],
-)
-
-zig_library(
-    name = "get",
-    import_name = "get.zig",
-    main = "src/get.zig",
-    deps = [
-        ":tables_lib",
-        ":types",
-    ],
+    deps = [":build_config", ":config", ":storage"],
 )
 
 zig_library(
@@ -141,19 +93,11 @@ zig_library(
     main = "src/root.zig",
     srcs = [
         "src/ascii.zig",
-        "src/build/Ucd.zig",
         "src/code_point.zig",
+        "src/get.zig",
         "src/grapheme.zig",
         "src/utf8.zig",
-        "src/x/grapheme.zig",
-        "src/x/root.zig",
     ],
-    deps = [
-        ":config",
-        ":get",
-        ":tables_lib",
-        ":types",
-        ":types_x",
-    ],
+    deps = [":config", ":tables_lib", ":types"],
     visibility = ["//visibility:public"],
 )

--- a/third_party/zigimg/bump-zig.patch
+++ b/third_party/zigimg/bump-zig.patch
@@ -37,6 +37,15 @@ index d67cd61..6472129 100644
      error{ EndOfStream, InvalidData, UnfinishedBits };
  
  pub const ConvertError = Error ||
+@@ -101,7 +101,7 @@
+ };
+ 
+ pub const Animation = struct {
+-    frames: FrameList = .{},
++    frames: FrameList = .empty,
+     loop_count: i32 = AnimationLoopInfinite,
+ 
+     pub const FrameList = std.ArrayList(AnimationFrame);
 @@ -150,16 +150,16 @@ pub fn deinit(self: *Image, allocator: std.mem.Allocator) void {
  }
  
@@ -295,6 +304,14 @@ diff --git a/src/formats/pam.zig b/src/formats/pam.zig
 index f366d95..7ef9833 100644
 --- a/src/formats/pam.zig
 +++ b/src/formats/pam.zig
+@@ -70,7 +70,7 @@
+         var maybe_maxval: ?u16 = null;
+         var maybe_tuple_type: ?TupleType = null;
+-        var comments = std.ArrayListUnmanaged([]const u8){};
++        var comments: std.ArrayListUnmanaged([]const u8) = .empty;
+         defer {
+             for (comments.items) |comment| allocator.free(comment);
+             comments.deinit(allocator);
 @@ -77,7 +77,7 @@ const Header = struct {
          }
  
@@ -4336,3 +4353,139 @@ index 9f6b1a8..a53b23c 100644
 -    }) |source_file| std.testing.refAllDeclsRecursive(source_file);
 +    }) |source_file| std.testing.refAllDecls(source_file);
  }
+diff --git a/src/formats/gif.zig b/src/formats/gif.zig
+--- a/src/formats/gif.zig
++++ b/src/formats/gif.zig
+@@ -8,7 +8,7 @@
+ const std = @import("std");
+ const utils = @import("../utils.zig");
+ 
+-pub const HeaderFlags = packed struct {
++pub const HeaderFlags = packed struct(u8) {
+     global_color_table_size: u3 = 0,
+     sorted: bool = false,
+     color_resolution: u3 = 0,
+@@ -129,9 +129,9 @@
+ pub const GIF = struct {
+     header: Header = .{},
+     global_color_table: utils.FixedStorage(color.Rgb24, 256) = .{},
+-    frames: std.ArrayList(FrameData) = .{},
+-    comments: std.ArrayList(CommentExtension) = .{},
+-    application_infos: std.ArrayList(ApplicationExtension) = .{},
++    frames: std.ArrayList(FrameData) = .empty,
++    comments: std.ArrayList(CommentExtension) = .empty,
++    application_infos: std.ArrayList(ApplicationExtension) = .empty,
+     arena_allocator: std.heap.ArenaAllocator = undefined,
+ 
+     pub const SubImage = struct {
+@@ -147,6 +147,6 @@
+     pub const FrameData = struct {
+         graphics_control: ?GraphicControlExtension = null,
+-        sub_images: std.ArrayList(*SubImage) = .{},
++        sub_images: std.ArrayList(*SubImage) = .empty,
+ 
+         pub fn deinit(self: *FrameData, allocator: std.mem.Allocator) void {
+             for (self.sub_images.items) |sub_image| {
+@@ -683,7 +683,7 @@
+         const final_pixel_format = self.findBestPixelFormat();
+ 
+         const frame_list_allocator = self.arena_allocator.child_allocator;
+ 
+-        var frame_list = Image.Animation.FrameList{};
++        var frame_list: Image.Animation.FrameList = .empty;
+ 
+         if (self.frames.items.len == 0) {
+diff --git a/src/compressions/lzw.zig b/src/compressions/lzw.zig
+--- a/src/compressions/lzw.zig
++++ b/src/compressions/lzw.zig
+@@ -11,9 +11,10 @@
+         next_code: u13 = 0,
+         previous_code: ?u13 = null,
+-        dictionary: std.AutoArrayHashMap(u13, []const u8),
++        dictionary: std.AutoArrayHashMapUnmanaged(u13, []const u8) = .empty,
++        dict_allocator: std.mem.Allocator,
+ 
+         remaining_data: ?u13 = null,
+         remaining_bits: u4 = 0,
+@@ -27,7 +28,7 @@
+             var result = Self{
+                 .area_allocator = std.heap.ArenaAllocator.init(allocator),
+                 .code_size = initial_code_size,
+-                .dictionary = std.AutoArrayHashMap(u13, []const u8).init(allocator),
++                .dict_allocator = allocator,
+                 .initial_code_size = initial_code_size,
+                 .clear_code = @as(u13, 1) << @intCast(initial_code_size),
+                 .end_information_code = (@as(u13, 1) << @intCast(initial_code_size)) + 1,
+@@ -43,7 +44,7 @@
+ 
+         pub fn deinit(self: *Self) void {
+             self.area_allocator.deinit();
+-            self.dictionary.deinit();
++            self.dictionary.deinit(self.dict_allocator);
+         }
+ 
+         pub fn decode(self: *Self, reader: *std.Io.Reader, writer: *std.Io.Writer) !void {
+@@ -85,7 +86,7 @@
+                             var new_value = try allocator.alloc(u8, previous_value.len + 1);
+                             std.mem.copyForwards(u8, new_value, previous_value);
+                             new_value[previous_value.len] = value[0];
+-                            try self.dictionary.put(self.next_code, new_value);
++                            try self.dictionary.put(self.dict_allocator, self.next_code, new_value);
+ 
+                             self.next_code += 1;
+ 
+@@ -109,7 +110,7 @@
+                                 var new_value = try allocator.alloc(u8, previous_value.len + 1);
+                                 std.mem.copyForwards(u8, new_value, previous_value);
+                                 new_value[previous_value.len] = previous_value[0];
+-                                try self.dictionary.put(self.next_code, new_value);
++                                try self.dictionary.put(self.dict_allocator, self.next_code, new_value);
+ 
+                                 _ = try writer.write(new_value);
+ 
+@@ -154,7 +155,7 @@
+                 var data = try allocator.alloc(u8, 1);
+                 data[0] = @as(u8, @truncate(index));
+ 
+-                try self.dictionary.put(index, data);
++                try self.dictionary.put(self.dict_allocator, index, data);
+             }
+         }
+     };
+diff --git a/src/formats/jpeg/huffman.zig b/src/formats/jpeg/huffman.zig
+--- a/src/formats/jpeg/huffman.zig
++++ b/src/formats/jpeg/huffman.zig
+@@ -9,7 +9,7 @@
+ 
+ const HuffmanCode = struct { length_minus_one: u4, code: u16 };
+-const HuffmanCodeMap = std.AutoArrayHashMap(HuffmanCode, u8);
++const HuffmanCodeMap = std.AutoArrayHashMapUnmanaged(HuffmanCode, u8);
+ 
+ const JPEG_DEBUG = false;
+ const JPEG_VERY_DEBUG = false;
+@@ -40,8 +40,8 @@
+         for (code_counts) |count| total_huffman_codes += count;
+ 
+-        var huffman_code_map = HuffmanCodeMap.init(allocator);
+-        errdefer huffman_code_map.deinit();
++        var huffman_code_map: HuffmanCodeMap = .empty;
++        errdefer huffman_code_map.deinit(allocator);
+ 
+         var fast_table: [1 << fast_bits]u8 = @splat(255);
+         var fast_size: [1 << fast_bits]u5 = @splat(0);
+@@ -65,7 +65,7 @@
+ 
+                 const byte = try reader.takeByte();
+-                try huffman_code_map.put(.{ .length_minus_one = @as(u4, @intCast(i)), .code = code }, byte);
++                try huffman_code_map.put(allocator, .{ .length_minus_one = @as(u4, @intCast(i)), .code = code }, byte);
+ 
+                 // construct accelaration structure see stb_image
+                 if (i + 1 <= fast_bits) {
+@@ -96,5 +96,5 @@
+ 
+     pub fn deinit(self: *Table) void {
+-        self.code_map.deinit();
++        self.code_map.deinit(self.allocator);
+     }
+ };
+

--- a/zml/io.zig
+++ b/zml/io.zig
@@ -591,9 +591,9 @@ pub const DirectMemoryWriter = struct {
         allocator: std.mem.Allocator,
         shape: Shape,
         placement: Placement,
-        raw_segments: std.ArrayListUnmanaged(RawSegment) = .{},
-        segments: std.ArrayListUnmanaged(StreamSegment) = .{},
-        mirrors: std.ArrayListUnmanaged(usize) = .{},
+        raw_segments: std.ArrayListUnmanaged(RawSegment) = .empty,
+        segments: std.ArrayListUnmanaged(StreamSegment) = .empty,
+        mirrors: std.ArrayListUnmanaged(usize) = .empty,
 
         fn init(allocator: std.mem.Allocator, shape: Shape, placement: Placement) StreamPlanner {
             return .{
@@ -617,6 +617,7 @@ pub const DirectMemoryWriter = struct {
             const owned_segments = try self.segments.toOwnedSlice(self.allocator);
             errdefer self.allocator.free(owned_segments);
             const owned_mirrors = try self.mirrors.toOwnedSlice(self.allocator);
+            errdefer self.allocator.free(owned_mirrors);
 
             return .{
                 .segments = owned_segments,

--- a/zml/io/vfs.zig
+++ b/zml/io/vfs.zig
@@ -23,15 +23,15 @@ pub const VFS = struct {
     mutex: std.Io.Mutex = .init,
 
     backends: std.StringArrayHashMapUnmanaged(std.Io) = .empty,
-    handles: Handles = .{},
-    closed_handles: ClosedHandles = .{},
+    handles: Handles = .empty,
+    closed_handles: ClosedHandles = .empty,
 
     base: VFSBase,
 
     pub fn init(allocator: std.mem.Allocator, base_io: std.Io) !VFS {
         const base = VFSBase.init(base_io);
 
-        var handles: Handles = .{};
+        var handles: Handles = .empty;
         try handles.append(allocator, .{ .handle = CWD_HANDLE, .backend_idx = null });
         try handles.append(allocator, .{ .handle = std.posix.STDIN_FILENO, .backend_idx = null });
         try handles.append(allocator, .{ .handle = std.posix.STDOUT_FILENO, .backend_idx = null });
@@ -176,7 +176,7 @@ pub const VFS = struct {
                     .data = o.data,
                 } });
             },
-            .device_io_control, .file_write_streaming => {
+            .device_io_control, .file_write_streaming, .net_receive => {
                 return self.base.inner.vtable.operate(self.base.inner.userdata, operation);
             },
         }
@@ -228,7 +228,7 @@ pub const VFS = struct {
         const self: *VFS = @fieldParentPtr("base", VFSBase.as(userdata));
         const backend_idx, const dir_, const backend = self.lookupDir(dir, sub_path) catch |err| {
             log.err("Failed to lookup backend for dir create file '{s}' : {any}", .{ sub_path, err });
-            return std.Io.Dir.AccessError.Unexpected;
+            return std.Io.File.OpenError.Unexpected;
         };
 
         const file = try backend.vtable.dirCreateFile(backend.userdata, dir_, stripScheme(sub_path), flags);
@@ -271,7 +271,7 @@ pub const VFS = struct {
         const self: *VFS = @fieldParentPtr("base", VFSBase.as(userdata));
         _, const dir_, const backend = self.lookupDir(reader.dir, null) catch |err| {
             log.err("Failed to lookup backend for dir real path : {any}", .{err});
-            return std.Io.Dir.RealPathError.Unexpected;
+            return std.Io.Dir.Reader.Error.Unexpected;
         };
 
         const original_dir = reader.dir;

--- a/zml/io/vfs/base.zig
+++ b/zml/io/vfs/base.zig
@@ -91,6 +91,7 @@ pub const VFSBase = struct {
             .unlockStderr = unlockStderr,
             .processCurrentPath = processCurrentPath,
             .processSetCurrentDir = processSetCurrentDir,
+            .processSetCurrentPath = processSetCurrentPath,
             .processReplace = processReplace,
             .processReplacePath = processReplacePath,
             .processSpawn = processSpawn,
@@ -111,7 +112,6 @@ pub const VFSBase = struct {
             .netConnectUnix = netConnectUnix,
             .netSocketCreatePair = netSocketCreatePair,
             .netSend = netSend,
-            .netReceive = netReceive,
             .netRead = netRead,
             .netWrite = netWrite,
             .netWriteFile = netWriteFile,
@@ -531,6 +531,11 @@ pub const VFSBase = struct {
         return self.inner.vtable.processSetCurrentDir(self.inner.userdata, dir);
     }
 
+    pub fn processSetCurrentPath(userdata: ?*anyopaque, path: []const u8) std.process.SetCurrentPathError!void {
+        const self: *VFSBase = @ptrCast(@alignCast(userdata.?));
+        return self.inner.vtable.processSetCurrentPath(self.inner.userdata, path);
+    }
+
     pub fn processReplace(userdata: ?*anyopaque, options: std.process.ReplaceOptions) std.process.ReplaceError {
         const self: *VFSBase = @ptrCast(@alignCast(userdata.?));
         return self.inner.vtable.processReplace(self.inner.userdata, options);
@@ -591,14 +596,14 @@ pub const VFSBase = struct {
         return self.inner.vtable.randomSecure(self.inner.userdata, buffer);
     }
 
-    pub fn netListenIp(userdata: ?*anyopaque, address: std.Io.net.IpAddress, options: std.Io.net.IpAddress.ListenOptions) std.Io.net.IpAddress.ListenError!std.Io.net.Server {
+    pub fn netListenIp(userdata: ?*anyopaque, address: *const std.Io.net.IpAddress, options: std.Io.net.IpAddress.ListenOptions) std.Io.net.IpAddress.ListenError!std.Io.net.Socket {
         const self: *VFSBase = @ptrCast(@alignCast(userdata.?));
         return self.inner.vtable.netListenIp(self.inner.userdata, address, options);
     }
 
-    pub fn netAccept(userdata: ?*anyopaque, server: std.Io.net.Socket.Handle) std.Io.net.Server.AcceptError!std.Io.net.Stream {
+    pub fn netAccept(userdata: ?*anyopaque, server: std.Io.net.Socket.Handle, options: std.Io.net.Server.AcceptOptions) std.Io.net.Server.AcceptError!std.Io.net.Socket {
         const self: *VFSBase = @ptrCast(@alignCast(userdata.?));
-        return self.inner.vtable.netAccept(self.inner.userdata, server);
+        return self.inner.vtable.netAccept(self.inner.userdata, server, options);
     }
 
     pub fn netBindIp(userdata: ?*anyopaque, address: *const std.Io.net.IpAddress, options: std.Io.net.IpAddress.BindOptions) std.Io.net.IpAddress.BindError!std.Io.net.Socket {
@@ -606,7 +611,7 @@ pub const VFSBase = struct {
         return self.inner.vtable.netBindIp(self.inner.userdata, address, options);
     }
 
-    pub fn netConnectIp(userdata: ?*anyopaque, address: *const std.Io.net.IpAddress, options: std.Io.net.IpAddress.ConnectOptions) std.Io.net.IpAddress.ConnectError!std.Io.net.Stream {
+    pub fn netConnectIp(userdata: ?*anyopaque, address: *const std.Io.net.IpAddress, options: std.Io.net.IpAddress.ConnectOptions) std.Io.net.IpAddress.ConnectError!std.Io.net.Socket {
         const self: *VFSBase = @ptrCast(@alignCast(userdata.?));
         return self.inner.vtable.netConnectIp(self.inner.userdata, address, options);
     }
@@ -629,11 +634,6 @@ pub const VFSBase = struct {
     pub fn netSend(userdata: ?*anyopaque, handle: std.Io.net.Socket.Handle, msgs: []std.Io.net.OutgoingMessage, flags: std.Io.net.SendFlags) struct { ?std.Io.net.Socket.SendError, usize } {
         const self: *VFSBase = @ptrCast(@alignCast(userdata.?));
         return self.inner.vtable.netSend(self.inner.userdata, handle, msgs, flags);
-    }
-
-    pub fn netReceive(userdata: ?*anyopaque, handle: std.Io.net.Socket.Handle, message_buffer: []std.Io.net.IncomingMessage, data_buffer: []u8, flags: std.Io.net.ReceiveFlags, timeout: std.Io.Timeout) struct { ?std.Io.net.Socket.ReceiveTimeoutError, usize } {
-        const self: *VFSBase = @ptrCast(@alignCast(userdata.?));
-        return self.inner.vtable.netReceive(self.inner.userdata, handle, message_buffer, data_buffer, flags, timeout);
     }
 
     pub fn netRead(userdata: ?*anyopaque, src: std.Io.net.Socket.Handle, data: [][]u8) std.Io.net.Stream.Reader.Error!usize {

--- a/zml/io/vfs/file.zig
+++ b/zml/io/vfs/file.zig
@@ -85,7 +85,7 @@ pub const File = struct {
     allocator: std.mem.Allocator,
     mutex: std.Io.Mutex = .init,
     handles: stdx.SegmentedList(Handle, 0) = .{},
-    closed_handles: std.ArrayList(u32) = .{},
+    closed_handles: std.ArrayList(u32) = .empty,
     config: Config,
     base: VFSBase,
 
@@ -201,7 +201,7 @@ pub const File = struct {
                     },
                 });
             },
-            .file_write_streaming, .device_io_control => {
+            .file_write_streaming, .device_io_control, .net_receive => {
                 return self.base.inner.vtable.operate(self.base.inner.userdata, operation);
             },
         }

--- a/zml/io/vfs/gcs.zig
+++ b/zml/io/vfs/gcs.zig
@@ -165,7 +165,7 @@ pub const GCS = struct {
     config: Config,
     token: Token,
     handles: stdx.SegmentedList(Handle, 0) = .{},
-    closed_handles: std.ArrayList(u32) = .{},
+    closed_handles: std.ArrayList(u32) = .empty,
     dir_read_states: std.AutoHashMapUnmanaged(*std.Io.Dir.Reader, ReadState) = .{},
     base: VFSBase,
 
@@ -473,17 +473,17 @@ pub const GCS = struct {
                 const handle = self.getFileHandle(o.file);
                 const total = self.performRead(handle, o.data, handle.pos) catch |err| {
                     log.err("Failed to perform read for file {s} at pos {d}: {any}", .{ handle.uri, handle.pos, err });
-                    return .{ .file_read_streaming = std.Io.File.ReadStreamingError.EndOfStream };
+                    return .{ .file_read_streaming = error.EndOfStream };
                 };
 
                 if (total == 0) {
-                    return .{ .file_read_streaming = std.Io.File.ReadStreamingError.EndOfStream };
+                    return .{ .file_read_streaming = error.EndOfStream };
                 }
 
                 handle.pos += @intCast(total);
                 return .{ .file_read_streaming = total };
             },
-            .file_write_streaming, .device_io_control => {
+            .file_write_streaming, .device_io_control, .net_receive => {
                 return self.base.inner.vtable.operate(self.base.inner.userdata, operation);
             },
         }
@@ -667,7 +667,7 @@ pub const GCS = struct {
         const handle = self.getFileHandle(file);
         return self.performRead(handle, data, offset) catch |err| {
             log.err("Failed to perform read for file {s} at pos {d}: {any}", .{ handle.uri, offset, err });
-            return std.Io.File.Reader.Error.Unexpected;
+            return std.Io.File.ReadPositionalError.Unexpected;
         };
     }
 

--- a/zml/io/vfs/hf.zig
+++ b/zml/io/vfs/hf.zig
@@ -103,7 +103,7 @@ pub const HF = struct {
     client: *std.http.Client,
     authorization: std.http.Client.Request.Headers.Value,
     handles: stdx.SegmentedList(Handle, 0) = .{},
-    closed_handles: std.ArrayList(u32) = .{},
+    closed_handles: std.ArrayList(u32) = .empty,
     base: VFSBase,
     trees: std.StringHashMapUnmanaged(std.ArrayList(TreeNode)) = .{},
     dir_read_states: std.AutoHashMapUnmanaged(*std.Io.Dir.Reader, ReadState) = .{},
@@ -319,7 +319,7 @@ pub const HF = struct {
         );
         defer parsed.deinit();
 
-        var tree_root: std.ArrayList(TreeNode) = .{};
+        var tree_root: std.ArrayList(TreeNode) = .empty;
         for (parsed.value) |item| {
             try insertTreeNode(self.allocator, &tree_root, item);
         }
@@ -407,7 +407,7 @@ pub const HF = struct {
         var parts = std.mem.tokenizeScalar(u8, item.path, '/');
         var current_list = root;
 
-        var parents: std.ArrayList(*TreeNode) = .{};
+        var parents: std.ArrayList(*TreeNode) = .empty;
         defer parents.deinit(allocator);
 
         while (true) {
@@ -426,7 +426,7 @@ pub const HF = struct {
                 if (!is_last) {
                     try parents.append(allocator, f);
                     if (f.children == null) {
-                        f.children = .{};
+                        f.children = .empty;
                     }
                     current_list = &f.children.?;
                 } else if (std.mem.eql(u8, item.type, "file")) {
@@ -438,7 +438,7 @@ pub const HF = struct {
                     .name = try allocator.dupe(u8, part),
                     .kind = if (is_file) .file else .directory,
                     .size = if (is_last) item.size else 0,
-                    .children = if (is_file) null else .{},
+                    .children = if (is_file) null else .empty,
                 };
                 try current_list.append(allocator, new_node);
 
@@ -462,17 +462,17 @@ pub const HF = struct {
                 const handle = self.getFileHandle(o.file);
                 const total = self.performRead(handle, o.data, handle.pos) catch |err| {
                     log.err("Failed to perform read for file {s} at pos {d}: {any}", .{ handle.uri, handle.pos, err });
-                    return .{ .file_read_streaming = std.Io.File.ReadStreamingError.EndOfStream };
+                    return .{ .file_read_streaming = error.EndOfStream };
                 };
 
                 if (total == 0) {
-                    return .{ .file_read_streaming = std.Io.File.ReadStreamingError.EndOfStream };
+                    return .{ .file_read_streaming = error.EndOfStream };
                 }
 
                 handle.pos += @intCast(total);
                 return .{ .file_read_streaming = total };
             },
-            .file_write_streaming, .device_io_control => {
+            .file_write_streaming, .device_io_control, .net_receive => {
                 return self.base.inner.vtable.operate(self.base.inner.userdata, operation);
             },
         }
@@ -667,7 +667,7 @@ pub const HF = struct {
         const handle = self.getFileHandle(file);
         return self.performRead(handle, data, offset) catch |err| {
             log.err("Failed to perform read for file {s} at pos {d}: {any}", .{ handle.uri, offset, err });
-            return std.Io.File.Reader.Error.Unexpected;
+            return std.Io.File.ReadPositionalError.Unexpected;
         };
     }
 

--- a/zml/io/vfs/http.zig
+++ b/zml/io/vfs/http.zig
@@ -42,7 +42,7 @@ pub const HTTP = struct {
     client: *std.http.Client,
     protocol: Protocol,
     handles: stdx.SegmentedList(Handle, 0) = .{},
-    closed_handles: std.ArrayList(u32) = .{},
+    closed_handles: std.ArrayList(u32) = .empty,
     base: VFSBase,
 
     pub fn init(allocator: std.mem.Allocator, inner: std.Io, http_client: *std.http.Client, protocol: Protocol) !HTTP {
@@ -146,17 +146,17 @@ pub const HTTP = struct {
                 const handle = self.getFileHandle(o.file);
                 const total = self.performRead(handle, o.data, handle.pos) catch |err| {
                     log.err("Failed to perform read for file {s} at pos {d}: {any}", .{ handle.uri, handle.pos, err });
-                    return .{ .file_read_streaming = std.Io.File.ReadStreamingError.EndOfStream };
+                    return .{ .file_read_streaming = error.EndOfStream };
                 };
 
                 if (total == 0) {
-                    return .{ .file_read_streaming = std.Io.File.ReadStreamingError.EndOfStream };
+                    return .{ .file_read_streaming = error.EndOfStream };
                 }
 
                 handle.pos += @intCast(total);
                 return .{ .file_read_streaming = total };
             },
-            .file_write_streaming, .device_io_control => {
+            .file_write_streaming, .device_io_control, .net_receive => {
                 return self.base.inner.vtable.operate(self.base.inner.userdata, operation);
             },
         }
@@ -284,7 +284,7 @@ pub const HTTP = struct {
         const handle = self.getFileHandle(file);
         return self.performRead(handle, data, offset) catch |err| {
             log.err("Failed to perform read for file {s} at pos {d}: {any}", .{ handle.uri, offset, err });
-            return std.Io.File.Reader.Error.Unexpected;
+            return std.Io.File.ReadPositionalError.Unexpected;
         };
     }
 

--- a/zml/io/vfs/s3.zig
+++ b/zml/io/vfs/s3.zig
@@ -175,7 +175,7 @@ pub const S3 = struct {
     client: *std.http.Client,
     config: Config,
     handles: stdx.SegmentedList(Handle, 0) = .{},
-    closed_handles: std.ArrayList(u32) = .{},
+    closed_handles: std.ArrayList(u32) = .empty,
     dir_read_states: std.AutoHashMapUnmanaged(*std.Io.Dir.Reader, ReadState) = .{},
     base: VFSBase,
 
@@ -350,17 +350,17 @@ pub const S3 = struct {
                 const handle = self.getFileHandle(o.file);
                 const total = self.performRead(handle, o.data, handle.pos) catch |err| {
                     log.err("Failed to perform read for file {s} at pos {d}: {any}", .{ handle.uri, handle.pos, err });
-                    return .{ .file_read_streaming = std.Io.File.ReadStreamingError.EndOfStream };
+                    return .{ .file_read_streaming = error.EndOfStream };
                 };
 
                 if (total == 0) {
-                    return .{ .file_read_streaming = std.Io.File.ReadStreamingError.EndOfStream };
+                    return .{ .file_read_streaming = error.EndOfStream };
                 }
 
                 handle.pos += @intCast(total);
                 return .{ .file_read_streaming = total };
             },
-            .file_write_streaming, .device_io_control => {
+            .file_write_streaming, .device_io_control, .net_receive => {
                 return self.base.inner.vtable.operate(self.base.inner.userdata, operation);
             },
         }
@@ -539,7 +539,7 @@ pub const S3 = struct {
         const handle = self.getFileHandle(file);
         return self.performRead(handle, data, offset) catch |err| {
             log.err("Failed to perform read for file {s} at pos {d}: {any}", .{ handle.uri, offset, err });
-            return std.Io.File.Reader.Error.Unexpected;
+            return std.Io.File.ReadPositionalError.Unexpected;
         };
     }
 
@@ -687,7 +687,7 @@ pub const S3 = struct {
     }
 
     fn parseListObjectsResponse(self: *S3, xml: []const u8, prefix: []const u8) ![][]const u8 {
-        var results = std.ArrayListUnmanaged([]const u8){};
+        var results: std.ArrayListUnmanaged([]const u8) = .empty;
         errdefer {
             for (results.items) |item| self.allocator.free(item);
             results.deinit(self.allocator);

--- a/zml/mem.zig
+++ b/zml/mem.zig
@@ -360,7 +360,7 @@ fn bufferizeInner(allocator: std.mem.Allocator, model: anytype, bufferized_: *Bu
         .pointer => |p| {
             switch (p.size) {
                 .slice => {
-                    bufferized_.* = try allocator.alignedAlloc(p.child, .fromByteUnits(p.alignment), model.len);
+                    bufferized_.* = try allocator.alignedAlloc(p.child, .fromByteUnits(p.alignment orelse @alignOf(p.child)), model.len);
                     for (model, bufferized_.*) |src, *dst| {
                         try bufferizeInner(allocator, src, dst);
                     }

--- a/zml/meta.zig
+++ b/zml/meta.zig
@@ -444,83 +444,81 @@ pub fn VisitReturn(comptime cb: anytype) type {
         void;
 }
 
-pub fn visit(comptime cb: anytype, ctx: FnParam(cb, 0), v: anytype) VisitReturn(cb) {
-    const Callback = @TypeOf(cb);
-    const Ptr = @TypeOf(v);
-    const type_info_v = @typeInfo(Ptr);
-    if (type_info_v != .pointer) {
-        stdx.debug.compileError("zml.meta.visit({}) is expecting a pointer/slice input, but received: {}", .{ Callback, Ptr });
-    }
-    const ptr_info = type_info_v.pointer;
-    const Child = ptr_info.child;
-    const can_error = stdx.meta.FnReturnErrorSet(cb) != null;
-
-    const K, const mutating_cb = switch (@typeInfo(FnParam(cb, 1))) {
-        .pointer => |info| .{ info.child, !info.is_const },
-        else => stdx.debug.compileError("zml.meta.visit is expecting a callback with a pointer as second argument but found {}", .{FnParam(cb, 1)}),
+const Visitor = struct {
+    pub const VisitorType = enum {
+        callback,
+        recurse,
     };
-    // Abort if v doesnt' contain any K.
-    if (comptime !Contains(Ptr, K)) return;
 
-    // Handle simple cases.
-    switch (Ptr) {
-        *const K, *K => return cb(ctx, v),
-        *const ?K, *?K => return if (v.*) |*val| cb(ctx, val) else {},
-        []const K, []K => {
-            for (v) |*v_elem| if (can_error) try cb(ctx, v_elem) else cb(ctx, v_elem);
-            return;
-        },
-        else => {},
+    pub fn determineAction(comptime callback: anytype, comptime PtrTypeOfV: type) VisitorType {
+        const ptr_info = switch (@typeInfo(PtrTypeOfV)) {
+            .pointer => |info| info,
+            else => stdx.debug.compileError("zml.meta.visit({any}) is expecting a pointer/slice input, but received: {any}", .{ @TypeOf(callback), PtrTypeOfV }),
+        };
+
+        const TargetType = switch (@typeInfo(FnParam(callback, 1))) {
+            .pointer => |info| info.child,
+            else => stdx.debug.compileError("zml.meta.visit({any}) is expecting a callback with a pointer as second argument but found {any}", .{ @TypeOf(callback), FnParam(callback, 1) }),
+        };
+
+        if (ptr_info.size == .one and ptr_info.child == TargetType) {
+            return .callback;
+        }
+
+        return .recurse;
     }
+};
 
-    // Handle stdx.BoundedArray that contains uninitalized data.
-    if (@typeInfo(Child) == .@"struct" and @hasDecl(Child, "constSlice") and @hasDecl(Child, "slice")) {
-        return visit(cb, ctx, if (mutating_cb) v.slice() else v.constSlice());
-    }
+pub fn visit(comptime callback: anytype, ctx: FnParam(callback, 0), v: anytype) VisitReturn(callback) {
+    const action = comptime Visitor.determineAction(callback, @TypeOf(v));
 
-    // Recursively visit fields of v.
-    switch (ptr_info.size) {
-        .one => switch (@typeInfo(Child)) {
-            .@"struct" => |s| inline for (s.fields) |field| {
-                if (field.is_comptime or comptime !Contains(field.type, K)) continue;
-                const field_type_info = @typeInfo(field.type);
-                // If the field is already a pointer, we recurse with it directly, otherwise, we recurse with a pointer to the field.
-                switch (field_type_info) {
-                    .pointer => if (can_error) try visit(cb, ctx, @field(v, field.name)) else visit(cb, ctx, @field(v, field.name)),
-                    .array, .optional, .@"union", .@"struct" => if (can_error) try visit(cb, ctx, &@field(v, field.name)) else visit(cb, ctx, &@field(v, field.name)),
-                    else => {},
-                }
-            },
-            .array => for (v) |*elem| if (can_error) try visit(cb, ctx, elem) else visit(cb, ctx, elem),
-            .optional => if (v.* != null) if (can_error) try visit(cb, ctx, &v.*.?) else visit(cb, ctx, &v.*.?),
-            .@"union" => switch (v.*) {
-                inline else => |*v_field| if (can_error) try visit(cb, ctx, v_field) else visit(cb, ctx, v_field),
-            },
-            else => stdx.debug.compileError("zml.meta.visit({}) doesn't support fields of type: {}", .{ Callback, Child }),
+    const PtrTypeOfV = @TypeOf(v);
+    const ptr_info_v = @typeInfo(PtrTypeOfV).pointer;
+    const ChildTypeV = ptr_info_v.child;
+
+    const can_error = stdx.meta.FnReturnErrorSet(callback) != null;
+
+    switch (action) {
+        .callback => {
+            return if (can_error) try callback(ctx, v) else callback(ctx, v);
         },
-        .slice => {
-            for (v) |*v_elem| {
-                switch (@typeInfo(Child)) {
+        .recurse => {
+            const TargetType, const mutating_cb = switch (@typeInfo(FnParam(callback, 1))) {
+                .pointer => |info| .{ info.child, !info.is_const },
+                else => stdx.debug.compileError("zml.meta.visit({any}) is expecting a callback with a pointer as second argument but found {any}", .{ @TypeOf(callback), FnParam(callback, 1) }),
+            };
+
+            if (comptime !Contains(PtrTypeOfV, TargetType)) return;
+
+            if (@typeInfo(ChildTypeV) == .@"struct" and @hasDecl(ChildTypeV, "constSlice") and @hasDecl(ChildTypeV, "slice")) {
+                return visit(callback, ctx, if (mutating_cb) v.slice() else v.constSlice());
+            }
+
+            switch (ptr_info_v.size) {
+                .one => switch (@typeInfo(ChildTypeV)) {
                     .@"struct" => |s| inline for (s.fields) |field| {
-                        if (field.is_comptime or comptime !Contains(field.type, K)) continue;
-                        const field_type_info = @typeInfo(field.type);
-                        // If the field is already a pointer, we recurse with it directly, otherwise, we recurse with a pointer to the field.
-                        if (field_type_info == .pointer) {
-                            if (can_error) try visit(cb, ctx, @field(v_elem, field.name)) else visit(cb, ctx, @field(v_elem, field.name));
+                        if (field.is_comptime or comptime !Contains(field.type, TargetType)) continue;
+                        if (@typeInfo(field.type) == .pointer) {
+                            if (can_error) try visit(callback, ctx, @field(v, field.name)) else visit(callback, ctx, @field(v, field.name));
                         } else {
-                            if (can_error) try visit(cb, ctx, &@field(v_elem, field.name)) else visit(cb, ctx, &@field(v_elem, field.name));
+                            if (can_error) try visit(callback, ctx, &@field(v, field.name)) else visit(callback, ctx, &@field(v, field.name));
                         }
                     },
-                    .array => for (v) |*elem| if (can_error) try visit(cb, ctx, elem) else visit(cb, ctx, elem),
-                    .optional => if (v.* != null) if (can_error) try visit(cb, ctx, &v.*.?) else visit(cb, ctx, &v.*.?),
-                    .@"union" => switch (v_elem.*) {
-                        inline else => |*v_field| if (can_error) try visit(cb, ctx, v_field) else visit(cb, ctx, v_field),
+                    .array => inline for (v) |*elem| if (can_error) try visit(callback, ctx, elem) else visit(callback, ctx, elem),
+                    .optional => if (v.* != null) if (can_error) try visit(callback, ctx, &v.*.?) else visit(callback, ctx, &v.*.?),
+                    .@"union" => switch (v.*) {
+                        inline else => |*v_field| if (can_error) try visit(callback, ctx, v_field) else visit(callback, ctx, v_field),
                     },
-                    else => stdx.debug.compileError("zml.meta.visit({}) doesn't support fields of type: {}", .{ Callback, Child }),
-                }
+                    else => stdx.debug.compileError("zml.meta.visit({any}) doesn't support visiting pointer type {any}", .{ @TypeOf(callback), ChildTypeV }),
+                },
+                .slice => {
+                    for (v) |*v_elem| {
+                        if (can_error) try visit(callback, ctx, v_elem) else visit(callback, ctx, v_elem);
+                    }
+                },
+                .many, .c => stdx.debug.compileError("zml.meta.visit({any}) doesn't support [*] style pointers got {any}", .{ @TypeOf(callback), ChildTypeV }),
             }
         },
-        .many, .c => stdx.debug.compileError("zml.meta.visit({}) doesn't support [*] style pointers, got: {}", .{ Callback, Ptr }),
     }
 }
 

--- a/zml/sharding.zig
+++ b/zml/sharding.zig
@@ -1109,7 +1109,7 @@ pub const Sharding = struct {
         }
 
         var folds: Folds = try .init(0);
-        var folds_consumed = std.EnumSet(PhysicalAxisTag).initEmpty();
+        var folds_consumed: std.EnumSet(PhysicalAxisTag) = .empty;
         for (strategy.folding.constSlice()) |entry| {
             for (entry.sources.constSlice()) |src| {
                 if (!physical.hasAxis(src)) return error.InvalidPhysicalAxis;
@@ -1188,7 +1188,7 @@ pub const Sharding = struct {
         const logical_tag = Shape.toTag(logical_axis);
         const bound_axes = self.binding(logical_tag) orelse return 1;
 
-        var physical_axes = std.EnumSet(PhysicalAxisTag).initEmpty();
+        var physical_axes: std.EnumSet(PhysicalAxisTag) = .empty;
         for (bound_axes) |bound_axis| {
             if (self.foldSources(bound_axis)) |sources| {
                 for (sources) |source| physical_axes.insert(source);
@@ -1242,7 +1242,7 @@ pub const Sharding = struct {
         const view = self.physicalView();
         var axes_per_dim = stdx.BoundedArray(stdx.BoundedArray(usize, Shape.MAX_RANK), Shape.MAX_RANK).init(0) catch unreachable;
         var used_mask = [_]bool{false} ** Shape.MAX_RANK;
-        var globally_used = std.EnumSet(PhysicalAxisTag).initEmpty();
+        var globally_used: std.EnumSet(PhysicalAxisTag) = .empty;
 
         for (0..shape.rank()) |ax| {
             var dim_axes = stdx.BoundedArray(usize, Shape.MAX_RANK).init(0) catch unreachable;
@@ -1715,7 +1715,7 @@ pub const Placement = struct {
         };
 
         for (self.shards.slice()) |*s| {
-            var used_axes = std.EnumSet(PhysicalAxisTag).initEmpty();
+            var used_axes: std.EnumSet(PhysicalAxisTag) = .empty;
 
             for (0..shape.rank()) |ax| {
                 const axis_index: u8 = @intCast(ax);

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -209,7 +209,7 @@ pub const Tensor = struct {
             .unknown(ctx.mlir_ctx),
         ).appendTo(currentBlock());
 
-        var res = _result(self._shape, op.result(0));
+        const res = _result(self._shape, op.result(0));
         ctx.currentScope().id_to_output_memory_kind.put(ctx.currentScope().arena.allocator(), res.id, kind) catch unreachable;
         return res;
     }

--- a/zml/tokenizer/homemade.zig
+++ b/zml/tokenizer/homemade.zig
@@ -963,13 +963,14 @@ pub const Gpt2TextDecoder = struct {
     const Code = stdx.BoundedArray(u8, 2);
 
     // TODO: benchmark this is more efficient than doing the conversion at runtime.
-    code_to_byte: std.AutoArrayHashMap(Code, u8),
+    code_to_byte: std.AutoArrayHashMapUnmanaged(Code, u8) = .empty,
+    allocator: std.mem.Allocator,
 
     pub fn init(allocator: std.mem.Allocator) !Gpt2TextDecoder {
         var self = Gpt2TextDecoder{
-            .code_to_byte = std.AutoArrayHashMap(Code, u8).init(allocator),
+            .allocator = allocator,
         };
-        try self.code_to_byte.ensureTotalCapacity(256);
+        try self.code_to_byte.ensureTotalCapacity(allocator, 256);
         errdefer unreachable;
 
         var n: usize = 0;
@@ -995,7 +996,7 @@ pub const Gpt2TextDecoder = struct {
     }
 
     pub fn deinit(self: *Gpt2TextDecoder) void {
-        self.code_to_byte.deinit();
+        self.code_to_byte.deinit(self.allocator);
     }
 
     /// Transform bytes representing text under the gpt2 encoding,

--- a/zml/tokenizer/main.zig
+++ b/zml/tokenizer/main.zig
@@ -13,8 +13,7 @@ const Flags = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
-    var gpa: std.heap.GeneralPurposeAllocator(.{}) = .{};
-    const allocator = gpa.allocator();
+    const allocator = init.gpa;
 
     var threaded: std.Io.Threaded = .init(allocator, .{});
     defer threaded.deinit();


### PR DESCRIPTION
zml/chore: bump Zig to 0.16.0-dev.3133 and adapt codebase

Update Zig compiler to 0.16.0-dev.3133+5ec8e45f3 and adjust code
for breaking standard library changes:

- Replace ArrayListUnmanaged/ArrayList init with .empty
- Switch to unmanaged AutoArrayHashMap/StringArrayHashMap
- Use debug.GeneralPurposeAllocator (renamed upstream)
- Replace std.Io.File.ReadStreamingError with error.EndOfStream
- Refactor meta.visit to use structured visitor pattern
- Fix alignment allocation in mem.bufferizeInner

Also update third-party dependencies: flashattn 0.0.6-rc8, arocc,
uucode, libvaxis, and zigimg patches.

