### PR TITLE
platforms/rocm: update amdgpuids URL and bump llvm version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -36,7 +36,7 @@ git_override(
 )
 
 bazel_dep(name = "tar.bzl", version = "0.9.0")
-bazel_dep(name = "llvm", version = "0.7.1")
+bazel_dep(name = "llvm", version = "0.7.3")
 bazel_dep(name = "jsoncpp", version = "1.9.6", repo_name = "jsoncpp_git")
 bazel_dep(name = "with_cfg.bzl", version = "0.14.4")
 bazel_dep(name = "grpc", version = "1.74.0")

--- a/platforms/rocm/rocm.bzl
+++ b/platforms/rocm/rocm.bzl
@@ -246,7 +246,7 @@ def _rocm_impl(mctx):
 
     http_file(
         name = "libdrm_mesa_amdgpu_ids",
-        url = "https://cgit.freedesktop.org/mesa/drm/plain/data/amdgpu.ids?id=b9dea73dfa310bc945ae6f09004a08fd624952ec",
+        url = "https://gitlab.freedesktop.org/mesa/libdrm/-/raw/979f607906ad64f629967ac1f3ba3590e756442c/data/amdgpu.ids?inline=false",
         sha256 = "ffd2a8f1bfa755f4d90f537b4969fc4676f116e5af051ce2f18ef93a96d8beb6",
         downloaded_file_path = "amdgpu.ids",
     )


### PR DESCRIPTION
This PR fixes two issues:

- Update `amdgpu.ids` URL to Gitlab, now that the old link is dead
- Bump LLVM version to `0.7.3`