### PR TITLE
bin/zml-smi: Fix zml logo rendering in KDE Konsole

### DIFF
--- a/bin/zml-smi/tui/BUILD.bazel
+++ b/bin/zml-smi/tui/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_zig//zig:defs.bzl", "zig_library")
+load("@rules_zig//zig:defs.bzl", "zig_library", "zig_test")
 
 zig_library(
     name = "tui",
@@ -49,4 +49,9 @@ zig_library(
         "@platforms//os:macos": ["//bin/zml-smi/platforms/macos"],
         "//conditions:default": ["//bin/zml-smi/platforms/linux"],
     }),
+)
+
+zig_test(
+    name = "test",
+    deps = [":tui"],
 )

--- a/bin/zml-smi/tui/lib/image.zig
+++ b/bin/zml-smi/tui/lib/image.zig
@@ -38,7 +38,9 @@ pub fn draw(self: *const Image, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surf
         .image = .{
             .img_id = self.image.id,
             .options = .{
-                .size = .{ .rows = target_rows },
+                // Emit both rows and cols so that target bounds are unambiguous.
+                // Rows alone lets some terminals fall back to native pixel size.
+                .size = .{ .rows = target_rows, .cols = cols },
             },
         },
     });
@@ -71,6 +73,10 @@ test Image {
     const cell = surface.buffer[0];
     try std.testing.expect(cell.image != null);
     try std.testing.expectEqual(@as(u32, 1), cell.image.?.img_id);
+    // Both rows and cols must be emitted so terminals don't fall back to native pixel size.
+    const size = cell.image.?.options.size.?;
+    try std.testing.expectEqual(@as(?u16, 5), size.rows);
+    try std.testing.expectEqual(@as(?u16, 20), size.cols);
 }
 
 test "refAllDecls" {


### PR DESCRIPTION
Specifying both `rows` and `cols` makes the zml logo in `zml-smi` render correctly in KDE Konsole.  Verified that the fix didn't cause any regression in a terminal emulator where logo rendering was already functional (`Ghostty`). 

`BUILD.bazel` is also updated to run the `zml-smi`  tests.

**Before**
<img width="348" height="238" alt="image" src="https://github.com/user-attachments/assets/7abc604d-14b9-4c0a-a561-9acde1d5359e" />
**With Fix**
<img width="348" height="162" alt="image" src="https://github.com/user-attachments/assets/d93a7253-c1fc-4ff9-891b-2e0c6ec46a65" />

**Test Discovery Fix**

```
master $ bazel query 'kind(zig_test, //bin/zml-smi/...)'
INFO: Empty results

master $ git checkout -
Switched to branch 'fix/zml-smi-logo-size'

fix/zml-smi-logo-size $ bazel query 'kind(zig_test, //bin/zml-smi/...)'
//bin/zml-smi/tui:test
```