### PR TITLE
Remove BoundedArray.init 

### DIFF
--- a/examples/benchmark/main.zig
+++ b/examples/benchmark/main.zig
@@ -28,7 +28,7 @@ pub fn main(init: std.process.Init) !void {
         .m = .low_bandwidth,
         .n = .high_bandwidth,
     });
-    const strategy: zml.sharding.Strategy = try .suggest(logical_mesh, platform.physical_mesh);
+    const strategy: zml.sharding.Strategy = .suggest(logical_mesh, platform.physical_mesh);
     const benchmark_sharding: zml.sharding.Sharding = try .initFromStrategy(platform, logical_mesh, strategy);
 
     const cli_args: CliArgs = stdx.flags.parse(init.minimal.args, CliArgs);

--- a/examples/benchmark/main.zig
+++ b/examples/benchmark/main.zig
@@ -24,7 +24,7 @@ pub fn main(init: std.process.Init) !void {
     const platform: *zml.Platform = try .auto(allocator, io, .{});
     defer platform.deinit(allocator, io);
 
-    const logical_mesh: zml.sharding.LogicalMesh = try .init("benchmark_mesh", .{
+    const logical_mesh: zml.sharding.LogicalMesh = .init("benchmark_mesh", .{
         .m = .low_bandwidth,
         .n = .high_bandwidth,
     });

--- a/examples/io/main.zig
+++ b/examples/io/main.zig
@@ -194,7 +194,7 @@ pub fn main(init: std.process.Init) !void {
 
             const sharded_sharding: zml.sharding.Sharding = blk: {
                 const model_logical_mesh: zml.sharding.LogicalMesh = .init("playground_model", .{ .model = .high_bandwidth });
-                const model_strategy: zml.sharding.Strategy = try .suggest(model_logical_mesh, platform.physical_mesh);
+                const model_strategy: zml.sharding.Strategy = .suggest(model_logical_mesh, platform.physical_mesh);
                 break :blk try .initFromStrategy(platform, model_logical_mesh, model_strategy);
             };
 
@@ -230,7 +230,7 @@ const TreeCounts = struct {
 fn printTree(io: std.Io, writer: *std.Io.Writer, dir: std.Io.Dir, prefix: []const u8, max_depth: usize, counts: *TreeCounts) !void {
     if (max_depth == 0) return;
 
-    var entries: stdx.BoundedArray(std.Io.Dir.Entry, 1024) = .{};
+    var entries: stdx.BoundedArray(std.Io.Dir.Entry, 1024) = .empty;
     var it = dir.iterate();
     while (try it.next(io)) |entry| {
         entries.appendAssumeCapacity(entry);

--- a/examples/io/main.zig
+++ b/examples/io/main.zig
@@ -193,7 +193,7 @@ pub fn main(init: std.process.Init) !void {
             const replicated_sharding = try zml.sharding.replicatedSharding(platform);
 
             const sharded_sharding: zml.sharding.Sharding = blk: {
-                const model_logical_mesh: zml.sharding.LogicalMesh = try .init("playground_model", .{ .model = .high_bandwidth });
+                const model_logical_mesh: zml.sharding.LogicalMesh = .init("playground_model", .{ .model = .high_bandwidth });
                 const model_strategy: zml.sharding.Strategy = try .suggest(model_logical_mesh, platform.physical_mesh);
                 break :blk try .initFromStrategy(platform, model_logical_mesh, model_strategy);
             };

--- a/examples/llm/models/common.zig
+++ b/examples/llm/models/common.zig
@@ -18,7 +18,7 @@ pub const Shardings = struct {
 
     pub fn init(platform: *zml.Platform) !Shardings {
         const model_mesh: zml.sharding.LogicalMesh = .init("model", .{ .model = .high_bandwidth });
-        const model_sharding_strategy: zml.sharding.Strategy = try .suggest(model_mesh, platform.physical_mesh);
+        const model_sharding_strategy: zml.sharding.Strategy = .suggest(model_mesh, platform.physical_mesh);
         return .{
             .replicated = try zml.sharding.replicatedSharding(platform),
             .model = try .initFromStrategy(platform, model_mesh, model_sharding_strategy),

--- a/examples/llm/models/common.zig
+++ b/examples/llm/models/common.zig
@@ -17,7 +17,7 @@ pub const Shardings = struct {
     model: zml.sharding.Sharding,
 
     pub fn init(platform: *zml.Platform) !Shardings {
-        const model_mesh: zml.sharding.LogicalMesh = try .init("model", .{ .model = .high_bandwidth });
+        const model_mesh: zml.sharding.LogicalMesh = .init("model", .{ .model = .high_bandwidth });
         const model_sharding_strategy: zml.sharding.Strategy = try .suggest(model_mesh, platform.physical_mesh);
         return .{
             .replicated = try zml.sharding.replicatedSharding(platform),

--- a/examples/llm/models/lfm2_tests.zig
+++ b/examples/llm/models/lfm2_tests.zig
@@ -47,7 +47,7 @@ pub fn main(init: std.process.Init) !void {
     defer repo_model.deinit(allocator);
 
     var progress = std.Progress.start(io, .{ .root_name = args.model });
-    const tp_mesh: zml.sharding.LogicalMesh = try .init("tp_mesh", .{ .model = .high_bandwidth });
+    const tp_mesh: zml.sharding.LogicalMesh = .init("tp_mesh", .{ .model = .high_bandwidth });
     const tp_strategy: zml.sharding.Strategy = try .suggest(tp_mesh, platform.physical_mesh);
     const shardings: common.Shardings = .{
         .replicated = try zml.sharding.replicatedSharding(platform),

--- a/examples/llm/models/lfm2_tests.zig
+++ b/examples/llm/models/lfm2_tests.zig
@@ -48,7 +48,7 @@ pub fn main(init: std.process.Init) !void {
 
     var progress = std.Progress.start(io, .{ .root_name = args.model });
     const tp_mesh: zml.sharding.LogicalMesh = .init("tp_mesh", .{ .model = .high_bandwidth });
-    const tp_strategy: zml.sharding.Strategy = try .suggest(tp_mesh, platform.physical_mesh);
+    const tp_strategy: zml.sharding.Strategy = .suggest(tp_mesh, platform.physical_mesh);
     const shardings: common.Shardings = .{
         .replicated = try zml.sharding.replicatedSharding(platform),
         .model = try .initFromStrategy(platform, tp_mesh, tp_strategy),

--- a/examples/llm/models/llama_tests.zig
+++ b/examples/llm/models/llama_tests.zig
@@ -44,7 +44,7 @@ pub fn main(init: std.process.Init) !void {
     defer repo_model.deinit(allocator);
 
     var progress = std.Progress.start(io, .{ .root_name = args.model });
-    const tp_mesh: zml.sharding.LogicalMesh = try .init("tp_mesh", .{ .model = .high_bandwidth });
+    const tp_mesh: zml.sharding.LogicalMesh = .init("tp_mesh", .{ .model = .high_bandwidth });
     const tp_strategy: zml.sharding.Strategy = try .suggest(tp_mesh, platform.physical_mesh);
     const shardings: common.Shardings = .{
         .replicated = try zml.sharding.replicatedSharding(platform),

--- a/examples/llm/models/llama_tests.zig
+++ b/examples/llm/models/llama_tests.zig
@@ -45,7 +45,7 @@ pub fn main(init: std.process.Init) !void {
 
     var progress = std.Progress.start(io, .{ .root_name = args.model });
     const tp_mesh: zml.sharding.LogicalMesh = .init("tp_mesh", .{ .model = .high_bandwidth });
-    const tp_strategy: zml.sharding.Strategy = try .suggest(tp_mesh, platform.physical_mesh);
+    const tp_strategy: zml.sharding.Strategy = .suggest(tp_mesh, platform.physical_mesh);
     const shardings: common.Shardings = .{
         .replicated = try zml.sharding.replicatedSharding(platform),
         .model = try .initFromStrategy(platform, tp_mesh, tp_strategy),

--- a/examples/sharding/main.zig
+++ b/examples/sharding/main.zig
@@ -193,7 +193,7 @@ pub fn main(init: std.process.Init) !void {
         .data = .low_bandwidth,
         .model = .high_bandwidth,
     });
-    const strategy: zml.sharding.Strategy = try .suggest(mesh, physical_mesh);
+    const strategy: zml.sharding.Strategy = .suggest(mesh, physical_mesh);
     const sharding: zml.sharding.Sharding = try .initFromStrategy(platform, mesh, strategy);
 
     log.info("{f}", .{mesh});

--- a/examples/sharding/main.zig
+++ b/examples/sharding/main.zig
@@ -189,7 +189,7 @@ pub fn main(init: std.process.Init) !void {
     log.info("{f}", .{platform.physical_mesh});
 
     const physical_mesh = platform.physical_mesh;
-    const mesh: zml.sharding.LogicalMesh = try .init("demo_mesh", .{
+    const mesh: zml.sharding.LogicalMesh = .init("demo_mesh", .{
         .data = .low_bandwidth,
         .model = .high_bandwidth,
     });

--- a/mlir/dialects/func.zig
+++ b/mlir/dialects/func.zig
@@ -22,10 +22,10 @@ const FuncOpArgs = struct {
 };
 
 pub fn func(ctx: *mlir.Context, args: FuncOpArgs) *mlir.Operation {
-    var args_buffer: stdx.BoundedArray(*const mlir.Type, 1024) = .{};
-    var results_buffer: stdx.BoundedArray(*const mlir.Type, 32) = .{};
+    var args_buffer: stdx.BoundedArray(*const mlir.Type, 1024) = .empty;
+    var results_buffer: stdx.BoundedArray(*const mlir.Type, 32) = .empty;
 
-    var attr_tuples_buffer: stdx.BoundedArray(mlir.NamedAttribute, 16) = .{};
+    var attr_tuples_buffer: stdx.BoundedArray(mlir.NamedAttribute, 16) = .empty;
     attr_tuples_buffer.appendSliceAssumeCapacity(&.{
         .named(ctx, "sym_name", mlir.stringAttribute(ctx, args.name)),
         .named(ctx, "sym_visibility", mlir.stringAttribute(ctx, @tagName(args.visibility))),

--- a/mlir/dialects/stablehlo/stablehlo.zig
+++ b/mlir/dialects/stablehlo/stablehlo.zig
@@ -759,7 +759,7 @@ pub fn custom_call(ctx: *mlir.Context, inputs: []const *const mlir.Value, result
         break :blk ret;
     };
 
-    var attrs: stdx.BoundedArray(mlir.NamedAttribute, 32) = .{};
+    var attrs: stdx.BoundedArray(mlir.NamedAttribute, 32) = .empty;
     attrs.appendSliceAssumeCapacity(&.{
         .named(ctx, "call_target_name", mlir.stringAttribute(ctx, opts.call_target_name)),
     });
@@ -787,7 +787,7 @@ pub fn custom_call(ctx: *mlir.Context, inputs: []const *const mlir.Value, result
     }
 
     if (opts.output_operand_aliases) |output_operand_aliases| {
-        var buffer: stdx.BoundedArray(*const mlir.Attribute, MAX_RESULTS) = .{};
+        var buffer: stdx.BoundedArray(*const mlir.Attribute, MAX_RESULTS) = .empty;
         for (output_operand_aliases) |alias| {
             const output_tuple_indices = if (result_types.len > 1) &[1]i64{alias.output_index} else &.{};
             buffer.appendAssumeCapacity(
@@ -799,7 +799,7 @@ pub fn custom_call(ctx: *mlir.Context, inputs: []const *const mlir.Value, result
         );
     }
 
-    var layouts_buffer: stdx.BoundedArray(*const mlir.Attribute, MAX_OPERANDS) = .{};
+    var layouts_buffer: stdx.BoundedArray(*const mlir.Attribute, MAX_OPERANDS) = .empty;
     if (opts.operand_layouts) |layouts| {
         for (layouts) |ol| {
             layouts_buffer.appendAssumeCapacity(

--- a/mlir/mlir.zig
+++ b/mlir/mlir.zig
@@ -1169,7 +1169,7 @@ pub const Operation = opaque {
         if (args.operands) |operands| switch (operands) {
             .flat => |v| state.addOperands(v),
             .variadic => |segments| {
-                var sizes: stdx.BoundedArray(i32, MAX_SEGMENTS) = .{};
+                var sizes: stdx.BoundedArray(i32, MAX_SEGMENTS) = .empty;
                 for (segments) |segment_operands| {
                     state.addOperands(segment_operands);
                     sizes.appendAssumeCapacity(@intCast(segment_operands.len));
@@ -1182,7 +1182,7 @@ pub const Operation = opaque {
         if (args.results) |results| switch (results) {
             .flat => |v| state.addResults(v),
             .variadic => |segments| {
-                var sizes: stdx.BoundedArray(i32, MAX_SEGMENTS) = .{};
+                var sizes: stdx.BoundedArray(i32, MAX_SEGMENTS) = .empty;
                 for (segments) |segment_results| {
                     state.addResults(segment_results);
                     sizes.appendAssumeCapacity(@intCast(segment_results.len));
@@ -1393,7 +1393,7 @@ pub const RankedTensorType = opaque {
     }
 
     pub fn fromShaped(other: *const ShapedType) *const RankedTensorType {
-        var dims: stdx.BoundedArray(i64, ShapedType.MAX_RANK) = .{};
+        var dims: stdx.BoundedArray(i64, ShapedType.MAX_RANK) = .empty;
         for (0..other.rank()) |i| {
             dims.appendAssumeCapacity(other.dimension(i));
         }
@@ -1618,7 +1618,7 @@ pub const MemRefType = opaque {
     }
 
     pub fn fromShaped(other: *const ShapedType) *const MemRefType {
-        var dims: stdx.BoundedArray(i64, ShapedType.MAX_RANK) = .{};
+        var dims: stdx.BoundedArray(i64, ShapedType.MAX_RANK) = .empty;
         for (0..other.rank()) |i| {
             dims.appendAssumeCapacity(other.dimension(i));
         }

--- a/stdx/bounded_array.zig
+++ b/stdx/bounded_array.zig
@@ -27,12 +27,16 @@ pub fn BoundedArray(comptime T: type, comptime buffer_capacity: usize) type {
 /// only known at runtime, but whose maximum size is known at comptime, without
 /// requiring an `Allocator`.
 /// ```zig
-//  var a = try BoundedArrayAligned(u8, 16, 2).init(0);
-//  try a.append(255);
-//  try a.append(255);
-//  const b = @ptrCast(*const [1]u16, a.constSlice().ptr);
-//  try testing.expectEqual(@as(u16, 65535), b[0]);
+/// var a: BoundedArrayAligned(u8, 16, 2) = .empty;
+/// try a.append(255);
+/// try a.append(255);
+/// const b: *const [1]u16 = @ptrCast(a.constSlice().ptr);
+/// try testing.expectEqual(@as(u16, 65535), b[0]);
 /// ```
+///
+/// Note: there is no init anymore. It's generally unsafe because it makes `slice()` return undefined.;
+/// If you used `try init(0)` use `.empty`
+/// If you used `try init(n)` use `.{ .buffer = undefined, .len = n }` and fill `buffer` yourself.
 pub fn BoundedArrayAligned(
     comptime T: type,
     comptime alignment: Alignment,
@@ -40,15 +44,10 @@ pub fn BoundedArrayAligned(
 ) type {
     return struct {
         const Self = @This();
-        buffer: [buffer_capacity]T align(alignment.toByteUnits()) = undefined,
-        len: usize = 0,
+        buffer: [buffer_capacity]T align(alignment.toByteUnits()),
+        len: usize,
 
-        /// Set the actual length of the slice.
-        /// Returns error.Overflow if it exceeds the length of the backing array.
-        pub fn init(len: usize) error{Overflow}!Self {
-            if (len > buffer_capacity) return error.Overflow;
-            return Self{ .len = len };
-        }
+        pub const empty: Self = .{ .buffer = undefined, .len = 0 };
 
         /// View the internal array as a slice whose size was previously set.
         pub fn slice(self: anytype) switch (@TypeOf(&self.buffer)) {
@@ -78,8 +77,10 @@ pub fn BoundedArrayAligned(
 
         /// Copy the content of an existing slice.
         pub fn fromSlice(m: []const T) error{Overflow}!Self {
-            var list = try init(m.len);
-            @memcpy(list.slice(), m);
+            if (m.len > buffer_capacity) return error.Overflow;
+
+            var list: Self = .{ .buffer = undefined, .len = m.len };
+            @memcpy(list.buffer[0..m.len], m);
             return list;
         }
 

--- a/stdx/bounded_array.zig
+++ b/stdx/bounded_array.zig
@@ -304,8 +304,8 @@ test BoundedArray {
     try a.resize(48);
     try testing.expectEqual(a.len, 48);
 
-    const x = [_]u8{1} ** 10;
-    a = try BoundedArray(u8, 64).fromSlice(&x);
+    const x: [10]u8 = @splat(1);
+    a = try .fromSlice(&x);
     try testing.expectEqualSlices(u8, &x, a.constSlice());
 
     var a2 = a;

--- a/stdx/bounded_array.zig
+++ b/stdx/bounded_array.zig
@@ -295,7 +295,7 @@ pub fn BoundedArrayAligned(
 }
 
 test BoundedArray {
-    var a = try BoundedArray(u8, 64).init(32);
+    var a: BoundedArray(u8, 64) = .{ .buffer = undefined, .len = 32 };
 
     try testing.expectEqual(a.capacity(), 64);
     try testing.expectEqual(a.slice().len, 32);
@@ -400,7 +400,7 @@ test BoundedArray {
 }
 
 test "BoundedArrayAligned" {
-    var a = try BoundedArrayAligned(u8, .@"16", 4).init(0);
+    var a: BoundedArrayAligned(u8, .@"16", 4) = .empty;
     try a.append(0);
     try a.append(0);
     try a.append(255);

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -101,7 +101,7 @@ pub const Buffer = struct {
             ._platform = platform,
             ._shape = sh,
             ._sharding = sharding,
-            ._shards = .{},
+            ._shards = .empty,
         };
 
         const buffer_type = pjrtx.bufferTypeFromDtype(sh.dtype());
@@ -193,7 +193,7 @@ pub const Buffer = struct {
             ._platform = platform,
             ._shape = sh,
             ._sharding = sharding,
-            ._shards = .{},
+            ._shards = .empty,
         };
         errdefer for (res._shards.slice()) |shard| {
             shard.deinit(platform.pjrt_api);

--- a/zml/exe.zig
+++ b/zml/exe.zig
@@ -73,9 +73,10 @@ pub const Exe = struct {
 
     pub const FlatBuffers = struct {
         buffers: []const [*]*pjrt.Buffer,
-        raw_buffers: []const *pjrt.Buffer,
+        raw_buffers: []*pjrt.Buffer,
 
-        num_devices: usize,
+        num_devices: u32,
+        buffer_count: u32,
 
         pub fn init(allocator: std.mem.Allocator, count: usize, num_devices: usize) !FlatBuffers {
             const raw_buffers = try allocator.alloc(*pjrt.Buffer, num_devices * count);
@@ -224,7 +225,7 @@ pub const Exe = struct {
             var context: LocalContext = .{ .self = self, .current_index = 0 };
             meta.visit(struct {
                 fn cb(context_: *LocalContext, buffer: *Buffer) void {
-                    var shards: Buffer.Shards = .{};
+                    var shards: Buffer.Shards = .empty;
                     for (0..context_.self.flat_buffers.num_devices) |device_index| {
                         shards.appendAssumeCapacity(context_.self.flat_buffers.buffers[device_index][context_.current_index]);
                     }
@@ -244,7 +245,7 @@ pub const Exe = struct {
             meta.visit(struct {
                 fn cb(context_: *LocalContext, buffer: *Buffer) void {
                     //stdx.debug.assert(context_.self.expected_shapes[context_.current_index].eql(buffer.shape()), "Expected result {} to have shape {f}, got {f}", .{ context_.current_index, context_.self.expected_shapes[context_.current_index], buffer.shape() });
-                    var shards: Buffer.Shards = .{};
+                    var shards: Buffer.Shards = .empty;
                     for (0..context_.self.flat_buffers.num_devices) |device_index| {
                         shards.appendAssumeCapacity(context_.self.flat_buffers.buffers[device_index][context_.current_index]);
                     }

--- a/zml/exe.zig
+++ b/zml/exe.zig
@@ -73,7 +73,7 @@ pub const Exe = struct {
 
     pub const FlatBuffers = struct {
         buffers: []const [*]*pjrt.Buffer,
-        raw_buffers: []*pjrt.Buffer,
+        raw_buffers: []const *pjrt.Buffer,
 
         num_devices: usize,
 

--- a/zml/exe.zig
+++ b/zml/exe.zig
@@ -75,8 +75,7 @@ pub const Exe = struct {
         buffers: []const [*]*pjrt.Buffer,
         raw_buffers: []*pjrt.Buffer,
 
-        num_devices: u32,
-        buffer_count: u32,
+        num_devices: usize,
 
         pub fn init(allocator: std.mem.Allocator, count: usize, num_devices: usize) !FlatBuffers {
             const raw_buffers = try allocator.alloc(*pjrt.Buffer, num_devices * count);

--- a/zml/io.zig
+++ b/zml/io.zig
@@ -795,7 +795,7 @@ pub const DirectMemoryWriter = struct {
             writer.deinit();
         };
 
-        var pjrt_buffers: Buffer.Shards = .{};
+        var pjrt_buffers: Buffer.Shards = .empty;
         for (placement.shards.constSlice(), 0..) |shard, i| {
             defer initialized += 1;
 
@@ -1374,10 +1374,10 @@ test "DirectMemoryWriter: replicated with auto topology" {
         },
         .shape = Shape.init(.{ .rows = 8, .cols = 128 }, .f32)
             .withPartitioning(.{ .rows = .replicated, .cols = .replicated }),
-        .logical_mesh = try .init("replicated_cpu", .{ .x = .high_bandwidth }),
+        .logical_mesh = .init("replicated_cpu", .{ .x = .high_bandwidth }),
         .strategy = blk: {
             var strategy: sharding_.Strategy = .init;
-            try strategy.addBinding(.x, .link_x);
+            strategy.addBinding(.x, .link_x);
 
             break :blk strategy;
         },
@@ -1398,10 +1398,10 @@ test "DirectMemoryWriter: 1D model split with 2x2 physical mesh" {
         },
         .shape = Shape.init(.{ .rows = 8, .cols = 1024 }, .f32)
             .withPartitioning(.{ .rows = .replicated, .cols = .model }),
-        .logical_mesh = try .init("model_cpu", .{ .model = .high_bandwidth }),
+        .logical_mesh = .init("model_cpu", .{ .model = .high_bandwidth }),
         .strategy = blk: {
             var strategy: sharding_.Strategy = .init;
-            try strategy.addBinding(.model, .link_x);
+            strategy.addBinding(.model, .link_x);
 
             break :blk strategy;
         },
@@ -1422,14 +1422,14 @@ test "DirectMemoryWriter: 2D batch/model split with 2x2 physical mesh" {
         },
         .shape = Shape.init(.{ .batch = 8, .model = 1024 }, .f32)
             .withPartitioning(.{ .batch = .batch, .model = .model }),
-        .logical_mesh = try .init("batch_model_cpu", .{
+        .logical_mesh = .init("batch_model_cpu", .{
             .batch = .low_bandwidth,
             .model = .high_bandwidth,
         }),
         .strategy = blk: {
             var strategy: sharding_.Strategy = .init;
-            try strategy.addBinding(.batch, .link_x);
-            try strategy.addBinding(.model, .link_y);
+            strategy.addBinding(.batch, .link_x);
+            strategy.addBinding(.model, .link_y);
 
             break :blk strategy;
         },
@@ -1449,11 +1449,11 @@ test "DirectMemoryWriter: folded model sharding with 2x2 physical mesh" {
             .cpu = .{ .device_count = 4 },
         },
         .shape = Shape.init(.{ .model = 4096 }, .f32).withPartitioning(.{ .model = .model }),
-        .logical_mesh = try .init("model_folded_cpu", .{ .model = .high_bandwidth }),
+        .logical_mesh = .init("model_folded_cpu", .{ .model = .high_bandwidth }),
         .strategy = blk: {
             var strategy: sharding_.Strategy = .init;
-            try strategy.addBinding(.model, .link_x);
-            try strategy.addFold(.link_x, &.{ .link_x, .link_y });
+            strategy.addBinding(.model, .link_x);
+            strategy.addFold(.link_x, &.{ .link_x, .link_y });
 
             break :blk strategy;
         },
@@ -1474,10 +1474,10 @@ test "DirectMemoryWriter: writableSliceGreedy with mirrored shards" {
         },
         .shape = Shape.init(.{ .rows = 8, .cols = 1024 }, .f32)
             .withPartitioning(.{ .rows = .replicated, .cols = .model }),
-        .logical_mesh = try .init("model_cpu_greedy", .{ .model = .high_bandwidth }),
+        .logical_mesh = .init("model_cpu_greedy", .{ .model = .high_bandwidth }),
         .strategy = blk: {
             var strategy: sharding_.Strategy = .init;
-            try strategy.addBinding(.model, .link_x);
+            strategy.addBinding(.model, .link_x);
 
             break :blk strategy;
         },
@@ -1501,14 +1501,14 @@ test "DirectMemoryWriter: 3D topology folded model + replicated batch" {
         },
         .shape = Shape.init(.{ .batch = 16, .model = 4096 }, .f32)
             .withPartitioning(.{ .batch = .replicated, .model = .model }),
-        .logical_mesh = try .init("topology_3d_folded_model_mesh", .{
+        .logical_mesh = .init("topology_3d_folded_model_mesh", .{
             .batch = .low_bandwidth,
             .model = .high_bandwidth,
         }),
         .strategy = blk: {
             var strategy: sharding_.Strategy = .init;
-            try strategy.addBinding(.model, .link_x);
-            try strategy.addFold(.link_x, &.{ .link_x, .link_z });
+            strategy.addBinding(.model, .link_x);
+            strategy.addFold(.link_x, &.{ .link_x, .link_z });
 
             break :blk strategy;
         },

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -91,7 +91,7 @@ pub const CompilationContext = struct {
     platform: *const Platform,
     partitioning: Partitioning,
 
-    scopes: stdx.BoundedArray(Scope, 16) = .{},
+    scopes: stdx.BoundedArray(Scope, 16) = .empty,
     manual_computation_depth: usize = 0,
 
     threadlocal var _current: ?*CompilationContext = null;
@@ -429,7 +429,7 @@ fn emitMlir(compilation_context: *CompilationContext, comptime func: anytype, ar
     errdefer input_info.deinit(compilation_context.allocator);
 
     const input_attributes = try arena.allocator().alloc(AttributeList, input_info.shapes.len);
-    @memset(input_attributes, .{});
+    @memset(input_attributes, .empty);
 
     const output_info = b: {
         compilation_context.activate();
@@ -445,7 +445,7 @@ fn emitMlir(compilation_context: *CompilationContext, comptime func: anytype, ar
     errdefer output_info.deinit(compilation_context.allocator);
 
     const output_attributes = try arena.allocator().alloc(AttributeList, output_info.shapes.len);
-    @memset(output_attributes, .{});
+    @memset(output_attributes, .empty);
 
     for (output_info.donations, 0..) |donation, index| if (donation) |argument_index| {
         input_attributes[argument_index].appendAssumeCapacity(.named(compilation_context.mlir_ctx, "tf.aliasing_output", mlir.integerAttribute(compilation_context.mlir_ctx, .i32, index)));

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -88,7 +88,7 @@ pub fn reduce(inputs: anytype, inits: anytype, axes_: []const i64, comptime func
     // To that order, we initialize `result` to `inputs`, then we use stdx.meta.visit,
     // to find the correct mlir.Value, but we first broadcast before creating the final
     // Tensor struct.
-    var broadcasting_axes: stdx.BoundedArray(i64, constants.MAX_RANK) = .{};
+    var broadcasting_axes: stdx.BoundedArray(i64, constants.MAX_RANK) = .empty;
     for (0..constants.MAX_RANK) |i| {
         if (std.mem.indexOfScalar(i64, axes_, @intCast(i)) == null) {
             broadcasting_axes.append(@intCast(i)) catch unreachable;
@@ -713,11 +713,11 @@ pub fn scatter(
 }
 
 const ScatterConfig = struct {
-    op_kind: stdx.BoundedArray(ScatterAxisKind, constants.MAX_RANK) = .{},
-    up_kind: stdx.BoundedArray(ScatterAxisKind, constants.MAX_RANK) = .{},
-    indices_batch_axes: Shape.DimsArray = .{},
-    scatter_to_operand_axes: Shape.DimsArray = .{},
-    updates_transpose: Shape.AxesArray = .{},
+    op_kind: stdx.BoundedArray(ScatterAxisKind, constants.MAX_RANK) = .empty,
+    up_kind: stdx.BoundedArray(ScatterAxisKind, constants.MAX_RANK) = .empty,
+    indices_batch_axes: Shape.DimsArray = .empty,
+    scatter_to_operand_axes: Shape.DimsArray = .empty,
+    updates_transpose: Shape.AxesArray = .empty,
 };
 
 const ScatterAxisKind = enum { batching, update_window, inserted_window, window_id };
@@ -728,11 +728,11 @@ fn scatterConfig(
     indices_per_axis: stdx.BoundedArray(Tensor, constants.MAX_RANK),
     indices_axes: Shape.TagsArray,
 ) ScatterConfig {
-    var op_kind: stdx.BoundedArray(ScatterAxisKind, constants.MAX_RANK) = .{};
-    var up_kind: stdx.BoundedArray(ScatterAxisKind, constants.MAX_RANK) = .{};
-    var indices_batch_axes: Shape.DimsArray = .{};
-    var scatter_to_operand_axes: Shape.DimsArray = .{};
-    var updates_transpose: Shape.AxesArray = .{};
+    var op_kind: stdx.BoundedArray(ScatterAxisKind, constants.MAX_RANK) = .empty;
+    var up_kind: stdx.BoundedArray(ScatterAxisKind, constants.MAX_RANK) = .empty;
+    var indices_batch_axes: Shape.DimsArray = .empty;
+    var scatter_to_operand_axes: Shape.DimsArray = .empty;
+    var updates_transpose: Shape.AxesArray = .empty;
 
     const tagged_api = indices_axes.len > 0;
     const indices = indices_per_axis.get(0).shape();
@@ -878,12 +878,12 @@ fn scatterPrepareIndices(
         cfg.up_kind.buffer[update.axis(batch_tag)] = .window_id;
         old_scatter_to_op_axes.appendAssumeCapacity(batch_ax);
     }
-    cfg.indices_batch_axes = .{};
+    cfg.indices_batch_axes = .empty;
 
     // Reorder the axes so that in indices_per_axis is ordered like in op if possible.
     // TODO: transpose updates if needed
-    var indices: stdx.BoundedArray(Tensor, constants.MAX_RANK) = .{};
-    var scatter_to_op_axes: Shape.DimsArray = .{};
+    var indices: stdx.BoundedArray(Tensor, constants.MAX_RANK) = .empty;
+    var scatter_to_op_axes: Shape.DimsArray = .empty;
 
     while (old_scatter_to_op_axes.len > 0) {
         const scatter_ax = std.sort.argMin(i64, old_scatter_to_op_axes.constSlice(), {}, std.sort.asc(i64)).?;
@@ -927,7 +927,7 @@ pub fn gather(self: Tensor, idx_axes: []const u3, idx_per_axis: []const Tensor, 
         stdx.debug.assert(idx.shape().canBroadcastTo(indices_shape), "gather indices can't be broadcasted together {any}", .{idx_per_axis});
     }
 
-    var idx_batch_axes: Shape.DimsArray = .{};
+    var idx_batch_axes: Shape.DimsArray = .empty;
 
     var self_kind: stdx.BoundedArray(GatherAxisKind, constants.MAX_RANK) = .{ .buffer = @splat(.offset), .len = self.rank() };
 
@@ -950,7 +950,7 @@ pub fn gather(self: Tensor, idx_axes: []const u3, idx_per_axis: []const Tensor, 
 
     // compute res shape
     var res_shape = Shape.init(.{}, self.dtype());
-    var res_kind: stdx.BoundedArray(GatherAxisKind, constants.MAX_RANK) = .{};
+    var res_kind: stdx.BoundedArray(GatherAxisKind, constants.MAX_RANK) = .empty;
     for (self_kind.slice(), 0..) |kind, ax_usize| {
         const ax: u3 = @intCast(ax_usize);
         if (ax == idx_axes[0]) {
@@ -980,7 +980,7 @@ pub fn gather(self: Tensor, idx_axes: []const u3, idx_per_axis: []const Tensor, 
         return self.dynamicSlice1d(idx_axes[0], .{ .start = idx_per_axis[0].asScalar(), .len = 1 }).reshape(res_shape);
     }
 
-    var slice_dims: Shape.DimsArray = .{};
+    var slice_dims: Shape.DimsArray = .empty;
     for (self_kind.slice(), self.dims()) |k, d| {
         slice_dims.appendAssumeCapacity(switch (k) {
             .batching, .collapsed => 1,
@@ -1015,7 +1015,7 @@ pub fn gather(self: Tensor, idx_axes: []const u3, idx_per_axis: []const Tensor, 
 }
 
 pub fn _collectAxes(T: type, bounded_array: stdx.BoundedArray(T, constants.MAX_RANK), value: T) stdx.BoundedArray(i64, constants.MAX_RANK) {
-    var res: stdx.BoundedArray(i64, constants.MAX_RANK) = .{};
+    var res: stdx.BoundedArray(i64, constants.MAX_RANK) = .empty;
     for (bounded_array.constSlice(), 0..) |v, ax| {
         if (v == value) {
             res.appendAssumeCapacity(@intCast(ax));
@@ -2010,7 +2010,7 @@ test "CustomCallOutputOperandAliases maps named fields to indices" {
 }
 
 fn toUsize(values: anytype) stdx.BoundedArray(usize, constants.MAX_RANK) {
-    var res: stdx.BoundedArray(usize, constants.MAX_RANK) = .{};
+    var res: stdx.BoundedArray(usize, constants.MAX_RANK) = .empty;
     for (values) |val| res.appendAssumeCapacity(@intCast(val));
     return res;
 }

--- a/zml/safetensors.zig
+++ b/zml/safetensors.zig
@@ -434,7 +434,7 @@ pub fn parseSafetensors(
         const start: u64 = @intCast(offset_field.array.items[0].integer);
         const dtype = try stringToDtype(value.object.get("dtype").?.string);
 
-        var dims: Dims = .{};
+        var dims: Dims = .empty;
         for (shape_field.items) |d| {
             dims.appendAssumeCapacity(d.integer);
         }

--- a/zml/shape.zig
+++ b/zml/shape.zig
@@ -156,9 +156,9 @@ pub const Shape = struct {
     const UnknownTags: TagsArray = .{ .len = 0, .buffer = [_]Tag{TagUnknown} ** constants.MAX_RANK };
 
     _dtype: DataType,
-    _dims: DimsArray = .{},
+    _dims: DimsArray = .empty,
     _tags: TagsArray = UnknownTags,
-    _partitioning: PartitionArray = .{},
+    _partitioning: PartitionArray = .empty,
 
     pub fn parseDimensions(v: anytype) struct { DimsArray, TagsArray } {
         const T = @TypeOf(v);
@@ -168,8 +168,8 @@ pub const Shape = struct {
         }
 
         if (comptime stdx.meta.isSliceOfAny(T, stdx.meta.isInteger)) {
-            var dims_ = DimsArray.init(0) catch unreachable;
-            var tags_ = TagsArray.init(0) catch unreachable;
+            var dims_: DimsArray = .empty;
+            var tags_: TagsArray = .empty;
             for (v) |d| {
                 dims_.appendAssumeCapacity(@intCast(d));
                 tags_.appendAssumeCapacity(TagUnknown);
@@ -178,8 +178,8 @@ pub const Shape = struct {
         }
 
         if (comptime stdx.meta.isStruct(T)) {
-            var dims_: DimsArray = .{};
-            var tags_: TagsArray = .{};
+            var dims_: DimsArray = .empty;
+            var tags_: TagsArray = .empty;
             inline for (std.meta.fields(T)) |field| {
                 const fv = @field(v, field.name);
                 if (comptime stdx.meta.isInteger(field.type)) {
@@ -217,8 +217,8 @@ pub const Shape = struct {
             return self.parseAxes(self.tags());
         }
 
-        var axes_ = AxesArray.init(0) catch unreachable;
-        var tags_ = TagsArray.init(0) catch unreachable;
+        var axes_: AxesArray = .empty;
+        var tags_: TagsArray = .empty;
 
         if (comptime stdx.meta.isSliceOfAny(T, isAxisConvertible)) {
             for (v) |d| {
@@ -242,7 +242,7 @@ pub const Shape = struct {
     pub fn parseTags(v: anytype) TagsArray {
         const T = @TypeOf(v);
         stdx.debug.assertComptime(stdx.meta.isTupleOf(T, @EnumLiteral()), "Wrong type, got {}. Expected .{{ .a, .b }}", .{T});
-        var tags_ = TagsArray.init(0) catch unreachable;
+        var tags_: TagsArray = .empty;
         inline for (v) |field| {
             tags_.appendAssumeCapacity(toTag(field));
         }
@@ -407,7 +407,7 @@ pub const Shape = struct {
             return self.axes(axes_.tags());
         }
 
-        var res = AxesArray.init(0) catch unreachable;
+        var res: AxesArray = .empty;
 
         if (comptime stdx.meta.isSliceOfAny(T, stdx.meta.isInteger) or stdx.meta.isSliceOf(T, Tag)) {
             for (axes_) |ax| {
@@ -917,7 +917,7 @@ pub const Shape = struct {
         }
 
         // Check that no mesh axis is used to partition multiple tensor dimensions.
-        var used_mesh_axes: stdx.BoundedArray(Tag, constants.MAX_RANK) = .{ .len = 0 };
+        var used_mesh_axes: stdx.BoundedArray(Tag, constants.MAX_RANK) = .empty;
 
         for (res._partitioning.constSlice()) |spec| {
             const axis_tag = spec.toTag();
@@ -1249,7 +1249,7 @@ pub const Shape = struct {
 
     fn computeStrides(self: Shape, element_size: i64) stdx.BoundedArray(i64, constants.MAX_RANK) {
         const rk = self.rank();
-        var strides: stdx.BoundedArray(i64, constants.MAX_RANK) = .{ .len = rk };
+        var strides: stdx.BoundedArray(i64, constants.MAX_RANK) = .{ .buffer = undefined, .len = rk };
         if (rk == 0) return strides;
 
         const V = @Vector(constants.MAX_RANK, i64);
@@ -1269,7 +1269,7 @@ pub const Shape = struct {
     /// so that the given axes are contiguous.
     pub fn contiguousPerm(self: Shape, axes_: anytype) AxesArray {
         const axes__, _ = self.parseAxes(axes_);
-        var perms = AxesArray.init(0) catch unreachable;
+        var perms: AxesArray = .empty;
         for (0..self.rank()) |i| {
             if (std.mem.indexOfScalar(u3, axes__.constSlice(), @intCast(i))) |_| {
                 continue;
@@ -1493,7 +1493,7 @@ pub const Shape = struct {
     }
 
     fn intersectTags(a: []const Tag, b: []const Tag) TagsArray {
-        var res = TagsArray.init(0) catch unreachable;
+        var res: TagsArray = .empty;
         for (a) |tag_| {
             if (std.mem.indexOfScalar(Tag, b, tag_)) {
                 res.appendAssumeCapacity(tag_);
@@ -1505,8 +1505,8 @@ pub const Shape = struct {
     pub fn parseStruct(T: type, v: anytype) struct { stdx.BoundedArray(T, constants.MAX_RANK), TagsArray } {
         const V = @TypeOf(v);
 
-        var vals_: stdx.BoundedArray(T, constants.MAX_RANK) = .{};
-        var tags_: TagsArray = .{};
+        var vals_: stdx.BoundedArray(T, constants.MAX_RANK) = .empty;
+        var tags_: TagsArray = .empty;
 
         if (comptime stdx.meta.isSliceOf(V, T)) {
             for (v) |d| {
@@ -1543,7 +1543,7 @@ pub const Shape = struct {
     pub fn parseAxesOptions(self: Shape, T: type, options: anytype, default: T) stdx.BoundedArray(T, constants.MAX_RANK) {
         const V = @TypeOf(options);
 
-        var res: stdx.BoundedArray(T, constants.MAX_RANK) = .{};
+        var res: stdx.BoundedArray(T, constants.MAX_RANK) = .empty;
         if (comptime stdx.meta.isSliceOf(V, T)) {
             stdx.debug.assert(options.len == self.rank(), "expects exactly {} options in slice, for {} got {}", .{ self.rank(), self, options.len });
             for (options) |d| {

--- a/zml/sharding.zig
+++ b/zml/sharding.zig
@@ -194,7 +194,7 @@ pub const Device = struct {
     id: usize,
 
     /// Coordinates in the physical mesh
-    coords: stdx.BoundedArray(usize, Shape.MAX_RANK) = .{},
+    coords: stdx.BoundedArray(usize, Shape.MAX_RANK) = .empty,
 
     /// Placeholder
     pjrt_device: ?*const pjrt.Device = null,
@@ -279,7 +279,7 @@ pub const PhysicalNode = union(enum) {
         return .{
             .leaf = .{
                 .id = @intCast(device_.id()),
-                .coords = .{},
+                .coords = .empty,
                 .pjrt_device = device_.pjrt_device,
             },
         };
@@ -324,8 +324,8 @@ pub const PhysicalMesh = struct {
         depth_by_tag: DepthByTag,
 
         /// Build axis order and depth mapping from a topology tree.
-        pub fn init(root: PhysicalNode) !AxisTraversal {
-            var order: Order = try .init(0);
+        pub fn init(root: PhysicalNode) AxisTraversal {
+            var order: Order = .empty;
             axisOrderNode(root, &order);
 
             var depth_by_tag: DepthByTag = .initFill(null);
@@ -415,17 +415,16 @@ pub const PhysicalMesh = struct {
     }
 
     fn fromOwnedTree(target: Target, root: PhysicalNode) !PhysicalMesh {
+        try validateGeometry(root);
+
         var owned_root = root;
-
-        try validateGeometry(owned_root);
-
-        var path = [_]usize{0} ** Shape.MAX_RANK;
-        try assignCoords(&owned_root, &path, 0);
+        var path: [Shape.MAX_RANK]usize = @splat(0);
+        assignCoords(&owned_root, &path, 0);
 
         return .{
             .target = target,
             .root = owned_root,
-            .axis_traversal = try .init(owned_root),
+            .axis_traversal = .init(owned_root),
         };
     }
 
@@ -513,20 +512,18 @@ pub const PhysicalMesh = struct {
     /// coords:
     ///   (0,0) (0,1)
     ///   (1,0) (1,1)
-    fn assignCoords(node: *PhysicalNode, path: *[Shape.MAX_RANK]usize, depth: usize) !void {
+    fn assignCoords(node: *PhysicalNode, path: *[Shape.MAX_RANK]usize, depth: usize) void {
         switch (node.*) {
             .leaf => |*d| {
                 // Coords can already been set by caller
                 if (d.coords.len > 0) return;
 
-                var coords = stdx.BoundedArray(usize, Shape.MAX_RANK).init(0) catch unreachable;
-                for (path[0..depth]) |c| coords.appendAssumeCapacity(c);
-                d.coords = coords;
+                d.coords = stdx.BoundedArray(usize, Shape.MAX_RANK).fromSlice(path[0..depth]) catch unreachable;
             },
             .branch => |*b| {
                 for (b.children, 0..) |*child, i| {
                     path[depth] = i;
-                    try assignCoords(child, path, depth + 1);
+                    assignCoords(child, path, depth + 1);
                 }
             },
         }
@@ -536,25 +533,18 @@ pub const PhysicalMesh = struct {
         return self.root.countDevices();
     }
 
-    pub fn devices(self: PhysicalMesh, allocator: std.mem.Allocator) ![]Device {
-        var list: Devices = .init(0) catch unreachable;
-        try self.devicesInto(&list);
-
-        const out = try allocator.alloc(Device, list.len);
-        @memcpy(out, list.constSlice());
-        return out;
+    pub fn devices(self: PhysicalMesh) Devices {
+        var list: Devices = .empty;
+        devicesNodeInto(self.root, &list);
+        return list;
     }
 
-    pub fn devicesInto(self: PhysicalMesh, out: *Devices) !void {
-        try devicesNodeInto(self.root, out);
-    }
-
-    fn devicesNodeInto(node: PhysicalNode, out: *Devices) !void {
+    fn devicesNodeInto(node: PhysicalNode, out: *Devices) void {
         switch (node) {
             .leaf => |d| out.appendAssumeCapacity(d),
             .branch => |b| {
                 for (b.children) |child| {
-                    try devicesNodeInto(child, out);
+                    devicesNodeInto(child, out);
                 }
             },
         }
@@ -692,8 +682,7 @@ pub const PhysicalMesh = struct {
         fn parseDevice(device: PlatformDevice) !CoordPlacement {
             const api = device.platform.pjrt_api;
             const coords_attr = device.pjrt_desc.attribute(api, "coords") orelse return error.MissingDeviceCoords;
-            var coords: stdx.BoundedArray(usize, Shape.MAX_RANK) = try .init(0);
-
+            var coords: stdx.BoundedArray(usize, Shape.MAX_RANK) = .empty;
             switch (coords_attr) {
                 .int64list => |values| {
                     if (values.len == 0 or values.len > Shape.MAX_RANK) return error.InvalidDeviceCoords;
@@ -782,20 +771,17 @@ pub const PhysicalMesh = struct {
         }
 
         pub fn leaf(placement: *const CoordPlacement, coords_slice: []const usize) !PhysicalNode {
-            var coords: stdx.BoundedArray(usize, Shape.MAX_RANK) = try .init(0);
-            for (coords_slice) |coord| coords.appendAssumeCapacity(coord);
-
             return .{
                 .leaf = .{
                     .id = placement.device_id,
-                    .coords = coords,
+                    .coords = try .fromSlice(coords_slice),
                     .pjrt_device = placement.pjrt_device,
                 },
             };
         }
 
         pub fn axisStrides(axis_sizes: []const usize) ![Shape.MAX_RANK]usize {
-            var strides = [_]usize{0} ** Shape.MAX_RANK;
+            var strides: [Shape.MAX_RANK]usize = @splat(0);
             var stride: usize = 1;
 
             var i = axis_sizes.len;
@@ -973,11 +959,11 @@ pub const LogicalMesh = struct {
     axes: Axes,
     intents: Intents,
 
-    pub fn init(name: []const u8, axes_: anytype) !LogicalMesh {
+    pub fn init(name: []const u8, axes_: anytype) LogicalMesh {
         const T = @TypeOf(axes_);
 
-        var axes: Axes = try .init(0);
-        var intents: Intents = try .init(0);
+        var axes: Axes = .empty;
+        var intents: Intents = .empty;
 
         inline for (std.meta.fields(T)) |field| {
             const value = @field(axes_, field.name);
@@ -1099,16 +1085,12 @@ pub const Sharding = struct {
         const axis_order = physical.axisOrder().constSlice();
         if (axis_order.len == 0) return error.InvalidPhysicalMesh;
 
-        var bindings: Bindings = try .init(0);
+        var bindings: Bindings = .empty;
         for (strategy.bindings.constSlice()) |bind| {
-            var list: AxisList = try .init(0);
-            for (bind.physical.constSlice()) |p_tag| {
-                list.appendAssumeCapacity(p_tag);
-            }
-            bindings.appendAssumeCapacity(.{ .logical = bind.logical, .physical = list });
+            bindings.appendAssumeCapacity(.{ .logical = bind.logical, .physical = bind.physical });
         }
 
-        var folds: Folds = try .init(0);
+        var folds: Folds = .empty;
         var folds_consumed: std.EnumSet(PhysicalAxisTag) = .empty;
         for (strategy.folding.constSlice()) |entry| {
             for (entry.sources.constSlice()) |src| {
@@ -1137,7 +1119,7 @@ pub const Sharding = struct {
     pub fn physicalView(self: Sharding) PhysicalView {
         const physical = self.platform.physical_mesh;
         var view: PhysicalView = .{
-            .axes = stdx.BoundedArray(Axis, Shape.MAX_RANK).init(0) catch unreachable,
+            .axes = .empty,
             .total_devices = 1,
         };
 
@@ -1147,7 +1129,7 @@ pub const Sharding = struct {
             if (!physical.hasAxis(tag)) continue;
             if (self.folds_consumed.contains(tag) and self.foldSources(tag) == null) continue;
 
-            var folded = stdx.BoundedArray(PhysicalAxisTag, Shape.MAX_RANK).init(0) catch unreachable;
+            var folded: stdx.BoundedArray(PhysicalAxisTag, Shape.MAX_RANK) = .empty;
             var size: i64 = 1;
 
             if (self.foldSources(tag)) |sources| {
@@ -1240,12 +1222,12 @@ pub const Sharding = struct {
     /// Common logic to map tensor dimensions to physical mesh indices.
     fn getDimMapping(self: *const Sharding, shape: Shape) DimMapping {
         const view = self.physicalView();
-        var axes_per_dim = stdx.BoundedArray(stdx.BoundedArray(usize, Shape.MAX_RANK), Shape.MAX_RANK).init(0) catch unreachable;
-        var used_mask = [_]bool{false} ** Shape.MAX_RANK;
+        var axes_per_dim: stdx.BoundedArray(stdx.BoundedArray(usize, Shape.MAX_RANK), Shape.MAX_RANK) = .empty;
+        var used_mask: [Shape.MAX_RANK]bool = @splat(false);
         var globally_used: std.EnumSet(PhysicalAxisTag) = .empty;
 
         for (0..shape.rank()) |ax| {
-            var dim_axes = stdx.BoundedArray(usize, Shape.MAX_RANK).init(0) catch unreachable;
+            var dim_axes: stdx.BoundedArray(usize, Shape.MAX_RANK) = .empty;
             const spec = shape.partition(ax);
 
             if (spec == .axis) {
@@ -1265,7 +1247,7 @@ pub const Sharding = struct {
             axes_per_dim.appendAssumeCapacity(dim_axes);
         }
 
-        var replicated_axes = stdx.BoundedArray(usize, Shape.MAX_RANK).init(0) catch unreachable;
+        var replicated_axes: stdx.BoundedArray(usize, Shape.MAX_RANK) = .empty;
         for (0..view.axes.len) |i| {
             if (!used_mask[i]) replicated_axes.appendAssumeCapacity(i);
         }
@@ -1349,7 +1331,7 @@ pub const Sharding = struct {
         if (!has_sharding) return try allocator.dupe(u8, "{replicated}");
 
         const mapping = self.getDimMapping(shape);
-        var tile_shape = stdx.BoundedArray(i64, Shape.MAX_RANK + 1).init(0) catch unreachable;
+        var tile_shape: stdx.BoundedArray(i64, Shape.MAX_RANK + 1) = .empty;
 
         //  Calculate tile sizes per tensor dimension
         for (mapping.axes_per_dim.constSlice()) |dim_axes| {
@@ -1409,7 +1391,7 @@ pub const Sharding = struct {
         var ids = try allocator.alloc(usize, count);
         @memset(ids, std.math.maxInt(usize));
 
-        const ordered_devices = try self.devicesInCanonicalOrder();
+        const ordered_devices = self.devicesInCanonicalOrder();
         for (ordered_devices.constSlice()) |d| {
             const coords = d.coordsSlice() orelse return error.MissingDeviceCoords;
             const idx = self.platform.physical_mesh.linearIndexFromCoords(coords);
@@ -1423,10 +1405,9 @@ pub const Sharding = struct {
         return ids;
     }
 
-    fn devicesInCanonicalOrder(self: Sharding) !Devices {
+    fn devicesInCanonicalOrder(self: Sharding) Devices {
         const physical = self.platform.physical_mesh;
-        var devices: Devices = try .init(0);
-        try physical.devicesInto(&devices);
+        var devices: Devices = physical.devices();
 
         const Order = struct {
             mesh: PhysicalMesh,
@@ -1520,11 +1501,11 @@ pub const Strategy = struct {
     folding: Folding,
 
     pub const init: Strategy = .{
-        .bindings = .{},
-        .folding = .{},
+        .bindings = .empty,
+        .folding = .empty,
     };
 
-    pub fn addBinding(self: *Strategy, logical: anytype, physical: PhysicalAxisTag) !void {
+    pub fn addBinding(self: *Strategy, logical: anytype, physical: PhysicalAxisTag) void {
         const raw_tag = Shape.toTag(logical);
         const logical_tag: []const u8 = std.mem.span(raw_tag);
 
@@ -1535,15 +1516,15 @@ pub const Strategy = struct {
             }
         }
 
-        var list: PhysicalList = try .init(0);
+        var list: PhysicalList = .empty;
         list.appendAssumeCapacity(physical);
         self.bindings.appendAssumeCapacity(.{ .logical = raw_tag, .physical = list });
     }
 
     /// Explicitly fold axes: `target` is the kept axis, `sources` define order.
     /// If `target` is missing from `sources`, it is prepended.
-    pub fn addFold(self: *Strategy, target: PhysicalAxisTag, sources: []const PhysicalAxisTag) !void {
-        var list: PhysicalList = try .init(0);
+    pub fn addFold(self: *Strategy, target: PhysicalAxisTag, sources: []const PhysicalAxisTag) void {
+        var list: PhysicalList = .empty;
 
         var has_target = false;
         for (sources) |s| {
@@ -1567,11 +1548,11 @@ pub const Strategy = struct {
     }
 
     /// suggest builds a Strategy from logical intents.
-    pub fn suggest(logical: LogicalMesh, physical: PhysicalMesh) !Strategy {
+    pub fn suggest(logical: LogicalMesh, physical: PhysicalMesh) Strategy {
         var strategy: Strategy = .init;
 
         const base_order = physical.shardableAxes();
-        var available = stdx.BoundedArray(PhysicalAxisTag, Shape.MAX_RANK).init(0) catch unreachable;
+        var available: stdx.BoundedArray(PhysicalAxisTag, Shape.MAX_RANK) = .empty;
         for (base_order) |tag| {
             if (physical.hasAxis(tag)) available.appendAssumeCapacity(tag);
         }
@@ -1594,7 +1575,7 @@ pub const Strategy = struct {
                     .low_bandwidth => avail[avail.len - 1 - (i % avail.len)],
                 };
 
-                try strategy.addBinding(l_tag, p_tag);
+                strategy.addBinding(l_tag, p_tag);
                 counters.set(target_intent, i + 1);
             }
         }
@@ -1667,12 +1648,16 @@ pub const Placement = struct {
         counts: stdx.BoundedArray(i64, Shape.MAX_RANK),
         indices: stdx.BoundedArray(i64, Shape.MAX_RANK),
 
-        pub fn init() !AxisSplit {
-            return .{
-                .product = 1,
-                .counts = try .init(0),
-                .indices = try .init(0),
-            };
+        pub const empty: AxisSplit = .{
+            .product = 1,
+            .counts = .empty,
+            .indices = .empty,
+        };
+
+        pub fn add(split: *AxisSplit, size: i64, coord: usize) void {
+            split.counts.appendAssumeCapacity(size);
+            split.indices.appendAssumeCapacity(@intCast(coord));
+            split.product *= size;
         }
 
         pub fn linearIndex(self: AxisSplit) i64 {
@@ -1692,9 +1677,8 @@ pub const Placement = struct {
         sharding: Sharding,
         shape: Shape,
     ) !Placement {
-        const ordered_devices = try sharding.devicesInCanonicalOrder();
-
-        var shards: Shards = try .init(0);
+        const ordered_devices = sharding.devicesInCanonicalOrder();
+        var shards: Shards = .empty;
 
         for (ordered_devices.constSlice()) |d| {
             if (d.coords.len == 0) return error.MissingDeviceCoords;
@@ -1704,7 +1688,7 @@ pub const Placement = struct {
                 .device_coords = d.coords,
                 .shape = undefined, // Calculated below
                 .global_shape = shape,
-                .slices = try .init(0),
+                .slices = .empty,
             });
         }
 
@@ -1771,20 +1755,20 @@ pub const Placement = struct {
         device_coords: []const usize,
         used_axes: *std.EnumSet(PhysicalAxisTag),
     ) !AxisSplit {
-        var plan: AxisSplit = try .init();
+        var plan: AxisSplit = .empty;
 
         for (binding) |p_tag| {
             // Expand the physical tag: check if it's a target for folded source axes
             if (self.sharding.foldSources(p_tag)) |sources| {
                 for (sources) |src| {
                     if (used_axes.contains(src)) continue;
-                    try self.addPhysicalToSplit(&plan, src, device_coords);
+                    self.addPhysicalToSplit(&plan, src, device_coords);
                     used_axes.insert(src);
                 }
             } else {
                 // Standard case: directly bound, not part of an explicit fold
                 if (used_axes.contains(p_tag)) continue;
-                try self.addPhysicalToSplit(&plan, p_tag, device_coords);
+                self.addPhysicalToSplit(&plan, p_tag, device_coords);
                 used_axes.insert(p_tag);
             }
         }
@@ -1797,15 +1781,13 @@ pub const Placement = struct {
     }
 
     /// Extract coordinate data from the physical mesh for a specific axis.
-    fn addPhysicalToSplit(self: *Placement, plan: *AxisSplit, tag: PhysicalAxisTag, device_coords: []const usize) !void {
+    fn addPhysicalToSplit(self: *Placement, plan: *AxisSplit, tag: PhysicalAxisTag, device_coords: []const usize) void {
         const physical = self.sharding.platform.physical_mesh;
         const info = physical.axisInfo(tag) orelse return;
         const depth = physical.axis_traversal.depth(tag) orelse return;
         const coord = device_coords[depth];
 
-        plan.counts.appendAssumeCapacity(@intCast(info.size));
-        plan.indices.appendAssumeCapacity(@intCast(coord));
-        plan.product *= info.size;
+        plan.add(info.size, coord);
     }
 
     pub fn format(self: Placement, writer: *std.Io.Writer) !void {
@@ -1872,17 +1854,15 @@ const ShardingTest = struct {
     /// Creates a 1D-3D PhysicalMesh from simple dimensions.
     pub fn physical(self: ShardingTest, dims: anytype, geometry: AxisGeometry) !PhysicalMesh {
         const info = @typeInfo(@TypeOf(dims)).@"struct";
-        var tags = try stdx.BoundedArray(PhysicalAxisTag, 3).init(0);
-        var sizes = try stdx.BoundedArray(usize, 3).init(0);
-
-        const tag_names = [_]PhysicalAxisTag{ .link_x, .link_y, .link_z };
-        inline for (info.fields, 0..) |field, i| {
-            tags.appendAssumeCapacity(tag_names[i]);
-            sizes.appendAssumeCapacity(@intCast(@field(dims, field.name)));
+        const N = info.fields.len;
+        var sizes: [N]usize = undefined;
+        inline for (info.fields, sizes[0..]) |field, *s| {
+            s.* = @intCast(@field(dims, field.name));
         }
 
+        const tags: [3]PhysicalAxisTag = .{ .link_x, .link_y, .link_z };
         var next_id: usize = 0;
-        const root = try self.buildNode(tags.constSlice(), sizes.constSlice(), 0, &next_id, geometry);
+        const root = try self.buildNode(tags[0..N], sizes[0..N], 0, &next_id, geometry);
         return try .fromTree(self.allocator, .tpu, root);
     }
 
@@ -1905,6 +1885,7 @@ const ShardingTest = struct {
         return .{
             .arena_state = .{},
             .target = mesh.target,
+            .execution_context = undefined,
             .pjrt_api = undefined,
             .pjrt_client = undefined,
             .devices = &.{},
@@ -1952,10 +1933,10 @@ test "sharding: unknown partitioning implies replication" {
     const runner: ShardingTest = .init(arena.allocator());
 
     const physical: PhysicalMesh = try runner.physical(.{ 2, 2 }, .{ .mesh = .torus });
-    const logical: LogicalMesh = try .init("folded_mesh", .{ .batch = .low_bandwidth });
+    const logical: LogicalMesh = .init("folded_mesh", .{ .batch = .low_bandwidth });
 
     var strategy: Strategy = .init;
-    try strategy.addBinding(.batch, .link_x);
+    strategy.addBinding(.batch, .link_x);
 
     const scenario: ShardingTest.Scenario = .{
         .platform = runner.platformForMesh(physical),
@@ -1980,12 +1961,12 @@ test "sharding: suggest strategy realization" {
 
     const physical = try runner.physical(.{ 2, 2, 2 }, .{ .mesh = .torus });
 
-    const logical: LogicalMesh = try .init("suggested_mesh", .{
+    const logical: LogicalMesh = .init("suggested_mesh", .{
         .batch = .low_bandwidth,
         .model = .high_bandwidth,
     });
 
-    const strategy: Strategy = try .suggest(logical, physical);
+    const strategy: Strategy = .suggest(logical, physical);
 
     const scenario: ShardingTest.Scenario = .{
         .platform = runner.platformForMesh(physical),
@@ -2015,12 +1996,12 @@ test "sharding: suggest folds logical axes with same intent" {
 
     const physical = try runner.physical(.{4}, .point_to_point);
 
-    const logical: LogicalMesh = try .init("fold_mesh", .{
+    const logical: LogicalMesh = .init("fold_mesh", .{
         .model = .high_bandwidth,
         .experts = .high_bandwidth,
     });
 
-    const strategy: Strategy = try .suggest(logical, physical);
+    const strategy: Strategy = .suggest(logical, physical);
 
     const scenario: ShardingTest.Scenario = .{
         .platform = runner.platformForMesh(physical),
@@ -2045,11 +2026,11 @@ test "sharding: multiple physical axes on one logical dimension (folding)" {
     const runner: ShardingTest = .init(arena.allocator());
 
     const physical: PhysicalMesh = try runner.physical(.{ 2, 2 }, .{ .mesh = .torus });
-    const logical: LogicalMesh = try .init("folded_mesh", .{ .model = .high_bandwidth });
+    const logical: LogicalMesh = .init("folded_mesh", .{ .model = .high_bandwidth });
 
     var strategy: Strategy = .init;
-    try strategy.addBinding(.model, .link_x);
-    try strategy.addBinding(.model, .link_y);
+    strategy.addBinding(.model, .link_x);
+    strategy.addBinding(.model, .link_y);
 
     const scenario: ShardingTest.Scenario = .{
         .platform = runner.platformForMesh(physical),
@@ -2073,11 +2054,11 @@ test "sharding: explicit strategy folding" {
     const runner: ShardingTest = .init(arena.allocator());
 
     const physical: PhysicalMesh = try runner.physical(.{ 2, 2, 2 }, .{ .mesh = .torus });
-    const logical: LogicalMesh = try .init("strategy_fold", .{ .model = .high_bandwidth });
+    const logical: LogicalMesh = .init("strategy_fold", .{ .model = .high_bandwidth });
 
     var strategy: Strategy = .init;
-    try strategy.addBinding(.model, .link_x);
-    try strategy.addFold(.link_x, &.{ .link_x, .link_z });
+    strategy.addBinding(.model, .link_x);
+    strategy.addFold(.link_x, &.{ .link_x, .link_z });
 
     const scenario: ShardingTest.Scenario = .{
         .platform = runner.platformForMesh(physical),
@@ -2105,11 +2086,11 @@ test "sharding: open and replicated dimension mix" {
     const runner: ShardingTest = .init(arena.allocator());
 
     const physical: PhysicalMesh = try runner.physical(.{ 2, 2 }, .{ .mesh = .torus });
-    const logical: LogicalMesh = try .init("mix_mesh", .{ .batch = .low_bandwidth, .model = .high_bandwidth });
+    const logical: LogicalMesh = .init("mix_mesh", .{ .batch = .low_bandwidth, .model = .high_bandwidth });
 
     var strategy: Strategy = .init;
-    try strategy.addBinding(.batch, .link_x);
-    try strategy.addBinding(.model, .link_y);
+    strategy.addBinding(.batch, .link_x);
+    strategy.addBinding(.model, .link_y);
 
     const scenario: ShardingTest.Scenario = .{
         .platform = runner.platformForMesh(physical),
@@ -2133,12 +2114,12 @@ test "sharding: full 3D cluster sharding" {
     const runner: ShardingTest = .init(arena.allocator());
 
     const physical: PhysicalMesh = try runner.physical(.{ 2, 2, 2 }, .{ .mesh = .torus });
-    const logical: LogicalMesh = try .init("3d_mesh", .{ .batch = .low_bandwidth, .model = .high_bandwidth, .context = .balanced });
+    const logical: LogicalMesh = .init("3d_mesh", .{ .batch = .low_bandwidth, .model = .high_bandwidth, .context = .balanced });
 
     var strategy: Strategy = .init;
-    try strategy.addBinding(.batch, .link_x);
-    try strategy.addBinding(.model, .link_y);
-    try strategy.addBinding(.context, .link_z);
+    strategy.addBinding(.batch, .link_x);
+    strategy.addBinding(.model, .link_y);
+    strategy.addBinding(.context, .link_z);
 
     const scenario: ShardingTest.Scenario = .{
         .platform = runner.platformForMesh(physical),
@@ -2167,14 +2148,14 @@ test "sharding: num partitions for logical axis" {
     const runner: ShardingTest = .init(arena.allocator());
 
     const physical: PhysicalMesh = try runner.physical(.{ 2, 2, 2 }, .{ .mesh = .torus });
-    const logical: LogicalMesh = try .init("axis_parts_mesh", .{
+    const logical: LogicalMesh = .init("axis_parts_mesh", .{
         .model = .high_bandwidth,
         .batch = .low_bandwidth,
     });
 
     var strategy: Strategy = .init;
-    try strategy.addBinding(.model, .link_x);
-    try strategy.addFold(.link_x, &.{ .link_x, .link_z });
+    strategy.addBinding(.model, .link_x);
+    strategy.addFold(.link_x, &.{ .link_x, .link_z });
 
     var platform = runner.platformForMesh(physical);
     const sharding: Sharding = try .initFromStrategy(&platform, logical, strategy);

--- a/zml/sharding.zig
+++ b/zml/sharding.zig
@@ -1479,8 +1479,8 @@ pub const Sharding = struct {
 
 pub fn replicatedSharding(platform: *const Platform) !Sharding {
     const physical_mesh = platform.physical_mesh;
-    const logical_mesh: LogicalMesh = try .init("replicated", .{ .x = .high_bandwidth });
-    const strategy: Strategy = try .suggest(logical_mesh, physical_mesh);
+    const logical_mesh: LogicalMesh = .init("replicated", .{ .x = .high_bandwidth });
+    const strategy: Strategy = .suggest(logical_mesh, physical_mesh);
     return try .initFromStrategy(platform, logical_mesh, strategy);
 }
 
@@ -1885,7 +1885,6 @@ const ShardingTest = struct {
         return .{
             .arena_state = .{},
             .target = mesh.target,
-            .execution_context = undefined,
             .pjrt_api = undefined,
             .pjrt_client = undefined,
             .devices = &.{},

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1143,7 +1143,7 @@ pub const Tensor = struct {
         const lhs_contracting_dim: i8 = @intCast(lhs.shape().hasTag(args).?);
         const rhs_contracting_dim: i8 = @intCast(rhs.shape().hasTag(args).?);
 
-        var batching_axes: stdx.BoundedArray([2]i8, constants.MAX_RANK) = .{};
+        var batching_axes: stdx.BoundedArray([2]i8, constants.MAX_RANK) = .empty;
         for (0..lhs.rank()) |lhs_tag_index| {
             const lhs_tag = lhs.shape().tag(lhs_tag_index);
             if (lhs_tag == Shape.toTag(args)) continue;
@@ -1221,8 +1221,8 @@ pub const Tensor = struct {
 
         var res_shape: Shape = .{ ._dtype = lhs.dtype() };
         // Validate batching axes
-        var lhs_batching_axes: Axes = .{};
-        var rhs_batching_axes: Axes = .{};
+        var lhs_batching_axes: Axes = .empty;
+        var rhs_batching_axes: Axes = .empty;
         for (batching_axes) |b_axes| {
             const l, const r = b_axes;
             stdx.debug.assert(lhs._shape.dim(l) == rhs._shape.dim(r), "dotGeneral expects batching dimensions to be equal, got {} and {} in {f} and {f}", .{ l, r, lhs, rhs });
@@ -1234,8 +1234,8 @@ pub const Tensor = struct {
         }
 
         // Validate contracting axes
-        var lhs_contracting_axes: Axes = .{};
-        var rhs_contracting_axes: Axes = .{};
+        var lhs_contracting_axes: Axes = .empty;
+        var rhs_contracting_axes: Axes = .empty;
         for (contracting_axes) |c_axes| {
             const l, const r = c_axes;
             stdx.debug.assert(lhs._shape.dim(l) == rhs._shape.dim(r), "dotGeneral expects contracting dimensions to be equal, got {} and {} in {f} and {f}", .{ l, r, lhs, rhs });
@@ -1531,7 +1531,7 @@ pub const Tensor = struct {
 
     pub fn swapAxes(self: Tensor, a: anytype, b: anytype) Tensor {
         if (self.axis(a) == self.axis(b)) return self;
-        var perm: Shape.AxesArray = .{};
+        var perm: Shape.AxesArray = .empty;
         for (0..self.rank()) |i| {
             perm.appendAssumeCapacity(@intCast(i));
         }
@@ -1671,7 +1671,7 @@ pub const Tensor = struct {
         ).appendTo(currentBlock());
 
         var res = _result(res_shape, slice_op.result(0));
-        var to_remove: Shape.AxesArray = .{};
+        var to_remove: Shape.AxesArray = .empty;
         for (slices, 0..) |s, a| {
             if (s.singleton) to_remove.appendAssumeCapacity(@intCast(a));
         }
@@ -2188,7 +2188,7 @@ pub const Tensor = struct {
         }
 
         // check that each axis of self maps to an axis of other
-        var axes_: stdx.BoundedArray(i64, constants.MAX_RANK) = .{};
+        var axes_: stdx.BoundedArray(i64, constants.MAX_RANK) = .empty;
         for (self._shape.tags()) |t| {
             axes_.appendAssumeCapacity(@intCast(other.axis(t)));
         }
@@ -2324,7 +2324,7 @@ pub const Tensor = struct {
     /// so that gather can
     pub fn gather(self: Tensor, _indices: anytype, opts: GatherOpts) Tensor {
         const idx_per_axis, const idx_tags = Shape.parseStruct(Tensor, _indices);
-        var idx_axes: Shape.AxesArray = .{};
+        var idx_axes: Shape.AxesArray = .empty;
         for (idx_tags.slice()) |t| {
             idx_axes.appendAssumeCapacity(self.axis(t));
         }
@@ -2439,10 +2439,10 @@ pub const Tensor = struct {
         // Compute result shape
         var res_shape = indices._shape.remove(index_coord_axis).withDtype(self.dtype());
         var slice_dims = self._shape._dims;
-        var self_batch_axes: stdx.BoundedArray(i64, constants.MAX_RANK) = .{};
-        var indices_batch_axes: stdx.BoundedArray(i64, constants.MAX_RANK) = .{};
-        var start_index_map: stdx.BoundedArray(i64, constants.MAX_RANK) = .{};
-        var self_offset_axes: stdx.BoundedArray(i64, constants.MAX_RANK) = .{};
+        var self_batch_axes: stdx.BoundedArray(i64, constants.MAX_RANK) = .empty;
+        var indices_batch_axes: stdx.BoundedArray(i64, constants.MAX_RANK) = .empty;
+        var start_index_map: stdx.BoundedArray(i64, constants.MAX_RANK) = .empty;
+        var self_offset_axes: stdx.BoundedArray(i64, constants.MAX_RANK) = .empty;
         for (self._shape.tags(), 0..self.rank()) |t, self_ax| {
             const maybe_slice_ax: ?u3 = if (tagged_api) slice_shape.hasTag(t) else @intCast(self_ax);
 
@@ -4287,13 +4287,13 @@ fn _parseGatherCoord(self: Tensor, axes_: anytype) struct { bool, stdx.BoundedAr
 }
 
 fn toI64(values: anytype) stdx.BoundedArray(i64, constants.MAX_RANK) {
-    var res: stdx.BoundedArray(i64, constants.MAX_RANK) = .{};
+    var res: stdx.BoundedArray(i64, constants.MAX_RANK) = .empty;
     for (values) |val| res.appendAssumeCapacity(@intCast(val));
     return res;
 }
 
 fn transposeIsJustAReshape(x: Shape, permutation: []const i64) bool {
-    var perm: stdx.BoundedArray(struct { u8, bool }, constants.MAX_RANK) = .{};
+    var perm: stdx.BoundedArray(struct { u8, bool }, constants.MAX_RANK) = .empty;
     // Don't rewrite on invalid inputs.
     if (permutation.len > x.rank()) return false;
     for (permutation) |ax| {

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -525,7 +525,6 @@ pub const Tensor = struct {
             return .{ ._state = .init(.{2}, .u64) };
         }
 
-        // TODO(codex): swap the field around to match fromBytes signature: io, platform, sharding, seed
         pub fn initBuffer(platform: *const Platform, seed: u128, io: std.Io, sharding: Sharding) !Bufferized(Rng) {
             return .{
                 ._state = try .fromBytes(io, platform, Shape.init(.{2}, .u64), sharding, std.mem.asBytes(&seed)),

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -525,6 +525,7 @@ pub const Tensor = struct {
             return .{ ._state = .init(.{2}, .u64) };
         }
 
+        // TODO(codex): swap the field around to match fromBytes signature: io, platform, sharding, seed
         pub fn initBuffer(platform: *const Platform, seed: u128, io: std.Io, sharding: Sharding) !Bufferized(Rng) {
             return .{
                 ._state = try .fromBytes(io, platform, Shape.init(.{2}, .u64), sharding, std.mem.asBytes(&seed)),
@@ -4038,7 +4039,7 @@ pub const Tensor = struct {
     ///
     /// - res[a, b, c, d] == (A[a], B[b], C[c], D[d])
     pub fn cartesianProductStacked(vectors: []const Tensor) Tensor {
-        var out = stdx.BoundedArray(Tensor, constants.MAX_RANK).init(vectors.len) catch unreachable;
+        var out: stdx.BoundedArray(Tensor, constants.MAX_RANK) = .{ .buffer = undefined, .len = vectors.len };
         _cartesianProduct(vectors, out.slice());
 
         return Tensor.stack(out.constSlice(), .last, .coord);

--- a/zml/tokenizer/hftokenizers/hftokenizers.zig
+++ b/zml/tokenizer/hftokenizers/hftokenizers.zig
@@ -40,8 +40,8 @@ pub const Decoder = struct {
 
     inner: *HFTokenizer,
     current_string: ?[]const u8 = null,
-    last_string: StringBuffer = .{ .len = 0 },
-    last_token_ids: TokensIdsBuffer = .{ .len = 0 },
+    last_string: StringBuffer = .empty,
+    last_token_ids: TokensIdsBuffer = .empty,
 
     fn init(inner: *HFTokenizer) Decoder {
         return .{ .inner = inner };

--- a/zml/tokenizer/homemade.zig
+++ b/zml/tokenizer/homemade.zig
@@ -46,7 +46,7 @@ pub const Tokenizer = struct {
         errdefer arena_state.deinit();
         const arena = arena_state.allocator();
 
-        var token_lookup: std.StringHashMapUnmanaged(u32) = .{};
+        var token_lookup: std.StringHashMapUnmanaged(u32) = .empty;
         errdefer token_lookup.deinit(arena);
 
         try token_lookup.ensureTotalCapacity(arena, @intCast(vocab_size));
@@ -442,8 +442,8 @@ pub const Decoder = struct {
     arena: std.heap.ArenaAllocator,
 
     current_string: ?[]const u8 = null,
-    last_string: StringBuffer = .{ .len = 0 },
-    last_token_ids: TokensIdsBuffer = .{ .len = 0 },
+    last_string: StringBuffer = .empty,
+    last_token_ids: TokensIdsBuffer = .empty,
 
     fn init(inner: *Tokenizer) !Decoder {
         var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
@@ -566,7 +566,7 @@ test CharTokenIterator {
     {
         tokenizer.byte_fallback = false;
         var it: CharTokenIterator = .{ .input = "ζℳL" };
-        var res: stdx.BoundedArray(u32, 8) = .{};
+        var res: stdx.BoundedArray(u32, 8) = .empty;
         while (try it.nextCodepointToken(&tokenizer)) |token| {
             res.appendAssumeCapacity(token);
         }
@@ -577,7 +577,7 @@ test CharTokenIterator {
     {
         tokenizer.byte_fallback = true;
         var it: CharTokenIterator = .{ .input = "ζℳL" };
-        var res: stdx.BoundedArray(u32, 8) = .{};
+        var res: stdx.BoundedArray(u32, 8) = .empty;
         while (try it.nextCodepointToken(&tokenizer)) |token| {
             res.appendAssumeCapacity(token);
         }
@@ -591,7 +591,7 @@ pub const Normalizer = struct {
     /// Space token used by sentencepiece derived tokenizer.
     pub const sentencepiece_space = "▁"; // \xe2\x96\x81
 
-    _whitespace: stdx.BoundedArray(u8, 8) = .{},
+    _whitespace: stdx.BoundedArray(u8, 8) = .empty,
 
     flags: packed struct {
         remove_extra_whitespaces: bool,

--- a/zml/tokenizer/sentencepiece/sentencepiece.zig
+++ b/zml/tokenizer/sentencepiece/sentencepiece.zig
@@ -89,7 +89,7 @@ pub const Decoder = struct {
     inner: *SentencePieceProcessor,
     vec: *c.std_vector_int,
     str: *c.std_string,
-    last_string: StringBuffer = .{ .len = 0 },
+    last_string: StringBuffer = .empty,
 
     fn init(inner: *SentencePieceProcessor) !Decoder {
         const vec = try (c.std_vector_int_new() orelse std.mem.Allocator.Error.OutOfMemory);


### PR DESCRIPTION
When looking at the new Sharding code I was triggered by the high number of "try".

I then realized most of the try where traced back to `axes = try .init(0)` which can never fail.
So I removed BoundedArray.init (aka Andrew mode)

It's generally unsafe because it makes `slice()` return undefined.;
I replaced`try init(0)` by `.empty`
I replaced `try init(n)` by `.fromSlice` or with `.{ .buffer = undefined, .len = n }` to explicitly show the unsafeness

This leads to widespread changes because it means that most of the sharding operations can't fail anymore.