### PR TITLE
zml/tpu: implement pagedAttentionDense for fused K V cache

### DIFF
--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -223,7 +223,7 @@ pub fn pagedAttention(parameters: Parameters, context: Context, q: zml.Tensor, k
             .split => |split| triton.paged.pagedAttention(triton_parameters, context.triton, q, split.k, split.v, opts),
             .dense => std.debug.panic("fused KV pages are only supported with the mosaic_tpu backend", .{}),
         },
-        .mosaic_tpu => |mosaic_tpu_parameters| tpu.mosaic_tpu.pagedAttention(mosaic_tpu_parameters, context.mosaic_tpu, q, kv_cache, opts),
+        .mosaic_tpu => |mosaic_tpu_parameters| tpu.mosaic_tpu.pagedAttention(mosaic_tpu_parameters, context.mosaic_tpu, q, kv_cache.dense, opts),
     };
 }
 

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -199,23 +199,31 @@ pub const AttentionOptions = struct {
     scale: ?f32 = null,
 };
 
-pub const Layout = tpu.mosaic_tpu.Layout;
+pub const KVCache = union(enum) {
+    split: struct {
+        k: zml.Tensor,
+        v: zml.Tensor,
+    },
+    dense: zml.Tensor,
+};
 
-pub fn pagedAttention(parameters: Parameters, context: Context, q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, layout: Layout, opts: AttentionOptions) zml.Tensor {
+pub fn pagedAttention(parameters: Parameters, context: Context, q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, kv_cache: KVCache, opts: AttentionOptions) zml.Tensor {
+    _ = k;
+    _ = v;
     return switch (parameters) {
-        .cuda_fa2 => |cuda_fa2_parameters| switch (layout) {
+        .cuda_fa2 => |cuda_fa2_parameters| switch (kv_cache) {
             .split => |split| flashattn.paged_fa2.pagedAttention(cuda_fa2_parameters, context.cuda_fa2, q, split.k, split.v, opts),
-            .pages => std.debug.panic("fused KV pages are only supported with the mosaic_tpu backend", .{}),
+            .dense => std.debug.panic("fused KV pages are only supported with the mosaic_tpu backend", .{}),
         },
-        .cuda_fa3 => |cuda_fa3_parameters| switch (layout) {
+        .cuda_fa3 => |cuda_fa3_parameters| switch (kv_cache) {
             .split => |split| flashattn.paged_fa3.pagedAttention(cuda_fa3_parameters, context.cuda_fa3, q, split.k, split.v, opts),
-            .pages => std.debug.panic("fused KV pages are only supported with the mosaic_tpu backend", .{}),
+            .dense => std.debug.panic("fused KV pages are only supported with the mosaic_tpu backend", .{}),
         },
-        .triton => |triton_parameters| switch (layout) {
+        .triton => |triton_parameters| switch (kv_cache) {
             .split => |split| triton.paged.pagedAttention(triton_parameters, context.triton, q, split.k, split.v, opts),
-            .pages => std.debug.panic("fused KV pages are only supported with the mosaic_tpu backend", .{}),
+            .dense => std.debug.panic("fused KV pages are only supported with the mosaic_tpu backend", .{}),
         },
-        .mosaic_tpu => |mosaic_tpu_parameters| tpu.mosaic_tpu.pagedAttention(mosaic_tpu_parameters, context.mosaic_tpu, q, k, v, layout, opts),
+        .mosaic_tpu => |mosaic_tpu_parameters| tpu.mosaic_tpu.pagedAttention(mosaic_tpu_parameters, context.mosaic_tpu, q, kv_cache, opts),
     };
 }
 

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -199,7 +199,7 @@ pub const AttentionOptions = struct {
     scale: ?f32 = null,
 };
 
-pub const KVCache = union(enum) {
+pub const KvCache = union(enum) {
     split: struct {
         k: zml.Tensor,
         v: zml.Tensor,
@@ -207,7 +207,7 @@ pub const KVCache = union(enum) {
     dense: zml.Tensor,
 };
 
-pub fn pagedAttention(parameters: Parameters, context: Context, q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, kv_cache: KVCache, opts: AttentionOptions) zml.Tensor {
+pub fn pagedAttention(parameters: Parameters, context: Context, q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, kv_cache: KvCache, opts: AttentionOptions) zml.Tensor {
     _ = k;
     _ = v;
     return switch (parameters) {

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -199,12 +199,23 @@ pub const AttentionOptions = struct {
     scale: ?f32 = null,
 };
 
-pub fn pagedAttention(parameters: Parameters, context: Context, q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, k_cache: zml.Tensor, v_cache: zml.Tensor, opts: AttentionOptions) zml.Tensor {
+pub const Layout = tpu.mosaic_tpu.Layout;
+
+pub fn pagedAttention(parameters: Parameters, context: Context, q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, layout: Layout, opts: AttentionOptions) zml.Tensor {
     return switch (parameters) {
-        .cuda_fa2 => |cuda_fa2_parameters| flashattn.paged_fa2.pagedAttention(cuda_fa2_parameters, context.cuda_fa2, q, k_cache, v_cache, opts),
-        .cuda_fa3 => |cuda_fa3_parameters| flashattn.paged_fa3.pagedAttention(cuda_fa3_parameters, context.cuda_fa3, q, k_cache, v_cache, opts),
-        .triton => |triton_parameters| triton.paged.pagedAttention(triton_parameters, context.triton, q, k_cache, v_cache, opts),
-        .mosaic_tpu => |mosaic_tpu_parameters| tpu.mosaic_tpu.pagedAttention(mosaic_tpu_parameters, context.mosaic_tpu, q, k, v, k_cache, v_cache, opts),
+        .cuda_fa2 => |cuda_fa2_parameters| switch (layout) {
+            .split => |split| flashattn.paged_fa2.pagedAttention(cuda_fa2_parameters, context.cuda_fa2, q, split.k, split.v, opts),
+            .pages => std.debug.panic("fused KV pages are only supported with the mosaic_tpu backend", .{}),
+        },
+        .cuda_fa3 => |cuda_fa3_parameters| switch (layout) {
+            .split => |split| flashattn.paged_fa3.pagedAttention(cuda_fa3_parameters, context.cuda_fa3, q, split.k, split.v, opts),
+            .pages => std.debug.panic("fused KV pages are only supported with the mosaic_tpu backend", .{}),
+        },
+        .triton => |triton_parameters| switch (layout) {
+            .split => |split| triton.paged.pagedAttention(triton_parameters, context.triton, q, split.k, split.v, opts),
+            .pages => std.debug.panic("fused KV pages are only supported with the mosaic_tpu backend", .{}),
+        },
+        .mosaic_tpu => |mosaic_tpu_parameters| tpu.mosaic_tpu.pagedAttention(mosaic_tpu_parameters, context.mosaic_tpu, q, k, v, layout, opts),
     };
 }
 

--- a/zml/attention/tpu_attention.zig
+++ b/zml/attention/tpu_attention.zig
@@ -279,20 +279,16 @@ pub const mosaic_tpu = struct {
             .merge(.{ .hkv = .{ .hkv, .kv } });
     }
 
-    inline fn prepareInputs(parameters: Parameters, q: zml.Tensor, k_cache: zml.Tensor, v_cache: zml.Tensor) PreparedInputs {
-        stdx.debug.assert(k_cache.shape().eqlWithTags(v_cache.shape()), "Expected paged K/V cache shapes to match, got {f} and {f}", .{ k_cache.shape(), v_cache.shape() });
-
+    inline fn prepareDenseInputs(parameters: Parameters, q: zml.Tensor, kv_pages: zml.Tensor) PreparedInputs {
         const q_ragged = q.merge(.{ .h = .{ .hkv, .hg } }).withPartitioning(.{ .h = .model });
-        // Note :
-        // In a future PR, we'll have to change the pagedAttention API a bit so that we don't have to fuse keys and values
-        const kv_pages = fuseKvPages(k_cache, v_cache).withPartitioning(.{ .hkv = .model });
+        const kv_pages_partitioned = kv_pages.withPartitioning(.{ .hkv = .model });
         const query_start_len = parameters.query_start_len.withPartitioning(.{ .n = .replicated });
 
         // Note
         // activeSequenceCount could probably be computed when preparing the inputs and injected through Parameters, but we'll keep that for later.
         return .{
             .q = q_ragged,
-            .kv_pages = kv_pages,
+            .kv_pages = kv_pages_partitioned,
             .seq_lens = parameters.seq_lens.withPartitioning(.{ ._0 = .replicated }),
             .block_table = parameters.block_table.withPartitioning(.{ ._0 = .replicated, ._1 = .replicated }),
             .query_start_len = query_start_len,
@@ -351,12 +347,8 @@ pub const mosaic_tpu = struct {
         }
     };
 
-    pub fn pagedAttention(parameters: Parameters, context: Context, q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, k_cache: zml.Tensor, v_cache: zml.Tensor, opts: AttentionOptions) zml.Tensor {
-        _ = k;
-        _ = v;
+    fn runPreparedAttention(parameters: Parameters, context: Context, q: zml.Tensor, prepared: PreparedInputs, opts: AttentionOptions) zml.Tensor {
         stdx.debug.assert(opts.is_causal, "mosaic_tpu ragged paged attention currently only supports causal attention", .{});
-
-        const prepared = prepareInputs(parameters, q, k_cache, v_cache);
 
         // Keep sharding intent on the `manualComputation` boundary only. The
         // TPU smoke compile regressed when the body restated
@@ -408,5 +400,15 @@ pub const mosaic_tpu = struct {
         const restored = restoreQueryHeads(q, q_out);
         stdx.debug.assert(restored.shape().eql(q.shape()), "mosaic_tpu ragged paged attention output shape mismatch, got {f}, expected {f}", .{ restored.shape(), q.shape() });
         return restored;
+    }
+
+    pub fn pagedAttention(parameters: Parameters, context: Context, q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, k_cache: zml.Tensor, v_cache: zml.Tensor, opts: AttentionOptions) zml.Tensor {
+        _ = k;
+        _ = v;
+        return runPreparedAttention(parameters, context, q, prepareDenseInputs(parameters, q, fuseKvPages(k_cache, v_cache)), opts);
+    }
+
+    pub fn pagedAttentionDense(parameters: Parameters, context: Context, q: zml.Tensor, kv_pages: zml.Tensor, opts: AttentionOptions) zml.Tensor {
+        return runPreparedAttention(parameters, context, q, prepareDenseInputs(parameters, q, kv_pages), opts);
     }
 };

--- a/zml/attention/tpu_attention.zig
+++ b/zml/attention/tpu_attention.zig
@@ -341,10 +341,10 @@ pub const mosaic_tpu = struct {
         }
     };
 
-    pub fn pagedAttention(parameters: Parameters, context: Context, q: zml.Tensor, layout: paged_attention.KVCache, opts: AttentionOptions) zml.Tensor {
+    pub fn pagedAttention(parameters: Parameters, context: Context, q: zml.Tensor, kv_cache: zml.Tensor, opts: AttentionOptions) zml.Tensor {
         stdx.debug.assert(opts.is_causal, "mosaic_tpu ragged paged attention currently only supports causal attention", .{});
 
-        const prepared = prepareInputs(parameters, q, layout.dense);
+        const prepared = prepareInputs(parameters, q, kv_cache);
 
         // Keep sharding intent on the `manualComputation` boundary only. The
         // TPU smoke compile regressed when the body restated

--- a/zml/attention/tpu_attention.zig
+++ b/zml/attention/tpu_attention.zig
@@ -135,6 +135,14 @@ pub const mosaic_tpu = struct {
         num_seqs: zml.Tensor,
     };
 
+    pub const Layout = union(enum) {
+        split: struct {
+            k: zml.Tensor,
+            v: zml.Tensor,
+        },
+        pages: zml.Tensor,
+    };
+
     pub const Options = struct {
         is_prefill: bool,
         batch_size: usize,
@@ -272,14 +280,19 @@ pub const mosaic_tpu = struct {
         return q_out.splitAxis(.h, .{ .hkv = q_template.dim(.hkv), .hg = q_template.dim(.hg) });
     }
 
-    inline fn fuseKvPages(k_cache: zml.Tensor, v_cache: zml.Tensor) zml.Tensor {
-        const k_pages = k_cache.insertAxes(.hd, .{.kv});
-        const v_pages = v_cache.insertAxes(.hd, .{.kv});
-        return zml.Tensor.concatenate(&.{ k_pages, v_pages }, .kv)
-            .merge(.{ .hkv = .{ .hkv, .kv } });
+    inline fn cachePages(layout: Layout) zml.Tensor {
+        return switch (layout) {
+            .pages => |pages| pages,
+            .split => |split| b: {
+                const k_pages = split.k.insertAxes(.hd, .{.kv});
+                const v_pages = split.v.insertAxes(.hd, .{.kv});
+                break :b zml.Tensor.concatenate(&.{ k_pages, v_pages }, .kv)
+                    .merge(.{ .hkv = .{ .hkv, .kv } });
+            },
+        };
     }
 
-    inline fn prepareDenseInputs(parameters: Parameters, q: zml.Tensor, kv_pages: zml.Tensor) PreparedInputs {
+    inline fn prepareInputs(parameters: Parameters, q: zml.Tensor, kv_pages: zml.Tensor) PreparedInputs {
         const q_ragged = q.merge(.{ .h = .{ .hkv, .hg } }).withPartitioning(.{ .h = .model });
         const kv_pages_partitioned = kv_pages.withPartitioning(.{ .hkv = .model });
         const query_start_len = parameters.query_start_len.withPartitioning(.{ .n = .replicated });
@@ -347,8 +360,12 @@ pub const mosaic_tpu = struct {
         }
     };
 
-    fn runPreparedAttention(parameters: Parameters, context: Context, q: zml.Tensor, prepared: PreparedInputs, opts: AttentionOptions) zml.Tensor {
+    pub fn pagedAttention(parameters: Parameters, context: Context, q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, layout: Layout, opts: AttentionOptions) zml.Tensor {
+        _ = k;
+        _ = v;
         stdx.debug.assert(opts.is_causal, "mosaic_tpu ragged paged attention currently only supports causal attention", .{});
+
+        const prepared = prepareInputs(parameters, q, cachePages(layout));
 
         // Keep sharding intent on the `manualComputation` boundary only. The
         // TPU smoke compile regressed when the body restated
@@ -400,15 +417,5 @@ pub const mosaic_tpu = struct {
         const restored = restoreQueryHeads(q, q_out);
         stdx.debug.assert(restored.shape().eql(q.shape()), "mosaic_tpu ragged paged attention output shape mismatch, got {f}, expected {f}", .{ restored.shape(), q.shape() });
         return restored;
-    }
-
-    pub fn pagedAttention(parameters: Parameters, context: Context, q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, k_cache: zml.Tensor, v_cache: zml.Tensor, opts: AttentionOptions) zml.Tensor {
-        _ = k;
-        _ = v;
-        return runPreparedAttention(parameters, context, q, prepareDenseInputs(parameters, q, fuseKvPages(k_cache, v_cache)), opts);
-    }
-
-    pub fn pagedAttentionDense(parameters: Parameters, context: Context, q: zml.Tensor, kv_pages: zml.Tensor, opts: AttentionOptions) zml.Tensor {
-        return runPreparedAttention(parameters, context, q, prepareDenseInputs(parameters, q, kv_pages), opts);
     }
 };

--- a/zml/attention/tpu_attention.zig
+++ b/zml/attention/tpu_attention.zig
@@ -9,6 +9,7 @@ const stdx = @import("stdx");
 const CompilationContext = @import("../module.zig").CompilationContext;
 const zml = @import("../zml.zig");
 const AttentionOptions = @import("paged_attention.zig").AttentionOptions;
+const paged_attention = @import("paged_attention.zig");
 
 const log = std.log.scoped(.tpu_attention);
 
@@ -133,14 +134,6 @@ pub const mosaic_tpu = struct {
         block_table: zml.Tensor,
         query_start_len: zml.Tensor,
         num_seqs: zml.Tensor,
-    };
-
-    pub const Layout = union(enum) {
-        split: struct {
-            k: zml.Tensor,
-            v: zml.Tensor,
-        },
-        pages: zml.Tensor,
     };
 
     pub const Options = struct {
@@ -280,18 +273,6 @@ pub const mosaic_tpu = struct {
         return q_out.splitAxis(.h, .{ .hkv = q_template.dim(.hkv), .hg = q_template.dim(.hg) });
     }
 
-    inline fn cachePages(layout: Layout) zml.Tensor {
-        return switch (layout) {
-            .pages => |pages| pages,
-            .split => |split| b: {
-                const k_pages = split.k.insertAxes(.hd, .{.kv});
-                const v_pages = split.v.insertAxes(.hd, .{.kv});
-                break :b zml.Tensor.concatenate(&.{ k_pages, v_pages }, .kv)
-                    .merge(.{ .hkv = .{ .hkv, .kv } });
-            },
-        };
-    }
-
     inline fn prepareInputs(parameters: Parameters, q: zml.Tensor, kv_pages: zml.Tensor) PreparedInputs {
         const q_ragged = q.merge(.{ .h = .{ .hkv, .hg } }).withPartitioning(.{ .h = .model });
         const kv_pages_partitioned = kv_pages.withPartitioning(.{ .hkv = .model });
@@ -360,12 +341,10 @@ pub const mosaic_tpu = struct {
         }
     };
 
-    pub fn pagedAttention(parameters: Parameters, context: Context, q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, layout: Layout, opts: AttentionOptions) zml.Tensor {
-        _ = k;
-        _ = v;
+    pub fn pagedAttention(parameters: Parameters, context: Context, q: zml.Tensor, layout: paged_attention.KVCache, opts: AttentionOptions) zml.Tensor {
         stdx.debug.assert(opts.is_causal, "mosaic_tpu ragged paged attention currently only supports causal attention", .{});
 
-        const prepared = prepareInputs(parameters, q, cachePages(layout));
+        const prepared = prepareInputs(parameters, q, layout.dense);
 
         // Keep sharding intent on the `manualComputation` boundary only. The
         // TPU smoke compile regressed when the body restated


### PR DESCRIPTION
refactor: introduce KVCache union and wire dense/split layout through pagedAttention

Adds a `KVCache` union type to `paged_attention.zig` with two variants:
- `.split { k, v }`: separate K and V page tensors (used by cuda_fa2, cuda_fa3, triton)
- `.dense`: a single pre-fused K/V page tensor (used by mosaic_tpu)

Changes:

- `pagedAttention()` in `paged_attention.zig` now accepts a `kv_cache: KVCache`
  parameter alongside `k`/`v` (unused); dispatches `.split` to CUDA/Triton
  backends and the full `KVCache` union to `mosaic_tpu`.
- `mosaic_tpu.pagedAttention()` in `tpu_attention.zig` now takes
  `layout: paged_attention.KVCache` instead of separate k/v tensors, and
  passes `layout.dense` to the existing `prepareInputs()` helper.
- `KvCache.Layer` in `llmd/models.zig` is now a tagged union of `.dense`
  (fused tensor) and `.split { k, v }`. `attentionLayout()` converts it to
  `attention.KVCache`. The `.dense` update path in `Layer.update()` fuses
  K and V by inserting a `.kv` axis, concatenating, and merging `.hkv`
  before scattering into the page cache.
