### PR TITLE
zml/attention/triton: thread-safe generateTtir

### DIFF
--- a/zml/attention/triton.zig
+++ b/zml/attention/triton.zig
@@ -211,14 +211,19 @@ fn generateTtir(allocator: std.mem.Allocator, io: std.Io, config: GenerationConf
     const platform = compilation_context.platform;
     const triton_runtime = platform.triton_runtime.?;
 
-    var writer = triton_runtime.process.stdin.?.writer(io, writer_buffer);
-    try writer.interface.print("{f}\n", .{std.json.fmt(config, .{ .emit_null_optional_fields = false })});
-    try writer.interface.flush();
-
-    var reader = triton_runtime.process.stdout.?.reader(io, reader_buffer);
     var allocating: std.Io.Writer.Allocating = .init(arena.allocator());
-    _ = try reader.interface.streamDelimiter(&allocating.writer, '\n');
-    _ = try reader.interface.discardShort(1);
+    {
+        try triton_runtime.process_mutex.lock(compilation_context.io);
+        defer triton_runtime.process_mutex.unlock(compilation_context.io);
+
+        var writer = triton_runtime.process.stdin.?.writer(io, writer_buffer);
+        try writer.interface.print("{f}\n", .{std.json.fmt(config, .{ .emit_null_optional_fields = false })});
+        try writer.interface.flush();
+
+        var reader = triton_runtime.process.stdout.?.reader(io, reader_buffer);
+        _ = try reader.interface.streamDelimiter(&allocating.writer, '\n');
+        _ = try reader.interface.discardShort(1);
+    }
 
     const response: std.json.Value = try std.json.parseFromSliceLeaky(std.json.Value, arena.allocator(), allocating.written(), .{});
     return if (response.object.get("ok").?.bool)
@@ -638,6 +643,7 @@ pub const paged = struct {
 
 pub const Runtime = struct {
     process: std.process.Child,
+    process_mutex: *std.Io.Mutex,
 
     pub fn init(allocator: std.mem.Allocator, io: std.Io) !Runtime {
         var arena: std.heap.ArenaAllocator = .init(allocator);
@@ -649,18 +655,25 @@ pub const Runtime = struct {
         var map: std.process.Environ.Map = .init(arena.allocator());
         try map.put("LD_LIBRARY_PATH", std.Io.Dir.path.join(arena.allocator(), &.{ sandbox_path.?, "lib" }) catch unreachable);
 
+        const process_mutex = try allocator.create(std.Io.Mutex);
+        errdefer allocator.destroy(process_mutex);
+        process_mutex.* = .init;
+
         const process = try std.process.spawn(io, .{
             .argv = &.{std.Io.Dir.path.join(arena.allocator(), &.{ sandbox_path.?, "bin", "generate" }) catch unreachable},
             .stdin = .pipe,
             .stdout = .pipe,
             .environ_map = &map,
         });
-        errdefer process.kill(io);
 
-        return .{ .process = process };
+        return .{
+            .process = process,
+            .process_mutex = process_mutex,
+        };
     }
 
-    pub fn deinit(self: *Runtime, io: std.Io) void {
+    pub fn deinit(self: *Runtime, allocator: std.mem.Allocator, io: std.Io) void {
+        allocator.destroy(self.process_mutex);
         // NOTE(Corendos): This is not portable, but I couldn't find a better way with the current std.Io.
         _ = std.c.kill(self.process.id.?, .INT);
         _ = self.process.wait(io) catch unreachable;

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -424,7 +424,7 @@ pub const Platform = struct {
     pub fn deinit(self: *Platform, allocator: std.mem.Allocator, io: std.Io) void {
         self.pjrt_client.deinit(self.pjrt_api);
         if (self.tpu_ir_runtime) |*rt| rt.deinit(io);
-        if (self.triton_runtime) |*rt| rt.deinit(io);
+        if (self.triton_runtime) |*rt| rt.deinit(allocator, io);
         self.arena_state.promote(allocator).deinit();
     }
 


### PR DESCRIPTION
generateTtir isn't thread-safe as we keep a single process alive. Using different processes didn't seem to be better from a quick try. So just locking it with a mutex.