### PR TITLE
FeedForward: do not upcast in fp32 for GELU

### DIFF
--- a/examples/ltx/model.zig
+++ b/examples/ltx/model.zig
@@ -63,9 +63,7 @@ pub const FeedForward = struct {
         _ = self;
         const x_ = x.withPartialTags(.{ .b, .t, .d });
         const h1 = params.proj.forward(x_);
-        // GELU in f32 for precision parity with Python reference, then cast back.
-        const dt = h1.dtype();
-        const h2 = h1.convert(.f32).gelu().convert(dt);
+        const h2 = h1.gelu();
         return params.out.forward(h2);
     }
 };


### PR DESCRIPTION
Remove f32 upcast around GELU in FeedForward: keep activation in native bf16. 

Eliminates two unnecessary dtype conversions per FF call (92 blocks × 2 FF calls per block × 30 steps for stage 1). 

~0.7s execution saving.
