### PR TITLE
perf: async block execution + GPU trace analysis tooling

### DIFF
--- a/examples/ltx/inference.zig
+++ b/examples/ltx/inference.zig
@@ -1629,7 +1629,24 @@ fn runStage1(
     // ---- Denoising loop ----
     std.log.info("Starting {d}-step denoising loop (4-pass guidance)...", .{num_stage1_steps});
 
+    // Profile step 2 (step_idx == 1) to capture a single denoising step trace,
+    // skipping step 1 to avoid warmup effects.
+    var step_profiler = platform.profiler(allocator, io, .{
+        .repository_path = "/tmp/xprof",
+        .session_id = "stage1_step1",
+    }) catch |err| blk: {
+        std.log.warn("Could not create profiler: {}", .{err});
+        break :blk null;
+    };
+    defer if (step_profiler) |*p| p.deinit();
+
     for (0..num_stage1_steps) |step_idx| {
+        if (step_idx == 1) {
+            if (step_profiler) |*p| p.start() catch |err| {
+                std.log.warn("Could not start profiler: {}", .{err});
+            };
+        }
+
         const step_start: std.Io.Timestamp = .now(io, .awake);
         const sigma = sigmas[step_idx];
         const sigma_next = sigmas[step_idx + 1];
@@ -2111,6 +2128,14 @@ fn runStage1(
         const step_ns = step_start.untilNow(io, .awake).nanoseconds;
         timer.recordStep(step_ns);
         std.log.info("  Step {d} complete ({d:.1}s).", .{ step_idx + 1, PhaseTimer.fmtSecs(step_ns) });
+
+        if (step_idx == 1) {
+            if (step_profiler) |*p| {
+                if (p.stop() catch null) |profile| {
+                    std.log.info("Profile dumped: {s}", .{profile.perfetto_path});
+                }
+            }
+        }
     }
     timer.addExec();
 

--- a/examples/ltx/inference.zig
+++ b/examples/ltx/inference.zig
@@ -219,6 +219,7 @@ const CliArgs = struct {
     bf16_attn_stage2: bool,
     num_inference_steps: usize,
     dump_intermediates: bool,
+    profile: bool,
     image: ?[]const u8,
     gemma_hidden_states_pos: []const u8,
     gemma_hidden_states_neg: []const u8,
@@ -250,6 +251,7 @@ fn parseArgs(it: anytype) !CliArgs {
         .bf16_attn_stage2 = false,
         .num_inference_steps = model.stage1_default_schedule.num_steps,
         .dump_intermediates = false,
+        .profile = false,
         .image = null,
         .gemma_hidden_states_pos = undefined,
         .gemma_hidden_states_neg = undefined,
@@ -301,6 +303,8 @@ fn parseArgs(it: anytype) !CliArgs {
             }
         } else if (std.mem.eql(u8, arg, "--dump-intermediates")) {
             args.dump_intermediates = true;
+        } else if (std.mem.eql(u8, arg, "--profile")) {
+            args.profile = true;
         } else if (std.mem.eql(u8, arg, "--image")) {
             args.image = it.next() orelse return error.InvalidArgs;
         } else if (std.mem.eql(u8, arg, "--gemma-hidden-states-pos")) {
@@ -356,7 +360,7 @@ fn parseArgs(it: anytype) !CliArgs {
                     "--gemma-hidden-states-pos <path> --gemma-hidden-states-neg <path> " ++
                     "[--height <int>] [--width <int>] [--num-frames <int>] [--fps <float>] " ++
                     "[--num-inference-steps <int>] [--meta <path>] [--seed <int>] [--image <path>] " ++
-                    "[--bf16-attn-stage1] [--bf16-attn-stage2] [--dump-intermediates] " ++
+                    "[--bf16-attn-stage1] [--bf16-attn-stage2] [--dump-intermediates] [--profile] " ++
                     "[--cfg-v <float>] [--stg-v <float>] [--mod-v <float>] [--rescale-v <float>] " ++
                     "[--cfg-a <float>] [--stg-a <float>] [--mod-a <float>] [--rescale-a <float>]",
                 .{},
@@ -754,6 +758,7 @@ pub fn main(init: std.process.Init) !void {
         &timer_s1_noise_gen,
         &timer_s1_noise_init,
         &timer_s1_img_cond,
+        args.profile,
     );
 
     if (args.dump_intermediates) {
@@ -793,7 +798,7 @@ pub fn main(init: std.process.Init) !void {
     std.log.info("", .{});
     std.log.info("=== Phase 3: Stage 2 — {d}-step distilled denoising ===", .{stage2_sigmas.len - 1});
 
-    const s2 = try runStage2(allocator, io, platform, sharding, args.stage2_ckpt, &bridge, args.bf16_attn_stage2, stage2_sigmas, &timer_s2);
+    const s2 = try runStage2(allocator, io, platform, sharding, args.stage2_ckpt, &bridge, args.bf16_attn_stage2, stage2_sigmas, &timer_s2, args.profile);
 
     // Free bridge-only buffers (positions, masks, clean latents, contexts).
     // The noised latents (v_latent, a_latent) were consumed by Stage 2's loop
@@ -823,7 +828,7 @@ pub fn main(init: std.process.Init) !void {
     std.log.info("", .{});
     std.log.info("=== Phase 4: Video VAE Decode ===", .{});
 
-    var video_frames = try runVideoVaeDecode(allocator, io, platform, sharding, args.stage2_ckpt, s2.v_latent, pipe_meta, &timer_video_vae);
+    var video_frames = try runVideoVaeDecode(allocator, io, platform, sharding, args.stage2_ckpt, s2.v_latent, pipe_meta, &timer_video_vae, args.profile);
     defer video_frames.deinit();
 
     if (args.dump_intermediates) {
@@ -942,6 +947,7 @@ fn runStage1(
     timer_noise_gen: *PhaseTimer,
     timer_noise_init: *PhaseTimer,
     timer_img_cond: *PhaseTimer,
+    profile: bool,
 ) !Stage1Result {
     timer_host_prep.start();
 
@@ -1664,13 +1670,13 @@ fn runStage1(
 
     // Profile step 2 (step_idx == 1) to capture a single denoising step trace,
     // skipping step 1 to avoid warmup effects.
-    var step_profiler = platform.profiler(allocator, io, .{
+    var step_profiler = if (profile) platform.profiler(allocator, io, .{
         .repository_path = "/tmp/xprof",
         .session_id = "stage1_step1",
     }) catch |err| blk: {
         std.log.warn("Could not create profiler: {}", .{err});
         break :blk null;
-    };
+    } else null;
     defer if (step_profiler) |*p| p.deinit();
 
     for (0..num_stage1_steps) |step_idx| {
@@ -2164,8 +2170,8 @@ fn runStage1(
 
         if (step_idx == 1) {
             if (step_profiler) |*p| {
-                if (p.stop() catch null) |profile| {
-                    std.log.info("Profile dumped: {s}", .{profile.perfetto_path});
+                if (p.stop() catch null) |prof| {
+                    std.log.info("Profile dumped: {s}", .{prof.perfetto_path});
                 }
             }
         }
@@ -2605,6 +2611,7 @@ fn runStage2(
     use_bf16_attn: bool,
     stage2_sigmas: []const f32,
     timer: *PhaseTimer,
+    profile: bool,
 ) !Stage2Result {
     timer.start();
     // ---- Open checkpoint store ----
@@ -2900,13 +2907,13 @@ fn runStage2(
     std.log.info("Starting {d}-step denoising loop...", .{num_steps});
 
     // Profile step 1 (step_idx == 0) to capture a single denoising step trace.
-    var s2_profiler = platform.profiler(allocator, io, .{
+    var s2_profiler = if (profile) platform.profiler(allocator, io, .{
         .repository_path = "/tmp/xprof",
         .session_id = "stage2_step0",
     }) catch |err| blk: {
         std.log.warn("Could not create Stage 2 profiler: {}", .{err});
         break :blk null;
-    };
+    } else null;
     defer if (s2_profiler) |*p| p.deinit();
 
     for (0..num_steps) |step_idx| {
@@ -3102,8 +3109,8 @@ fn runStage2(
 
         if (step_idx == 0) {
             if (s2_profiler) |*p| {
-                if (p.stop() catch null) |profile| {
-                    std.log.info("Stage 2 profile dumped: {s}", .{profile.perfetto_path});
+                if (p.stop() catch null) |prof| {
+                    std.log.info("Stage 2 profile dumped: {s}", .{prof.perfetto_path});
                 }
             }
         }
@@ -3382,6 +3389,7 @@ fn runVideoVaeDecode(
     v_latent_patchified: zml.Buffer,
     pipe_meta: PipelineMeta,
     timer: *PhaseTimer,
+    profile: bool,
 ) !VideoFrames {
     timer.start();
 
@@ -3534,6 +3542,7 @@ fn runVideoVaeDecode(
             W,
             tiling_config,
             timer,
+            profile,
         );
     }
 
@@ -3558,13 +3567,13 @@ fn runVideoVaeDecode(
     std.log.info("Running VAE decode...", .{});
 
     // Profile the VAE decode execution.
-    var vae_profiler = platform.profiler(allocator, io, .{
+    var vae_profiler = if (profile) platform.profiler(allocator, io, .{
         .repository_path = "/tmp/xprof",
         .session_id = "video_vae_decode",
     }) catch |err| blk: {
         std.log.warn("Could not create VAE profiler: {}", .{err});
         break :blk null;
-    };
+    } else null;
     defer if (vae_profiler) |*p| p.deinit();
     if (vae_profiler) |*p| p.start() catch |err| {
         std.log.warn("Could not start VAE profiler: {}", .{err});
@@ -3581,8 +3590,8 @@ fn runVideoVaeDecode(
     std.log.info("  Decoded video: {any}", .{decoded_video.shape().dims()});
 
     if (vae_profiler) |*p| {
-        if (p.stop() catch null) |profile| {
-            std.log.info("VAE decode profile dumped: {s}", .{profile.perfetto_path});
+        if (p.stop() catch null) |prof| {
+            std.log.info("VAE decode profile dumped: {s}", .{prof.perfetto_path});
         }
     }
 
@@ -3610,6 +3619,7 @@ fn runVideoVaeDecodeTiled(
     W: i64,
     config: video_vae.TemporalTilingConfig,
     timer: *PhaseTimer,
+    profile: bool,
 ) !VideoFrames {
     const C: i64 = 128;
 
@@ -3666,13 +3676,13 @@ fn runVideoVaeDecodeTiled(
     defer vae_results.deinit(allocator);
 
     // Profile the first tile's VAE decode execution.
-    var vae_tile_profiler = platform.profiler(allocator, io, .{
+    var vae_tile_profiler = if (profile) platform.profiler(allocator, io, .{
         .repository_path = "/tmp/xprof",
         .session_id = "video_vae_tile0",
     }) catch |err| blk: {
         std.log.warn("Could not create VAE tile profiler: {}", .{err});
         break :blk null;
-    };
+    } else null;
     defer if (vae_tile_profiler) |*p| p.deinit();
 
     for (0..tile_plan.count) |tile_idx| {
@@ -3733,8 +3743,8 @@ fn runVideoVaeDecodeTiled(
 
         if (tile_idx == 0) {
             if (vae_tile_profiler) |*p| {
-                if (p.stop() catch null) |profile| {
-                    std.log.info("VAE tile 0 profile dumped: {s}", .{profile.perfetto_path});
+                if (p.stop() catch null) |prof| {
+                    std.log.info("VAE tile 0 profile dumped: {s}", .{prof.perfetto_path});
                 }
             }
         }

--- a/examples/ltx/inference.zig
+++ b/examples/ltx/inference.zig
@@ -707,6 +707,11 @@ pub fn main(init: std.process.Init) !void {
 
     // ---- Phase timers ----
     var timer_s1 = PhaseTimer.init("Stage 1", io);
+    var timer_s1_host_prep = PhaseTimer.init("  S1 Host Prep", io);
+    var timer_s1_text_emb = PhaseTimer.init("  S1 Text Emb", io);
+    var timer_s1_noise_gen = PhaseTimer.init("  S1 Noise Gen", io);
+    var timer_s1_noise_init = PhaseTimer.init("  S1 Noise Init", io);
+    var timer_s1_img_cond = PhaseTimer.init("  S1 Image Cond", io);
     var timer_bridge = PhaseTimer.init("Bridge", io);
     var timer_s2 = PhaseTimer.init("Stage 2", io);
     var timer_video_vae = PhaseTimer.init("Video VAE Decode", io);
@@ -744,6 +749,11 @@ pub fn main(init: std.process.Init) !void {
         args.mod_a,
         args.rescale_a,
         &timer_s1,
+        &timer_s1_host_prep,
+        &timer_s1_text_emb,
+        &timer_s1_noise_gen,
+        &timer_s1_noise_init,
+        &timer_s1_img_cond,
     );
 
     if (args.dump_intermediates) {
@@ -881,8 +891,17 @@ pub fn main(init: std.process.Init) !void {
     // Timing Summary
     // ========================================================================
     const all_timers = [_]*const PhaseTimer{
-        &timer_s1,        &timer_bridge,    &timer_s2,
-        &timer_video_vae, &timer_audio_vae, &timer_vocoder,
+        &timer_s1_host_prep,
+        &timer_s1_text_emb,
+        &timer_s1_noise_gen,
+        &timer_s1_noise_init,
+        &timer_s1_img_cond,
+        &timer_s1,
+        &timer_bridge,
+        &timer_s2,
+        &timer_video_vae,
+        &timer_audio_vae,
+        &timer_vocoder,
         &timer_mp4,
     };
     printTimingSummary(&all_timers);
@@ -918,8 +937,13 @@ fn runStage1(
     mod_a: f32,
     rescale_a: f32,
     timer: *PhaseTimer,
+    timer_host_prep: *PhaseTimer,
+    timer_text_emb: *PhaseTimer,
+    timer_noise_gen: *PhaseTimer,
+    timer_noise_init: *PhaseTimer,
+    timer_img_cond: *PhaseTimer,
 ) !Stage1Result {
-    timer.start();
+    timer_host_prep.start();
 
     // ---- Sigma schedule ----
     // sigmas is [MAX_STAGE1_STEPS + 1]f32; only entries [0..num_stage1_steps] are valid.
@@ -1029,9 +1053,11 @@ fn runStage1(
     // Text contexts — positive AND negative for Stage 1 guidance.
     // Positive contexts are kept alive and returned for Stage 2.
     // Compute from Gemma hidden states using the Zig EmbeddingsProcessor.
+    timer_host_prep.addOther();
+
     std.log.info("Computing text embeddings from Gemma hidden states...", .{});
 
-    const emb_result = try computeTextEmbeddings(allocator, io, platform, sharding, &ckpt_store, gemma_hs_pos_path, gemma_hs_neg_path);
+    const emb_result = try computeTextEmbeddings(allocator, io, platform, sharding, &ckpt_store, gemma_hs_pos_path, gemma_hs_neg_path, timer_text_emb);
     var v_context_pos_buf = emb_result.v_context_pos;
     var a_context_pos_buf = emb_result.a_context_pos;
     var v_context_neg_buf = emb_result.v_context_neg;
@@ -1040,6 +1066,7 @@ fn runStage1(
     defer a_context_neg_buf.deinit();
 
     // ---- Generate noise and run noise init ----
+    timer_noise_gen.start();
     std.log.info("Generating Stage 1 noise (seed={d})...", .{seed});
 
     var rng_buf = try zml.Tensor.Rng.initBuffer(io, platform, sharding, seed);
@@ -1103,6 +1130,7 @@ fn runStage1(
         try writeBuffer(allocator, io, v_noise_buf, output_dir, "s1_video_noise.bin");
         try writeBuffer(allocator, io, a_noise_buf, output_dir, "s1_audio_noise.bin");
     }
+    timer_noise_gen.addExec(); // compile+exec x2 (tiny graphs)
 
     // Compile noise init
     const sigma_scalar_shape = zml.Shape.init(.{}, .f32);
@@ -1113,6 +1141,7 @@ fn runStage1(
     var noise_scale_buf = try zml.Buffer.scalar(io, platform, noise_scale, .f32, sharding);
     defer noise_scale_buf.deinit();
 
+    timer_noise_init.start();
     // Video noise init
     var v_latent_buf = blk: {
         var exe = try platform.compileFn(
@@ -1165,8 +1194,10 @@ fn runStage1(
 
     std.log.info("  video_latent (noised): {any}", .{v_latent_buf.shape().dims()});
     std.log.info("  audio_latent (noised): {any}", .{a_latent_buf.shape().dims()});
+    timer_noise_init.addExec(); // compile+exec x2 (tiny graphs)
 
     // ---- Image conditioning (optional) ----
+    timer_img_cond.start();
     if (image_path) |img_path| {
         std.log.info("Applying image conditioning to Stage 1...", .{});
 
@@ -1211,7 +1242,9 @@ fn runStage1(
     }
 
     // ---- Compile executables ----
-    timer.addOther(); // host prep + text embeddings + noise gen/init + image cond
+    timer_img_cond.addExec(); // 0 if no image
+
+    timer.start();
 
     std.log.info("Compiling preprocessing exe...", .{});
     const preprocess_shape = model.initPreprocessParams(ckpt_store.view());
@@ -1734,7 +1767,7 @@ fn runStage1(
                         block_params_bufs[i],
                     });
                 }
-                block_normal_exe.callOpts(io, blk_args, &blk_results, .{ .wait = true });
+                block_normal_exe.callOpts(io, blk_args, &blk_results, .{ .wait = false });
                 const out = blk_results.get(zml.Bufferized(model.BasicAVTransformerBlock.FullOutputs));
                 if (i > 0) {
                     cond_h_v.deinit();
@@ -1808,7 +1841,7 @@ fn runStage1(
                         block_params_bufs[i],
                     });
                 }
-                block_normal_exe.callOpts(io, blk_args, &blk_results, .{ .wait = true });
+                block_normal_exe.callOpts(io, blk_args, &blk_results, .{ .wait = false });
                 const out = blk_results.get(zml.Bufferized(model.BasicAVTransformerBlock.FullOutputs));
                 if (i > 0) {
                     neg_h_v.deinit();
@@ -1888,7 +1921,7 @@ fn runStage1(
                             block_params_bufs[i],
                         });
                     }
-                    block_stg_exe.callOpts(io, blk_stg_args, &blk_stg_results, .{ .wait = true });
+                    block_stg_exe.callOpts(io, blk_stg_args, &blk_stg_results, .{ .wait = false });
                     const out = blk_stg_results.get(zml.Bufferized(model.BasicAVTransformerBlock.FullOutputs));
                     if (i > 0) {
                         ptb_h_v.deinit();
@@ -1938,7 +1971,7 @@ fn runStage1(
                             block_params_bufs[i],
                         });
                     }
-                    block_normal_exe.callOpts(io, blk_normal_args, &blk_normal_results, .{ .wait = true });
+                    block_normal_exe.callOpts(io, blk_normal_args, &blk_normal_results, .{ .wait = false });
                     const out = blk_normal_results.get(zml.Bufferized(model.BasicAVTransformerBlock.FullOutputs));
                     if (i > 0) {
                         ptb_h_v.deinit();
@@ -2015,7 +2048,7 @@ fn runStage1(
                         block_params_bufs[i],
                     });
                 }
-                block_iso_exe.callOpts(io, blk_args, &blk_results, .{ .wait = true });
+                block_iso_exe.callOpts(io, blk_args, &blk_results, .{ .wait = false });
                 const out = blk_results.get(zml.Bufferized(model.BasicAVTransformerBlock.FullOutputs));
                 if (i > 0) {
                     iso_h_v.deinit();
@@ -2866,7 +2899,23 @@ fn runStage2(
     const num_steps = stage2_sigmas.len - 1;
     std.log.info("Starting {d}-step denoising loop...", .{num_steps});
 
+    // Profile step 1 (step_idx == 0) to capture a single denoising step trace.
+    var s2_profiler = platform.profiler(allocator, io, .{
+        .repository_path = "/tmp/xprof",
+        .session_id = "stage2_step0",
+    }) catch |err| blk: {
+        std.log.warn("Could not create Stage 2 profiler: {}", .{err});
+        break :blk null;
+    };
+    defer if (s2_profiler) |*p| p.deinit();
+
     for (0..num_steps) |step_idx| {
+        if (step_idx == 0) {
+            if (s2_profiler) |*p| p.start() catch |err| {
+                std.log.warn("Could not start Stage 2 profiler: {}", .{err});
+            };
+        }
+
         const step_start: std.Io.Timestamp = .now(io, .awake);
         const sigma = stage2_sigmas[step_idx];
         const sigma_next = stage2_sigmas[step_idx + 1];
@@ -2952,7 +3001,7 @@ fn runStage2(
                         block_params_bufs[i],
                     });
                 }
-                block_exe.callOpts(io, blk_args, &blk_results, .{ .wait = true });
+                block_exe.callOpts(io, blk_args, &blk_results, .{ .wait = false });
 
                 const out = blk_results.get(zml.Bufferized(model.BasicAVTransformerBlock.FullOutputs));
                 if (i > 0) {
@@ -3050,6 +3099,14 @@ fn runStage2(
         const step_ns = step_start.untilNow(io, .awake).nanoseconds;
         timer.recordStep(step_ns);
         std.log.info("  Step {d} complete ({d:.1}s).", .{ step_idx, PhaseTimer.fmtSecs(step_ns) });
+
+        if (step_idx == 0) {
+            if (s2_profiler) |*p| {
+                if (p.stop() catch null) |profile| {
+                    std.log.info("Stage 2 profile dumped: {s}", .{profile.perfetto_path});
+                }
+            }
+        }
     }
     timer.addExec();
 
@@ -3126,7 +3183,10 @@ fn computeTextEmbeddings(
     ckpt_store: *zml.io.TensorStore,
     pos_path: []const u8,
     neg_path: []const u8,
+    timer: *PhaseTimer,
 ) !TextEmbeddingsResult {
+    timer.start();
+
     // ---- Initialize processor params from checkpoint ----
     const proc_init = text_embeddings.EmbeddingsProcessor.initParams(ckpt_store.view());
     const processor = proc_init.processor;
@@ -3154,6 +3214,8 @@ fn computeTextEmbeddings(
     std.log.info("  pos stacked_hidden_states: {s} {any}", .{ @tagName(pos_hs_buf.shape().dtype()), pos_hs_buf.shape().dims() });
     std.log.info("  pos attention_mask:        {s} {any}", .{ @tagName(pos_mask_buf.shape().dtype()), pos_mask_buf.shape().dims() });
 
+    timer.addOther(); // load hidden states from safetensors
+
     // ---- Compile graph ----
     std.log.info("Compiling text embeddings processor...", .{});
     var exe = try platform.compileFn(
@@ -3169,6 +3231,8 @@ fn computeTextEmbeddings(
         .{ .shardings = &.{sharding} },
     );
     defer exe.deinit();
+
+    timer.addCompile();
 
     // ---- Load model weights ----
     std.log.info("Loading text embeddings weights...", .{});
@@ -3188,6 +3252,8 @@ fn computeTextEmbeddings(
     );
     defer text_embeddings.EmbeddingsProcessor.unloadBuffers(&weight_bufs);
 
+    timer.addLoad();
+
     // ---- Run on positive hidden states ----
     std.log.info("Running text embeddings on positive prompt...", .{});
     var exe_args = try exe.args(allocator);
@@ -3205,6 +3271,8 @@ fn computeTextEmbeddings(
 
     std.log.info("  v_context_pos: {s} {any}", .{ @tagName(v_context_pos.shape().dtype()), v_context_pos.shape().dims() });
     std.log.info("  a_context_pos: {s} {any}", .{ @tagName(a_context_pos.shape().dtype()), a_context_pos.shape().dims() });
+
+    timer.addExec();
 
     // ---- Run on negative hidden states ----
     var neg_hs_buf: zml.Buffer = undefined;
@@ -3259,6 +3327,8 @@ fn computeTextEmbeddings(
 
     std.log.info("  v_context_neg: {s} {any}", .{ @tagName(v_context_neg.shape().dtype()), v_context_neg.shape().dims() });
     std.log.info("  a_context_neg: {s} {any}", .{ @tagName(a_context_neg.shape().dtype()), a_context_neg.shape().dims() });
+
+    timer.addExec(); // neg load hs + exec
 
     return .{
         .v_context_pos = v_context_pos,
@@ -3486,6 +3556,20 @@ fn runVideoVaeDecode(
     timer.addCompile();
 
     std.log.info("Running VAE decode...", .{});
+
+    // Profile the VAE decode execution.
+    var vae_profiler = platform.profiler(allocator, io, .{
+        .repository_path = "/tmp/xprof",
+        .session_id = "video_vae_decode",
+    }) catch |err| blk: {
+        std.log.warn("Could not create VAE profiler: {}", .{err});
+        break :blk null;
+    };
+    defer if (vae_profiler) |*p| p.deinit();
+    if (vae_profiler) |*p| p.start() catch |err| {
+        std.log.warn("Could not start VAE profiler: {}", .{err});
+    };
+
     var vae_args = try vae_exe.args(allocator);
     defer vae_args.deinit(allocator);
     var vae_results = try vae_exe.results(allocator);
@@ -3495,6 +3579,13 @@ fn runVideoVaeDecode(
     v_latent_5d.deinit(); // Free GPU latent after VAE consumes it
     var decoded_video = vae_results.get(zml.Buffer); // [1, 3, F_out, H_out, W_out] bf16
     std.log.info("  Decoded video: {any}", .{decoded_video.shape().dims()});
+
+    if (vae_profiler) |*p| {
+        if (p.stop() catch null) |profile| {
+            std.log.info("VAE decode profile dumped: {s}", .{profile.perfetto_path});
+        }
+    }
+
     timer.addExec();
 
     defer decoded_video.deinit(); // Free GPU buffer after download to host
@@ -3574,6 +3665,16 @@ fn runVideoVaeDecodeTiled(
     var vae_results = try vae_exe.results(allocator);
     defer vae_results.deinit(allocator);
 
+    // Profile the first tile's VAE decode execution.
+    var vae_tile_profiler = platform.profiler(allocator, io, .{
+        .repository_path = "/tmp/xprof",
+        .session_id = "video_vae_tile0",
+    }) catch |err| blk: {
+        std.log.warn("Could not create VAE tile profiler: {}", .{err});
+        break :blk null;
+    };
+    defer if (vae_tile_profiler) |*p| p.deinit();
+
     for (0..tile_plan.count) |tile_idx| {
         const tile = tile_plan.tiles[tile_idx];
         const actual_lat_frames: usize = @intCast(tile.lat_actual_end - tile.lat_start);
@@ -3618,11 +3719,25 @@ fn runVideoVaeDecodeTiled(
         const tile_slice = zml.Slice.init(tile_latent_shape, tile_buf);
         var tile_gpu = try zml.Buffer.fromSlice(io, platform, tile_slice, sharding);
 
+        if (tile_idx == 0) {
+            if (vae_tile_profiler) |*p| p.start() catch |err| {
+                std.log.warn("Could not start VAE tile profiler: {}", .{err});
+            };
+        }
+
         // Run VAE decoder
         vae_args.set(.{ tile_gpu, stats_bufs, vae_bufs });
         vae_exe.callOpts(io, vae_args, &vae_results, .{ .wait = true });
         var decoded_tile = vae_results.get(zml.Buffer); // [1, 3, F_tile_px, H_px, W_px] bf16
         defer decoded_tile.deinit();
+
+        if (tile_idx == 0) {
+            if (vae_tile_profiler) |*p| {
+                if (p.stop() catch null) |profile| {
+                    std.log.info("VAE tile 0 profile dumped: {s}", .{profile.perfetto_path});
+                }
+            }
+        }
 
         // Free GPU tile input immediately
         tile_gpu.deinit();

--- a/tools/analyze_trace.py
+++ b/tools/analyze_trace.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Analyze GPU kernel breakdown from a raw Perfetto/XLA trace JSON file.
+
+Handles overlapping events that occur in XLA/CUDA traces (e.g. prepare_varlen_num_blocks
+overlapping with FlashAttention kernels by ~1-2 us). On a GPU stream, only one kernel
+runs at a time, so overlaps are trace artifacts. This script de-overlaps by sweeping
+through events sorted by start time and clipping any portion that falls within an
+already-accounted interval.
+
+Usage:
+    python3 analyze_trace.py <trace.json>
+    python3 analyze_trace.py <trace.json> --details
+    python3 analyze_trace.py <trace.json> --gpu-tid 7
+    python3 analyze_trace.py <trace.json> --fix                  # writes <input>_fixed.trace.json
+    python3 analyze_trace.py <trace.json> --fix -o fixed.json    # custom output path
+"""
+
+import json
+import sys
+import argparse
+from collections import defaultdict
+
+
+def load_trace_raw(path):
+    """Load trace JSON, returning the raw top-level structure."""
+    with open(path) as f:
+        return json.load(f)
+
+
+def get_events(data):
+    """Extract the events list from the raw trace data."""
+    if isinstance(data, list):
+        return data
+    return data.get("traceEvents", [])
+
+
+def fix_overlaps(events, gpu_tid):
+    """Fix overlapping X events in-place, only on GPU stream tracks.
+
+    CPU tracks legitimately have nested/overlapping spans (e.g. a parent
+    "inference" span containing child "compile" and "execute" spans), so
+    we leave those untouched. GPU streams execute kernels sequentially, so
+    overlaps there are trace artifacts from XLA's CUDA profiler.
+
+    Runs multiple passes to handle nested call hierarchies where fixing one
+    overlap may expose the next level.
+    """
+    total_fixed = 0
+
+    for pass_num in range(20):  # safety limit
+        # Collect X events on GPU tracks only, indexed by position in events list
+        gpu_x = []
+        for i, e in enumerate(events):
+            if (e.get("ph") == "X" and "ts" in e and "dur" in e
+                    and e.get("tid") == gpu_tid):
+                gpu_x.append((i, e))
+
+        # Sort by timestamp, then by duration descending (parent before child)
+        gpu_x.sort(key=lambda x: (x[1]["ts"], -x[1]["dur"]))
+
+        pass_fixed = 0
+        for j in range(len(gpu_x) - 1):
+            idx_a, a = gpu_x[j]
+            idx_b, b = gpu_x[j + 1]
+
+            a_end = a["ts"] + a["dur"]
+            b_start = b["ts"]
+            overlap = a_end - b_start
+
+            if overlap > 0:
+                if b["dur"] == 0:
+                    # Zero-duration event inside a parent: move to parent end
+                    events[idx_b]["ts"] = a_end
+                elif a["dur"] <= b["dur"]:
+                    # Shorten a so it ends at b's start
+                    events[idx_a]["dur"] = max(0, b_start - a["ts"])
+                else:
+                    # Delay b so it starts at a's end
+                    events[idx_b]["ts"] = a_end
+                    events[idx_b]["dur"] = max(0, b["dur"] - overlap)
+                pass_fixed += 1
+
+        total_fixed += pass_fixed
+        if pass_fixed == 0:
+            break
+
+    return total_fixed
+
+
+def find_gpu_stream_tid(events):
+    """Find the GPU compute stream tid.
+
+    Strategy:
+    1. Look for thread_name metadata naming a CUDA stream.
+    2. Fallback: pick the tid with the most 'X' (complete) events whose names
+       look like GPU kernels (fusion_, nvjet_, flash, etc.).
+    """
+    # Try metadata events first
+    stream_tids = []
+    for e in events:
+        if e.get("ph") == "M" and e.get("name") == "thread_name":
+            tname = e.get("args", {}).get("name", "")
+            if "stream" in tname.lower():
+                stream_tids.append((e.get("tid"), tname))
+
+    if stream_tids:
+        # If multiple streams, pick the one with most X events
+        tid_counts = defaultdict(int)
+        for e in events:
+            if e.get("ph") == "X":
+                tid_counts[e.get("tid")] += 1
+        best = max(stream_tids, key=lambda t: tid_counts.get(t[0], 0))
+        print(f"GPU stream: tid={best[0]} ({best[1]})")
+        return best[0]
+
+    # Fallback: tid with most X events that look like GPU kernels
+    tid_gpu_counts = defaultdict(int)
+    gpu_patterns = ["fusion_", "nvjet_", "flash", "gemm", "memset", "memcpy",
+                    "loop_", "input_", "wrapped_", "reduce_", "scatter_"]
+    for e in events:
+        if e.get("ph") == "X":
+            name = (e.get("name") or "").lower()
+            if any(p in name for p in gpu_patterns):
+                tid_gpu_counts[e.get("tid")] += 1
+
+    if tid_gpu_counts:
+        best_tid = max(tid_gpu_counts, key=tid_gpu_counts.get)
+        print(f"GPU stream (heuristic): tid={best_tid} ({tid_gpu_counts[best_tid]} GPU-like events)")
+        return best_tid
+
+    # Last resort: tid with most events
+    tid_counts = defaultdict(int)
+    for e in events:
+        if e.get("ph") == "X":
+            tid_counts[e.get("tid")] += 1
+    if tid_counts:
+        best_tid = max(tid_counts, key=tid_counts.get)
+        print(f"GPU stream (fallback): tid={best_tid} ({tid_counts[best_tid]} events)")
+        return best_tid
+
+    return None
+
+
+def categorize_kernel(name):
+    """Classify a GPU kernel name into a high-level category.
+
+    Order matters: more specific patterns are checked first to avoid
+    'gemm_fusion' matching as Fusion instead of GEMM.
+    """
+    # FlashAttention kernels (check before GEMM since some use cutlass)
+    if any(k in name for k in ["FlashAttn", "flash_fwd", "flash_bwd",
+                                "cutlass::device_kernel<flash", "flash::",
+                                "prepare_varlen_num_blocks"]):
+        return "FlashAttn"
+    # GEMM / matmul kernels
+    if any(k in name for k in ["nvjet_", "gemm_fusion", "gemm", "cublas"]):
+        return "GEMM"
+    # Memory operations
+    if any(k in name.lower() for k in ["memset", "memcpy", "nccl"]):
+        return "Memops"
+    # XLA fused kernels
+    if any(name.startswith(p) for p in ["fusion_", "loop_", "input_",
+                                         "wrapped_", "reduce_", "scatter_"]):
+        return "Fusion"
+    return "Other"
+
+
+def deoverlap_and_analyze(gpu_events):
+    """De-overlap GPU events and compute per-category breakdown.
+
+    Algorithm (greedy sweep with high-water mark):
+    1. Sort events by (start_time, -duration). When two events start at the
+       same time, the longer one comes first — it's the "real" kernel.
+    2. Sweep left-to-right tracking a high-water mark (hwm) = end of the
+       latest committed interval.
+    3. For each event:
+       - Starts at or after hwm → no overlap, use full duration.
+       - Starts before hwm but ends after → partial overlap, clip start to hwm.
+       - Fully contained within hwm → skip (0 contribution).
+
+    This correctly handles the XLA pattern where a short metadata event
+    (prepare_varlen_num_blocks, ~1.5 us) starts just before a long kernel
+    (FlashAttention, ~35 ms). The short event gets its tiny duration; the
+    long event gets clipped by ~1.5 us — negligible error.
+    """
+    gpu_events.sort(key=lambda e: (e["ts"], -e["dur"]))
+
+    intervals = []  # (effective_start, effective_end, category, original_name)
+    hwm = 0
+    n_clipped = 0
+    n_dropped = 0
+
+    for e in gpu_events:
+        ts = e["ts"]
+        dur = e["dur"]
+        end = ts + dur
+        cat = categorize_kernel(e.get("name", ""))
+
+        if ts >= hwm:
+            # No overlap
+            intervals.append((ts, end, cat, e.get("name", "")))
+            hwm = end
+        elif end > hwm:
+            # Partial overlap: clip the beginning
+            intervals.append((hwm, end, cat, e.get("name", "")))
+            n_clipped += 1
+            hwm = end
+        else:
+            # Fully contained in a previous event: skip
+            n_dropped += 1
+
+    return intervals, n_clipped, n_dropped
+
+
+def print_summary(intervals, n_clipped, n_dropped, show_details=False):
+    if not intervals:
+        print("No GPU events found.")
+        return
+
+    # Aggregate by category
+    cat_time_us = defaultdict(float)
+    cat_count = defaultdict(int)
+    cat_kernels = defaultdict(lambda: defaultdict(lambda: [0, 0.0]))  # cat -> name -> [count, us]
+
+    for start, end, cat, name in intervals:
+        dur = end - start
+        cat_time_us[cat] += dur
+        cat_count[cat] += 1
+        cat_kernels[cat][name][0] += 1
+        cat_kernels[cat][name][1] += dur
+
+    total_busy_us = sum(cat_time_us.values())
+    wall_us = intervals[-1][1] - intervals[0][0]
+    idle_us = wall_us - total_busy_us
+
+    # Print overlap resolution stats
+    print(f"Overlap resolution: {n_clipped} clipped, {n_dropped} fully contained (dropped)")
+    print()
+
+    # Category table
+    print(f"{'Category':<12} {'Count':>7} {'Time (ms)':>11} {'%':>7}")
+    print("-" * 40)
+    for cat in sorted(cat_time_us, key=cat_time_us.get, reverse=True):
+        ms = cat_time_us[cat] / 1000
+        pct = 100.0 * cat_time_us[cat] / wall_us
+        print(f"{cat:<12} {cat_count[cat]:>7} {ms:>11.1f} {pct:>6.1f}%")
+
+    print("-" * 40)
+    print(f"{'Busy':<12} {'':>7} {total_busy_us/1000:>11.1f} {100*total_busy_us/wall_us:>6.1f}%")
+    print(f"{'Idle':<12} {'':>7} {idle_us/1000:>11.1f} {100*idle_us/wall_us:>6.1f}%")
+    print(f"{'Wall':<12} {'':>7} {wall_us/1000:>11.1f}")
+    print()
+    print(f"GPU utilization: {100*total_busy_us/wall_us:.1f}%")
+
+    # Detailed per-kernel breakdown within each category
+    if show_details:
+        print()
+        print("=" * 70)
+        print("Per-kernel breakdown")
+        print("=" * 70)
+        for cat in sorted(cat_time_us, key=cat_time_us.get, reverse=True):
+            print(f"\n--- {cat} ({cat_time_us[cat]/1000:.1f} ms) ---")
+            kernels = cat_kernels[cat]
+            # Sort by total time descending
+            for name, (cnt, us) in sorted(kernels.items(), key=lambda x: -x[1][1])[:15]:
+                avg_us = us / cnt if cnt else 0
+                print(f"  {cnt:>5}x  {us/1000:>9.1f} ms  (avg {avg_us:.1f} us)  {name[:80]}")
+            remaining = len(kernels) - 15
+            if remaining > 0:
+                print(f"  ... and {remaining} more kernel types")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Analyze GPU kernel breakdown from a Perfetto/XLA trace JSON file."
+    )
+    parser.add_argument("trace", help="Path to trace JSON file (raw or fixed)")
+    parser.add_argument("--gpu-tid", type=int, default=None,
+                        help="Thread ID of the GPU compute stream (auto-detected if omitted)")
+    parser.add_argument("--details", action="store_true",
+                        help="Show per-kernel breakdown within each category")
+    parser.add_argument("--fix", action="store_true",
+                        help="Fix overlapping events and write a corrected trace file")
+    parser.add_argument("-o", "--output", default=None,
+                        help="Output path for fixed trace (default: <input>_fixed.trace.json)")
+    args = parser.parse_args()
+
+    print(f"Loading {args.trace}...")
+    data = load_trace_raw(args.trace)
+    events = get_events(data)
+    x_events = [e for e in events if e.get("ph") == "X" and "ts" in e and "dur" in e]
+    print(f"Total events: {len(events)}, complete (X) events: {len(x_events)}")
+
+    gpu_tid = args.gpu_tid
+    if gpu_tid is None:
+        gpu_tid = find_gpu_stream_tid(events)
+        if gpu_tid is None:
+            print("ERROR: Could not detect GPU stream. Use --gpu-tid.", file=sys.stderr)
+            sys.exit(1)
+
+    if args.fix:
+        n_fixed = fix_overlaps(events, gpu_tid)
+        output_path = args.output
+        if output_path is None:
+            base = args.trace.rsplit(".", 1)[0] if "." in args.trace else args.trace
+            output_path = base + "_fixed.trace.json"
+        with open(output_path, "w") as f:
+            json.dump(data, f)
+        print(f"Overlaps fixed: {n_fixed} (GPU stream only, tid={gpu_tid})")
+        print(f"Fixed trace written to: {output_path}")
+        # Re-extract X events after fixing for analysis below
+        x_events = [e for e in events if e.get("ph") == "X" and "ts" in e and "dur" in e]
+
+    gpu_events = [e for e in x_events if e.get("tid") == gpu_tid]
+    print(f"GPU stream events: {len(gpu_events)}")
+    print()
+
+    intervals, n_clipped, n_dropped = deoverlap_and_analyze(gpu_events)
+    print_summary(intervals, n_clipped, n_dropped, show_details=args.details)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Changes:

* Switch transformer block calls to async execution in Stage 1 and Stage 2 denoising loops
* Edit timing reporting summary table to the old `other` column is actually split into {Compile, Load, Execute}
* Gate all GPU profiling behind `--profile` CLI flag
* Add `analyze_trace.py`: analyzes XLA trace JSON files with GPU kernel categorization, de-overlap correction, and `--fix` flag to emit corrected traces (so even overlapping GPU events appear on Perfetto)

Impact: ~1.9s saved per generation (GPU utilization 92.5% --> 99.2% for Stage 1, and 98.4% --> 99.7% Stage 2)