### PR TITLE
zml/profiler: post-process saved xplane profiles and clean up profiler FFI

### DIFF
--- a/ffi/zig_allocator.zig
+++ b/ffi/zig_allocator.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+
 const c = @import("c");
 
 pub const ZigAllocator = struct {
@@ -12,7 +13,7 @@ pub const ZigAllocator = struct {
 
     pub fn alloc(ctx: ?*const anyopaque, elem: usize, nelems: usize, alignment: usize) callconv(.c) ?*anyopaque {
         const self: *const std.mem.Allocator = @ptrCast(@alignCast(ctx));
-        const ret = self.rawAlloc(elem * nelems, std.math.log2_int(usize, alignment), @returnAddress()) orelse return null;
+        const ret = self.rawAlloc(elem * nelems, .fromByteUnits(alignment), @returnAddress()) orelse return null;
         return @ptrCast(ret);
     }
 
@@ -20,6 +21,6 @@ pub const ZigAllocator = struct {
         const self: *const std.mem.Allocator = @ptrCast(@alignCast(ctx));
         const memory: [*c]u8 = @ptrCast(ptr);
         const size = elem * nelems;
-        self.rawFree(memory[0..size], std.math.log2_int(usize, alignment), @returnAddress());
+        self.rawFree(memory[0..size], .fromByteUnits(alignment), @returnAddress());
     }
 };

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -17,8 +17,10 @@ cc_library(
     deps = [
         "//ffi:cc",
         "@tsl//tsl/profiler/protobuf:xplane_proto_cc",
+        "@xla//xla/tsl/profiler/convert:post_process_single_host_xplane",
         "@xla//xla/tsl/profiler/convert:trace_events_to_json",
         "@xla//xla/tsl/profiler/convert:xplane_to_trace_events",
+        "@xla//xla/tsl/profiler/utils:xplane_utils",
     ],
 )
 

--- a/tools/xspace_to_perfetto.cc
+++ b/tools/xspace_to_perfetto.cc
@@ -17,11 +17,11 @@ void PrintUsage(std::string_view argv0) {
   std::cerr << "Usage: " << argv0 << " <input_xspace.pb> [output_trace.json]\n";
 }
 
-void* MallocAlloc(const void*, size_t elem, size_t nelems, size_t) {
+void* Alloc(const void*, size_t elem, size_t nelems, size_t) {
   return std::malloc(elem * nelems);
 }
 
-void MallocFree(const void*, void* ptr, size_t, size_t, size_t) {
+void Free(const void*, void* ptr, size_t, size_t, size_t) {
   std::free(ptr);
 }
 
@@ -36,8 +36,8 @@ int main(int argc, char** argv) {
 
   zig_allocator error_allocator = {
       .ctx = nullptr,
-      .alloc = &MallocAlloc,
-      .free = &MallocFree,
+      .alloc = &Alloc,
+      .free = &Free,
   };
   zig_slice error = {.ptr = nullptr, .len = 0};
   if (!zml::tools::DumpXSpaceFileToTraceJsonFile(input_path, output_path,

--- a/tools/xspace_to_perfetto.cc
+++ b/tools/xspace_to_perfetto.cc
@@ -1,15 +1,28 @@
+#include <cstdlib>
 #include <iostream>
 #include <string>
 #include <string_view>
 
+#include "ffi/zig_allocator.h"
+#include "ffi/zig_slice.h"
+
 namespace zml::tools {
 bool DumpXSpaceFileToTraceJsonFile(std::string_view input_path,
                                    std::string_view output_path,
-                                   std::string* error);
+                                   zig_allocator* error_allocator,
+                                   zig_slice* error);
 }
 
 void PrintUsage(std::string_view argv0) {
   std::cerr << "Usage: " << argv0 << " <input_xspace.pb> [output_trace.json]\n";
+}
+
+void* MallocAlloc(const void*, size_t elem, size_t nelems, size_t) {
+  return std::malloc(elem * nelems);
+}
+
+void MallocFree(const void*, void* ptr, size_t, size_t, size_t) {
+  std::free(ptr);
 }
 
 int main(int argc, char** argv) {
@@ -21,10 +34,19 @@ int main(int argc, char** argv) {
   const std::string input_path = argv[1];
   const std::string output_path = argc == 3 ? argv[2] : input_path + ".trace.json";
 
-  std::string error;
+  zig_allocator error_allocator = {
+      .ctx = nullptr,
+      .alloc = &MallocAlloc,
+      .free = &MallocFree,
+  };
+  zig_slice error = {.ptr = nullptr, .len = 0};
   if (!zml::tools::DumpXSpaceFileToTraceJsonFile(input_path, output_path,
-                                                 &error)) {
-    std::cerr << error << "\n";
+                                                 &error_allocator, &error)) {
+    std::cerr << std::string_view(static_cast<const char*>(error.ptr), error.len)
+              << "\n";
+    if (error.ptr != nullptr) {
+      error_allocator.deallocate(static_cast<char*>(error.ptr), error.len);
+    }
     return 1;
   }
 

--- a/tools/xspace_to_perfetto.h
+++ b/tools/xspace_to_perfetto.h
@@ -1,14 +1,22 @@
 #pragma once
 
+#include <stdint.h>
+
+#include "ffi/zig_allocator.h"
 #include "ffi/zig_slice.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-zig_slice zml_xspace_to_perfetto_dump(zig_slice xspace_proto,
+zig_slice zml_xspace_to_perfetto_dump(zig_allocator* error_allocator,
+                                      zig_slice xspace_proto,
                                       zig_slice output_path);
-void zml_xspace_to_perfetto_str_free(zig_slice text);
+zig_slice zml_xspace_normalize_and_dump(zig_allocator* error_allocator,
+                                        zig_slice xspace_proto,
+                                        uint64_t start_time_ns,
+                                        uint64_t stop_time_ns,
+                                        zig_slice output_path);
 
 #ifdef __cplusplus
 }

--- a/tools/xspace_to_perfetto_lib.cc
+++ b/tools/xspace_to_perfetto_lib.cc
@@ -1,27 +1,88 @@
-#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <limits>
 #include <string>
 #include <string_view>
+#include <unistd.h>
 
 #include "tools/xspace_to_perfetto.h"
+#include "xla/tsl/profiler/convert/post_process_single_host_xplane.h"
 #include "xla/tsl/profiler/convert/trace_events_to_json.h"
 #include "xla/tsl/profiler/convert/xplane_to_trace_events.h"
+#include "xla/tsl/profiler/utils/xplane_utils.h"
 #include "tsl/profiler/protobuf/xplane.pb.h"
 
 namespace {
 
+zig_slice EmptySlice() { return {.ptr = nullptr, .len = 0}; }
+
+std::string_view ToStringView(zig_slice slice) {
+  return std::string_view(static_cast<const char*>(slice.ptr), slice.len);
+}
+
+bool SetError(zig_allocator* error_allocator,
+              zig_slice* error,
+              std::string_view message) {
+  char* buffer = error_allocator->allocate<char>(message.size());
+  if (buffer == nullptr) {
+    *error = EmptySlice();
+    return false;
+  }
+
+  std::memcpy(buffer, message.data(), message.size());
+  *error = {.ptr = buffer, .len = message.size()};
+  return true;
+}
+
+bool SetErrorWithPath(zig_allocator* error_allocator,
+                      zig_slice* error,
+                      std::string_view prefix,
+                      std::string_view path) {
+  const size_t len = prefix.size() + path.size();
+  char* buffer = error_allocator->allocate<char>(len);
+  if (buffer == nullptr) {
+    *error = EmptySlice();
+    return false;
+  }
+
+  std::memcpy(buffer, prefix.data(), prefix.size());
+  std::memcpy(buffer + prefix.size(), path.data(), path.size());
+  *error = {.ptr = buffer, .len = len};
+  return true;
+}
+
+void PostProcessXSpace(tensorflow::profiler::XSpace* xspace,
+                       uint64_t start_time_ns,
+                       uint64_t stop_time_ns) {
+  tsl::profiler::SetXSpacePidIfNotSet(*xspace, getpid());
+  tsl::profiler::PostProcessSingleHostXSpace(
+      xspace, start_time_ns, stop_time_ns);
+}
+
+bool SerializeXSpace(const tensorflow::profiler::XSpace& xspace,
+                     std::string* serialized_xspace,
+                     zig_allocator* error_allocator,
+                     zig_slice* error) {
+  if (!xspace.SerializeToString(serialized_xspace)) {
+    SetError(error_allocator, error,
+             "Failed to serialize normalized XSpace protobuf");
+    return false;
+  }
+  return true;
+}
+
 bool ParseXSpace(std::string_view xspace_proto,
                  tensorflow::profiler::XSpace* xspace,
-                 std::string* error) {
-  if (xspace_proto.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
-    *error = "XSpace protobuf is too large to parse";
+                 zig_allocator* error_allocator,
+                 zig_slice* error) {
+  if (xspace_proto.size() >
+      static_cast<size_t>(std::numeric_limits<int>::max())) {
+    SetError(error_allocator, error, "XSpace protobuf is too large to parse");
     return false;
   }
   if (!xspace->ParseFromArray(xspace_proto.data(),
                               static_cast<int>(xspace_proto.size()))) {
-    *error = "Failed to parse XSpace protobuf";
+    SetError(error_allocator, error, "Failed to parse XSpace protobuf");
     return false;
   }
   return true;
@@ -29,30 +90,34 @@ bool ParseXSpace(std::string_view xspace_proto,
 
 bool WriteFile(std::string_view output_path,
                std::string_view contents,
-               std::string* error) {
+               zig_allocator* error_allocator,
+               zig_slice* error) {
   std::ofstream output(std::string(output_path), std::ios::binary);
   if (!output.is_open()) {
-    *error = "Failed to open output file: " + std::string(output_path);
+    SetErrorWithPath(error_allocator, error, "Failed to open output file: ",
+                     output_path);
     return false;
   }
 
   output.write(contents.data(), static_cast<std::streamsize>(contents.size()));
   if (!output) {
-    *error = "Failed to write output file: " + std::string(output_path);
+    SetErrorWithPath(error_allocator, error, "Failed to write output file: ",
+                     output_path);
     return false;
   }
   return true;
 }
 
-}
+}  // namespace
 
 namespace zml::tools {
 
 bool ConvertXSpaceProtoToTraceJson(std::string_view xspace_proto,
                                    std::string* json,
-                                   std::string* error) {
+                                   zig_allocator* error_allocator,
+                                   zig_slice* error) {
   tensorflow::profiler::XSpace xspace;
-  if (!ParseXSpace(xspace_proto, &xspace, error)) {
+  if (!ParseXSpace(xspace_proto, &xspace, error_allocator, error)) {
     return false;
   }
 
@@ -64,62 +129,74 @@ bool ConvertXSpaceProtoToTraceJson(std::string_view xspace_proto,
 
 bool DumpXSpaceProtoToTraceJsonFile(std::string_view xspace_proto,
                                     std::string_view output_path,
-                                    std::string* error) {
+                                    zig_allocator* error_allocator,
+                                    zig_slice* error) {
   std::string json;
-  if (!ConvertXSpaceProtoToTraceJson(xspace_proto, &json, error)) {
+  if (!ConvertXSpaceProtoToTraceJson(xspace_proto, &json, error_allocator,
+                                     error)) {
     return false;
   }
-  return WriteFile(output_path, json, error);
+  return WriteFile(output_path, json, error_allocator, error);
 }
 
 bool DumpXSpaceFileToTraceJsonFile(std::string_view input_path,
                                    std::string_view output_path,
-                                   std::string* error) {
+                                   zig_allocator* error_allocator,
+                                   zig_slice* error) {
   std::ifstream input(std::string(input_path), std::ios::binary);
   if (!input.is_open()) {
-    *error = "Failed to open input file: " + std::string(input_path);
+    SetErrorWithPath(error_allocator, error, "Failed to open input file: ",
+                     input_path);
     return false;
   }
 
   tensorflow::profiler::XSpace xspace;
   if (!xspace.ParseFromIstream(&input)) {
-    *error = "Failed to parse XSpace protobuf from: " + std::string(input_path);
+    SetErrorWithPath(error_allocator, error,
+                     "Failed to parse XSpace protobuf from: ", input_path);
     return false;
   }
 
   const tsl::profiler::TraceContainer container =
       tsl::profiler::ConvertXSpaceToTraceContainer(xspace);
   const std::string json = tsl::profiler::TraceContainerToJson(container);
-  return WriteFile(output_path, json, error);
+  return WriteFile(output_path, json, error_allocator, error);
 }
 
-}
+}  // namespace zml::tools
 
-extern "C" zig_slice zml_xspace_to_perfetto_dump(zig_slice xspace_proto,
-                                                 zig_slice output_path) {
-  std::string error;
+extern "C" zig_slice zml_xspace_to_perfetto_dump(
+    zig_allocator* error_allocator,
+    zig_slice xspace_proto,
+    zig_slice output_path) {
+  zig_slice error = EmptySlice();
   if (zml::tools::DumpXSpaceProtoToTraceJsonFile(
-          std::string_view(static_cast<const char*>(xspace_proto.ptr),
-                           xspace_proto.len),
-          std::string_view(static_cast<const char*>(output_path.ptr),
-                           output_path.len),
+          ToStringView(xspace_proto),
+          ToStringView(output_path),
+          error_allocator,
           &error)) {
-    return {.ptr = nullptr, .len = 0};
+    return EmptySlice();
   }
-
-  if (error.empty()) {
-    return {.ptr = nullptr, .len = 0};
-  }
-
-  void* buffer = std::malloc(error.size());
-  if (buffer == nullptr) {
-    return {.ptr = nullptr, .len = 0};
-  }
-
-  std::memcpy(buffer, error.data(), error.size());
-  return {.ptr = buffer, .len = error.size()};
+  return error;
 }
 
-extern "C" void zml_xspace_to_perfetto_str_free(zig_slice text) {
-  std::free(text.ptr);
+extern "C" zig_slice zml_xspace_normalize_and_dump(
+    zig_allocator* error_allocator, zig_slice xspace_proto,
+    uint64_t start_time_ns, uint64_t stop_time_ns, zig_slice output_path) {
+  zig_slice error = EmptySlice();
+  tensorflow::profiler::XSpace xspace;
+  if (!ParseXSpace(ToStringView(xspace_proto), &xspace, error_allocator,
+                   &error)) {
+    return error;
+  }
+
+  PostProcessXSpace(&xspace, start_time_ns, stop_time_ns);
+  std::string normalized_xspace;
+  if (!SerializeXSpace(xspace, &normalized_xspace, error_allocator, &error) ||
+      !WriteFile(ToStringView(output_path), normalized_xspace, error_allocator,
+                 &error)) {
+    return error;
+  }
+
+  return EmptySlice();
 }

--- a/zml/profiler.zig
+++ b/zml/profiler.zig
@@ -142,6 +142,8 @@ pub const Profiler = struct {
     allocator: std.mem.Allocator,
     io: std.Io,
     inner: ?pjrt.Profiler,
+    start_timestamp_ns: ?u64,
+    stop_timestamp_ns: ?u64,
     session_dir: []const u8,
     profile: Profile,
 
@@ -170,6 +172,8 @@ pub const Profiler = struct {
             .allocator = allocator,
             .io = io,
             .inner = inner,
+            .start_timestamp_ns = null,
+            .stop_timestamp_ns = null,
             .session_dir = session_dir,
             .profile = .{
                 .protobuf_path = protobuf_path,
@@ -187,6 +191,7 @@ pub const Profiler = struct {
 
     pub fn start(self: *Profiler) !void {
         if (self.inner) |*inner| {
+            self.start_timestamp_ns = @intCast(std.Io.Timestamp.now(self.io, .real).nanoseconds);
             try inner.start();
         }
     }
@@ -195,30 +200,41 @@ pub const Profiler = struct {
         var inner = self.inner orelse return null;
         self.inner = null;
         try inner.stop();
+        self.stop_timestamp_ns = @intCast(std.Io.Timestamp.now(self.io, .real).nanoseconds);
 
         const protobuf = try inner.collectData(self.arena.allocator());
+        var error_allocator = zffi.ZigAllocator.from(self.arena.allocator());
+        const normalization_error = c.zml_xspace_normalize_and_dump(
+            &error_allocator,
+            zffi.ZigSlice.from(protobuf),
+            self.start_timestamp_ns.?,
+            self.stop_timestamp_ns.?,
+            zffi.ZigSlice.from(self.profile.protobuf_path),
+        );
 
-        try self.writeFile(self.profile.protobuf_path, protobuf);
+        if (normalization_error.len != 0) {
+            log.err("Failed to normalize profile protobuf: {s}", .{zffi.ZigSlice.to(u8, normalization_error)});
+            return error.ProfileTraceNormalizationFailed;
+        }
+
+        const normalized_protobuf = try std.Io.Dir.cwd().readFileAlloc(
+            self.io,
+            self.profile.protobuf_path,
+            self.arena.allocator(),
+            .unlimited,
+        );
 
         const conversion_error = c.zml_xspace_to_perfetto_dump(
-            zffi.ZigSlice.from(protobuf),
+            &error_allocator,
+            zffi.ZigSlice.from(normalized_protobuf),
             zffi.ZigSlice.from(self.profile.perfetto_path),
         );
-        defer if (conversion_error.len != 0) {
-            c.zml_xspace_to_perfetto_str_free(conversion_error);
-        };
+
         if (conversion_error.len != 0) {
-            log.err("Failed to convert profile protobuf to Perfetto trace: {s}", .{zffi.ZigSlice.to(u8, conversion_error)});
+            log.err("Failed to convert normalized profile protobuf to Perfetto trace: {s}", .{zffi.ZigSlice.to(u8, conversion_error)});
             return error.ProfileTraceConversionFailed;
         }
 
         return self.profile;
-    }
-
-    fn writeFile(self: *const Profiler, path: []const u8, contents: []const u8) !void {
-        const file = try std.Io.Dir.createFile(.cwd(), self.io, path, .{});
-        defer file.close(self.io);
-
-        try file.writePositionalAll(self.io, contents, 0);
     }
 };


### PR DESCRIPTION
This change fixes profile timestamp handling so saved xplane.pb data is post-processed like JAX/XLA’s `ProfilerSession`, and also cleans up the Zig/C++ FFI used by the profile export bridge.

Before this, we were writing raw profiler output from the PJRT extension directly to `profiling.xplane.pb`, which bypassed XLA’s single-host post-processing step done by JAX that we can find here: https://github.com/google/tsl/blob/efac222ebfdbd682d3a407ef165865c6b6759e2d/tsl/profiler/lib/profiler_session.cc#L100

That made ZML behave differently from JAX, including wrong timeline origins in downstream viewers like XProf. 
To fix that, we now run `tsl::profiler::PostProcessSingleHostXSpace(...)` before writing the protobuf, and we treat that post-processed xplane.pb as the source for subsequent Perfetto conversion. 
We also register start/stop timestamps in `zml/profiler.zig` so they match XLA’s expectations for session timestamps with `real` clock.

While touching this path, I tightened the FFI boundary as well. 
Error text returned from the xspace export bridge is now allocated with the provided Zig allocator instead of malloc, C receives a pointer to the `zig_allocator wrapper` to avoid lifetime issues from passing allocator state by value, and error propagation in `tools/xspace_to_perfetto_lib.cc `now uses `zig_slice` outputs directly instead of building std::string error objects just to copy them back out. This removes mixed allocation ownership between C++ and Zig and fixes the allocator lifetime bug that could crash across the FFI boundary.