### PR TITLE
zml/ops: Merge the two customCall and add compute_on_host

### DIFF
--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -15,7 +15,9 @@ const meta = @import("meta.zig");
 const mlirx = @import("mlirx.zig");
 const Platform = @import("platform.zig").Platform;
 const Shape = @import("shape.zig").Shape;
+pub const ShapeToCustomCallBuffer = @import("pjrtx.zig").ShapeToCustomCallBuffer;
 const Tensor = @import("tensor.zig").Tensor;
+pub const TensorToCustomCallBuffer = @import("pjrtx.zig").TensorToCustomCallBuffer;
 
 pub const ReduceArgs = struct {
     left: Tensor,
@@ -1052,7 +1054,20 @@ fn CustomCallResultTypeFromOutputSpec(comptime OutputSpecT: type) type {
 pub const CustomCallOptions = struct {
     has_side_effect: bool,
     output_operand_aliases: ?[]const dialects.stablehlo.CustomCallOpts.OutputOperandAlias = null,
+    compute_on_host: bool = false,
 };
+
+fn customCallAdditionalAttributes(ctx: *CompilationContext, opts: CustomCallOptions) []const mlir.NamedAttribute {
+    if (!opts.compute_on_host or ctx.platform.target == .cpu) return &.{};
+
+    const frontend_attributes = mlir.dictionaryAttribute(ctx.mlir_ctx, &.{
+        .named(ctx.mlir_ctx, "_xla_compute_type", mlir.stringAttribute(ctx.mlir_ctx, "host")),
+    });
+
+    const additional_attributes = ctx.arena.allocator().alloc(mlir.NamedAttribute, 1) catch unreachable;
+    additional_attributes[0] = .named(ctx.mlir_ctx, "mhlo.frontend_attributes", frontend_attributes);
+    return additional_attributes;
+}
 
 fn customCallOutputOperandAliases(
     comptime I: type,
@@ -1133,7 +1148,13 @@ pub fn customCall(target_name: [:0]const u8, inputs: anytype, outputs: anytype, 
         else => @compileError("Unsupported type: " ++ @typeName(@TypeOf(outputs))),
     };
 
-    const outputs_flat = customCallInternal(target_name, inputs_, output_shapes, metadata, opts);
+    const outputs_flat = typedCustomCall(
+        target_name,
+        opts,
+        inputs_,
+        output_shapes,
+        metadata,
+    );
     if (comptime CustomCallResultTypeFromOutputSpec(@TypeOf(outputs)) == void) {
         stdx.debug.assert(outputs_flat.len == 0, "customCall expected zero outputs for void return, got {}", .{outputs_flat.len});
         return;
@@ -1530,6 +1551,10 @@ fn metadataFieldToMlirAttribute(mlir_ctx: *mlir.Context, comptime T: type, value
     const type_info = @typeInfo(T);
     return switch (type_info) {
         .comptime_int => mlir.integerAttribute(mlir_ctx, .u64, @as(u64, value)),
+        .@"enum" => |enum_field| switch (@typeInfo(enum_field.tag_type)) {
+            .int => |int_tag| metadataIntegerFieldToMlirAttribute(mlir_ctx, int_tag, @intFromEnum(value)),
+            else => @compileError("Unsupported tag type for enum metadata: " ++ @typeName(enum_field.tag_type)),
+        },
         .int => |int_field| metadataIntegerFieldToMlirAttribute(mlir_ctx, int_field, value),
         .float => |float_field| metadataFloatFieldToMlirAttribute(mlir_ctx, float_field, value),
         .bool => mlir.boolAttribute(mlir_ctx, value),
@@ -1548,77 +1573,6 @@ fn metadataFieldToMlirAttribute(mlir_ctx: *mlir.Context, comptime T: type, value
         } else null,
         else => @compileError("Unsupported metadata type: " ++ @typeName(T)),
     };
-}
-
-fn customCallInternal(target_name: [:0]const u8, inputs: []const Tensor, outputs: []const Shape, metadata: anytype, opts: CustomCallOptions) []Tensor {
-    const ctx = CompilationContext.current();
-    const allocator = ctx.arena.allocator();
-
-    stdx.debug.assert(!opts.has_side_effect or ctx.manual_computation_depth > 0, "side-effect customCall '{s}' must be emitted inside manualComputation", .{target_name});
-
-    const values = allocator.alloc(*const mlir.Value, inputs.len) catch unreachable;
-    const input_shapes = allocator.alloc(Shape, inputs.len) catch unreachable;
-    for (inputs, 0..) |input, i| {
-        values[i] = input.value();
-        input_shapes[i] = input.shape();
-    }
-
-    const result_types = allocator.alloc(*const mlir.Type, outputs.len) catch unreachable;
-    for (outputs, 0..) |shape, i| {
-        result_types[i] = mlir.rankedTensorType(shape.dims(), mlirx.Type.fromDType(ctx.mlir_ctx, shape.dtype()));
-    }
-
-    const metadata_type_info = @typeInfo(@TypeOf(metadata));
-    var metadata_attribute_list = std.ArrayList(mlir.NamedAttribute).initCapacity(allocator, metadata_type_info.@"struct".fields.len + 2) catch unreachable;
-    inline for (metadata_type_info.@"struct".fields) |field| {
-        if (metadataFieldToMlirAttribute(ctx.mlir_ctx, field.type, @field(metadata, field.name))) |attribute| {
-            metadata_attribute_list.appendAssumeCapacity(mlir.NamedAttribute.named(ctx.mlir_ctx, field.name, attribute));
-        }
-    }
-
-    metadata_attribute_list.appendSliceAssumeCapacity(&[_]mlir.NamedAttribute{
-        .named(ctx.mlir_ctx, "pjrt_api", mlir.integerAttribute(ctx.mlir_ctx, .u64, @as(u64, @bitCast(@intFromPtr(ctx.platform.pjrt_api))))),
-        .named(ctx.mlir_ctx, "pjrt_client", mlir.integerAttribute(ctx.mlir_ctx, .u64, @as(u64, @bitCast(@intFromPtr(ctx.platform.pjrt_client))))),
-    });
-
-    const backend_config = mlir.dictionaryAttribute(ctx.mlir_ctx, metadata_attribute_list.items);
-
-    const operand_layouts = allocator.alloc([]const usize, input_shapes.len) catch unreachable;
-    for (input_shapes, 0..) |shape, i| {
-        operand_layouts[i] = allocator.dupe(usize, toUsize(constants.minorToMajor(shape.rank())).constSlice()) catch unreachable;
-    }
-
-    const result_layouts = allocator.alloc([]const usize, outputs.len) catch unreachable;
-    for (outputs, 0..) |shape, i| {
-        result_layouts[i] = allocator.dupe(usize, toUsize(constants.minorToMajor(shape.rank())).constSlice()) catch unreachable;
-    }
-
-    const op = dialects.stablehlo.custom_call(
-        ctx.mlir_ctx,
-        values,
-        result_types,
-        .{
-            .call_target_name = target_name,
-            .backend_config = .{ .typed_ffi = backend_config },
-            .has_side_effect = opts.has_side_effect,
-            .operand_layouts = operand_layouts,
-            .result_layouts = result_layouts,
-            .output_operand_aliases = opts.output_operand_aliases orelse &.{},
-            .additional_attributes = &.{},
-        },
-        .unknown(ctx.mlir_ctx),
-    ).appendTo(ctx.currentScope().block);
-
-    if (ctx.manual_computation_depth > 0 and ctx.partitioning.partitioner == .gspmd) {
-        op.setAttributeByName("mhlo.sharding", mlir.stringAttribute(ctx.mlir_ctx, "{manual}"));
-    }
-
-    const outputs_ = allocator.alloc(Tensor, outputs.len) catch unreachable;
-    for (outputs, 0..) |output_shape, i| {
-        outputs_[i] = Tensor._result(output_shape, op.result(i));
-    }
-
-    return outputs_;
 }
 
 pub fn CustomCall(
@@ -1643,6 +1597,9 @@ pub fn CustomCall(
         /// Similar to reuseBuffer on tensors, tells XLA that the custom call re-uses an input buffer for its output.
         /// Use the input/output field names to express the mapping: `{ .<out field> = .<in field> }`
         output_operand_aliases: ?CustomCallOutputOperandAliases(I, O) = null,
+        /// Request XLA host-compute offload for this custom call on accelerator backends.
+        /// Input/Output buffers will automatically be moved d2h/h2d without the need for an explicit `.toMemory(...)`.
+        compute_on_host: bool = false,
     },
 ) type {
     return struct {
@@ -1654,7 +1611,7 @@ pub fn CustomCall(
         pub fn register(platform: *const Platform) !void {
             try platform.registerFfi(.{
                 .name = params.name,
-                .platform_name = null,
+                .platform_name = if (params.compute_on_host) "Host" else null,
                 .handler = @This().handler,
                 .traits = .{
                     .command_buffer_compatible = true,
@@ -1663,32 +1620,26 @@ pub fn CustomCall(
         }
 
         pub fn call(input_tensors: I, output_shapes: O, attributes: A) ShapeToTensor(O) {
-            const args: CustomCallArgs(I, O, A) = .{
-                .input_tensors = input_tensors,
-                .output_shapes = output_shapes,
-                .attributes = attributes,
-            };
             const opts: CustomCallOptions = .{
                 .has_side_effect = params.has_side_effect,
                 .output_operand_aliases = comptime customCallOutputOperandAliases(I, O, params.output_operand_aliases),
+                .compute_on_host = params.compute_on_host,
             };
             if (params.sharding_aware) {
                 return shardingAwareTypedCustomCall(
-                    I,
-                    O,
-                    A,
                     params.name,
                     opts,
-                    args,
+                    input_tensors,
+                    output_shapes,
+                    attributes,
                 );
             } else {
                 return typedCustomCall(
-                    I,
-                    O,
-                    A,
                     params.name,
                     opts,
-                    args,
+                    input_tensors,
+                    output_shapes,
+                    attributes,
                 );
             }
         }
@@ -1703,171 +1654,137 @@ pub fn CustomCall(
     };
 }
 
-fn CustomCallArgs(I: type, O: type, A: type) type {
-    return struct {
-        input_tensors: I,
-        output_shapes: O,
-        attributes: A,
-    };
-}
-
-pub fn TensorToCustomCallBuffer(T: type) type {
-    return meta.MapRestrict(Tensor, CustomCallBuffer).map(T);
-}
-
-pub fn ShapeToCustomCallBuffer(T: type) type {
-    return meta.MapRestrict(Shape, CustomCallBuffer).map(T);
-}
-
 pub fn ShapeToTensor(T: type) type {
     return meta.MapRestrict(Shape, Tensor).map(T);
 }
 
 pub fn CustomCallOutputOperandAliases(I: type, O: type) type {
-    return meta.MapRestrict(Shape, ?std.meta.FieldEnum(I)).map(O);
+    const output_fields = @typeInfo(O).@"struct".fields;
+    var field_names: [output_fields.len][]const u8 = undefined;
+    inline for (output_fields, 0..) |field, i| {
+        field_names[i] = field.name;
+    }
+    return @Struct(
+        .auto,
+        null,
+        &field_names,
+        &@splat(?std.meta.FieldEnum(I)),
+        &@splat(.{ .default_value_ptr = &@as(?std.meta.FieldEnum(I), null) }),
+    );
 }
 
 pub fn shardingAwareTypedCustomCall(
-    I: type,
-    O: type,
-    A: type,
     comptime target_name: [:0]const u8,
     comptime opts: CustomCallOptions,
-    args: CustomCallArgs(I, O, A),
-) ShapeToTensor(O) {
+    input: anytype,
+    output: anytype,
+    attributes: anytype,
+) ShapeToTensor(@TypeOf(output)) {
+    const Input = @TypeOf(input);
+    const Output = @TypeOf(output);
+    const Attributes = @TypeOf(attributes);
+
     // Convert to slices so that manualComputationInternal can inspect the input/output.
-    var input_tensors: [@typeInfo(@TypeOf(args.input_tensors)).@"struct".fields.len]Tensor = undefined;
-    inline for (@typeInfo(@TypeOf(args.input_tensors)).@"struct".fields, 0..) |field, i| {
-        input_tensors[i] = @field(args.input_tensors, field.name);
+    var input_tensors: [@typeInfo(Input).@"struct".fields.len]Tensor = undefined;
+    inline for (@typeInfo(Input).@"struct".fields, 0..) |field, i| {
+        input_tensors[i] = @field(input, field.name);
     }
 
-    var output_shapes: [@typeInfo(@TypeOf(args.output_shapes)).@"struct".fields.len]Shape = undefined;
-    inline for (@typeInfo(@TypeOf(args.output_shapes)).@"struct".fields, 0..) |field, i| {
-        output_shapes[i] = @field(args.output_shapes, field.name);
+    var output_shapes: [@typeInfo(Output).@"struct".fields.len]Shape = undefined;
+    inline for (@typeInfo(Output).@"struct".fields, 0..) |field, i| {
+        output_shapes[i] = @field(output, field.name);
     }
 
-    const output_tensors = manualComputationInternal(&input_tensors, &output_shapes, args.attributes, (struct {
-        fn body(attributes: A, _: std.mem.Allocator, sharded_input_tensors: []const Tensor, sharded_output_shapes: []const Shape) []const Tensor {
+    const output_tensors = manualComputationInternal(&input_tensors, &output_shapes, attributes, (struct {
+        fn body(attributes_: Attributes, _: std.mem.Allocator, sharded_input_tensors: []const Tensor, sharded_output_shapes: []const Shape) []const Tensor {
             return typedCustomCall(
-                []const Tensor,
-                []const Shape,
-                A,
                 target_name,
                 opts,
-                .{
-                    .input_tensors = sharded_input_tensors,
-                    .output_shapes = sharded_output_shapes,
-                    .attributes = attributes,
-                },
+                sharded_input_tensors,
+                sharded_output_shapes,
+                attributes_,
             );
         }
     }).body);
 
     // Convert the slice back to a struct
-    var out: ShapeToTensor(O) = undefined;
-    inline for (@typeInfo(@TypeOf(args.output_shapes)).@"struct".fields, 0..) |field, i| {
+    var out: ShapeToTensor(Output) = undefined;
+    inline for (@typeInfo(Output).@"struct".fields, 0..) |field, i| {
         @field(out, field.name) = output_tensors[i];
     }
     return out;
 }
 
 pub fn typedCustomCall(
-    I: type,
-    O: type,
-    A: type,
-    comptime target_name: [:0]const u8,
-    comptime opts: CustomCallOptions,
-    args: CustomCallArgs(I, O, A),
-) ShapeToTensor(O) {
+    target_name: [:0]const u8,
+    opts: CustomCallOptions,
+    input: anytype,
+    output: anytype,
+    attributes: anytype,
+) ShapeToTensor(@TypeOf(output)) {
+    const Input = @TypeOf(input);
+    const Output = @TypeOf(output);
+    const Attributes = @TypeOf(attributes);
+
     const ctx = CompilationContext.current();
     const allocator = ctx.arena.allocator();
 
     stdx.debug.assert(!opts.has_side_effect or ctx.manual_computation_depth > 0, "side-effect customCall '{s}' must be emitted inside manualComputation", .{target_name});
 
-    const input_tensors: []const Tensor = switch (@typeInfo(@TypeOf(args.input_tensors))) {
+    const input_tensors: []const Tensor = switch (@typeInfo(Input)) {
         .@"struct" => |struct_info| b: {
             var input_tensors: [struct_info.fields.len]Tensor = undefined;
             inline for (struct_info.fields, 0..) |field, i| {
-                input_tensors[i] = @field(args.input_tensors, field.name);
+                input_tensors[i] = @field(input, field.name);
             }
             break :b &input_tensors;
         },
         // Extra case to support []const Tensor from shardingAwareTypedCustomCall
         .pointer => |pointer_info| b: {
             if (pointer_info.size != .slice) @compileError("Expected input slice");
-            break :b args.input_tensors;
+            break :b input;
         },
-        else => @compileError("Unsupported input type: " ++ @typeName(@TypeOf(args.input_tensor))),
+        else => @compileError("Unsupported input type: " ++ @typeName(Input)),
     };
 
-    const output_shapes: []const Shape = switch (@typeInfo(@TypeOf(args.output_shapes))) {
+    const output_shapes: []const Shape = switch (@typeInfo(Output)) {
         .@"struct" => |struct_info| b: {
             var output_shapes: [struct_info.fields.len]Shape = undefined;
             inline for (struct_info.fields, 0..) |field, i| {
-                output_shapes[i] = @field(args.output_shapes, field.name);
+                output_shapes[i] = @field(output, field.name);
             }
             break :b &output_shapes;
         },
         // Extra case to support []const Shape from shardingAwareTypedCustomCall
         .pointer => |pointer_info| b: {
             if (pointer_info.size != .slice) @compileError("Expected input slice");
-            break :b args.output_shapes;
+            break :b output;
         },
-        else => @compileError("Unsupported input type: " ++ @typeName(@TypeOf(args.input_tensor))),
+        else => @compileError("Unsupported output type: " ++ @typeName(Output)),
     };
 
-    const metadata_attributes =
-        switch (@typeInfo(@TypeOf(args.attributes))) {
-            .@"struct" => |struct_info| b: {
-                var mlir_attributes_array: [struct_info.fields.len]mlir.NamedAttribute = undefined;
-                inline for (struct_info.fields, 0..) |field, i| {
-                    const attribute: *const mlir.Attribute = switch (@typeInfo(field.type)) {
-                        .comptime_int => mlir.integerAttribute(ctx.mlir_ctx, .u64, @as(u64, @field(args.attributes, field.name))),
-                        .int => |int_field| switch (int_field.signedness) {
-                            .signed => switch (int_field.bits) {
-                                8 => mlir.integerAttribute(ctx.mlir_ctx, .i8, @field(args.attributes, field.name)),
-                                16 => mlir.integerAttribute(ctx.mlir_ctx, .i16, @field(args.attributes, field.name)),
-                                32 => mlir.integerAttribute(ctx.mlir_ctx, .i32, @field(args.attributes, field.name)),
-                                64 => mlir.integerAttribute(ctx.mlir_ctx, .i64, @field(args.attributes, field.name)),
-                                else => @panic("Unsupported DataType"),
-                            },
-                            .unsigned => switch (int_field.bits) {
-                                8 => mlir.integerAttribute(ctx.mlir_ctx, .u8, @field(args.attributes, field.name)),
-                                16 => mlir.integerAttribute(ctx.mlir_ctx, .u16, @field(args.attributes, field.name)),
-                                32 => mlir.integerAttribute(ctx.mlir_ctx, .u32, @field(args.attributes, field.name)),
-                                64 => mlir.integerAttribute(ctx.mlir_ctx, .u64, @field(args.attributes, field.name)),
-                                else => @panic("Unsupported DataType"),
-                            },
-                        },
-                        .float => |float_field| switch (float_field.bits) {
-                            16 => mlir.floatAttribute(ctx.mlir_ctx, .f16, @as(f64, @field(args.attributes, field.name))),
-                            32 => mlir.floatAttribute(ctx.mlir_ctx, .f32, @as(f64, @field(args.attributes, field.name))),
-                            64 => mlir.floatAttribute(ctx.mlir_ctx, .f64, @as(f64, @field(args.attributes, field.name))),
-                            else => @panic("Unsupported DataType"),
-                        },
-                        .bool => mlir.boolAttribute(ctx.mlir_ctx, @field(args.attributes, field.name)),
-                        .pointer => |pointer_info| switch (pointer_info.size) {
-                            .slice => if (pointer_info.child == u8)
-                                mlir.stringAttribute(ctx.mlir_ctx, @field(args.attributes, field.name))
-                            else
-                                @panic("Unsupported pointer type in metadata"),
-                            else => @panic("Unsupported pointer type in metadata"),
-                        },
-                        else => @compileError("Unsupported metadata type: " ++ @typeName(field.type)),
-                    };
-                    mlir_attributes_array[i] = mlir.NamedAttribute.named(ctx.mlir_ctx, field.name, attribute);
-                }
-
-                break :b mlir_attributes_array;
-            },
-            else => @compileError("Unsupported type: " ++ @typeName(@TypeOf(args.attributes))),
-        };
+    var metadata_attribute_list = switch (@typeInfo(Attributes)) {
+        .void => std.ArrayList(mlir.NamedAttribute).initCapacity(allocator, 2) catch unreachable,
+        .@"struct" => |struct_info| std.ArrayList(mlir.NamedAttribute).initCapacity(allocator, struct_info.fields.len + 2) catch unreachable,
+        else => @compileError("Unsupported type: " ++ @typeName(Attributes)),
+    };
+    if (@typeInfo(Attributes) == .@"struct") {
+        inline for (@typeInfo(Attributes).@"struct".fields) |field| {
+            if (metadataFieldToMlirAttribute(ctx.mlir_ctx, field.type, @field(attributes, field.name))) |attribute| {
+                metadata_attribute_list.appendAssumeCapacity(mlir.NamedAttribute.named(ctx.mlir_ctx, field.name, attribute));
+            }
+        }
+    }
+    metadata_attribute_list.appendSliceAssumeCapacity(&[_]mlir.NamedAttribute{
+        .named(ctx.mlir_ctx, "pjrt_api", mlir.integerAttribute(ctx.mlir_ctx, .u64, @as(u64, @bitCast(@intFromPtr(ctx.platform.pjrt_api))))),
+        .named(ctx.mlir_ctx, "pjrt_client", mlir.integerAttribute(ctx.mlir_ctx, .u64, @as(u64, @bitCast(@intFromPtr(ctx.platform.pjrt_client))))),
+    });
 
     const values = allocator.alloc(*const mlir.Value, input_tensors.len) catch unreachable;
     const input_shapes = allocator.alloc(Shape, input_tensors.len) catch unreachable;
-    for (input_tensors, 0..) |input, i| {
-        values[i] = input.value();
-        input_shapes[i] = input.shape();
+    for (input_tensors, 0..) |input_tensor, i| {
+        values[i] = input_tensor.value();
+        input_shapes[i] = input_tensor.shape();
     }
 
     const result_types = allocator.alloc(*const mlir.Type, output_shapes.len) catch unreachable;
@@ -1875,10 +1792,7 @@ pub fn typedCustomCall(
         result_types[i] = mlir.rankedTensorType(shape.dims(), mlirx.Type.fromDType(ctx.mlir_ctx, shape.dtype()));
     }
 
-    const backend_config = mlir.dictionaryAttribute(ctx.mlir_ctx, &(metadata_attributes ++ [_]mlir.NamedAttribute{
-        .named(ctx.mlir_ctx, "pjrt_api", mlir.integerAttribute(ctx.mlir_ctx, .u64, @as(u64, @bitCast(@intFromPtr(ctx.platform.pjrt_api))))),
-        .named(ctx.mlir_ctx, "pjrt_client", mlir.integerAttribute(ctx.mlir_ctx, .u64, @as(u64, @bitCast(@intFromPtr(ctx.platform.pjrt_client))))),
-    }));
+    const backend_config = mlir.dictionaryAttribute(ctx.mlir_ctx, metadata_attribute_list.items);
 
     const operand_layouts = allocator.alloc([]const usize, input_shapes.len) catch unreachable;
     for (input_shapes, 0..) |shape, i| {
@@ -1901,7 +1815,7 @@ pub fn typedCustomCall(
             .operand_layouts = operand_layouts,
             .result_layouts = result_layouts,
             .output_operand_aliases = opts.output_operand_aliases orelse &.{},
-            .additional_attributes = &.{},
+            .additional_attributes = customCallAdditionalAttributes(ctx, opts),
         },
         .unknown(ctx.mlir_ctx),
     ).appendTo(ctx.currentScope().block);
@@ -1910,9 +1824,9 @@ pub fn typedCustomCall(
         op.setAttributeByName("mhlo.sharding", mlir.stringAttribute(ctx.mlir_ctx, "{manual}"));
     }
 
-    switch (@typeInfo(@TypeOf(args.output_shapes))) {
+    switch (@typeInfo(Output)) {
         .@"struct" => |struct_info| {
-            var out: ShapeToTensor(O) = undefined;
+            var out: ShapeToTensor(Output) = undefined;
             inline for (output_shapes, struct_info.fields, 0..) |output_shape, field, i| {
                 @field(out, field.name) = Tensor._result(output_shape, op.result(i));
             }
@@ -1921,13 +1835,13 @@ pub fn typedCustomCall(
         // Extra case to support []const Shape from shardingAwareTypedCustomCall
         .pointer => |pointer_info| {
             if (pointer_info.size != .slice) @compileError("Expected input slice");
-            var out: []Tensor = allocator.alloc(Tensor, args.output_shapes.len) catch unreachable;
+            var out: []Tensor = allocator.alloc(Tensor, output_shapes.len) catch unreachable;
             for (output_shapes, 0..) |output_shape, i| {
                 out[i] = Tensor._result(output_shape, op.result(i));
             }
             return out;
         },
-        else => @compileError("Unsupported input type: " ++ @typeName(@TypeOf(args.input_tensor))),
+        else => @compileError("Unsupported output type: " ++ @typeName(Output)),
     }
 }
 
@@ -1948,12 +1862,20 @@ fn customCallArgsFromPjrtCallFrame(I: type, O: type, A: type, call_frame: *pjrt.
         @field(output, field.name) = .fromPjrt(shape_buf);
     }
 
-    var attributes: A = undefined;
-    inline for (@typeInfo(A).@"struct".fields) |field| {
-        const attribute = call_frame.attrs.getByName(.scalar, field.name) orelse
-            @panic("Attribute not found: " ++ field.name);
-        @field(attributes, field.name) = attribute.get(field.type);
-    }
+    const attributes: A = switch (@typeInfo(A)) {
+        .void => {},
+        .@"struct" => blk: {
+            var attrs: A = undefined;
+            inline for (@typeInfo(A).@"struct".fields) |field| {
+                // TODO: Use getByIndex instead?
+                const attribute = call_frame.attrs.getByName(.scalar, field.name) orelse
+                    @panic("Attribute not found: " ++ field.name);
+                @field(attrs, field.name) = attribute.get(field.type);
+            }
+            break :blk attrs;
+        },
+        else => @compileError("Unsupported attributes type: " ++ @typeName(A)),
+    };
 
     return .{ input, output, attributes };
 }

--- a/zml/pjrtx.zig
+++ b/zml/pjrtx.zig
@@ -5,7 +5,9 @@ const mlir = @import("mlir");
 const pjrt = @import("pjrt");
 
 pub const DataType = @import("dtype.zig").DataType;
+const meta = @import("meta.zig");
 const Shape = @import("shape.zig").Shape;
+const Tensor = @import("tensor.zig").Tensor;
 
 const log = std.log.scoped(.@"zml/pjrtx");
 
@@ -43,6 +45,14 @@ pub const Client = opaque {
     }
 };
 
+pub fn TensorToCustomCallBuffer(T: type) type {
+    return meta.MapRestrict(Tensor, CustomCallBuffer).map(T);
+}
+
+pub fn ShapeToCustomCallBuffer(T: type) type {
+    return meta.MapRestrict(Shape, CustomCallBuffer).map(T);
+}
+
 pub const CustomCallBuffer = struct {
     shape: Shape,
     ptr: *anyopaque,
@@ -64,6 +74,24 @@ pub const CustomCallBuffer = struct {
             .ptr = buffer.data,
             .shape = .init(buffer.dims(), dt),
         };
+    }
+
+    // Assumes as host-side buffer
+    pub fn asHostSlice(self: CustomCallBuffer) []u8 {
+        const bytes: [*]u8 = @ptrCast(@alignCast(self.ptr));
+        return bytes[0..self.shape.byteSize()];
+    }
+
+    // Assumes as host-side buffer
+    pub fn asHostConstSlice(self: CustomCallBuffer) []const u8 {
+        const bytes: [*]const u8 = @ptrCast(@alignCast(self.ptr));
+        return bytes[0..self.shape.byteSize()];
+    }
+
+    // Assumes as host-side buffer
+    pub fn asHostScalar(self: CustomCallBuffer, T: type) T {
+        std.debug.assert(self.shape.byteSize() == @sizeOf(T));
+        return std.mem.bytesAsValue(T, self.asHostConstSlice()[0..@sizeOf(T)]).*;
     }
 };
 

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -182,7 +182,7 @@ pub const Tensor = struct {
         return _result(partitioned_shape, op_result);
     }
 
-    pub fn toMemory(self: Tensor, kind: Memory) Tensor {
+    pub fn toMemory(self: Tensor, kind: Memory.Kind) Tensor {
         const ctx = CompilationContext.current();
         if (ctx.platform.target == .cpu) return self;
 


### PR DESCRIPTION
Add `compute_on_host` to force host offloading and merging the `customCallInternal` and `typeCustomCall` function into one to avoid duplication. I've slightly simplified the signature of some of the functions I wrote initially to avoid passing the types explicitly.