### PR TITLE
workspace: Update ZLS to 0.16.0 and rules_zig new providers

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,7 +31,7 @@ bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "rules_zig", version = "0.12.2")
 git_override(
     module_name = "rules_zig",
-    commit = "56911842f4527df036e8d52e78dd0f54a22d4215",
+    commit = "b65a2bb460b9dbcbcc3231ba648c3c1a266c4eb5",
     remote = "https://github.com/zml/rules_zig.git",
 )
 

--- a/third_party/zls/zls_runner.zig
+++ b/third_party/zls/zls_runner.zig
@@ -4,6 +4,7 @@
 ///
 /// This file is used as a template by `zls_write_runner_zig_src.bzl`.
 const std = @import("std");
+const fs = std.fs;
 
 const bazel_builtin = @import("bazel_builtin");
 const runfiles = @import("runfiles");
@@ -42,23 +43,13 @@ pub fn main(init: std.process.Init) !void {
 
     const zig_exe_rpath = "@@__ZIG_EXE_RPATH__@@";
     var zig_exe_path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
-    const zig_exe_path = blk2: {
-        if (zig_exe_rpath[0] == '/') {
-            break :blk2 zig_exe_rpath;
-        } else {
-            break :blk2 try r.rlocation(zig_exe_rpath, &zig_exe_path_buf) orelse
-                return error.RLocationNotFound;
-        }
-    };
+    const zig_exe_path = try r.rlocation(zig_exe_rpath, &zig_exe_path_buf) orelse
+        return error.RLocationNotFound;
 
-    const zig_lib_path = "@@__ZIG_LIB_PATH__@@";
-    const zig_lib_computed_path = blk: {
-        if (zig_lib_path[0] == '/') {
-            break :blk zig_lib_path;
-        } else {
-            break :blk null;
-        }
-    };
+    const zig_lib_path = "@@__ZIG_LIB_RPATH__@@";
+    var zig_lib_path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const zig_lib_computed_path = try r.rlocation(zig_lib_path, &zig_lib_path_buf) orelse
+        return error.RLocationNotFound;
 
     const zls_build_runner_rpath = "@@__ZLS_BUILD_RUNNER_RPATH__@@";
     var zls_build_runner_path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;

--- a/third_party/zls/zls_toolchain.bzl
+++ b/third_party/zls/zls_toolchain.bzl
@@ -2,7 +2,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-_VERSION = "0.16.0-dev.254+695a1d5c"
+_VERSION = "0.16.0"
 
 _ZLS_PLATFORMS = {
     "x86_64-linux": struct(
@@ -26,9 +26,9 @@ _ZLS_PLATFORMS = {
 }
 
 _ZLS_VERSIONS = {
-    "x86_64-linux": "b02f9623a0cec2475c26268f12f49f48b81e9c41f2a8a6628806452685cd1013",
-    "x86_64-macos": "4cab46f56a9685822a5ad3665af3a9b11d2556313defa634b5e8b85cac8151cb",
-    "aarch64-macos": "8e4ef0603042a2081ae02672ad72f271d8c840746bbfa0ed9934c6b72ea10d7b",
+    "x86_64-linux": "ded6d562a0b86ee878b1ddf70ffab2797ce3cdca3b02d6077548f9d56dff96b6",
+    "x86_64-macos": "49f716ea96c1aadaecaa5d9c0a50874cbcf443dc42b825f1e7ee35499ad3eb96",
+    "aarch64-macos": "b93ec549f8558a7e85984a840e9276d274f1059b54ade4254296ef4982958359",
 }
 
 ZlsToolchainInfo = provider(

--- a/third_party/zls/zls_write_runner_zig_src.bzl
+++ b/third_party/zls/zls_write_runner_zig_src.bzl
@@ -11,8 +11,8 @@ def _zls_write_runner_zig_src_impl(ctx):
         output = zls_runner,
         template = ctx.file._runner_tpl,
         substitutions = {
-            "@@__ZIG_EXE_RPATH__@@": zigtoolchaininfo.zig_exe_rpath,
-            "@@__ZIG_LIB_PATH__@@": zigtoolchaininfo.zig_lib_rpath,
+            "@@__ZIG_EXE_RPATH__@@": to_rlocation_path(ctx, zigtoolchaininfo.zig_exe),
+            "@@__ZIG_LIB_RPATH__@@": to_rlocation_path(ctx, zigtoolchaininfo.zig_lib),
             "@@__ZLS_BIN_RPATH__@@": to_rlocation_path(ctx, zlstoolchaininfo.bin),
             "@@__ZLS_BUILD_RUNNER_RPATH__@@": to_rlocation_path(ctx, ctx.file.build_runner),
             "@@__GLOBAL_CACHE_PATH__@@": zigtoolchaininfo.zig_cache,


### PR DESCRIPTION
Bump rules_zig to latest zig_toolchain changes (for bootstrap)
Bump ZLS to 0.16.0
Amend ZLS completion rules and runners to match rules_zig new providers
