### PR TITLE
flash-attention: support for text <> {video/audio} cross attention on H100

### DIFF
--- a/examples/ltx/model.zig
+++ b/examples/ltx/model.zig
@@ -408,7 +408,6 @@ pub const AttentionKind = enum {
 pub const Attention = struct {
     pub const ForwardOpts = struct {
         context: ?Tensor = null,
-        mask: ?Tensor = null,
         pe_cos: ?Tensor = null,
         pe_sin: ?Tensor = null,
         k_pe_cos: ?Tensor = null,
@@ -607,22 +606,21 @@ pub const Attention = struct {
         kh = kh.withPartialTags(.{ .b, .k, .h, .hd });
         vh = vh.withPartialTags(.{ .b, .k, .h, .hd });
 
-        const sdpa_opts: zml.nn.SdpaOpts = .{ .attn_mask = if (opts.mask) |m| m.rename(.{ .b = .batch }) else null };
-        var attn = if (bf16_native and opts.attn_meta != null and opts.attn_params != null and opts.mask == null)
+        var attn = if (bf16_native and opts.attn_meta != null and opts.attn_params != null)
             attention.fullSequenceAttention(qh, kh, vh, opts.attn_meta.?, opts.attn_params.?)
         else if (bf16_native)
             sdpaNoF32Upcast(
                 qh.rename(.{ .b = .batch }),
                 kh.rename(.{ .b = .batch }),
                 vh.rename(.{ .b = .batch }),
-                sdpa_opts,
+                .{},
             ).rename(.{ .batch = .b })
         else
             zml.nn.sdpa(
                 qh.rename(.{ .b = .batch }),
                 kh.rename(.{ .b = .batch }),
                 vh.rename(.{ .b = .batch }),
-                sdpa_opts,
+                .{},
             ).rename(.{ .batch = .b }); // [B, Q, H, HD]
 
         // Compute per-head gates as 2 * sigmoid(logits) so zero-initialized logits preserve identity.

--- a/examples/ltx/model.zig
+++ b/examples/ltx/model.zig
@@ -882,8 +882,6 @@ pub const BasicAVTransformerBlock = struct {
         /// Text cross-attention contexts.
         v_text_ctx: Tensor,
         a_text_ctx: Tensor,
-        v_text_ctx_mask: ?Tensor = null,
-        a_text_ctx_mask: ?Tensor = null,
         /// AV cross-attention scale-shift timestep embeddings.
         v_cross_ss_ts: Tensor, // video.cross_scale_shift_timestep  [B, 1, 4 * D_video]
         v_cross_gate_ts: Tensor, // video.cross_gate_timestep          [B, 1, D_video]
@@ -965,10 +963,10 @@ pub const BasicAVTransformerBlock = struct {
             .add(v_shift_kv.broad(inputs.v_text_ctx.shape()));
         const v_text_ca_out = if (bf16_attn) self.attn2.forwardBf16(v_text_x, params.attn2, kindNumHeads(.attn2), .{
             .context = v_text_ctx_mod,
-            .mask = inputs.v_text_ctx_mask,
+            .attn_meta = inputs.video_attn_meta,
+            .attn_params = inputs.attn_params,
         }) else self.attn2.forward(v_text_x, params.attn2, kindNumHeads(.attn2), .{
             .context = v_text_ctx_mod,
-            .mask = inputs.v_text_ctx_mask,
         });
         const video_text_ca_delta = v_text_ca_out.mul(v_gate_q.broad(v_text_ca_out.shape()));
         if (video_all_residuals_f32) {
@@ -1019,10 +1017,10 @@ pub const BasicAVTransformerBlock = struct {
             .add(a_shift_kv.broad(inputs.a_text_ctx.shape()));
         const a_text_ca_out = if (bf16_attn) self.audio_attn2.forwardBf16(a_text_x, params.audio_attn2, kindNumHeads(.audio_attn2), .{
             .context = a_text_ctx_mod,
-            .mask = inputs.a_text_ctx_mask,
+            .attn_meta = inputs.audio_attn_meta,
+            .attn_params = inputs.attn_params,
         }) else self.audio_attn2.forward(a_text_x, params.audio_attn2, kindNumHeads(.audio_attn2), .{
             .context = a_text_ctx_mod,
-            .mask = inputs.a_text_ctx_mask,
         });
         const audio_text_ca_delta = a_text_ca_out.mul(a_gate_q.broad(a_text_ca_out.shape()));
         if (audio_all_residuals_f32) {


### PR DESCRIPTION
Route video and audio text cross-attention (`attn2`/`audio_attn2`) through FlashAttention3 when available, matching the existing FA3 path used by self-attention and AV cross-attention.

* Pass `attn_meta`/`attn_params` instead of mask for text cross-attn calls
* Remove unused `mask` field from `ForwardOpts` and `v_text_ctx_mask`/`a_text_ctx_mask` from `SharedInputs`
* Simplify `forwardImpl` dispatch (no dead mask guard)

Stage 1 execution: 81.2s → 75.6s (-6.9%), Stage 2 execution: 11.6s → 11.1s (-4.3%), total: 231.6s → 206.3s (-10.9%), total compile: 96.6s → 78.0s (-19.3%).