### PR TITLE
platforms/cuda+rocm: update pjrt artifact

### DIFF
--- a/examples/llm/main.zig
+++ b/examples/llm/main.zig
@@ -123,11 +123,12 @@ pub fn main(init: std.process.Init) !void {
     var tokenizer = try loadTokenizer(allocator, io, repo, &progress);
     defer tokenizer.deinit();
 
-    var model_buffers = try models.LoadedModel.loadBuffers(&model, allocator, io, platform, &store, &progress, shardings);
-    defer model.unloadBuffers(&model_buffers, allocator);
-
     var compiled_model = try models.LoadedModel.compile(&model, allocator, io, platform, backend, shardings, args.seqlen, &progress);
     defer compiled_model.deinit();
+
+    // Load buffers after the model compilation to be sure to give enough room to the autotune.
+    var model_buffers = try models.LoadedModel.loadBuffers(&model, allocator, io, platform, &store, &progress, shardings);
+    defer model.unloadBuffers(&model_buffers, allocator);
 
     progress.end();
 

--- a/platforms/cuda/cuda.bzl
+++ b/platforms/cuda/cuda.bzl
@@ -277,8 +277,8 @@ def _cuda_impl(mctx):
     http_archive(
         name = "libpjrt_cuda",
         build_file = "libpjrt_cuda.BUILD.bazel",
-        url = "https://github.com/zml/pjrt-artifacts/releases/download/nightly-2026-04-20/pjrt-cuda_linux-amd64.tar.gz",
-        sha256 = "90c67e30414c2644d2b9b25bc7418b24ee077b3933ed782ba9ca7318dcc724c9",
+        url = "https://github.com/zml/pjrt-artifacts/releases/download/manual-2026-04-20T16-00-00Z-2/pjrt-cuda_linux-amd64.tar.gz",
+        sha256 = "abad33460249b8104c9acf6eb5486569fda9f3a14750f5fcaffff2d6a24ca74f",
     )
 
     return mctx.extension_metadata(

--- a/platforms/rocm/rocm.bzl
+++ b/platforms/rocm/rocm.bzl
@@ -254,8 +254,8 @@ def _rocm_impl(mctx):
     http_archive(
         name = "libpjrt_rocm",
         build_file = "libpjrt_rocm.BUILD.bazel",
-        url = "https://github.com/zml/pjrt-artifacts/releases/download/nightly-2026-04-20/pjrt-rocm_linux-amd64.tar.gz",
-        sha256 = "5f85f35c90e36aa9557a51ff210392ffd27f8853226e05020f81309c4ca4e5e7",
+        url = "https://github.com/zml/pjrt-artifacts/releases/download/manual-2026-04-20T16-00-00Z-2/pjrt-rocm_linux-amd64.tar.gz",
+        sha256 = "50200ad4037d84149b87a5a541fa2a86b87ae159d43a799e92b905d863407449",
     )
 
     return mctx.extension_metadata(


### PR DESCRIPTION
Update with the XLA patches for improved parallel compilation.

`//examples/llm` goes from 27s to 8s for llama3.1 8B compilation

