### PR TITLE
ci: Improve cquery speed

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -166,7 +166,7 @@ cuda = use_extension("//platforms/cuda:cuda.bzl", "cuda_packages")
 use_repo(cuda, "libpjrt_cuda_linux_amd64", "libpjrt_cuda_linux_arm64", "cuda_nvml_dev_linux_x86_64", "cuda_nvml_dev_linux_sbsa", "zlib1g_linux_arm64", "zlib1g_linux_amd64")
 
 rocm = use_extension("//platforms/rocm:rocm.bzl", "rocm_packages")
-use_repo(rocm, "amd-smi-lib", "hipblaslt", "libdrm-amdgpu-amdgpu1", "libdrm2-amdgpu", "libpjrt_rocm", "rocblas")
+use_repo(rocm, "amd-smi-lib", "hipblaslt", "libdrm-amdgpu-amdgpu1", "libdrm-amdgpu-common", "libdrm2-amdgpu", "libdrm_mesa_amdgpu_ids", "libpjrt_rocm", "rocblas")
 
 tpu = use_extension("//platforms/tpu:tpu.bzl", "tpu_packages")
 use_repo(tpu, "libpjrt_tpu")

--- a/bin/zml-smi/BUILD.bazel
+++ b/bin/zml-smi/BUILD.bazel
@@ -48,7 +48,7 @@ copy_to_directory(
             "@amd-smi-lib//:libamd_smi",
             "@libdrm-amdgpu-amdgpu1",
             "@libdrm2-amdgpu//:libdrm2-amdgpu",
-            "@libpjrt_rocm//:amdgpu_ids",
+            "//platforms/rocm:amdgpu_ids",
         ],
         "@llvm//platforms/config:linux_aarch64": [],
     }),

--- a/platforms/rocm/BUILD.bazel
+++ b/platforms/rocm/BUILD.bazel
@@ -1,9 +1,34 @@
+load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
-load("@rules_zig//zig:defs.bzl", "zig_library", "zig_shared_library")
+load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_library", "zig_shared_library")
 
 exports_files(
     ["merge_amdgpu_ids.zig"],
-    visibility = ["@libpjrt_rocm//:__subpackages__"],
+    visibility = ["//visibility:public"],
+)
+
+zig_binary(
+    name = "merge_amdgpu_ids",
+    main = "merge_amdgpu_ids.zig",
+)
+
+run_binary(
+    name = "amdgpu_ids",
+    srcs = [
+        "@libdrm-amdgpu-common//:amdgpu_ids",
+        "@libdrm_mesa_amdgpu_ids//file:amdgpu.ids",
+    ],
+    outs = ["amdgpu.ids"],
+    args = [
+        "$(location @libdrm-amdgpu-common//:amdgpu_ids)",
+        "$(location @libdrm_mesa_amdgpu_ids//file:amdgpu.ids)",
+        "$(location amdgpu.ids)",
+    ],
+    tool = ":merge_amdgpu_ids",
+    visibility = [
+        "//bin/zml-smi:__pkg__",
+        "@libpjrt_rocm//:__subpackages__",
+    ],
 )
 
 zig_shared_library(
@@ -24,6 +49,7 @@ zig_shared_library(
 alias(
     name = "hipblaslt",
     actual = "@libpjrt_rocm//:hipblaslt",
+    tags = ["manual"],
 )
 
 cc_library(

--- a/platforms/rocm/libpjrt_rocm.BUILD.bazel
+++ b/platforms/rocm/libpjrt_rocm.BUILD.bazel
@@ -1,7 +1,5 @@
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_list_flag")
-load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
-load("@rules_zig//zig:defs.bzl", "zig_binary")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@zml//bazel:patchelf.bzl", "patchelf")
 
 bool_flag(
@@ -27,27 +25,6 @@ patchelf(
     set_rpath = "$ORIGIN",
 )
 
-zig_binary(
-    name = "merge_amdgpu_ids",
-    main = "@zml//platforms/rocm:merge_amdgpu_ids.zig",
-)
-
-run_binary(
-    name = "amdgpu_ids",
-    srcs = [
-        "@libdrm-amdgpu-common//:amdgpu_ids",
-        "@libdrm_mesa_amdgpu_ids//file:amdgpu.ids",
-    ],
-    outs = ["amdgpu.ids"],
-    args = [
-        "$(location @libdrm-amdgpu-common//:amdgpu_ids)",
-        "$(location @libdrm_mesa_amdgpu_ids//file:amdgpu.ids)",
-        "$(location amdgpu.ids)",
-    ],
-    tool = ":merge_amdgpu_ids",
-    visibility = ["@zml//bin/zml-smi:__pkg__"],
-)
-
 copy_to_directory(
     name = "sandbox",
     srcs = [
@@ -62,7 +39,7 @@ copy_to_directory(
         "@hsa-amd-aqlprofile//:hsa-amd-aqlprofile",
         "@hsa-rocr//:hsa-runtime",
         "@libdrm-amdgpu-amdgpu1",
-        ":amdgpu_ids",
+        "@zml//platforms/rocm:amdgpu_ids",
         "@libdrm2-amdgpu",
         "@libbz2-1.0",
         "@libelf1",

--- a/platforms/rocm/rocm.bzl
+++ b/platforms/rocm/rocm.bzl
@@ -260,7 +260,7 @@ def _rocm_impl(mctx):
 
     return mctx.extension_metadata(
         reproducible = True,
-        root_module_direct_deps = ["amd-smi-lib", "libpjrt_rocm", "libdrm2-amdgpu", "libdrm-amdgpu-amdgpu1", "hipblaslt", "rocblas"],
+        root_module_direct_deps = ["amd-smi-lib", "libpjrt_rocm", "libdrm2-amdgpu", "libdrm-amdgpu-amdgpu1", "libdrm-amdgpu-common", "libdrm_mesa_amdgpu_ids", "hipblaslt", "rocblas"],
         root_module_direct_dev_deps = [],
     )
 


### PR DESCRIPTION
Today `zml-smi` depends on `@libpjrt_rocm//:amdgpu_ids` which forces the download of the PJRT artifact even though it's not needed during the `cquery`. So I'm moving the `amdgpu_ids` further up. `cquery` went from 4min to 10s.

Also fixes the `sha256` for the cpu pjrt artifacts, didn't remove the `sha256:` prefix from github.