### PR TITLE
kernels/triton: add LLVM dialect, pipelining hints and fixes

### DIFF
--- a/kernels/common/control_flow.zig
+++ b/kernels/common/control_flow.zig
@@ -49,6 +49,7 @@ pub fn ForScope(comptime BuilderT: type, comptime ValueT: type, comptime N: usiz
         iv: ValueT,
         carried: [N]ValueT,
         results: [N]ValueT = undefined,
+        opts: scf.ForOpts = .{},
 
         const Self = @This();
 
@@ -63,7 +64,7 @@ pub fn ForScope(comptime BuilderT: type, comptime ValueT: type, comptime N: usiz
                 self.step_inner,
                 &self.inits_inner,
                 self.body,
-                .{},
+                self.opts,
                 k.loc(),
             );
             _ = for_op.appendTo(k.currentBlock());

--- a/kernels/mosaic_tpu/README.md
+++ b/kernels/mosaic_tpu/README.md
@@ -6,24 +6,28 @@ to read like `pallas.tpu` Python while staying in pure Zig. Used by
 op-for-op against what `pallas_call` produces.
 
 The DSL talks to the `tpu` dialect through `mlir.Operation.make(ctx, "tpu.<op>", …)`.
-The dialect must be registered into the MLIR context — see
-`mlir/dialects/mosaic_tpu`. Until the JAX repo is wired into `MODULE.bazel`, the
-whole stack is `manual`-tagged in Bazel.
+A Mosaic kernel is a pure IR generator: it builds its MLIR in a throwaway
+context, canonicalizes it, serializes it to a string, and hands that to a
+`stablehlo.custom_call` targeting `tpu_custom_call` — it never touches ZML's
+compilation context (which carries only `func`/`stablehlo`/`sdy`). Until the
+JAX repo is wired into `MODULE.bazel`, the whole stack is `manual`-tagged in Bazel.
 
 Two layers define the surface:
 
 - **Low layer** — `kernels/mosaic_tpu/builder.zig`: the IR builder primitives.
   `Builder.open(allocator, ctx, name)` → `b.declareArgsOpts(spec, results, opts)`
   → body via `b.*` helpers → `b.finishOpts(results, .{ .canonicalize = true })`
-  for the final IR string. (`Builder.buildOpts(...)` is a convenience that
-  bundles `open + declareArgs` into one call and returns a heap-allocated
-  `*Built(Spec)`; reach for it in escape-hatch code that drives the
-  lifecycle manually.)
+  for the final IR string. Pass `Builder.open` / `Builder.init` a
+  `zml.kernel.mosaic_tpu.newContext()` (a throwaway context with the dialects
+  the DSL emits), `defer ctx.deinit()` once you have the string — not a
+  `CompilationContext`'s `mlir_ctx`. (`Builder.buildOpts(...)` is a convenience
+  that bundles `open + declareArgs` into one call and returns a heap-allocated
+  `*Built(Spec)`; reach for it in escape-hatch code that drives the lifecycle manually.)
 - **High layer** — `zml.kernel.mosaic_tpu.Kernel(Config, spec)`: the
   declarative kernel form, mirroring the Triton DSL. Bundles a config
   type, a typed spec literal (name + named `inputs` / `outputs` + a typed
   `run` function pointer), and produces a kernel type. Exposes
-  `.emit(allocator, ctx, cfg)` (IR string) and
+  `.emit(allocator, cfg)` (IR string; manages its own context) and
   `.call(inputs, outputs, opts)` (IR string + `stablehlo.custom_call`
   targeting `tpu_custom_call` in one shot — the preferred form for
   production model code).
@@ -133,10 +137,11 @@ windows) can be runtime values from a config.
 
 ### Two ways to use a kernel
 
-**Offline / tooling** — get the MLIR string and print or diff it:
+**Offline / tooling** — get the MLIR string and print or diff it (no MLIR
+context needed; `emit` spins up and tears down its own):
 
 ```zig
-const ir = try MyKernel.Kernel.emit(allocator, ctx, .{ /* cfg */ });
+const ir = try MyKernel.Kernel.emit(allocator, .{ /* cfg */ });
 defer allocator.free(ir);
 try stdout.print("{s}\n", .{ir});
 ```

--- a/kernels/mosaic_tpu/builder.zig
+++ b/kernels/mosaic_tpu/builder.zig
@@ -402,6 +402,8 @@ pub const MinMaxOpts = struct {
 // Builder — the main DSL builder.
 // =============================================================================
 
+pub const dialects_needed = [_][]const u8{ "func", "tpu", "arith", "scf", "math", "cf", "memref", "vector", "affine" };
+
 /// The main DSL builder. Create with `init`, populate the body with helpers,
 /// then call `finish` to get the IR string.
 pub const Builder = struct {

--- a/kernels/triton/README.md
+++ b/kernels/triton/README.md
@@ -10,14 +10,19 @@ Two layers define the surface:
 - **Low layer** — `kernels/triton/builder.zig`: the IR builder primitives.
   `Builder`, `Value`, `DType`, `ArgSpec`. Use these directly when you need
   full control (custom op insertion, dynamic-arity arg lists, escape hatches).
+  `Builder.open` / `Builder.init` take an `*mlir.Context` — pass them a
+  `zml.kernel.triton.newContext()` (a throwaway context with the dialects the
+  DSL emits), `defer ctx.deinit()` once you have the IR string. Not a
+  `CompilationContext`'s `mlir_ctx`: that one carries only `func`/`stablehlo`/`sdy`
+  (a registered `llvm` dialect makes XLA:TPU choke).
 - **High layer** — `zml.kernel.triton.Kernel(Config, spec)`: the declarative
   kernel form. Bundles a config type, a typed spec literal (name + named
   `inputs` / `outputs` + a typed `run` function pointer), and produces a
-  kernel type. Exposes `.emit(allocator, ctx, cfg)` (TTIR string) and
-  `.call(inputs, outputs, opts)` (TTIR string + `stablehlo.custom_call` in
-  one shot — the preferred form for production model code). Inputs and
-  outputs are by-name structs generated from the spec, so missing / typo'd
-  / extra arguments are compile errors at the callsite.
+  kernel type. Exposes `.emit(allocator, cfg)` (TTIR string; manages its own
+  throwaway context) and `.call(inputs, outputs, opts)` (TTIR string +
+  `stablehlo.custom_call` in one shot — the preferred form for production
+  model code). Inputs and outputs are by-name structs generated from the
+  spec, so missing / typo'd / extra arguments are compile errors at the callsite.
 
 ## Table of contents
 
@@ -111,10 +116,11 @@ models where dtypes/sizes come from `Tensor.dim()` / `Options`).
 
 ### Two ways to use a kernel
 
-**Offline / tooling** — get the TTIR string:
+**Offline / tooling** — get the TTIR string (no MLIR context needed; `emit`
+spins up and tears down its own):
 
 ```zig
-const ttir = try MyKernel.Kernel.emit(allocator, ctx, .{ .BLOCK = 1024 });
+const ttir = try MyKernel.Kernel.emit(allocator, .{ .BLOCK = 1024 });
 defer allocator.free(ttir);
 ```
 
@@ -190,9 +196,10 @@ pub fn forward(self: Model, x: zml.Tensor, y: zml.Tensor) zml.Tensor {
 
 `call` is a thin wrapper over `Kernel.emit(...)` + `zml.ops.triton(...)`.
 It must be called from inside a `CompilationContext` (i.e., during
-`zml.module.compile(...)`). For offline tools without a CompilationContext
-(e.g., dump-to-disk diff harnesses), use `Kernel.emit(allocator, ctx, cfg)`
-directly to get the TTIR string.
+`zml.module.compile(...)`) — `emit` builds the TTIR string in its own
+throwaway context; `zml.ops.triton(...)` drops the `stablehlo.custom_call`
+into the model's context. For offline tools, `Kernel.emit(allocator, cfg)`
+gives you just the TTIR string.
 
 Signature: `Kernel.call(inputs: Inputs, outputs: Outputs, opts: CallOpts) Results`.
 
@@ -1001,6 +1008,10 @@ instead of a comptime struct literal; you grab block args with `b.arg(i)`.
 You can also use `Builder.open(allocator, ctx, name)` to create an empty
 builder and call `b.declareArgs(spec)` mid-stream — that's exactly what
 `zml.kernel.triton.Kernel(...)` does internally.
+
+Pass these constructors a `zml.kernel.triton.newContext()`, not a
+`CompilationContext`'s `mlir_ctx`; `defer ctx.deinit()` once you have the IR
+string. `Kernel.emit` does this for you, which is why it takes no context.
 
 Prefer `zml.kernel.triton.Kernel(Config, spec)` for the common case.
 

--- a/kernels/triton/README.md
+++ b/kernels/triton/README.md
@@ -666,6 +666,10 @@ Pairs in place today: `load` / `loadOpts`, `store` / `storeOpts`,
 `sum` / `sumOpts`, `max` / `maxOpts`, `min` / `minOpts`,
 `cumsum` / `cumsumOpts`, `cumprod` / `cumprodOpts`.
 
+DSL-only pair (no Python kwarg counterpart — `.inline_return` is about IR
+block layout, see the `returnIf` / `returnIfOpts` section under Control flow):
+`returnIf` / `returnIfOpts`.
+
 Ops with no kwargs in Python (pure positional): `gather(src, indices, axis)`,
 `trans(src, order)`, `permute(src, order)`, `cat(lhs, rhs)` (dim=0 default),
 `split(src)`, `join(lhs, rhs)`, `item(src)`, `broadcast(a, b)` (symmetric),
@@ -814,7 +818,7 @@ const r = w.results[0];
 - `yieldBefore(cond, forwarded)` — `forwarded` arity must match `after_types`.
 - `yieldAfter(values)` — arity must match `inits`.
 
-### `returnIf` — early `tt.return` via cf.cond_br
+### `returnIf` / `returnIfOpts` — early `tt.return` via cf.cond_br
 
 ```zig
 // Python: if pid_m * BLOCK >= num_tokens_post_padded: return
@@ -846,14 +850,32 @@ cf.cond_br %out_of_range, ^ret, ^cont
   `scf.if` for structured loops and value-carrying branches; our DSL does
   the same.
 
+**`returnIfOpts(cond, values, .{ .inline_return = true })` — match Python's
+per-`return` block layout.** By default `returnIf` routes every return path
+(every early `returnIf` / `openReturnIf` plus the natural fall-through from
+`b.finish`) through one **shared exit block** holding the single `tt.return`.
+Python's frontend does the opposite: each `if cond: return` (and the natural
+exit) gets its **own** `tt.return`-only block, and LLVM's SimplifyCFG later
+merges them into a single `common.ret`. The two are semantically identical
+but differ in the function-exit block's label and position — which renumbers
+every `$L__BB` label downstream and blows up the PTX diff. When the Python source contains *any* literal `return` statement (it then
+has ≥2 `ret` blocks in LLVM — the explicit one(s) plus the implicit
+function-end one — which SimplifyCFG merges into `common.ret`), pass
+`.{ .inline_return = true }` on *every* return site, and set
+`scope.inline_return = true` on each `openReturnIf` (see below). Each one
+then emits `tt.return` inline and SimplifyCFG reproduces Python's
+`common.ret`. The default shared exit block emits exactly one `tt.return`,
+so the merge never fires and the function-exit block lands somewhere else.
+
 ### `openReturnIf` — early `tt.return` with side-effects in the taken branch
 
 ```zig
 // Python: if off_experts == -1: write_zeros_to_output(...); return
 var scope = b.openReturnIf(is_dead);
+scope.inline_return = true;              // optional — see `returnIfOpts` above
 {
     writeZerosToOutput(k, c_ptr, ...);   // ops here emit into ^ret
-    scope.yieldReturn(.{});              // closes ^ret with tt.return
+    scope.yieldReturn(.{});              // closes ^ret with tt.return (or cf.br ^exit)
 }
 // ... ops here emit into ^cont (fall-through) ...
 ```
@@ -864,6 +886,12 @@ the `tt.return`. Use this instead of the
 `openIf(cond){body}yieldThen; returnIf(cond, values)` pair — that pattern
 duplicates the predicate (emits both `scf.if` and `cf.cond_br` on the same
 boolean) and drifts from Triton's reference IR.
+
+`scope.inline_return` is the per-scope twin of `returnIfOpts`'s
+`.inline_return` (default `false`): set it before `yieldReturn` to make
+`^ret` close with `tt.return` directly instead of `cf.br ^exit`. Flip it on
+every `returnIf` / `openReturnIf` of a kernel when matching a Python source
+that has literal `return` statements.
 
 Same restrictions as `returnIf`: top-level `tt.func` body only.
 
@@ -1041,8 +1069,8 @@ Prefer `zml.kernel.triton.Kernel(Config, spec)` for the common case.
 | `while cond: ...`                             | `var w = b.openWhile(.{inits}, .{after_types}); { ...; w.yieldBefore(cond, .{...}); }; { ...; w.yieldAfter(.{...}); }` |
 | `if cond: ...` (side-effects, no else)        | `var i = b.openIf(cond); { ...; i.yieldThen(.{}); }`                                         |
 | `if cond: ... else: ...`                      | `var i = b.openIfElse(cond, .{result_types}); { ...; i.yieldThen(.{...}); }; { ...; i.yieldElse(.{...}); }` |
-| `if cond: return` (early exit)                | `b.returnIf(cond, .{});` — emits `cf.cond_br` + `tt.return`, continues in fall-through block  |
-| `if cond: <stores>; return` (early exit, with side-effects) | `var s = b.openReturnIf(cond); { ...; s.yieldReturn(.{}); }` — single `cf.cond_br`; body emits into `^ret` before the `tt.return` |
+| `if cond: return` (early exit)                | `b.returnIf(cond, .{});` — emits `cf.cond_br` + `tt.return`, continues in fall-through block (add `b.returnIfOpts(cond, .{}, .{ .inline_return = true })` when matching a Python source that has literal `return`s) |
+| `if cond: <stores>; return` (early exit, with side-effects) | `var s = b.openReturnIf(cond); { ...; s.yieldReturn(.{}); }` — single `cf.cond_br`; body emits into `^ret` before the `tt.return` (set `s.inline_return = true` to match, alongside `returnIfOpts`) |
 
 ---
 

--- a/kernels/triton/builder.zig
+++ b/kernels/triton/builder.zig
@@ -370,6 +370,10 @@ pub const DeviceAssertOpts = struct {
     mask: ?Value = null,
 };
 
+pub const ReturnIfOpts = struct {
+    inline_return: bool = false,
+};
+
 const tupleArity = dsl.tupleArity;
 
 pub fn ForScope(comptime N: usize) type {
@@ -2049,33 +2053,41 @@ pub const Builder = struct {
     }
 
     pub fn returnIf(self: *Builder, cond: Value, values: anytype) void {
+        self.returnIfOpts(cond, values, .{});
+    }
+
+    pub fn returnIfOpts(self: *Builder, cond: Value, values: anytype, opts: ReturnIfOpts) void {
         const current = self.currentBlock();
         const region = current.parentRegion();
-
-        const fields = @typeInfo(@TypeOf(values)).@"struct".fields;
         const cont_block = mlir.Block.init(&.{}, &.{});
 
-        // Use a shared exit block for all returns. This ensures that every
-        // return path (early or natural) goes through a pure tt.return block,
-        // allowing MLIR's Canonicalizer/BlockMerging to create a single join
-        // point.
-        if (self.exit_block == null) {
-            self.exit_block = mlir.Block.init(&.{}, &.{});
-
-            var ret_operands: [fields.len]*const mlir.Value = undefined;
-            inline for (fields, 0..) |f, i| {
-                if (f.type != Value)
-                    @compileError("returnIf: every value must be a Value");
-                ret_operands[i] = @field(values, f.name).inner;
-            }
-            _ = ttir.return_(self.ctx, &ret_operands, self.loc()).appendTo(self.exit_block.?);
+        const fields = @typeInfo(@TypeOf(values)).@"struct".fields;
+        var ret_operands: [fields.len]*const mlir.Value = undefined;
+        inline for (fields, 0..) |f, i| {
+            if (f.type != Value)
+                @compileError("returnIfOpts: every value must be a Value");
+            ret_operands[i] = @field(values, f.name).inner;
         }
+
+        const ret_target: *mlir.Block = if (opts.inline_return) blk: {
+            const rb = mlir.Block.init(&.{}, &.{});
+            _ = ttir.return_(self.ctx, &ret_operands, self.loc()).appendTo(rb);
+            region.appendOwnedBlock(rb);
+            break :blk rb;
+        } else blk: {
+            if (self.exit_block == null) {
+                self.exit_block = mlir.Block.init(&.{}, &.{});
+                _ = ttir.return_(self.ctx, &ret_operands, self.loc()).appendTo(self.exit_block.?);
+            }
+            break :blk self.exit_block.?;
+        };
+
         region.appendOwnedBlock(cont_block);
 
         _ = cf.cond_br(
             self.ctx,
             cond.inner,
-            self.exit_block.?,
+            ret_target,
             &.{},
             cont_block,
             &.{},

--- a/kernels/triton/builder.zig
+++ b/kernels/triton/builder.zig
@@ -453,6 +453,8 @@ pub fn ScanArgs(comptime CtxT: type) type {
     };
 }
 
+pub const dialects_needed = [_][]const u8{ "func", "tt", "arith", "scf", "math", "cf", "llvm" };
+
 pub const Builder = struct {
     allocator: std.mem.Allocator,
     arena: std.heap.ArenaAllocator,

--- a/kernels/triton/builder.zig
+++ b/kernels/triton/builder.zig
@@ -380,24 +380,34 @@ pub const ReturnIfScope = struct {
     kernel: *Builder,
     ret_block: *mlir.Block,
     cont_block: *mlir.Block,
+    inline_return: bool = false,
 
     pub fn yieldReturn(self: *ReturnIfScope, values: anytype) void {
         const k = self.kernel;
         const fields = @typeInfo(@TypeOf(values)).@"struct".fields;
 
-        if (k.exit_block == null) {
-            k.exit_block = mlir.Block.init(&.{}, &.{});
-
+        if (self.inline_return) {
             var ret_operands: [fields.len]*const mlir.Value = undefined;
             inline for (fields, 0..) |f, i| {
                 if (f.type != Value)
                     @compileError("ReturnIfScope.yieldReturn: every value must be a Value");
                 ret_operands[i] = @field(values, f.name).inner;
             }
-            _ = ttir.return_(k.ctx, &ret_operands, k.loc()).appendTo(k.exit_block.?);
-        }
+            _ = ttir.return_(k.ctx, &ret_operands, k.loc()).appendTo(self.ret_block);
+        } else {
+            if (k.exit_block == null) {
+                k.exit_block = mlir.Block.init(&.{}, &.{});
 
-        _ = cf.br(k.ctx, k.exit_block.?, &.{}, k.loc()).appendTo(self.ret_block);
+                var ret_operands: [fields.len]*const mlir.Value = undefined;
+                inline for (fields, 0..) |f, i| {
+                    if (f.type != Value)
+                        @compileError("ReturnIfScope.yieldReturn: every value must be a Value");
+                    ret_operands[i] = @field(values, f.name).inner;
+                }
+                _ = ttir.return_(k.ctx, &ret_operands, k.loc()).appendTo(k.exit_block.?);
+            }
+            _ = cf.br(k.ctx, k.exit_block.?, &.{}, k.loc()).appendTo(self.ret_block);
+        }
         k.popBlock();
 
         if (k.block_stack.items.len == 0) {
@@ -726,6 +736,18 @@ pub const Builder = struct {
 
     pub fn numPrograms(self: *Builder, dim: ttir.ProgramIDDim) Value {
         return self.emit(ttir.get_num_programs(self.ctx, dim, self.loc()));
+    }
+
+    pub fn assume(self: *Builder, cond: Value) void {
+        const op = mlir.Operation.make(self.ctx, "llvm.intr.assume", .{
+            .operands = .{ .flat = &.{cond.inner} },
+            .attributes = &.{
+                .named(self.ctx, "op_bundle_sizes", mlir.denseArrayAttribute(self.ctx, .i32, &.{})),
+                .named(self.ctx, "op_bundle_tags", mlir.arrayAttribute(self.ctx, &.{})),
+            },
+            .location = self.loc(),
+        });
+        _ = op.appendTo(self.currentBlock());
     }
 
     // ==================== constants ====================
@@ -1318,7 +1340,10 @@ pub const Builder = struct {
         }
         const cur_bw = dtypeBitwidth(cur_dtype);
         const tgt_bw = dtypeBitwidth(dtype);
-        if (tgt_bw > cur_bw) return self.extsi(src, dtype);
+        if (tgt_bw > cur_bw) {
+            if (cur_dtype == .i1) return self.extui(src, dtype);
+            return self.extsi(src, dtype);
+        }
         if (tgt_bw < cur_bw) return self.trunci(src, dtype);
         return self.arithBitcast(src, dtype);
     }

--- a/mlir/BUILD.bazel
+++ b/mlir/BUILD.bazel
@@ -12,6 +12,7 @@ cc_library(
         "@llvm-project//mlir:CAPIArith",
         "@llvm-project//mlir:CAPICF",
         "@llvm-project//mlir:CAPIIR",
+        "@llvm-project//mlir:CAPILLVM",
         "@llvm-project//mlir:CAPIMath",
         "@llvm-project//mlir:CAPIMemRef",
         "@llvm-project//mlir:CAPISCF",

--- a/mlir/dialects/scf.zig
+++ b/mlir/dialects/scf.zig
@@ -8,6 +8,7 @@ pub const ForOpts = struct {
     /// the `unsignedCmp` UnitAttr so the induction variable advances with
     /// unsigned comparison instead.
     unsigned_cmp: bool = false,
+    num_stages: ?i32 = null,
 };
 
 /// scf.for — operands are (lower, upper, step, init_args...) as a flat list.
@@ -32,9 +33,12 @@ pub fn for_(
     var result_types: stdx.BoundedArray(*const mlir.Type, 64) = .empty;
     for (init_args) |v| result_types.appendAssumeCapacity(v.type_());
 
-    var attrs: stdx.BoundedArray(mlir.NamedAttribute, 1) = .empty;
+    var attrs: stdx.BoundedArray(mlir.NamedAttribute, 2) = .empty;
     if (opts.unsigned_cmp) {
         attrs.appendAssumeCapacity(.named(ctx, "unsignedCmp", mlir.unitAttribute(ctx)));
+    }
+    if (opts.num_stages) |n| {
+        attrs.appendAssumeCapacity(.named(ctx, "tt.num_stages", mlir.integerAttribute(ctx, .i32, n)));
     }
 
     return mlir.Operation.make(ctx, "scf.for", .{

--- a/mlir/mlir.h
+++ b/mlir/mlir.h
@@ -5,6 +5,7 @@
 #include <mlir-c/Dialect/Arith.h>
 #include <mlir-c/Dialect/ControlFlow.h>
 #include <mlir-c/Dialect/Func.h>
+#include <mlir-c/Dialect/LLVM.h>
 #include <mlir-c/Dialect/Math.h>
 #include <mlir-c/Dialect/MemRef.h>
 #include <mlir-c/Dialect/SCF.h>

--- a/zml/kernel.zig
+++ b/zml/kernel.zig
@@ -21,11 +21,33 @@ fn StructOf(comptime names: []const [:0]const u8, comptime FieldT: type) type {
     return @Struct(.auto, null, &name_slices, &@splat(FieldT), &@splat(.{}));
 }
 
+fn makeKernelContext(comptime dialects_needed: []const []const u8) std.mem.Allocator.Error!*mlir.Context {
+    mlir.registerPasses("Transforms");
+
+    const registry = try mlir.DialectRegistry.init();
+    defer registry.deinit();
+
+    inline for (dialects_needed) |d| {
+        mlir.DialectHandle.fromString(d).insertDialect(registry);
+    }
+
+    mlir.registerFuncExtensions(registry);
+
+    const ctx = try mlir.Context.init(.{ .registry = registry, .threading = false });
+    ctx.loadAllAvailableDialects();
+
+    return ctx;
+}
+
 pub const triton = struct {
     pub const Builder = triton_builder.Builder;
     pub const Value = triton_builder.Value;
     pub const DType = triton_builder.DType;
     pub const FinishError = triton_builder.FinishError;
+
+    pub fn newContext() std.mem.Allocator.Error!*mlir.Context {
+        return makeKernelContext(&triton_builder.dialects_needed);
+    }
 
     pub fn from(dt: DataType) DType {
         return switch (dt) {
@@ -73,21 +95,22 @@ pub const triton = struct {
                 debug: bool = false,
             };
 
-            pub fn emit(
-                allocator: std.mem.Allocator,
-                ctx: *mlir.Context,
-                cfg: ConfigT,
-            ) ![:0]const u8 {
+            pub fn emit(allocator: std.mem.Allocator, cfg: ConfigT) ![:0]const u8 {
+                const ctx = try newContext();
+                defer ctx.deinit();
+
                 var b = try triton_builder.Builder.open(allocator, ctx, name);
                 defer b.deinit();
+
                 try spec.run(&b, cfg);
+
                 return b.finish(&.{});
             }
 
             pub fn call(inputs: Inputs, outputs: Outputs, opts: CallOpts) Results {
                 const cur = CompilationContext.current();
 
-                const ttir = emit(cur.allocator, cur.mlir_ctx, opts.cfg) catch |err|
+                const ttir = emit(cur.allocator, opts.cfg) catch |err|
                     std.debug.panic("zml.kernel.triton.Kernel({s}).call: emit failed: {}", .{ name, err });
                 defer cur.allocator.free(ttir);
 
@@ -119,6 +142,10 @@ pub const mosaic_tpu = struct {
     const Builder = mosaic_tpu_builder.Builder;
     const DType = mosaic_tpu_builder.DType;
     const FinishError = mosaic_tpu_builder.FinishError;
+
+    pub fn newContext() std.mem.Allocator.Error!*mlir.Context {
+        return makeKernelContext(&mosaic_tpu_builder.dialects_needed);
+    }
 
     pub fn from(dt: DataType) DType {
         return switch (dt) {
@@ -162,25 +189,26 @@ pub const mosaic_tpu = struct {
                 extras: CallExtras = .{},
             };
 
-            pub fn emit(
-                allocator: std.mem.Allocator,
-                ctx: *mlir.Context,
-                cfg: ConfigT,
-            ) ![:0]const u8 {
+            pub fn emit(allocator: std.mem.Allocator, cfg: ConfigT) ![:0]const u8 {
+                const ctx = try newContext();
+                defer ctx.deinit();
+
                 var b = try mosaic_tpu_builder.Builder.open(allocator, ctx, name);
                 defer b.deinit();
+
                 try spec.run(&b, cfg);
+
                 return b.finishOpts(&.{}, .{ .canonicalize = true });
             }
 
             pub fn call(inputs: Inputs, outputs: Outputs, opts: CallOpts) Results {
                 const cur = CompilationContext.current();
 
-                const ir = emit(cur.allocator, cur.mlir_ctx, opts.cfg) catch |err|
+                const ir = emit(cur.allocator, opts.cfg) catch |err|
                     std.debug.panic("zml.kernel.mosaic_tpu.Kernel({s}).call: emit failed: {}", .{ name, err });
                 defer cur.allocator.free(ir);
 
-                const backend_config = buildBackendConfig(cur.allocator, cur.mlir_ctx, ir, opts.extras) catch |err|
+                const backend_config = buildBackendConfig(cur.allocator, ir, opts.extras) catch |err|
                     std.debug.panic("zml.kernel.mosaic_tpu.Kernel({s}).call: backend_config build failed: {}", .{ name, err });
                 defer cur.allocator.free(backend_config);
 
@@ -237,10 +265,12 @@ pub const mosaic_tpu = struct {
 
     fn buildBackendConfig(
         allocator: std.mem.Allocator,
-        ctx: *mlir.Context,
         ir: [:0]const u8,
         extras: CallExtras,
     ) ![]u8 {
+        const ctx = try newContext();
+        defer ctx.deinit();
+
         const module = try mlir.Module.parse(ctx, ir);
         defer module.deinit();
 

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -32,7 +32,7 @@ fn mlirRegistry(io: std.Io) *mlir.DialectRegistry {
         mlir.registerPasses("Transforms");
 
         const mlir_registry = mlir.DialectRegistry.init() catch unreachable;
-        inline for (.{ "func", "stablehlo", "sdy", "arith", "scf", "math", "tt", "affine", "memref", "vector", "tpu", "cf" }) |d| {
+        inline for (.{ "func", "stablehlo", "sdy", "arith", "scf", "math", "tt", "affine", "memref", "vector", "tpu", "cf", "llvm" }) |d| {
             mlir.DialectHandle.fromString(d).insertDialect(mlir_registry);
         }
         mlir.registerFuncExtensions(mlir_registry);

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -32,7 +32,7 @@ fn mlirRegistry(io: std.Io) *mlir.DialectRegistry {
         mlir.registerPasses("Transforms");
 
         const mlir_registry = mlir.DialectRegistry.init() catch unreachable;
-        inline for (.{ "func", "stablehlo", "sdy", "arith", "scf", "math", "tt", "affine", "memref", "vector", "tpu", "cf", "llvm" }) |d| {
+        inline for (.{ "func", "stablehlo", "sdy" }) |d| {
             mlir.DialectHandle.fromString(d).insertDialect(mlir_registry);
         }
         mlir.registerFuncExtensions(mlir_registry);


### PR DESCRIPTION
This PR introduces the following:

- Wire up the LLVM dialect so the Triton builder can emit `llvm.intr.assume` so we can match [`triton.language.assume`](https://triton-lang.org/main/python-api/generated/triton.language.assume.html#triton.language.assume)
- Thread `tt.num_stages` through `scf.for` for pipelining hints
- Add an inline-return mode to `ReturnIfScope`. Not necessary but better for IR matching with Python reference

Also fixes i1 extension to use `extui` instead of `extsi`.