### PR TITLE
zml/tokenizer: use correct API for decoding with HF

### DIFF
--- a/examples/llm/models/lfm2/session.zig
+++ b/examples/llm/models/lfm2/session.zig
@@ -145,7 +145,7 @@ pub const Session = struct {
 
             if (token_id == self.config.eos_token_id) break :generation;
 
-            const token = try decoder.feed_one(token_id);
+            const token = try decoder.feedOne(token_id);
             if (self.think_start) |think_start| if (token_id == think_start) {
                 try stdout.writeAll("\x1b[2m");
             };

--- a/examples/llm/models/llama/session.zig
+++ b/examples/llm/models/llama/session.zig
@@ -156,7 +156,7 @@ pub const Session = struct {
 
             if (isEosToken(self.config, token_id)) break :generation;
 
-            const token = try decoder.feed_one(token_id);
+            const token = try decoder.feedOne(token_id);
             try stdout.writeAll(token);
             try stdout.flush();
 

--- a/examples/llm/models/qwen3_5/session.zig
+++ b/examples/llm/models/qwen3_5/session.zig
@@ -117,7 +117,7 @@ pub const Session = struct {
             const token_id = self.generated_token_slice.items(u32)[0];
             if (token_id == self.eos_token_id) break :generation;
 
-            const token = try decoder.feed_one(token_id);
+            const token = try decoder.feedOne(token_id);
             if (self.think_start) |think_start| if (token_id == think_start) {
                 try stdout.writeAll("\x1b[2m");
             };

--- a/zml/tokenizer/tokenizer.zig
+++ b/zml/tokenizer/tokenizer.zig
@@ -191,49 +191,36 @@ pub const Tokenizer = union(Tokenizers) {
             }
         }
 
-        //
-        // Convenience methods built on top of the stream API
-        //
-
         pub fn decodeAlloc(self: *Decoder, allocator: std.mem.Allocator, token_ids: []const u32) !std.ArrayList(u8) {
-            var tokens: std.ArrayList(u8) = try .initCapacity(allocator, token_ids.len * 4);
-            var remaining = token_ids;
-            while (remaining.len > 0) {
-                const fout = try self.feed(remaining);
-                try tokens.appendSlice(allocator, fout.tokens);
-                remaining = remaining[fout.consumed..];
+            switch (self.*) {
+                .iree => |*d| {
+                    var tokens: std.ArrayList(u8) = try .initCapacity(allocator, token_ids.len * 4);
+                    var remaining = token_ids;
+                    while (remaining.len > 0) {
+                        const consumed, const decoded_tokens = try d.feed(remaining);
+                        try tokens.appendSlice(allocator, decoded_tokens);
+                        remaining = remaining[consumed..];
+                    }
+                    try tokens.appendSlice(allocator, try self.finalize());
+                    return tokens;
+                },
+                inline else => |*d| {
+                    return .fromOwnedSlice(try allocator.dupe(u8, try d.decode(token_ids)));
+                },
             }
-            try tokens.appendSlice(allocator, try self.finalize());
-            return tokens;
-        }
-
-        //
-        // Stream API
-        //
-
-        pub const FeedOutput = struct {
-            consumed: usize,
-            /// Only valid until the next feed/finalize call and while the decoder is alive.
-            tokens: []const u8,
-        };
-
-        pub fn feed(self: *Decoder, token_ids: []const u32) !FeedOutput {
-            return switch (self.*) {
-                .iree => |*v| {
-                    const consumed, const tokens = try v.feed(token_ids);
-                    return .{ .consumed = consumed, .tokens = tokens };
-                },
-                inline else => |*v| {
-                    const tokens = try v.decode(token_ids);
-                    return .{ .consumed = token_ids.len, .tokens = tokens };
-                },
-            };
         }
 
         // Only valid until the next decode and while the decoder is alive.
-        pub fn feed_one(self: *Decoder, token_id: u32) ![]const u8 {
-            const fout = try self.feed(&.{token_id});
-            return fout.tokens;
+        pub fn feedOne(self: *Decoder, token_id: u32) ![]const u8 {
+            switch (self.*) {
+                .iree => |*d| {
+                    _, const tokens = try d.feed(&.{token_id});
+                    return tokens;
+                },
+                inline else => |*d| {
+                    return try d.next(token_id) orelse &.{};
+                },
+            }
         }
 
         /// Output is only valid until the next feed/finalize call and while the decoder is alive.


### PR DESCRIPTION
The current API only worked with IREE. Reworked it to work with both HF and IREE