### PR TITLE
swig(tokenizer): remove unsupported SWIG optimal hint

### DIFF
--- a/zml/tokenizer/sentencepiece/sentencepiece.i
+++ b/zml/tokenizer/sentencepiece/sentencepiece.i
@@ -19,7 +19,7 @@
     $1 = absl::string_view((char *)$input.ptr, $input.len);
 }
 
-%typemap(out, optimal="1") const std::string& %{
+%typemap(out) const std::string& %{
     $result.ptr = (void *)($1->data());
     $result.len = (size_t)($1->length());
 %}


### PR DESCRIPTION
This PR removes `optimal="1"` from the `[const std::string&]` out typemap in `zml/tokenizer/sentencepiece/sentencepiece.i`.

SWIG cannot apply the requested optimal code path for the `%extend std::string { data() }` wrapper and emitted `Warning 474: ` during SwigC. Removing the unsupported hint preserves the generated behavior while eliminating the warning.

**Reproduce**
```
$ bazel build //examples/llm
[...]
zml/tokenizer/sentencepiece/sentencepiece.i:41: Warning 474: Method std::string::data() const usage of the optimal attribute ignored
zml/tokenizer/sentencepiece/sentencepiece.i:25: Warning 474: in the out typemap as the following cannot be used to generate optimal code: cppresult = (std::string *) &std_string_data__SWIG((std::string const *)arg1);
[...]
```

**Validation**

* Rebuilt `//examples/llm:llm` and a clean
* Confirmed `Warning 474: ` no longer appears
* Confirmed build still succeeds
* Warning 524 remains and is not addressed in this PR
