### PR TITLE
zml/attention: add option to set the softmax scaling

### DIFF
--- a/zml/attention/flashattn.zig
+++ b/zml/attention/flashattn.zig
@@ -950,6 +950,7 @@ pub const paged_fa2 = struct {
                             .max_seqlen_k = context.max_seqlen_k,
                             .num_heads = num_heads_per_shard,
                             .window_size_left = opts.sliding_window,
+                            .softmax_scale = opts.scale,
                         },
                         .opts = zml.ops.CustomCallOptions{
                             .has_side_effect = false,
@@ -1026,6 +1027,7 @@ pub const paged_fa2 = struct {
                             .max_seqlen_k = context.max_seqlen_k,
                             .num_heads = num_heads_per_shard,
                             .window_size_left = opts.sliding_window,
+                            .softmax_scale = opts.scale,
                         },
                         .opts = zml.ops.CustomCallOptions{
                             .has_side_effect = false,
@@ -1089,6 +1091,7 @@ pub const paged_fa2 = struct {
                             .max_seqlen_k = context.max_seqlen_k,
                             .num_heads = num_heads_per_shard,
                             .window_size_left = opts.sliding_window,
+                            .softmax_scale = opts.scale,
                         },
                         .opts = zml.ops.CustomCallOptions{
                             .has_side_effect = false,

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -175,6 +175,7 @@ pub const Context = union(Backend) {
 pub const AttentionOptions = struct {
     is_causal: bool = true,
     sliding_window: i32 = -1,
+    scale: ?f32 = null,
 };
 
 pub fn pagedAttention(parameters: Parameters, context: Context, q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, k_cache: zml.Tensor, v_cache: zml.Tensor, opts: AttentionOptions) zml.Tensor {

--- a/zml/attention/triton.zig
+++ b/zml/attention/triton.zig
@@ -319,6 +319,7 @@ pub const paged = struct {
         target_num_prgms: usize,
         num_2d_prgms: usize,
         max_seqlen_q: usize,
+        scale: ?f32,
 
         pub fn numQueriesPerKv(self: PagedAttentionOptions) usize {
             return self.num_heads / self.num_kv_heads;
@@ -382,6 +383,7 @@ pub const paged = struct {
                         .target_num_prgms = target_num_prgms,
                         .num_2d_prgms = num_2d_prgms,
                         .max_seqlen_q = ctx_.options.max_seqlen_q,
+                        .scale = ctx_.opts.scale,
                     };
 
                     const use_2d_kernel = use2dKernel(
@@ -458,7 +460,7 @@ pub const paged = struct {
         const v_strides_1_ptr = zml.Tensor.constant(zml.DataType.i64.constant(v_strides[1]));
         const v_strides_2_ptr = zml.Tensor.constant(zml.DataType.i64.constant(v_strides[2]));
         const num_seqs_ptr = zml.Tensor.constant(zml.DataType.i32.constant(parameters.block_table.dim(0)));
-        const scale: f32 = @floatCast(1.0 / @sqrt(@as(f64, @floatFromInt(q.dim(.hd)))));
+        const scale: f32 = paged_attention_opts.scale orelse @floatCast(1.0 / @sqrt(@as(f64, @floatFromInt(q.dim(.hd)))));
         const scale_ptr = zml.Tensor.constant(zml.DataType.f32.constant(scale));
 
         const output = zml.ops.triton(.{
@@ -575,7 +577,7 @@ pub const paged = struct {
         const v_strides_1_ptr = zml.Tensor.constant(zml.DataType.i64.constant(v_strides[1]));
         const v_strides_2_ptr = zml.Tensor.constant(zml.DataType.i64.constant(v_strides[2]));
         const num_seqs_ptr = zml.Tensor.constant(zml.DataType.i32.constant(parameters.block_table.dim(0)));
-        const scale: f32 = @floatCast(1.0 / @sqrt(@as(f64, @floatFromInt(q.dim(.hd)))));
+        const scale: f32 = paged_attention_opts.scale orelse @floatCast(1.0 / @sqrt(@as(f64, @floatFromInt(q.dim(.hd)))));
         const scale_ptr = zml.Tensor.constant(zml.DataType.f32.constant(scale));
 
         const attn_grid: [3]i32 = .{ @intCast(config.attention.total_q_blocks), @intCast(paged_attention_opts.num_kv_heads), @intCast(config.attention.num_segments_per_seq) };

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -1552,6 +1552,7 @@ fn customCallInternal(target_name: [:0]const u8, inputs: []const Tensor, outputs
                     @panic("Unsupported pointer type in metadata"),
                 else => @panic("Unsupported pointer type in metadata"),
             },
+            .optional => |optional_info| {},
             else => @compileError("Unsupported metadata type: " ++ @typeName(field.type)),
         };
         metadata_attributes[i] = mlir.NamedAttribute.named(ctx.mlir_ctx, field.name, attribute);

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -1518,7 +1518,7 @@ fn customCallInternal(target_name: [:0]const u8, inputs: []const Tensor, outputs
     }
 
     const metadata_type_info = @typeInfo(@TypeOf(metadata));
-    var metadata_attribute_list: std.ArrayList(mlir.NamedAttribute) = .initCapacity(allocator, metadata_type_info.@"struct".fields.len + 2) catch unreachable;
+    var metadata_attribute_list = std.ArrayList(mlir.NamedAttribute).initCapacity(allocator, metadata_type_info.@"struct".fields.len + 2) catch unreachable;
     inline for (metadata_type_info.@"struct".fields) |field| {
         const maybe_attribute: ?*const mlir.Attribute = switch (@typeInfo(field.type)) {
             .comptime_int => mlir.integerAttribute(ctx.mlir_ctx, .u64, @as(u64, @field(metadata, field.name))),

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -1518,9 +1518,9 @@ fn customCallInternal(target_name: [:0]const u8, inputs: []const Tensor, outputs
     }
 
     const metadata_type_info = @typeInfo(@TypeOf(metadata));
-    var metadata_attributes: [metadata_type_info.@"struct".fields.len]mlir.NamedAttribute = undefined;
-    inline for (metadata_type_info.@"struct".fields, 0..) |field, i| {
-        const attribute: *const mlir.Attribute = switch (@typeInfo(field.type)) {
+    var metadata_attribute_list: std.ArrayList(mlir.NamedAttribute) = .initCapacity(allocator, metadata_type_info.@"struct".fields.len + 2) catch unreachable;
+    inline for (metadata_type_info.@"struct".fields) |field| {
+        const maybe_attribute: ?*const mlir.Attribute = switch (@typeInfo(field.type)) {
             .comptime_int => mlir.integerAttribute(ctx.mlir_ctx, .u64, @as(u64, @field(metadata, field.name))),
             .int => |int_field| switch (int_field.signedness) {
                 .signed => switch (int_field.bits) {
@@ -1552,16 +1552,29 @@ fn customCallInternal(target_name: [:0]const u8, inputs: []const Tensor, outputs
                     @panic("Unsupported pointer type in metadata"),
                 else => @panic("Unsupported pointer type in metadata"),
             },
-            .optional => |optional_info| {},
+            .optional => |optional_info| if (@field(metadata, field.name) != null) switch (@typeInfo(optional_info.child)) {
+                .float => |float_field| switch (float_field.bits) {
+                    16 => mlir.floatAttribute(ctx.mlir_ctx, .f16, @as(f64, @field(metadata, field.name))),
+                    32 => mlir.floatAttribute(ctx.mlir_ctx, .f32, @as(f64, @field(metadata, field.name))),
+                    64 => mlir.floatAttribute(ctx.mlir_ctx, .f64, @as(f64, @field(metadata, field.name))),
+                    else => @panic("Unsupported DataType"),
+                },
+
+                else => @panic("Unsupported optional child type in metadata"),
+            } else null,
             else => @compileError("Unsupported metadata type: " ++ @typeName(field.type)),
         };
-        metadata_attributes[i] = mlir.NamedAttribute.named(ctx.mlir_ctx, field.name, attribute);
+        if (maybe_attribute) |attribute| {
+            metadata_attribute_list.appendAssumeCapacity(mlir.NamedAttribute.named(ctx.mlir_ctx, field.name, attribute));
+        }
     }
 
-    const backend_config = mlir.dictionaryAttribute(ctx.mlir_ctx, &(metadata_attributes ++ [_]mlir.NamedAttribute{
+    metadata_attribute_list.appendSliceAssumeCapacity(&[_]mlir.NamedAttribute{
         .named(ctx.mlir_ctx, "pjrt_api", mlir.integerAttribute(ctx.mlir_ctx, .u64, @as(u64, @bitCast(@intFromPtr(ctx.platform.pjrt_api))))),
         .named(ctx.mlir_ctx, "pjrt_client", mlir.integerAttribute(ctx.mlir_ctx, .u64, @as(u64, @bitCast(@intFromPtr(ctx.platform.pjrt_client))))),
-    }));
+    });
+
+    const backend_config = mlir.dictionaryAttribute(ctx.mlir_ctx, metadata_attribute_list.items);
 
     const operand_layouts = allocator.alloc([]const usize, input_shapes.len) catch unreachable;
     for (input_shapes, 0..) |shape, i| {


### PR DESCRIPTION
I added a `scale` field in the `AttentionOptions` struct that is passed through the attention backend.

I had to add support for optional in the custom call metadata. For now it only supports optional floats, we'll add support for other types later.