### PR TITLE
ci: bump ci actions (Node.js 20 actions are deprecated)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: runs-on/action@v2.1.0
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Ensure self hosted cache permissions
         if: ${{ matrix.self_hosted }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
             runner_labels: ["self-hosted", "platform=rocm"]
     runs-on: ${{ matrix.runner_labels }}
     steps:
-      - uses: runs-on/action@v1
+      - uses: runs-on/action@v2.1.0
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -106,14 +106,14 @@ jobs:
         "extras=s3-cache",
       ]
     steps:
-      - uses: runs-on/action@v1
+      - uses: runs-on/action@v2.1.0
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
           mirror: https://mirror.zml.ai/zig
 
       - name: Zig Format

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@v2.2.1
         with:
           version: 0.16.0
           mirror: https://mirror.zml.ai/zig


### PR DESCRIPTION
Use newer versions of several GitHub Actions. Also bump used Zig version. 
`mlugg/setup-zig` is still using Node.js v20 so warning still here but only for this action. Check https://codeberg.org/mlugg/setup-zig/pulls/55 in a near future in order to update the action.