### PR TITLE
bazel: suppress SWIG c-target warning due to intended behavior

### DIFF
--- a/bazel/swig.bzl
+++ b/bazel/swig.bzl
@@ -60,6 +60,7 @@ def _swig_cc_library_impl(ctx):
     ]
     args.add("-o", output_cpp)
     args.add("-w-305")
+    args.add("-w-524")
     args.add(ctx.file.interface)
 
     inputs = depset(ctx.attr.srcs, transitive = [


### PR DESCRIPTION
This suppresses SWIG Warning 524 in `bazel/swig.bzl`. 

The custom SWIG rule intentionally parses C++ interfaces while generating a C ABI wrapper for Zig consumption (in [sentencepiece.zig](zml/tokenizer/sentencepiece/sentencepiece.zig)), so this warning is expected noise from an intentional -c backend selection rather than a build problem.

**Reproduce**
```
$ bazel build //examples/llm
[...]
SWIG:1: Warning 524: Experimental target language. Target language C specified by -c is an experimental language. See the 'Target Languages' section in the Introduction chapter of the SWIG documentation.
[...]
```

**Validation**
* Built `//examples/llm:llm` after a clean
* Confirmed Warning 524 no longer appears
* Build still succeeds without changing generated binding behavior