### PR TITLE
mlir: add shardy dialect

### DIFF
--- a/mlir/dialects/BUILD.bazel
+++ b/mlir/dialects/BUILD.bazel
@@ -10,6 +10,7 @@ zig_library(
         "func.zig",
         "math.zig",
         "memref.zig",
+        "shardy.zig",
         "scf.zig",
         "vector.zig",
     ],

--- a/mlir/dialects/BUILD.bazel
+++ b/mlir/dialects/BUILD.bazel
@@ -19,6 +19,7 @@ zig_library(
     visibility = ["//visibility:public"],
     deps = [
         "//mlir",
+        "//mlir:c",
         "//mlir/dialects/mosaic_tpu",
         "//mlir/dialects/stablehlo",
         "//mlir/dialects/ttir",

--- a/mlir/dialects/dialects.zig
+++ b/mlir/dialects/dialects.zig
@@ -11,6 +11,7 @@ pub const func = @import("func.zig");
 pub const math = @import("math.zig");
 pub const memref = @import("memref.zig");
 pub const scf = @import("scf.zig");
+pub const shardy = @import("shardy.zig");
 pub const vector = @import("vector.zig");
 
 test {

--- a/mlir/dialects/shardy.zig
+++ b/mlir/dialects/shardy.zig
@@ -409,3 +409,113 @@ test TensorShardingAttribute {
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@\"3d_mesh\", [{\"link_x\"}, {\"link_y\"}, {\"link_z\"}]>", w.written());
     }
 }
+
+pub const TensorShardingPerValueAttribute = opaque {
+    const M = mlir.Methods(TensorShardingPerValueAttribute, c.MlirAttribute);
+
+    pub const isAFn = c.sdyAttributeIsATensorShardingPerValueAttr;
+    pub const ptr = M.ptr;
+    pub const eql = M.eql(c.mlirAttributeEqual);
+    pub const format = M.format(c.mlirAttributePrint);
+    pub const isA = M.isA;
+
+    pub fn get(ctx: *mlir.Context, shardings: []const *const TensorShardingAttribute) *const TensorShardingPerValueAttribute {
+        const attrs: []const c.struct_MlirAttribute = @ptrCast(shardings);
+        return @ptrCast(c.sdyTensorShardingPerValueAttrGet(ctx.ptr(), @intCast(attrs.len), attrs.ptr).ptr);
+    }
+
+    pub fn asAttr(self: *const TensorShardingPerValueAttribute) *const mlir.Attribute {
+        return @ptrCast(self);
+    }
+};
+
+test TensorShardingPerValueAttribute {
+    const registry: *mlir.DialectRegistry = try .init();
+    defer registry.deinit();
+    registry.registerDialect("sdy");
+    mlir.registerFuncExtensions(registry);
+
+    var ctx: *mlir.Context = try .init(.{ .registry = registry, .threading = false });
+    defer ctx.deinit();
+    ctx.loadAllAvailableDialects();
+
+    const shardings: [2]*const TensorShardingAttribute = .{
+        try .init(std.testing.allocator, ctx, .{
+            .mesh = "mesh",
+            .dimensions = &.{.closed(&.{.link_x})},
+        }),
+        try .init(std.testing.allocator, ctx, .{
+            .mesh = "mesh",
+            .dimensions = &.{.replicated},
+            .replicated_axes = &.{.link_y},
+        }),
+    };
+
+    const per_value = TensorShardingPerValueAttribute.get(ctx, &shardings);
+
+    var w: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer w.deinit();
+
+    try per_value.asAttr().format(&w.writer);
+    try std.testing.expectEqualSlices(
+        u8,
+        "#sdy.sharding_per_value<[<@mesh, [{\"link_x\"}]>, <@mesh, [{}], replicated={\"link_y\"}>]>",
+        w.written(),
+    );
+}
+
+pub const ManualAxesAttribute = opaque {
+    const M = mlir.Methods(ManualAxesAttribute, c.MlirAttribute);
+
+    pub const isAFn = c.sdyAttributeIsAManualAxesAttr;
+    pub const ptr = M.ptr;
+    pub const eql = M.eql(c.mlirAttributeEqual);
+    pub const format = M.format(c.mlirAttributePrint);
+    pub const isA = M.isA;
+
+    pub fn get(ctx: *mlir.Context, axes: []const *const mlir.StringAttribute) *const ManualAxesAttribute {
+        comptime std.debug.assert(@sizeOf(c.struct_MlirAttribute) == @sizeOf(*const mlir.StringAttribute));
+        const attrs: []const c.struct_MlirAttribute = @ptrCast(axes);
+        return @ptrCast(c.sdyManualAxesAttrGet(ctx.ptr(), @intCast(attrs.len), attrs.ptr).ptr);
+    }
+
+    pub fn asAttr(self: *const ManualAxesAttribute) *const mlir.Attribute {
+        return @ptrCast(self);
+    }
+
+    pub fn numAxes(self: *const ManualAxesAttribute) usize {
+        return @intCast(c.sdyManualAxesAttrGetAxesSize(self.ptr()));
+    }
+
+    pub fn axis(self: *const ManualAxesAttribute, index: usize) []const u8 {
+        return mlir.string(c.sdyManualAxesAttrGetAxesElem(self.ptr(), @intCast(index)));
+    }
+};
+
+test ManualAxesAttribute {
+    const registry: *mlir.DialectRegistry = try .init();
+    defer registry.deinit();
+    registry.registerDialect("sdy");
+    mlir.registerFuncExtensions(registry);
+
+    var ctx: *mlir.Context = try .init(.{ .registry = registry, .threading = false });
+    defer ctx.deinit();
+    ctx.loadAllAvailableDialects();
+
+    const axes: [2]*const mlir.StringAttribute = .{
+        @ptrCast(mlir.StringAttribute.init(ctx, "link_x")),
+        @ptrCast(mlir.StringAttribute.init(ctx, "link_y")),
+    };
+
+    const manual_axes = ManualAxesAttribute.get(ctx, &axes);
+
+    try std.testing.expectEqual(@as(usize, 2), manual_axes.numAxes());
+    try std.testing.expectEqualStrings("link_x", manual_axes.axis(0));
+    try std.testing.expectEqualStrings("link_y", manual_axes.axis(1));
+
+    var w: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer w.deinit();
+
+    try manual_axes.asAttr().format(&w.writer);
+    try std.testing.expectEqualSlices(u8, "#sdy<manual_axes{\"link_x\", \"link_y\"}>", w.written());
+}

--- a/mlir/dialects/shardy.zig
+++ b/mlir/dialects/shardy.zig
@@ -118,9 +118,9 @@ pub const Axis = union(enum) {
         size: i64,
     },
 
-    pub const link_x = .{ .named = "link_x" };
-    pub const link_y = .{ .named = "link_y" };
-    pub const link_z = .{ .named = "link_z" };
+    pub const link_x: Axis = .{ .named = "link_x" };
+    pub const link_y: Axis = .{ .named = "link_y" };
+    pub const link_z: Axis = .{ .named = "link_z" };
 
     pub fn named_(name: []const u8) Axis {
         return .{ .named = name };
@@ -370,7 +370,7 @@ test {
 
     const registry: *mlir.DialectRegistry = try .init();
     defer registry.deinit();
-    registerDialect(registry);
+    registry.registerDialect("sdy");
     mlir.registerFuncExtensions(registry);
 
     var ctx: *mlir.Context = try .init(.{ .registry = registry, .threading = false });
@@ -385,7 +385,7 @@ test {
         const sharding = try Sharding.init(std.testing.allocator, ctx, .{
             .mesh = "folded_mesh",
             .dimensions = &.{.replicated},
-            .replicated_axes = &.{ Axis.named_("link_x"), Axis.named_("link_y") },
+            .replicated_axes = &.{ .link_x, .link_y },
         });
         try sharding.asAttr().format(&w.writer);
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@folded_mesh, [{}], replicated={\"link_x\", \"link_y\"}>", w.written());
@@ -395,10 +395,10 @@ test {
         const sharding = try Sharding.init(std.testing.allocator, ctx, .{
             .mesh = "suggested_mesh",
             .dimensions = &.{
-                Dimension.closed(&.{Axis.named_("link_z")}),
-                Dimension.closed(&.{Axis.named_("link_x")}),
+                .closed(&.{.link_z}),
+                .closed(&.{.link_x}),
             },
-            .replicated_axes = &.{Axis.named_("link_y")},
+            .replicated_axes = &.{.link_y},
         });
         try sharding.asAttr().format(&w.writer);
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@suggested_mesh, [{\"link_z\"}, {\"link_x\"}], replicated={\"link_y\"}>", w.written());
@@ -408,7 +408,7 @@ test {
         const sharding = try Sharding.init(std.testing.allocator, ctx, .{
             .mesh = "fold_mesh",
             .dimensions = &.{
-                Dimension.closed(&.{Axis.named_("link_x")}),
+                .closed(&.{.link_x}),
                 .replicated,
             },
         });
@@ -420,7 +420,7 @@ test {
         const sharding = try Sharding.init(std.testing.allocator, ctx, .{
             .mesh = "folded_mesh",
             .dimensions = &.{
-                Dimension.closed(&.{ Axis.named_("link_x"), Axis.named_("link_y") }),
+                .closed(&.{ .link_x, .link_y }),
             },
         });
         try sharding.asAttr().format(&w.writer);
@@ -431,9 +431,9 @@ test {
         const sharding = try Sharding.init(std.testing.allocator, ctx, .{
             .mesh = "strategy_fold",
             .dimensions = &.{
-                Dimension.closed(&.{Axis.named_("link_x")}),
+                .closed(&.{.link_x}),
             },
-            .replicated_axes = &.{Axis.named_("link_y")},
+            .replicated_axes = &.{.link_y},
         });
         try sharding.asAttr().format(&w.writer);
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@strategy_fold, [{\"link_x\"}], replicated={\"link_y\"}>", w.written());
@@ -446,7 +446,7 @@ test {
                 Dimension.open(&.{}),
                 .replicated,
             },
-            .replicated_axes = &.{ Axis.named_("link_x"), Axis.named_("link_y") },
+            .replicated_axes = &.{ .link_x, .link_y },
         });
         try sharding.asAttr().format(&w.writer);
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@mix_mesh, [{?}, {}], replicated={\"link_x\", \"link_y\"}>", w.written());
@@ -456,9 +456,9 @@ test {
         const sharding = try Sharding.init(std.testing.allocator, ctx, .{
             .mesh = "3d_mesh",
             .dimensions = &.{
-                Dimension.closed(&.{Axis.named_("link_x")}),
-                Dimension.closed(&.{Axis.named_("link_y")}),
-                Dimension.closed(&.{Axis.named_("link_z")}),
+                .closed(&.{.link_x}),
+                .closed(&.{.link_y}),
+                .closed(&.{.link_z}),
             },
         });
         try sharding.asAttr().format(&w.writer);

--- a/mlir/dialects/shardy.zig
+++ b/mlir/dialects/shardy.zig
@@ -1,0 +1,86 @@
+//! Bindings for OpenXLA shardy dialect
+//!
+//! - dialect overview: https:openxla.org/shardy/sdy_dialect
+//! - C API: https://github.com/openxla/shardy/blob/main/shardy/integrations/c/attributes.h
+const std = @import("std");
+
+const mlir = @import("mlir");
+
+pub const Sharding = opaque {
+    // TODO(codex) get inspiration from mlir/mlir.zig and mlir/dialects/stablehlo/stablehlo.zig to bind
+    // openxla.org/shardy/sdy_dialect#tensorshardingattr
+    // You will probably need to add other helper structs.
+
+    pub fn init(ctx: *mlir.Context) *Sharding {
+        // TODO(codex): fill me up
+        _ = ctx;
+        return undefined;
+    }
+
+    pub fn asAttr(sharding: *const Sharding) *const mlir.Attribute {
+        return @ptrCast(sharding);
+    }
+};
+
+test {
+    const registry: *mlir.DialectRegistry = try .init();
+    registry.registerDialect("sdy");
+    mlir.registerFuncExtensions(registry);
+
+    var ctx: *mlir.Context = try .init(.{ .registry = registry, .threading = false });
+    ctx.loadAllAvailableDialects();
+    var w: std.Io.Writer.Allocating = .init(std.testing.allocator);
+
+    const physical: PhysicalMesh = try runner.physical(.{ 2, 2 }, .{ .mesh = .torus });
+    const logical: LogicalMesh = .mesh(.{ .batch = .low_bandwidth });
+
+    var strategy: Strategy = .init;
+    strategy.addBinding(.batch, .link_x);
+
+    {
+        defer w.clearRetainingCapacity();
+        // TODO(codex): properly init
+        // Tentative syntax: = .init(ctx, "folded_mesh", &.{}, &.{.link_x, .link_y});
+        const sharding: *const Sharding = .init(ctx);
+        try sharding.asAttr().format(&w.writer);
+        try std.testing.expectEqualSlices(u8, "#sdy.sharding<@folded_mesh, [{}], replicated={\"link_x\", \"link_y\"}>", w.written());
+    }
+    {
+        defer w.clearRetainingCapacity();
+        // TODO(codex): properly init
+        // Tentative syntax: = .init(ctx, "suggested_mesh", &.{ .link_z, .link_x }, &.{.link_y});
+        const sharding: *const Sharding = .init(ctx);
+        try sharding.asAttr().format(&w.writer);
+        try std.testing.expectEqualSlices(u8, "#sdy.sharding<@suggested_mesh, [{\"link_z\"}, {\"link_x\"}], replicated={\"link_y\"}>", w.written());
+    }
+    {
+        defer w.clearRetainingCapacity();
+        const sharding: *const Sharding = .init(ctx);
+        try sharding.asAttr().format(&w.writer);
+        try std.testing.expectEqualSlices(u8, "#sdy.sharding<@fold_mesh, [{\"link_x\"}, {}]>", w.written());
+    }
+    {
+        defer w.clearRetainingCapacity();
+        const sharding: *const Sharding = .init(ctx);
+        try sharding.asAttr().format(&w.writer);
+        try std.testing.expectEqualSlices(u8, "#sdy.sharding<@folded_mesh, [{\"link_x\", \"link_y\"}]>", w.written());
+    }
+    {
+        defer w.clearRetainingCapacity();
+        const sharding: *const Sharding = .init(ctx);
+        try sharding.asAttr().format(&w.writer);
+        try std.testing.expectEqualSlices(u8, "#sdy.sharding<@strategy_fold, [{\"link_x\"}], replicated={\"link_y\"}>", w.written());
+    }
+    {
+        defer w.clearRetainingCapacity();
+        const sharding: *const Sharding = .init(ctx);
+        try sharding.asAttr().format(&w.writer);
+        try std.testing.expectEqualSlices(u8, "#sdy.sharding<@mix_mesh, [{?}, {}], replicated={\"link_x\", \"link_y\"}>", w.written());
+    }
+    {
+        defer w.clearRetainingCapacity();
+        const sharding: *const Sharding = .init(ctx);
+        try sharding.asAttr().format(&w.writer);
+        try std.testing.expectEqualSlices(u8, "#sdy.sharding<@3d_mesh, [{\"link_x\"}, {\"link_y\"}, {\"link_z\"}]>", w.written());
+    }
+}

--- a/mlir/dialects/shardy.zig
+++ b/mlir/dialects/shardy.zig
@@ -24,7 +24,7 @@ pub const MeshAxisAttribute = opaque {
     pub const format = M.format(c.mlirAttributePrint);
     pub const isA = M.isA;
 
-    pub fn get(ctx: *mlir.Context, axis_name: []const u8, axis_size: i64) *const MeshAxisAttribute {
+    pub fn init(ctx: *mlir.Context, axis_name: []const u8, axis_size: i64) *const MeshAxisAttribute {
         return @ptrCast(c.sdyMeshAxisAttrGet(ctx.ptr(), mlir.stringRef(axis_name), axis_size).ptr);
     }
 
@@ -55,7 +55,7 @@ pub const MeshAttribute = opaque {
         device_ids: []const i64 = &.{},
     };
 
-    pub fn get(ctx: *mlir.Context, mesh: Mesh) *const MeshAttribute {
+    pub fn init(ctx: *mlir.Context, mesh: Mesh) *const MeshAttribute {
         const axes: []const c.struct_MlirAttribute = @ptrCast(mesh.axes);
         return @ptrCast(c.sdyMeshAttrGet(
             ctx.ptr(),
@@ -80,7 +80,7 @@ pub const SubAxisInfoAttribute = opaque {
     pub const format = M.format(c.mlirAttributePrint);
     pub const isA = M.isA;
 
-    pub fn get(ctx: *mlir.Context, pre_size: i64, sub_axis_size: i64) *const SubAxisInfoAttribute {
+    pub fn init(ctx: *mlir.Context, pre_size: i64, sub_axis_size: i64) *const SubAxisInfoAttribute {
         return @ptrCast(c.sdySubAxisInfoAttrGet(ctx.ptr(), pre_size, sub_axis_size).ptr);
     }
 
@@ -97,31 +97,6 @@ pub const SubAxisInfoAttribute = opaque {
     }
 };
 
-pub const Axis = union(enum) {
-    named: []const u8,
-    sub_axis: struct {
-        name: []const u8,
-        pre_size: i64,
-        size: i64,
-    },
-
-    pub const link_x: Axis = .{ .named = "link_x" };
-    pub const link_y: Axis = .{ .named = "link_y" };
-    pub const link_z: Axis = .{ .named = "link_z" };
-
-    pub fn named_(name: []const u8) Axis {
-        return .{ .named = name };
-    }
-
-    pub fn subAxis(name: []const u8, pre_size: i64, size: i64) Axis {
-        return .{ .sub_axis = .{
-            .name = name,
-            .pre_size = pre_size,
-            .size = size,
-        } };
-    }
-};
-
 pub const AxisRefAttribute = opaque {
     const M = mlir.Methods(AxisRefAttribute, c.MlirAttribute);
 
@@ -131,19 +106,13 @@ pub const AxisRefAttribute = opaque {
     pub const format = M.format(c.mlirAttributePrint);
     pub const isA = M.isA;
 
-    pub fn get(ctx: *mlir.Context, axis: Axis) *const AxisRefAttribute {
-        return switch (axis) {
-            .named => |axis_name| @ptrCast(c.sdyAxisRefAttrGet(
-                ctx.ptr(),
-                mlir.stringRef(axis_name),
-                c.MlirAttribute{ .ptr = null },
-            ).ptr),
-            .sub_axis => |sub_axis| @ptrCast(c.sdyAxisRefAttrGet(
-                ctx.ptr(),
-                mlir.stringRef(sub_axis.name),
-                SubAxisInfoAttribute.get(ctx, sub_axis.pre_size, sub_axis.size).ptr(),
-            ).ptr),
-        };
+    pub fn named(ctx: *mlir.Context, axis_name: []const u8) *const AxisRefAttribute {
+        return @ptrCast(c.sdyAxisRefAttrGet(ctx.ptr(), mlir.stringRef(axis_name), .{ .ptr = null }).ptr);
+    }
+
+    pub fn subAxis(ctx: *mlir.Context, axis_name: []const u8, pre_size: i64, size: i64) *const AxisRefAttribute {
+        const sub_axis: *const SubAxisInfoAttribute = .init(ctx, pre_size, size);
+        return @ptrCast(c.sdyAxisRefAttrGet(ctx.ptr(), mlir.stringRef(axis_name), sub_axis).ptr);
     }
 
     pub fn asAttr(self: *const AxisRefAttribute) *const mlir.Attribute {
@@ -160,22 +129,6 @@ pub const AxisRefAttribute = opaque {
     }
 };
 
-pub const Dimension = struct {
-    axes: []const Axis,
-    is_closed: bool,
-    priority: ?i64,
-
-    pub fn closed(axes: []const Axis) Dimension {
-        return .{ .axes = axes, .is_closed = true, .priority = null };
-    }
-
-    pub fn open(axes: []const Axis) Dimension {
-        return .{ .axes = axes, .is_closed = false, .priority = null };
-    }
-
-    pub const replicated: Dimension = .{ .axes = &.{}, .is_closed = true, .priority = null };
-};
-
 pub const DimensionShardingAttribute = opaque {
     const M = mlir.Methods(DimensionShardingAttribute, c.MlirAttribute);
 
@@ -185,19 +138,26 @@ pub const DimensionShardingAttribute = opaque {
     pub const format = M.format(c.mlirAttributePrint);
     pub const isA = M.isA;
 
-    pub fn get(ctx: *mlir.Context, args: struct {
-        axes: []const *const AxisRefAttribute = &.{},
-        is_closed: bool = true,
-        priority: ?i64 = null,
-    }) *const DimensionShardingAttribute {
-        const axes: []const c.struct_MlirAttribute = @ptrCast(args.axes);
-        return @ptrCast(c.sdyDimensionShardingAttrGet(
-            ctx.ptr(),
-            @intCast(axes.len),
-            axes.ptr,
-            args.is_closed,
-            args.priority orelse -1,
-        ).ptr);
+    pub fn init(
+        ctx: *mlir.Context,
+        axes: []const *const AxisRefAttribute,
+        is_closed: bool,
+        priority_: ?i64,
+    ) *const DimensionShardingAttribute {
+        const attrs: []const c.struct_MlirAttribute = @ptrCast(axes);
+        return @ptrCast(c.sdyDimensionShardingAttrGet(ctx.ptr(), @intCast(attrs.len), attrs.ptr, is_closed, priority_ orelse -1).ptr);
+    }
+
+    pub fn closed(ctx: *mlir.Context, axes: []const *const AxisRefAttribute) *const DimensionShardingAttribute {
+        return init(ctx, axes, true, null);
+    }
+
+    pub fn open(ctx: *mlir.Context, axes: []const *const AxisRefAttribute) *const DimensionShardingAttribute {
+        return init(ctx, axes, false, null);
+    }
+
+    pub fn replicated(ctx: *mlir.Context) *const DimensionShardingAttribute {
+        return closed(ctx, &.{});
     }
 
     pub fn asAttr(self: *const DimensionShardingAttribute) *const mlir.Attribute {
@@ -224,9 +184,9 @@ pub const DimensionShardingAttribute = opaque {
 
 pub const Sharding = struct {
     mesh: []const u8,
-    dimensions: []const Dimension,
-    replicated_axes: []const Axis = &.{},
-    unreduced_axes: []const Axis = &.{},
+    dimensions: []const *const DimensionShardingAttribute,
+    replicated_axes: []const *const AxisRefAttribute = &.{},
+    unreduced_axes: []const *const AxisRefAttribute = &.{},
 };
 
 pub const TensorShardingAttribute = opaque {
@@ -238,20 +198,14 @@ pub const TensorShardingAttribute = opaque {
     pub const format = M.format(c.mlirAttributePrint);
     pub const isA = M.isA;
 
-    pub fn get(
-        ctx: *mlir.Context,
-        mesh_or_ref: *const mlir.Attribute,
-        dim_shardings: []const *const DimensionShardingAttribute,
-        replicated_axes: []const *const AxisRefAttribute,
-        unreduced_axes: []const *const AxisRefAttribute,
-    ) *const TensorShardingAttribute {
+    pub fn init(ctx: *mlir.Context, args: Sharding) *const TensorShardingAttribute {
         comptime std.debug.assert(@sizeOf(c.struct_MlirAttribute) == @sizeOf(*const mlir.Attribute));
-        const dimensions: []const c.struct_MlirAttribute = @ptrCast(dim_shardings);
-        const replicated: []const c.struct_MlirAttribute = @ptrCast(replicated_axes);
-        const unreduced: []const c.struct_MlirAttribute = @ptrCast(unreduced_axes);
+        const dimensions: []const c.struct_MlirAttribute = @ptrCast(args.dimensions);
+        const replicated: []const c.struct_MlirAttribute = @ptrCast(args.replicated_axes);
+        const unreduced: []const c.struct_MlirAttribute = @ptrCast(args.unreduced_axes);
         return @ptrCast(c.sdyTensorShardingAttrGet(
             ctx.ptr(),
-            mesh_or_ref.ptr(),
+            mlir.flatSymbolRefAttribute(ctx, args.mesh).ptr(),
             @intCast(dimensions.len),
             dimensions.ptr,
             @intCast(replicated.len),
@@ -259,40 +213,6 @@ pub const TensorShardingAttribute = opaque {
             @intCast(unreduced.len),
             unreduced.ptr,
         ).ptr);
-    }
-
-    pub fn init(allocator: std.mem.Allocator, ctx: *mlir.Context, args: Sharding) !*const TensorShardingAttribute {
-        const dim_shardings = try allocator.alloc(*const DimensionShardingAttribute, args.dimensions.len);
-        defer allocator.free(dim_shardings);
-
-        for (args.dimensions, 0..) |dim_spec, i| {
-            const axis_attrs = try allocator.alloc(*const AxisRefAttribute, dim_spec.axes.len);
-            defer allocator.free(axis_attrs);
-
-            for (dim_spec.axes, 0..) |axis, j| {
-                axis_attrs[j] = AxisRefAttribute.get(ctx, axis);
-            }
-
-            dim_shardings[i] = DimensionShardingAttribute.get(ctx, .{
-                .axes = axis_attrs,
-                .is_closed = dim_spec.is_closed,
-                .priority = dim_spec.priority,
-            });
-        }
-
-        const replicated_axes = try allocator.alloc(*const AxisRefAttribute, args.replicated_axes.len);
-        defer allocator.free(replicated_axes);
-        for (args.replicated_axes, 0..) |axis, i| {
-            replicated_axes[i] = AxisRefAttribute.get(ctx, axis);
-        }
-
-        const unreduced_axes = try allocator.alloc(*const AxisRefAttribute, args.unreduced_axes.len);
-        defer allocator.free(unreduced_axes);
-        for (args.unreduced_axes, 0..) |axis, i| {
-            unreduced_axes[i] = AxisRefAttribute.get(ctx, axis);
-        }
-
-        return get(ctx, mlir.flatSymbolRefAttribute(ctx, args.mesh), dim_shardings, replicated_axes, unreduced_axes);
     }
 
     pub fn asAttr(self: *const TensorShardingAttribute) *const mlir.Attribute {
@@ -343,67 +263,74 @@ test TensorShardingAttribute {
 
     {
         defer w.clearRetainingCapacity();
-        const sharding = try TensorShardingAttribute.init(std.testing.allocator, ctx, .{
+        const sharding: *const TensorShardingAttribute = .init(ctx, .{
             .mesh = "folded_mesh",
-            .dimensions = &.{.replicated},
-            .replicated_axes = &.{ .link_x, .link_y },
+            .dimensions = &.{.replicated(ctx)},
+            .replicated_axes = &.{ .named(ctx, "link_x"), .named(ctx, "link_y") },
         });
         try sharding.asAttr().format(&w.writer);
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@folded_mesh, [{}], replicated={\"link_x\", \"link_y\"}>", w.written());
     }
     {
         defer w.clearRetainingCapacity();
-        const sharding = try TensorShardingAttribute.init(std.testing.allocator, ctx, .{
+        const sharding: *const TensorShardingAttribute = .init(ctx, .{
             .mesh = "suggested_mesh",
-            .dimensions = &.{ .closed(&.{.link_z}), .closed(&.{.link_x}) },
-            .replicated_axes = &.{.link_y},
+            .dimensions = &.{
+                .closed(ctx, &.{.named(ctx, "link_z")}),
+                .closed(ctx, &.{.named(ctx, "link_x")}),
+            },
+            .replicated_axes = &.{.named(ctx, "link_y")},
         });
         try sharding.asAttr().format(&w.writer);
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@suggested_mesh, [{\"link_z\"}, {\"link_x\"}], replicated={\"link_y\"}>", w.written());
     }
     {
         defer w.clearRetainingCapacity();
-        const sharding = try TensorShardingAttribute.init(std.testing.allocator, ctx, .{
+        const sharding: *const TensorShardingAttribute = .init(ctx, .{
             .mesh = "fold_mesh",
-            .dimensions = &.{ .closed(&.{.link_x}), .replicated },
+            .dimensions = &.{ .closed(ctx, &.{.named(ctx, "link_x")}), .replicated(ctx) },
         });
         try sharding.asAttr().format(&w.writer);
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@fold_mesh, [{\"link_x\"}, {}]>", w.written());
     }
     {
         defer w.clearRetainingCapacity();
-        const sharding = try TensorShardingAttribute.init(std.testing.allocator, ctx, .{
+        const sharding: *const TensorShardingAttribute = .init(ctx, .{
             .mesh = "folded_mesh",
-            .dimensions = &.{.closed(&.{ .link_x, .link_y })},
+            .dimensions = &.{.closed(ctx, &.{ .named(ctx, "link_x"), .named(ctx, "link_y") })},
         });
         try sharding.asAttr().format(&w.writer);
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@folded_mesh, [{\"link_x\", \"link_y\"}]>", w.written());
     }
     {
         defer w.clearRetainingCapacity();
-        const sharding = try TensorShardingAttribute.init(std.testing.allocator, ctx, .{
+        const sharding: *const TensorShardingAttribute = .init(ctx, .{
             .mesh = "strategy_fold",
-            .dimensions = &.{.closed(&.{.link_x})},
-            .replicated_axes = &.{.link_y},
+            .dimensions = &.{.closed(ctx, &.{.named(ctx, "link_x")})},
+            .replicated_axes = &.{.named(ctx, "link_y")},
         });
         try sharding.asAttr().format(&w.writer);
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@strategy_fold, [{\"link_x\"}], replicated={\"link_y\"}>", w.written());
     }
     {
         defer w.clearRetainingCapacity();
-        const sharding = try TensorShardingAttribute.init(std.testing.allocator, ctx, .{
+        const sharding: *const TensorShardingAttribute = .init(ctx, .{
             .mesh = "mix_mesh",
-            .dimensions = &.{ .open(&.{}), .replicated },
-            .replicated_axes = &.{ .link_x, .link_y },
+            .dimensions = &.{ .open(ctx, &.{}), .replicated(ctx) },
+            .replicated_axes = &.{ .named(ctx, "link_x"), .named(ctx, "link_y") },
         });
         try sharding.asAttr().format(&w.writer);
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@mix_mesh, [{?}, {}], replicated={\"link_x\", \"link_y\"}>", w.written());
     }
     {
         defer w.clearRetainingCapacity();
-        const sharding = try TensorShardingAttribute.init(std.testing.allocator, ctx, .{
+        const sharding: *const TensorShardingAttribute = .init(ctx, .{
             .mesh = "3d_mesh",
-            .dimensions = &.{ .closed(&.{.link_x}), .closed(&.{.link_y}), .closed(&.{.link_z}) },
+            .dimensions = &.{
+                .closed(ctx, &.{.named(ctx, "link_x")}),
+                .closed(ctx, &.{.named(ctx, "link_y")}),
+                .closed(ctx, &.{.named(ctx, "link_z")}),
+            },
         });
         try sharding.asAttr().format(&w.writer);
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@\"3d_mesh\", [{\"link_x\"}, {\"link_y\"}, {\"link_z\"}]>", w.written());
@@ -419,7 +346,7 @@ pub const TensorShardingPerValueAttribute = opaque {
     pub const format = M.format(c.mlirAttributePrint);
     pub const isA = M.isA;
 
-    pub fn get(ctx: *mlir.Context, shardings: []const *const TensorShardingAttribute) *const TensorShardingPerValueAttribute {
+    pub fn init(ctx: *mlir.Context, shardings: []const *const TensorShardingAttribute) *const TensorShardingPerValueAttribute {
         const attrs: []const c.struct_MlirAttribute = @ptrCast(shardings);
         return @ptrCast(c.sdyTensorShardingPerValueAttrGet(ctx.ptr(), @intCast(attrs.len), attrs.ptr).ptr);
     }
@@ -440,18 +367,18 @@ test TensorShardingPerValueAttribute {
     ctx.loadAllAvailableDialects();
 
     const shardings: [2]*const TensorShardingAttribute = .{
-        try .init(std.testing.allocator, ctx, .{
+        .init(ctx, .{
             .mesh = "mesh",
-            .dimensions = &.{.closed(&.{.link_x})},
+            .dimensions = &.{.closed(ctx, &.{.named(ctx, "link_x")})},
         }),
-        try .init(std.testing.allocator, ctx, .{
+        .init(ctx, .{
             .mesh = "mesh",
-            .dimensions = &.{.replicated},
-            .replicated_axes = &.{.link_y},
+            .dimensions = &.{.replicated(ctx)},
+            .replicated_axes = &.{.named(ctx, "link_y")},
         }),
     };
 
-    const per_value = TensorShardingPerValueAttribute.get(ctx, &shardings);
+    const per_value = TensorShardingPerValueAttribute.init(ctx, &shardings);
 
     var w: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer w.deinit();
@@ -473,7 +400,7 @@ pub const ManualAxesAttribute = opaque {
     pub const format = M.format(c.mlirAttributePrint);
     pub const isA = M.isA;
 
-    pub fn get(ctx: *mlir.Context, axes: []const *const mlir.StringAttribute) *const ManualAxesAttribute {
+    pub fn init(ctx: *mlir.Context, axes: []const *const mlir.StringAttribute) *const ManualAxesAttribute {
         comptime std.debug.assert(@sizeOf(c.struct_MlirAttribute) == @sizeOf(*const mlir.StringAttribute));
         const attrs: []const c.struct_MlirAttribute = @ptrCast(axes);
         return @ptrCast(c.sdyManualAxesAttrGet(ctx.ptr(), @intCast(attrs.len), attrs.ptr).ptr);
@@ -503,13 +430,13 @@ test ManualAxesAttribute {
     ctx.loadAllAvailableDialects();
 
     const axes: [2]*const mlir.StringAttribute = .{
-        @ptrCast(mlir.StringAttribute.init(ctx, "link_x")),
-        @ptrCast(mlir.StringAttribute.init(ctx, "link_y")),
+        .init(ctx, "link_x"),
+        .init(ctx, "link_y"),
     };
 
-    const manual_axes = ManualAxesAttribute.get(ctx, &axes);
+    const manual_axes: *const ManualAxesAttribute = .init(ctx, &axes);
 
-    try std.testing.expectEqual(@as(usize, 2), manual_axes.numAxes());
+    try std.testing.expectEqual(2, manual_axes.numAxes());
     try std.testing.expectEqualStrings("link_x", manual_axes.axis(0));
     try std.testing.expectEqualStrings("link_y", manual_axes.axis(1));
 

--- a/mlir/dialects/shardy.zig
+++ b/mlir/dialects/shardy.zig
@@ -1,86 +1,467 @@
 //! Bindings for OpenXLA shardy dialect
 //!
-//! - dialect overview: https:openxla.org/shardy/sdy_dialect
+//! - dialect overview: https://openxla.org/shardy/sdy_dialect
 //! - C API: https://github.com/openxla/shardy/blob/main/shardy/integrations/c/attributes.h
 const std = @import("std");
 
+const c = @import("c");
 const mlir = @import("mlir");
 
-pub const Sharding = opaque {
-    // TODO(codex) get inspiration from mlir/mlir.zig and mlir/dialects/stablehlo/stablehlo.zig to bind
-    // openxla.org/shardy/sdy_dialect#tensorshardingattr
-    // You will probably need to add other helper structs.
+pub fn dialectHandle() *const mlir.DialectHandle {
+    return @ptrCast(c.mlirGetDialectHandle__sdy__().ptr);
+}
 
-    pub fn init(ctx: *mlir.Context) *Sharding {
-        // TODO(codex): fill me up
-        _ = ctx;
-        return undefined;
+pub fn registerDialect(registry: *mlir.DialectRegistry) void {
+    dialectHandle().insertDialect(registry);
+}
+
+fn allocNativeAttrs(allocator: std.mem.Allocator, attrs: anytype) ![]c.MlirAttribute {
+    const native_attrs = try allocator.alloc(c.MlirAttribute, attrs.len);
+    errdefer allocator.free(native_attrs);
+
+    for (attrs, 0..) |attr, i| {
+        native_attrs[i] = attr.ptr();
     }
 
-    pub fn asAttr(sharding: *const Sharding) *const mlir.Attribute {
-        return @ptrCast(sharding);
+    return native_attrs;
+}
+
+pub const MeshAxisAttribute = opaque {
+    const M = mlir.Methods(MeshAxisAttribute, c.MlirAttribute);
+
+    pub const isAFn = c.sdyAttributeIsAMeshAxisAttr;
+    pub const ptr = M.ptr;
+    pub const eql = M.eql(c.mlirAttributeEqual);
+    pub const format = M.format(c.mlirAttributePrint);
+    pub const isA = M.isA;
+
+    pub fn get(ctx: *mlir.Context, axis_name: []const u8, axis_size: i64) *const MeshAxisAttribute {
+        return @ptrCast(c.sdyMeshAxisAttrGet(ctx.ptr(), mlir.stringRef(axis_name), axis_size).ptr);
+    }
+
+    pub fn asAttr(self: *const MeshAxisAttribute) *const mlir.Attribute {
+        return @ptrCast(self);
+    }
+
+    pub fn name(self: *const MeshAxisAttribute) []const u8 {
+        return mlir.string(c.sdyMeshAxisAttrGetName(self.ptr()));
+    }
+
+    pub fn size(self: *const MeshAxisAttribute) i64 {
+        return c.sdyMeshAxisAttrGetSize(self.ptr());
+    }
+};
+
+pub const MeshAttribute = opaque {
+    const M = mlir.Methods(MeshAttribute, c.MlirAttribute);
+
+    pub const isAFn = c.sdyAttributeIsAMeshAttr;
+    pub const ptr = M.ptr;
+    pub const eql = M.eql(c.mlirAttributeEqual);
+    pub const format = M.format(c.mlirAttributePrint);
+    pub const isA = M.isA;
+
+    pub const GetArgs = struct {
+        axes: []const *const MeshAxisAttribute,
+        device_ids: []const i64 = &.{},
+    };
+
+    pub fn get(allocator: std.mem.Allocator, ctx: *mlir.Context, args: GetArgs) !*const MeshAttribute {
+        const native_axes = try allocNativeAttrs(allocator, args.axes);
+        defer allocator.free(native_axes);
+
+        return @ptrCast(c.sdyMeshAttrGet(
+            ctx.ptr(),
+            @intCast(native_axes.len),
+            native_axes.ptr,
+            @intCast(args.device_ids.len),
+            args.device_ids.ptr,
+        ).ptr);
+    }
+
+    pub fn asAttr(self: *const MeshAttribute) *const mlir.Attribute {
+        return @ptrCast(self);
+    }
+};
+
+pub const SubAxisInfoAttribute = opaque {
+    const M = mlir.Methods(SubAxisInfoAttribute, c.MlirAttribute);
+
+    pub const isAFn = c.sdyAttributeIsASubAxisInfoAttr;
+    pub const ptr = M.ptr;
+    pub const eql = M.eql(c.mlirAttributeEqual);
+    pub const format = M.format(c.mlirAttributePrint);
+    pub const isA = M.isA;
+
+    pub fn get(ctx: *mlir.Context, pre_size: i64, sub_axis_size: i64) *const SubAxisInfoAttribute {
+        return @ptrCast(c.sdySubAxisInfoAttrGet(ctx.ptr(), pre_size, sub_axis_size).ptr);
+    }
+
+    pub fn asAttr(self: *const SubAxisInfoAttribute) *const mlir.Attribute {
+        return @ptrCast(self);
+    }
+
+    pub fn preSize(self: *const SubAxisInfoAttribute) i64 {
+        return c.sdySubAxisInfoAttrGetPreSize(self.ptr());
+    }
+
+    pub fn size(self: *const SubAxisInfoAttribute) i64 {
+        return c.sdySubAxisInfoAttrGetSize(self.ptr());
+    }
+};
+
+pub const Axis = union(enum) {
+    named: []const u8,
+    sub_axis: struct {
+        name: []const u8,
+        pre_size: i64,
+        size: i64,
+    },
+
+    pub const link_x = .{ .named = "link_x" };
+    pub const link_y = .{ .named = "link_y" };
+    pub const link_z = .{ .named = "link_z" };
+
+    pub fn named_(name: []const u8) Axis {
+        return .{ .named = name };
+    }
+
+    pub fn subAxis(name: []const u8, pre_size: i64, size: i64) Axis {
+        return .{ .sub_axis = .{
+            .name = name,
+            .pre_size = pre_size,
+            .size = size,
+        } };
+    }
+
+    fn toAttr(self: Axis, ctx: *mlir.Context) *const AxisRefAttribute {
+        return switch (self) {
+            .named => |name| AxisRefAttribute.get(ctx, .{ .name = name }),
+            .sub_axis => |sub_axis| AxisRefAttribute.get(ctx, .{
+                .name = sub_axis.name,
+                .sub_axis_info = SubAxisInfoAttribute.get(ctx, sub_axis.pre_size, sub_axis.size),
+            }),
+        };
+    }
+};
+
+pub const AxisRefAttribute = opaque {
+    const M = mlir.Methods(AxisRefAttribute, c.MlirAttribute);
+
+    pub const isAFn = c.sdyAttributeIsAnAxisRefAttr;
+    pub const ptr = M.ptr;
+    pub const eql = M.eql(c.mlirAttributeEqual);
+    pub const format = M.format(c.mlirAttributePrint);
+    pub const isA = M.isA;
+
+    pub const GetArgs = struct {
+        name: []const u8,
+        sub_axis_info: ?*const SubAxisInfoAttribute = null,
+    };
+
+    pub fn get(ctx: *mlir.Context, args: GetArgs) *const AxisRefAttribute {
+        const sub_axis_info = if (args.sub_axis_info) |info| info.ptr() else c.MlirAttribute{ .ptr = null };
+        return @ptrCast(c.sdyAxisRefAttrGet(
+            ctx.ptr(),
+            mlir.stringRef(args.name),
+            sub_axis_info,
+        ).ptr);
+    }
+
+    pub fn asAttr(self: *const AxisRefAttribute) *const mlir.Attribute {
+        return @ptrCast(self);
+    }
+
+    pub fn name(self: *const AxisRefAttribute) []const u8 {
+        return mlir.string(c.sdyAxisRefAttrGetName(self.ptr()));
+    }
+
+    pub fn subAxisInfo(self: *const AxisRefAttribute) ?*const SubAxisInfoAttribute {
+        const attr = c.sdyAxisRefAttrGetSubAxisInfo(self.ptr());
+        return if (attr.ptr == null) null else @ptrCast(attr.ptr);
+    }
+};
+
+pub const Dimension = struct {
+    axes: []const Axis,
+    is_closed: bool,
+    priority: ?i64,
+
+    pub fn closed(axes: []const Axis) Dimension {
+        return .{ .axes = axes, .is_closed = true, .priority = null };
+    }
+
+    pub fn open(axes: []const Axis) Dimension {
+        return .{ .axes = axes, .is_closed = false, .priority = null };
+    }
+
+    pub const replicated: Dimension = .{ .axes = &.{}, .is_closed = true, .priority = null };
+};
+
+pub const DimensionShardingAttribute = opaque {
+    const M = mlir.Methods(DimensionShardingAttribute, c.MlirAttribute);
+
+    pub const isAFn = c.sdyAttributeIsADimensionShardingAttr;
+    pub const ptr = M.ptr;
+    pub const eql = M.eql(c.mlirAttributeEqual);
+    pub const format = M.format(c.mlirAttributePrint);
+    pub const isA = M.isA;
+
+    pub const GetArgs = struct {
+        axes: []const *const AxisRefAttribute = &.{},
+        is_closed: bool = true,
+        priority: ?i64 = null,
+    };
+
+    pub fn get(allocator: std.mem.Allocator, ctx: *mlir.Context, args: GetArgs) !*const DimensionShardingAttribute {
+        const native_axes = try allocNativeAttrs(allocator, args.axes);
+        defer allocator.free(native_axes);
+
+        return @ptrCast(c.sdyDimensionShardingAttrGet(
+            ctx.ptr(),
+            @intCast(native_axes.len),
+            native_axes.ptr,
+            args.is_closed,
+            args.priority orelse -1,
+        ).ptr);
+    }
+
+    pub fn asAttr(self: *const DimensionShardingAttribute) *const mlir.Attribute {
+        return @ptrCast(self);
+    }
+
+    pub fn numAxes(self: *const DimensionShardingAttribute) usize {
+        return @intCast(c.sdyDimensionShardingAttrGetAxesSize(self.ptr()));
+    }
+
+    pub fn axis(self: *const DimensionShardingAttribute, index: usize) *const AxisRefAttribute {
+        return @ptrCast(c.sdyDimensionShardingAttrGetAxesElem(self.ptr(), @intCast(index)).ptr);
+    }
+
+    pub fn isClosed(self: *const DimensionShardingAttribute) bool {
+        return c.sdyDimensionShardingAttrGetIsClosed(self.ptr());
+    }
+
+    pub fn priority(self: *const DimensionShardingAttribute) ?i64 {
+        const value = c.sdyDimensionShardingAttrGetPriority(self.ptr());
+        return if (value == -1) null else value;
+    }
+};
+
+pub const TensorShardingAttribute = opaque {
+    const M = mlir.Methods(TensorShardingAttribute, c.MlirAttribute);
+
+    pub const isAFn = c.sdyAttributeIsATensorShardingAttr;
+    pub const ptr = M.ptr;
+    pub const eql = M.eql(c.mlirAttributeEqual);
+    pub const format = M.format(c.mlirAttributePrint);
+    pub const isA = M.isA;
+
+    pub const GetArgs = struct {
+        mesh_or_ref: *const mlir.Attribute,
+        dim_shardings: []const *const DimensionShardingAttribute,
+        replicated_axes: []const *const AxisRefAttribute = &.{},
+        unreduced_axes: []const *const AxisRefAttribute = &.{},
+    };
+
+    pub const InitArgs = struct {
+        mesh: []const u8,
+        dimensions: []const Dimension,
+        replicated_axes: []const Axis = &.{},
+        unreduced_axes: []const Axis = &.{},
+    };
+
+    pub fn get(allocator: std.mem.Allocator, ctx: *mlir.Context, args: GetArgs) !*const TensorShardingAttribute {
+        const native_dim_shardings = try allocNativeAttrs(allocator, args.dim_shardings);
+        defer allocator.free(native_dim_shardings);
+
+        const native_replicated_axes = try allocNativeAttrs(allocator, args.replicated_axes);
+        defer allocator.free(native_replicated_axes);
+
+        const native_unreduced_axes = try allocNativeAttrs(allocator, args.unreduced_axes);
+        defer allocator.free(native_unreduced_axes);
+
+        return @ptrCast(c.sdyTensorShardingAttrGet(
+            ctx.ptr(),
+            args.mesh_or_ref.ptr(),
+            @intCast(native_dim_shardings.len),
+            native_dim_shardings.ptr,
+            @intCast(native_replicated_axes.len),
+            native_replicated_axes.ptr,
+            @intCast(native_unreduced_axes.len),
+            native_unreduced_axes.ptr,
+        ).ptr);
+    }
+
+    pub fn init(allocator: std.mem.Allocator, ctx: *mlir.Context, args: InitArgs) !*const TensorShardingAttribute {
+        const dim_shardings = try allocator.alloc(*const DimensionShardingAttribute, args.dimensions.len);
+        defer allocator.free(dim_shardings);
+
+        for (args.dimensions, 0..) |dim_spec, i| {
+            const axis_attrs = try allocator.alloc(*const AxisRefAttribute, dim_spec.axes.len);
+            defer allocator.free(axis_attrs);
+
+            for (dim_spec.axes, 0..) |axis, j| {
+                axis_attrs[j] = axis.toAttr(ctx);
+            }
+
+            dim_shardings[i] = try DimensionShardingAttribute.get(allocator, ctx, .{
+                .axes = axis_attrs,
+                .is_closed = dim_spec.is_closed,
+                .priority = dim_spec.priority,
+            });
+        }
+
+        const replicated_axes = try allocator.alloc(*const AxisRefAttribute, args.replicated_axes.len);
+        defer allocator.free(replicated_axes);
+        for (args.replicated_axes, 0..) |axis, i| {
+            replicated_axes[i] = axis.toAttr(ctx);
+        }
+
+        const unreduced_axes = try allocator.alloc(*const AxisRefAttribute, args.unreduced_axes.len);
+        defer allocator.free(unreduced_axes);
+        for (args.unreduced_axes, 0..) |axis, i| {
+            unreduced_axes[i] = axis.toAttr(ctx);
+        }
+
+        return get(allocator, ctx, .{
+            .mesh_or_ref = mlir.flatSymbolRefAttribute(ctx, args.mesh),
+            .dim_shardings = dim_shardings,
+            .replicated_axes = replicated_axes,
+            .unreduced_axes = unreduced_axes,
+        });
+    }
+
+    pub fn asAttr(self: *const TensorShardingAttribute) *const mlir.Attribute {
+        return @ptrCast(self);
+    }
+
+    pub fn meshOrRef(self: *const TensorShardingAttribute) *const mlir.Attribute {
+        return @ptrCast(c.sdyTensorShardingAttrGetMeshOrRef(self.ptr()).ptr);
+    }
+
+    pub fn numDimensions(self: *const TensorShardingAttribute) usize {
+        return @intCast(c.sdyTensorShardingAttrGetDimShardingsSize(self.ptr()));
+    }
+
+    pub fn dimension(self: *const TensorShardingAttribute, index: usize) *const DimensionShardingAttribute {
+        return @ptrCast(c.sdyTensorShardingAttrGetDimShardingsElem(self.ptr(), @intCast(index)).ptr);
+    }
+
+    pub fn numReplicatedAxes(self: *const TensorShardingAttribute) usize {
+        return @intCast(c.sdyTensorShardingAttrGetReplicatedAxesSize(self.ptr()));
+    }
+
+    pub fn replicatedAxis(self: *const TensorShardingAttribute, index: usize) *const AxisRefAttribute {
+        return @ptrCast(c.sdyTensorShardingAttrGetReplicatedAxesElem(self.ptr(), @intCast(index)).ptr);
+    }
+
+    pub fn numUnreducedAxes(self: *const TensorShardingAttribute) usize {
+        return @intCast(c.sdyTensorShardingAttrGetUnreducedAxesSize(self.ptr()));
+    }
+
+    pub fn unreducedAxis(self: *const TensorShardingAttribute, index: usize) *const AxisRefAttribute {
+        return @ptrCast(c.sdyTensorShardingAttrGetUnreducedAxesElem(self.ptr(), @intCast(index)).ptr);
     }
 };
 
 test {
+    const Sharding = TensorShardingAttribute;
+
     const registry: *mlir.DialectRegistry = try .init();
-    registry.registerDialect("sdy");
+    defer registry.deinit();
+    registerDialect(registry);
     mlir.registerFuncExtensions(registry);
 
     var ctx: *mlir.Context = try .init(.{ .registry = registry, .threading = false });
+    defer ctx.deinit();
     ctx.loadAllAvailableDialects();
+
     var w: std.Io.Writer.Allocating = .init(std.testing.allocator);
-
-    const physical: PhysicalMesh = try runner.physical(.{ 2, 2 }, .{ .mesh = .torus });
-    const logical: LogicalMesh = .mesh(.{ .batch = .low_bandwidth });
-
-    var strategy: Strategy = .init;
-    strategy.addBinding(.batch, .link_x);
+    defer w.deinit();
 
     {
         defer w.clearRetainingCapacity();
-        // TODO(codex): properly init
-        // Tentative syntax: = .init(ctx, "folded_mesh", &.{}, &.{.link_x, .link_y});
-        const sharding: *const Sharding = .init(ctx);
+        const sharding = try Sharding.init(std.testing.allocator, ctx, .{
+            .mesh = "folded_mesh",
+            .dimensions = &.{.replicated},
+            .replicated_axes = &.{ Axis.named_("link_x"), Axis.named_("link_y") },
+        });
         try sharding.asAttr().format(&w.writer);
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@folded_mesh, [{}], replicated={\"link_x\", \"link_y\"}>", w.written());
     }
     {
         defer w.clearRetainingCapacity();
-        // TODO(codex): properly init
-        // Tentative syntax: = .init(ctx, "suggested_mesh", &.{ .link_z, .link_x }, &.{.link_y});
-        const sharding: *const Sharding = .init(ctx);
+        const sharding = try Sharding.init(std.testing.allocator, ctx, .{
+            .mesh = "suggested_mesh",
+            .dimensions = &.{
+                Dimension.closed(&.{Axis.named_("link_z")}),
+                Dimension.closed(&.{Axis.named_("link_x")}),
+            },
+            .replicated_axes = &.{Axis.named_("link_y")},
+        });
         try sharding.asAttr().format(&w.writer);
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@suggested_mesh, [{\"link_z\"}, {\"link_x\"}], replicated={\"link_y\"}>", w.written());
     }
     {
         defer w.clearRetainingCapacity();
-        const sharding: *const Sharding = .init(ctx);
+        const sharding = try Sharding.init(std.testing.allocator, ctx, .{
+            .mesh = "fold_mesh",
+            .dimensions = &.{
+                Dimension.closed(&.{Axis.named_("link_x")}),
+                .replicated,
+            },
+        });
         try sharding.asAttr().format(&w.writer);
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@fold_mesh, [{\"link_x\"}, {}]>", w.written());
     }
     {
         defer w.clearRetainingCapacity();
-        const sharding: *const Sharding = .init(ctx);
+        const sharding = try Sharding.init(std.testing.allocator, ctx, .{
+            .mesh = "folded_mesh",
+            .dimensions = &.{
+                Dimension.closed(&.{ Axis.named_("link_x"), Axis.named_("link_y") }),
+            },
+        });
         try sharding.asAttr().format(&w.writer);
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@folded_mesh, [{\"link_x\", \"link_y\"}]>", w.written());
     }
     {
         defer w.clearRetainingCapacity();
-        const sharding: *const Sharding = .init(ctx);
+        const sharding = try Sharding.init(std.testing.allocator, ctx, .{
+            .mesh = "strategy_fold",
+            .dimensions = &.{
+                Dimension.closed(&.{Axis.named_("link_x")}),
+            },
+            .replicated_axes = &.{Axis.named_("link_y")},
+        });
         try sharding.asAttr().format(&w.writer);
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@strategy_fold, [{\"link_x\"}], replicated={\"link_y\"}>", w.written());
     }
     {
         defer w.clearRetainingCapacity();
-        const sharding: *const Sharding = .init(ctx);
+        const sharding = try Sharding.init(std.testing.allocator, ctx, .{
+            .mesh = "mix_mesh",
+            .dimensions = &.{
+                Dimension.open(&.{}),
+                .replicated,
+            },
+            .replicated_axes = &.{ Axis.named_("link_x"), Axis.named_("link_y") },
+        });
         try sharding.asAttr().format(&w.writer);
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@mix_mesh, [{?}, {}], replicated={\"link_x\", \"link_y\"}>", w.written());
     }
     {
         defer w.clearRetainingCapacity();
-        const sharding: *const Sharding = .init(ctx);
+        const sharding = try Sharding.init(std.testing.allocator, ctx, .{
+            .mesh = "3d_mesh",
+            .dimensions = &.{
+                Dimension.closed(&.{Axis.named_("link_x")}),
+                Dimension.closed(&.{Axis.named_("link_y")}),
+                Dimension.closed(&.{Axis.named_("link_z")}),
+            },
+        });
         try sharding.asAttr().format(&w.writer);
-        try std.testing.expectEqualSlices(u8, "#sdy.sharding<@3d_mesh, [{\"link_x\"}, {\"link_y\"}, {\"link_z\"}]>", w.written());
+        try std.testing.expectEqualSlices(u8, "#sdy.sharding<@\"3d_mesh\", [{\"link_x\"}, {\"link_y\"}, {\"link_z\"}]>", w.written());
     }
 }

--- a/mlir/dialects/shardy.zig
+++ b/mlir/dialects/shardy.zig
@@ -15,17 +15,6 @@ pub fn registerDialect(registry: *mlir.DialectRegistry) void {
     dialectHandle().insertDialect(registry);
 }
 
-fn allocNativeAttrs(allocator: std.mem.Allocator, attrs: anytype) ![]c.MlirAttribute {
-    const native_attrs = try allocator.alloc(c.MlirAttribute, attrs.len);
-    errdefer allocator.free(native_attrs);
-
-    for (attrs, 0..) |attr, i| {
-        native_attrs[i] = attr.ptr();
-    }
-
-    return native_attrs;
-}
-
 pub const MeshAxisAttribute = opaque {
     const M = mlir.Methods(MeshAxisAttribute, c.MlirAttribute);
 
@@ -61,21 +50,19 @@ pub const MeshAttribute = opaque {
     pub const format = M.format(c.mlirAttributePrint);
     pub const isA = M.isA;
 
-    pub const GetArgs = struct {
+    pub const Mesh = struct {
         axes: []const *const MeshAxisAttribute,
         device_ids: []const i64 = &.{},
     };
 
-    pub fn get(allocator: std.mem.Allocator, ctx: *mlir.Context, args: GetArgs) !*const MeshAttribute {
-        const native_axes = try allocNativeAttrs(allocator, args.axes);
-        defer allocator.free(native_axes);
-
+    pub fn get(ctx: *mlir.Context, mesh: Mesh) *const MeshAttribute {
+        const axes: []const c.struct_MlirAttribute = @ptrCast(mesh.axes);
         return @ptrCast(c.sdyMeshAttrGet(
             ctx.ptr(),
-            @intCast(native_axes.len),
-            native_axes.ptr,
-            @intCast(args.device_ids.len),
-            args.device_ids.ptr,
+            @intCast(axes.len),
+            axes.ptr,
+            @intCast(mesh.device_ids.len),
+            mesh.device_ids.ptr,
         ).ptr);
     }
 
@@ -133,16 +120,6 @@ pub const Axis = union(enum) {
             .size = size,
         } };
     }
-
-    fn toAttr(self: Axis, ctx: *mlir.Context) *const AxisRefAttribute {
-        return switch (self) {
-            .named => |name| AxisRefAttribute.get(ctx, .{ .name = name }),
-            .sub_axis => |sub_axis| AxisRefAttribute.get(ctx, .{
-                .name = sub_axis.name,
-                .sub_axis_info = SubAxisInfoAttribute.get(ctx, sub_axis.pre_size, sub_axis.size),
-            }),
-        };
-    }
 };
 
 pub const AxisRefAttribute = opaque {
@@ -154,18 +131,19 @@ pub const AxisRefAttribute = opaque {
     pub const format = M.format(c.mlirAttributePrint);
     pub const isA = M.isA;
 
-    pub const GetArgs = struct {
-        name: []const u8,
-        sub_axis_info: ?*const SubAxisInfoAttribute = null,
-    };
-
-    pub fn get(ctx: *mlir.Context, args: GetArgs) *const AxisRefAttribute {
-        const sub_axis_info = if (args.sub_axis_info) |info| info.ptr() else c.MlirAttribute{ .ptr = null };
-        return @ptrCast(c.sdyAxisRefAttrGet(
-            ctx.ptr(),
-            mlir.stringRef(args.name),
-            sub_axis_info,
-        ).ptr);
+    pub fn get(ctx: *mlir.Context, axis: Axis) *const AxisRefAttribute {
+        return switch (axis) {
+            .named => |axis_name| @ptrCast(c.sdyAxisRefAttrGet(
+                ctx.ptr(),
+                mlir.stringRef(axis_name),
+                c.MlirAttribute{ .ptr = null },
+            ).ptr),
+            .sub_axis => |sub_axis| @ptrCast(c.sdyAxisRefAttrGet(
+                ctx.ptr(),
+                mlir.stringRef(sub_axis.name),
+                SubAxisInfoAttribute.get(ctx, sub_axis.pre_size, sub_axis.size).ptr(),
+            ).ptr),
+        };
     }
 
     pub fn asAttr(self: *const AxisRefAttribute) *const mlir.Attribute {
@@ -207,20 +185,16 @@ pub const DimensionShardingAttribute = opaque {
     pub const format = M.format(c.mlirAttributePrint);
     pub const isA = M.isA;
 
-    pub const GetArgs = struct {
+    pub fn get(ctx: *mlir.Context, args: struct {
         axes: []const *const AxisRefAttribute = &.{},
         is_closed: bool = true,
         priority: ?i64 = null,
-    };
-
-    pub fn get(allocator: std.mem.Allocator, ctx: *mlir.Context, args: GetArgs) !*const DimensionShardingAttribute {
-        const native_axes = try allocNativeAttrs(allocator, args.axes);
-        defer allocator.free(native_axes);
-
+    }) *const DimensionShardingAttribute {
+        const axes: []const c.struct_MlirAttribute = @ptrCast(args.axes);
         return @ptrCast(c.sdyDimensionShardingAttrGet(
             ctx.ptr(),
-            @intCast(native_axes.len),
-            native_axes.ptr,
+            @intCast(axes.len),
+            axes.ptr,
             args.is_closed,
             args.priority orelse -1,
         ).ptr);
@@ -248,6 +222,13 @@ pub const DimensionShardingAttribute = opaque {
     }
 };
 
+pub const Sharding = struct {
+    mesh: []const u8,
+    dimensions: []const Dimension,
+    replicated_axes: []const Axis = &.{},
+    unreduced_axes: []const Axis = &.{},
+};
+
 pub const TensorShardingAttribute = opaque {
     const M = mlir.Methods(TensorShardingAttribute, c.MlirAttribute);
 
@@ -257,43 +238,30 @@ pub const TensorShardingAttribute = opaque {
     pub const format = M.format(c.mlirAttributePrint);
     pub const isA = M.isA;
 
-    pub const GetArgs = struct {
+    pub fn get(
+        ctx: *mlir.Context,
         mesh_or_ref: *const mlir.Attribute,
         dim_shardings: []const *const DimensionShardingAttribute,
-        replicated_axes: []const *const AxisRefAttribute = &.{},
-        unreduced_axes: []const *const AxisRefAttribute = &.{},
-    };
-
-    pub const InitArgs = struct {
-        mesh: []const u8,
-        dimensions: []const Dimension,
-        replicated_axes: []const Axis = &.{},
-        unreduced_axes: []const Axis = &.{},
-    };
-
-    pub fn get(allocator: std.mem.Allocator, ctx: *mlir.Context, args: GetArgs) !*const TensorShardingAttribute {
-        const native_dim_shardings = try allocNativeAttrs(allocator, args.dim_shardings);
-        defer allocator.free(native_dim_shardings);
-
-        const native_replicated_axes = try allocNativeAttrs(allocator, args.replicated_axes);
-        defer allocator.free(native_replicated_axes);
-
-        const native_unreduced_axes = try allocNativeAttrs(allocator, args.unreduced_axes);
-        defer allocator.free(native_unreduced_axes);
-
+        replicated_axes: []const *const AxisRefAttribute,
+        unreduced_axes: []const *const AxisRefAttribute,
+    ) *const TensorShardingAttribute {
+        comptime std.debug.assert(@sizeOf(c.struct_MlirAttribute) == @sizeOf(*const mlir.Attribute));
+        const dimensions: []const c.struct_MlirAttribute = @ptrCast(dim_shardings);
+        const replicated: []const c.struct_MlirAttribute = @ptrCast(replicated_axes);
+        const unreduced: []const c.struct_MlirAttribute = @ptrCast(unreduced_axes);
         return @ptrCast(c.sdyTensorShardingAttrGet(
             ctx.ptr(),
-            args.mesh_or_ref.ptr(),
-            @intCast(native_dim_shardings.len),
-            native_dim_shardings.ptr,
-            @intCast(native_replicated_axes.len),
-            native_replicated_axes.ptr,
-            @intCast(native_unreduced_axes.len),
-            native_unreduced_axes.ptr,
+            mesh_or_ref.ptr(),
+            @intCast(dimensions.len),
+            dimensions.ptr,
+            @intCast(replicated.len),
+            replicated.ptr,
+            @intCast(unreduced.len),
+            unreduced.ptr,
         ).ptr);
     }
 
-    pub fn init(allocator: std.mem.Allocator, ctx: *mlir.Context, args: InitArgs) !*const TensorShardingAttribute {
+    pub fn init(allocator: std.mem.Allocator, ctx: *mlir.Context, args: Sharding) !*const TensorShardingAttribute {
         const dim_shardings = try allocator.alloc(*const DimensionShardingAttribute, args.dimensions.len);
         defer allocator.free(dim_shardings);
 
@@ -302,10 +270,10 @@ pub const TensorShardingAttribute = opaque {
             defer allocator.free(axis_attrs);
 
             for (dim_spec.axes, 0..) |axis, j| {
-                axis_attrs[j] = axis.toAttr(ctx);
+                axis_attrs[j] = AxisRefAttribute.get(ctx, axis);
             }
 
-            dim_shardings[i] = try DimensionShardingAttribute.get(allocator, ctx, .{
+            dim_shardings[i] = DimensionShardingAttribute.get(ctx, .{
                 .axes = axis_attrs,
                 .is_closed = dim_spec.is_closed,
                 .priority = dim_spec.priority,
@@ -315,21 +283,16 @@ pub const TensorShardingAttribute = opaque {
         const replicated_axes = try allocator.alloc(*const AxisRefAttribute, args.replicated_axes.len);
         defer allocator.free(replicated_axes);
         for (args.replicated_axes, 0..) |axis, i| {
-            replicated_axes[i] = axis.toAttr(ctx);
+            replicated_axes[i] = AxisRefAttribute.get(ctx, axis);
         }
 
         const unreduced_axes = try allocator.alloc(*const AxisRefAttribute, args.unreduced_axes.len);
         defer allocator.free(unreduced_axes);
         for (args.unreduced_axes, 0..) |axis, i| {
-            unreduced_axes[i] = axis.toAttr(ctx);
+            unreduced_axes[i] = AxisRefAttribute.get(ctx, axis);
         }
 
-        return get(allocator, ctx, .{
-            .mesh_or_ref = mlir.flatSymbolRefAttribute(ctx, args.mesh),
-            .dim_shardings = dim_shardings,
-            .replicated_axes = replicated_axes,
-            .unreduced_axes = unreduced_axes,
-        });
+        return get(ctx, mlir.flatSymbolRefAttribute(ctx, args.mesh), dim_shardings, replicated_axes, unreduced_axes);
     }
 
     pub fn asAttr(self: *const TensorShardingAttribute) *const mlir.Attribute {
@@ -365,9 +328,7 @@ pub const TensorShardingAttribute = opaque {
     }
 };
 
-test {
-    const Sharding = TensorShardingAttribute;
-
+test TensorShardingAttribute {
     const registry: *mlir.DialectRegistry = try .init();
     defer registry.deinit();
     registry.registerDialect("sdy");
@@ -382,7 +343,7 @@ test {
 
     {
         defer w.clearRetainingCapacity();
-        const sharding = try Sharding.init(std.testing.allocator, ctx, .{
+        const sharding = try TensorShardingAttribute.init(std.testing.allocator, ctx, .{
             .mesh = "folded_mesh",
             .dimensions = &.{.replicated},
             .replicated_axes = &.{ .link_x, .link_y },
@@ -392,12 +353,9 @@ test {
     }
     {
         defer w.clearRetainingCapacity();
-        const sharding = try Sharding.init(std.testing.allocator, ctx, .{
+        const sharding = try TensorShardingAttribute.init(std.testing.allocator, ctx, .{
             .mesh = "suggested_mesh",
-            .dimensions = &.{
-                .closed(&.{.link_z}),
-                .closed(&.{.link_x}),
-            },
+            .dimensions = &.{ .closed(&.{.link_z}), .closed(&.{.link_x}) },
             .replicated_axes = &.{.link_y},
         });
         try sharding.asAttr().format(&w.writer);
@@ -405,34 +363,27 @@ test {
     }
     {
         defer w.clearRetainingCapacity();
-        const sharding = try Sharding.init(std.testing.allocator, ctx, .{
+        const sharding = try TensorShardingAttribute.init(std.testing.allocator, ctx, .{
             .mesh = "fold_mesh",
-            .dimensions = &.{
-                .closed(&.{.link_x}),
-                .replicated,
-            },
+            .dimensions = &.{ .closed(&.{.link_x}), .replicated },
         });
         try sharding.asAttr().format(&w.writer);
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@fold_mesh, [{\"link_x\"}, {}]>", w.written());
     }
     {
         defer w.clearRetainingCapacity();
-        const sharding = try Sharding.init(std.testing.allocator, ctx, .{
+        const sharding = try TensorShardingAttribute.init(std.testing.allocator, ctx, .{
             .mesh = "folded_mesh",
-            .dimensions = &.{
-                .closed(&.{ .link_x, .link_y }),
-            },
+            .dimensions = &.{.closed(&.{ .link_x, .link_y })},
         });
         try sharding.asAttr().format(&w.writer);
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@folded_mesh, [{\"link_x\", \"link_y\"}]>", w.written());
     }
     {
         defer w.clearRetainingCapacity();
-        const sharding = try Sharding.init(std.testing.allocator, ctx, .{
+        const sharding = try TensorShardingAttribute.init(std.testing.allocator, ctx, .{
             .mesh = "strategy_fold",
-            .dimensions = &.{
-                .closed(&.{.link_x}),
-            },
+            .dimensions = &.{.closed(&.{.link_x})},
             .replicated_axes = &.{.link_y},
         });
         try sharding.asAttr().format(&w.writer);
@@ -440,12 +391,9 @@ test {
     }
     {
         defer w.clearRetainingCapacity();
-        const sharding = try Sharding.init(std.testing.allocator, ctx, .{
+        const sharding = try TensorShardingAttribute.init(std.testing.allocator, ctx, .{
             .mesh = "mix_mesh",
-            .dimensions = &.{
-                Dimension.open(&.{}),
-                .replicated,
-            },
+            .dimensions = &.{ .open(&.{}), .replicated },
             .replicated_axes = &.{ .link_x, .link_y },
         });
         try sharding.asAttr().format(&w.writer);
@@ -453,13 +401,9 @@ test {
     }
     {
         defer w.clearRetainingCapacity();
-        const sharding = try Sharding.init(std.testing.allocator, ctx, .{
+        const sharding = try TensorShardingAttribute.init(std.testing.allocator, ctx, .{
             .mesh = "3d_mesh",
-            .dimensions = &.{
-                .closed(&.{.link_x}),
-                .closed(&.{.link_y}),
-                .closed(&.{.link_z}),
-            },
+            .dimensions = &.{ .closed(&.{.link_x}), .closed(&.{.link_y}), .closed(&.{.link_z}) },
         });
         try sharding.asAttr().format(&w.writer);
         try std.testing.expectEqualSlices(u8, "#sdy.sharding<@\"3d_mesh\", [{\"link_x\"}, {\"link_y\"}, {\"link_z\"}]>", w.written());

--- a/stdx/stdx.zig
+++ b/stdx/stdx.zig
@@ -29,6 +29,15 @@ pub inline fn stackSlice(comptime max_len: usize, T: type, len: usize) []T {
 
 pub const noalloc: std.mem.Allocator = if (builtin.mode == .ReleaseFast) undefined else std.testing.failing_allocator;
 
+pub fn arenaWithCapacity(parent: std.mem.Allocator, initial_capacity: usize) std.mem.Allocator.Error!std.heap.ArenaAllocator {
+    var a: std.heap.ArenaAllocator = .init(parent);
+
+    _ = try a.allocator().alloc(u8, initial_capacity);
+    std.debug.assert(a.state.used_list.?.end_index == initial_capacity);
+    a.state.used_list.?.end_index = 0;
+    return a;
+}
+
 pub fn pinToCore(core_id: usize) void {
     if (builtin.os.tag == .linux) {
         const CPUSet = std.bit_set.ArrayBitSet(usize, std.os.linux.CPU_SETSIZE * @sizeOf(usize));

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -112,15 +112,15 @@ pub const Partitioning = struct {
         return sharding.data.numPartitionsForLogicalAxis(logical_axis);
     }
 
-    pub fn sdyPerValueShardingAttr(self: Partitioning, allocator: std.mem.Allocator, ctx: *mlir.Context, shapes: []const Shape) !*const mlir.Attribute {
+    pub fn sdyPerValueShardingAttr(self: Partitioning, allocator: std.mem.Allocator, ctx: *mlir.Context, shapes: []const Shape) !*const dialects.shardy.TensorShardingPerValueAttribute {
         stdx.debug.assert(self.partitioner == .shardy, "sdyPerValueShardingAttr requires shardy partitioner", .{});
 
-        const shardings = try allocator.alloc(*const mlir.Attribute, shapes.len);
+        const shardings = try allocator.alloc(*const dialects.shardy.TensorShardingAttribute, shapes.len);
         for (shapes, 0..) |shape, i| {
             const sharding = try self.selectSharding(shape);
-            shardings[i] = (try sharding.data.sdyShardingAttrForShape(allocator, ctx, shape)).asAttr();
+            shardings[i] = try sharding.data.sdyShardingAttrForShape(allocator, ctx, shape);
         }
-        return dialects.shardy.TensorShardingPerValueAttribute.get(ctx, shardings).asAttr();
+        return .init(ctx, shardings);
     }
 
     pub fn sdyManualAxesAttr(self: Partitioning, allocator: std.mem.Allocator, ctx: *mlir.Context, in_shapes: []const Shape, out_shapes: []const Shape) !*const dialects.shardy.ManualAxesAttribute {
@@ -170,7 +170,7 @@ pub const Partitioning = struct {
             axes[i] = mlir.StringAttribute.init(ctx, axis_name);
         }
 
-        return dialects.shardy.ManualAxesAttribute.get(ctx, axes);
+        return dialects.shardy.ManualAxesAttribute.init(ctx, axes);
     }
 
     pub fn selectSharding(self: Partitioning, shape: Shape) !Sharding {

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -1282,11 +1282,14 @@ pub const Data = struct {
     }
 
     pub fn sdyShardingAttrForShape(
-        self: *const Data,
-        allocator: std.mem.Allocator,
+        data: *const Data,
+        parent_allocator: std.mem.Allocator,
         ctx: *mlir.Context,
         shape: Shape,
     ) !*const dialects.shardy.TensorShardingAttribute {
+        var arena = try stdx.arenaWithCapacity(parent_allocator, 1024);
+        defer arena.deinit();
+        const allocator = arena.allocator();
         var any_explicit = false;
         for (0..shape.rank()) |ax| {
             if (shape.partition(ax) != .unknown) {
@@ -1296,56 +1299,39 @@ pub const Data = struct {
         }
         const all_replicated = !any_explicit;
 
-        const mapping = self.getDimMapping(shape);
-        const dimensions = try allocator.alloc(dialects.shardy.Dimension, shape.rank());
-        defer allocator.free(dimensions);
-        const dimension_axes = try allocator.alloc(?[]dialects.shardy.Axis, shape.rank());
-        defer {
-            for (dimension_axes) |axes| {
-                if (axes) |slice| allocator.free(slice);
-            }
-            allocator.free(dimension_axes);
-        }
-        @memset(dimension_axes, null);
+        const mapping = data.getDimMapping(shape);
+        const dimensions = try allocator.alloc(*const dialects.shardy.DimensionShardingAttribute, shape.rank());
 
-        for (0..shape.rank()) |ax| {
+        for (0.., dimensions) |ax, *d| {
             const spec = shape.partition(ax);
-            switch (spec) {
-                .axis => |logical_tag| {
-                    if (self.binding(logical_tag)) |_| {
+            d.* = switch (spec) {
+                .axis => |logical_tag| d: {
+                    if (data.binding(logical_tag)) |_| {
                         const dim_phys_indices = mapping.axes_per_dim.get(ax);
                         if (dim_phys_indices.len == 0) {
-                            dimensions[ax] = .replicated;
+                            break :d .replicated(ctx);
                         } else {
-                            const axes = try allocator.alloc(dialects.shardy.Axis, dim_phys_indices.len);
-                            dimension_axes[ax] = axes;
+                            const axes = try allocator.alloc(*const dialects.shardy.AxisRefAttribute, dim_phys_indices.len);
                             for (dim_phys_indices.constSlice(), 0..) |p_idx, i| {
-                                axes[i] = .named_(@tagName(mapping.view.axes.get(p_idx).tag));
+                                axes[i] = .named(ctx, @tagName(mapping.view.axes.get(p_idx).tag));
                             }
-                            dimensions[ax] = .closed(axes);
+                            break :d .closed(ctx, axes);
                         }
                     } else {
-                        dimensions[ax] = .open(&.{});
+                        break :d .open(ctx, &.{});
                     }
                 },
-                .replicated => dimensions[ax] = .replicated,
-                .open, .unknown => {
-                    dimensions[ax] = if (all_replicated) .replicated else .open(&.{});
-                },
-            }
+                .replicated => .replicated(ctx),
+                .open, .unknown => if (all_replicated) .replicated(ctx) else .open(ctx, &.{}),
+            };
         }
 
-        const replicated_axes = try allocator.alloc(dialects.shardy.Axis, mapping.replicated_axes.len);
-        defer allocator.free(replicated_axes);
-        for (mapping.replicated_axes.constSlice(), 0..) |p_idx, i| {
-            replicated_axes[i] = .named_(@tagName(mapping.view.axes.get(p_idx).tag));
+        const replicated_axes = try allocator.alloc(*const dialects.shardy.AxisRefAttribute, mapping.replicated_axes.len);
+        for (replicated_axes, mapping.replicated_axes.constSlice()) |*r, p_idx| {
+            r.* = .named(ctx, @tagName(mapping.view.axes.get(p_idx).tag));
         }
 
-        return dialects.shardy.TensorShardingAttribute.init(allocator, ctx, .{
-            .mesh = self.name,
-            .dimensions = dimensions,
-            .replicated_axes = replicated_axes,
-        });
+        return .init(ctx, .{ .mesh = data.name, .dimensions = dimensions, .replicated_axes = replicated_axes });
     }
 
     pub fn gspmdShardingAttrForShape(self: *const Data, allocator: std.mem.Allocator, shape: Shape) ![]const u8 {

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -1,6 +1,8 @@
 //! Explain how to split a buffer across different devices.
 const std = @import("std");
 
+const dialects = @import("mlir/dialects");
+const mlir = @import("mlir");
 const pjrt = @import("pjrt");
 const stdx = @import("stdx");
 
@@ -91,11 +93,11 @@ pub const Partitioning = struct {
         };
     }
 
-    pub fn tensorShardingAttr(self: Partitioning, allocator: std.mem.Allocator, shape: Shape, sharding: ?Sharding) ![]const u8 {
+    pub fn tensorShardingAttr(self: Partitioning, allocator: std.mem.Allocator, ctx: *mlir.Context, shape: Shape, sharding: ?Sharding) !*const mlir.Attribute {
         const selected_sharding = sharding orelse try self.selectSharding(shape);
         return switch (self.partitioner) {
-            .shardy => try selected_sharding.data.sdyShardingAttrForShape(allocator, shape),
-            .gspmd => try selected_sharding.data.gspmdShardingAttrForShape(allocator, shape),
+            .shardy => (try selected_sharding.data.sdyShardingAttrForShape(allocator, ctx, shape)).asAttr(),
+            .gspmd => mlir.stringAttribute(ctx, try selected_sharding.data.gspmdShardingAttrForShape(allocator, shape)),
         };
     }
 
@@ -110,21 +112,18 @@ pub const Partitioning = struct {
         return sharding.data.numPartitionsForLogicalAxis(logical_axis);
     }
 
-    pub fn sdyPerValueShardingAttr(self: Partitioning, allocator: std.mem.Allocator, shapes: []const Shape) ![]const u8 {
+    pub fn sdyPerValueShardingAttr(self: Partitioning, allocator: std.mem.Allocator, ctx: *mlir.Context, shapes: []const Shape) !*const mlir.Attribute {
         stdx.debug.assert(self.partitioner == .shardy, "sdyPerValueShardingAttr requires shardy partitioner", .{});
 
-        var out: std.Io.Writer.Allocating = .init(allocator);
-        out.writer.writeAll("#sdy.sharding_per_value<[") catch unreachable;
+        const shardings = try allocator.alloc(*const mlir.Attribute, shapes.len);
         for (shapes, 0..) |shape, i| {
-            const attr_str = try self.tensorShardingAttr(allocator, shape, null);
-            if (i > 0) out.writer.writeAll(", ") catch unreachable;
-            out.writer.writeAll(attr_str["#sdy.sharding".len..]) catch unreachable;
+            const sharding = try self.selectSharding(shape);
+            shardings[i] = (try sharding.data.sdyShardingAttrForShape(allocator, ctx, shape)).asAttr();
         }
-        out.writer.writeAll("]>") catch unreachable;
-        return out.toOwnedSlice() catch unreachable;
+        return dialects.shardy.TensorShardingPerValueAttribute.get(ctx, shardings).asAttr();
     }
 
-    pub fn sdyManualAxesAttr(self: Partitioning, allocator: std.mem.Allocator, in_shapes: []const Shape, out_shapes: []const Shape) ![]const u8 {
+    pub fn sdyManualAxesAttr(self: Partitioning, allocator: std.mem.Allocator, ctx: *mlir.Context, in_shapes: []const Shape, out_shapes: []const Shape) !*const dialects.shardy.ManualAxesAttribute {
         stdx.debug.assert(self.partitioner == .shardy, "sdyManualAxesAttr requires shardy partitioner", .{});
 
         var axis_names = std.ArrayList([]const u8).empty;
@@ -137,36 +136,41 @@ pub const Partitioning = struct {
                 }
                 list.append(allocator_, axis_name) catch unreachable;
             }
-
-            fn scan(list: *std.ArrayList([]const u8), allocator_: std.mem.Allocator, sharding: []const u8) void {
-                var i: usize = 0;
-                while (i < sharding.len) : (i += 1) {
-                    if (sharding[i] != '"') continue;
-                    const start = i + 1;
-                    i = start;
-                    while (i < sharding.len and sharding[i] != '"') : (i += 1) {}
-                    if (i > start) appendUnique(list, allocator_, sharding[start..i]);
-                }
-            }
         };
 
         for (in_shapes) |shape| {
-            const attr_str = try self.tensorShardingAttr(allocator, shape, null);
-            Collect.scan(&axis_names, allocator, attr_str);
+            const sharding = try self.selectSharding(shape);
+            const attr = try sharding.data.sdyShardingAttrForShape(allocator, ctx, shape);
+            for (0..attr.numReplicatedAxes()) |i| {
+                Collect.appendUnique(&axis_names, allocator, attr.replicatedAxis(i).name());
+            }
+            for (0..attr.numDimensions()) |i| {
+                const dim = attr.dimension(i);
+                for (0..dim.numAxes()) |j| {
+                    Collect.appendUnique(&axis_names, allocator, dim.axis(j).name());
+                }
+            }
         }
         for (out_shapes) |shape| {
-            const attr_str = try self.tensorShardingAttr(allocator, shape, null);
-            Collect.scan(&axis_names, allocator, attr_str);
+            const sharding = try self.selectSharding(shape);
+            const attr = try sharding.data.sdyShardingAttrForShape(allocator, ctx, shape);
+            for (0..attr.numReplicatedAxes()) |i| {
+                Collect.appendUnique(&axis_names, allocator, attr.replicatedAxis(i).name());
+            }
+            for (0..attr.numDimensions()) |i| {
+                const dim = attr.dimension(i);
+                for (0..dim.numAxes()) |j| {
+                    Collect.appendUnique(&axis_names, allocator, dim.axis(j).name());
+                }
+            }
         }
 
-        var out: std.Io.Writer.Allocating = .init(allocator);
-        out.writer.writeAll("#sdy<manual_axes{") catch unreachable;
+        const axes = try allocator.alloc(*const mlir.StringAttribute, axis_names.items.len);
         for (axis_names.items, 0..) |axis_name, i| {
-            if (i > 0) out.writer.writeAll(", ") catch unreachable;
-            out.writer.print("\"{s}\"", .{axis_name}) catch unreachable;
+            axes[i] = mlir.StringAttribute.init(ctx, axis_name);
         }
-        out.writer.writeAll("}>") catch unreachable;
-        return out.toOwnedSlice() catch unreachable;
+
+        return dialects.shardy.ManualAxesAttribute.get(ctx, axes);
     }
 
     pub fn selectSharding(self: Partitioning, shape: Shape) !Sharding {
@@ -1277,8 +1281,12 @@ pub const Data = struct {
         };
     }
 
-    // TODO: consider binding shardy dialect instead of generating strings then parsing later.
-    pub fn sdyShardingAttrForShape(self: *const Data, allocator: std.mem.Allocator, shape: Shape) ![]const u8 {
+    pub fn sdyShardingAttrForShape(
+        self: *const Data,
+        allocator: std.mem.Allocator,
+        ctx: *mlir.Context,
+        shape: Shape,
+    ) !*const dialects.shardy.TensorShardingAttribute {
         var any_explicit = false;
         for (0..shape.rank()) |ax| {
             if (shape.partition(ax) != .unknown) {
@@ -1289,54 +1297,55 @@ pub const Data = struct {
         const all_replicated = !any_explicit;
 
         const mapping = self.getDimMapping(shape);
-        var out: std.Io.Writer.Allocating = .init(allocator);
-        errdefer out.deinit();
+        const dimensions = try allocator.alloc(dialects.shardy.Dimension, shape.rank());
+        defer allocator.free(dimensions);
+        const dimension_axes = try allocator.alloc(?[]dialects.shardy.Axis, shape.rank());
+        defer {
+            for (dimension_axes) |axes| {
+                if (axes) |slice| allocator.free(slice);
+            }
+            allocator.free(dimension_axes);
+        }
+        @memset(dimension_axes, null);
 
-        try out.writer.print("#sdy.sharding<@{s}, [", .{self.name});
         for (0..shape.rank()) |ax| {
-            if (ax > 0) try out.writer.writeAll(", ");
             const spec = shape.partition(ax);
-
             switch (spec) {
                 .axis => |logical_tag| {
                     if (self.binding(logical_tag)) |_| {
                         const dim_phys_indices = mapping.axes_per_dim.get(ax);
                         if (dim_phys_indices.len == 0) {
-                            try out.writer.writeAll("{}");
+                            dimensions[ax] = .replicated;
                         } else {
-                            try out.writer.writeAll("{");
+                            const axes = try allocator.alloc(dialects.shardy.Axis, dim_phys_indices.len);
+                            dimension_axes[ax] = axes;
                             for (dim_phys_indices.constSlice(), 0..) |p_idx, i| {
-                                if (i > 0) try out.writer.writeAll(", ");
-                                try out.writer.print("\"{s}\"", .{@tagName(mapping.view.axes.get(p_idx).tag)});
+                                axes[i] = .named_(@tagName(mapping.view.axes.get(p_idx).tag));
                             }
-                            try out.writer.writeAll("}");
+                            dimensions[ax] = .closed(axes);
                         }
                     } else {
-                        try out.writer.writeAll("{?}");
+                        dimensions[ax] = .open(&.{});
                     }
                 },
-                .replicated => try out.writer.writeAll("{}"),
+                .replicated => dimensions[ax] = .replicated,
                 .open, .unknown => {
-                    if (all_replicated) {
-                        try out.writer.writeAll("{}");
-                    } else {
-                        try out.writer.writeAll("{?}");
-                    }
+                    dimensions[ax] = if (all_replicated) .replicated else .open(&.{});
                 },
             }
         }
-        try out.writer.writeAll("]");
 
-        if (mapping.replicated_axes.len > 0) {
-            try out.writer.writeAll(", replicated={");
-            for (mapping.replicated_axes.constSlice(), 0..) |p_idx, i| {
-                if (i > 0) try out.writer.writeAll(", ");
-                try out.writer.print("\"{s}\"", .{@tagName(mapping.view.axes.get(p_idx).tag)});
-            }
-            try out.writer.writeAll("}");
+        const replicated_axes = try allocator.alloc(dialects.shardy.Axis, mapping.replicated_axes.len);
+        defer allocator.free(replicated_axes);
+        for (mapping.replicated_axes.constSlice(), 0..) |p_idx, i| {
+            replicated_axes[i] = .named_(@tagName(mapping.view.axes.get(p_idx).tag));
         }
-        try out.writer.writeAll(">");
-        return try out.toOwnedSlice();
+
+        return dialects.shardy.TensorShardingAttribute.init(allocator, ctx, .{
+            .mesh = self.name,
+            .dimensions = dimensions,
+            .replicated_axes = replicated_axes,
+        });
     }
 
     pub fn gspmdShardingAttrForShape(self: *const Data, allocator: std.mem.Allocator, shape: Shape) ![]const u8 {
@@ -1895,9 +1904,20 @@ const ShardingTest = struct {
 
         // Verify MLIR String
         if (s.expected_sdy) |expected_attr| {
-            const actual_attr = try sharding.sdyShardingAttrForShape(self.allocator, s.shape);
-            defer self.allocator.free(actual_attr);
-            try std.testing.expectEqualStrings(expected_attr, actual_attr);
+            const registry: *mlir.DialectRegistry = try .init();
+            defer registry.deinit();
+            registry.registerDialect("sdy");
+            mlir.registerFuncExtensions(registry);
+
+            var ctx: *mlir.Context = try .init(.{ .registry = registry, .threading = false });
+            defer ctx.deinit();
+            ctx.loadAllAvailableDialects();
+
+            const actual_attr = try sharding.sdyShardingAttrForShape(self.allocator, ctx, s.shape);
+            var writer: std.Io.Writer.Allocating = .init(self.allocator);
+            defer writer.deinit();
+            try actual_attr.asAttr().format(&writer.writer);
+            try std.testing.expectEqualStrings(expected_attr, writer.written());
         }
 
         // Verify Placement logic / Error
@@ -2112,7 +2132,7 @@ test "sharding: full 3D cluster sharding" {
         .sharding = try .init("3d_mesh", physical, logical, strategy),
         .shape = Shape.init(.{ .batch = 4, .model = 4, .context = 4 }, .f32)
             .withPartitioning(.{ .batch = .batch, .model = .model, .context = .context }),
-        .expected_sdy = "#sdy.sharding<@3d_mesh, [{\"link_x\"}, {\"link_y\"}, {\"link_z\"}]>",
+        .expected_sdy = "#sdy.sharding<@\"3d_mesh\", [{\"link_x\"}, {\"link_y\"}, {\"link_z\"}]>",
         .expected_shards = &.{
             .{ .device_id = 0, .slices = &.{ .{ 0, 2 }, .{ 0, 2 }, .{ 0, 2 } } },
             .{ .device_id = 1, .slices = &.{ .{ 0, 2 }, .{ 0, 2 }, .{ 2, 2 } } },

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -475,22 +475,20 @@ fn emitMlir(compilation_context: *CompilationContext, comptime func: anytype, ar
     _ = dialects.func.returns(compilation_context.mlir_ctx, output_info.values, .unknown(compilation_context.mlir_ctx)).appendTo(compilation_context.currentScope().block);
 
     for (input_info.shapes, input_info.shardings, 0..) |shape, sharding, i| {
-        const attr_str = try compilation_context.partitioning.tensorShardingAttr(compilation_context.arena.allocator(), shape, sharding);
-
-        const name, const attr = switch (compilation_context.partitioning.partitioner) {
-            .gspmd => .{ "mhlo.sharding", mlir.stringAttribute(compilation_context.mlir_ctx, attr_str) },
-            .shardy => .{ "sdy.sharding", try mlir.Attribute.parse(compilation_context.mlir_ctx, attr_str) },
+        const attr = try compilation_context.partitioning.tensorShardingAttr(compilation_context.arena.allocator(), compilation_context.mlir_ctx, shape, sharding);
+        const name = switch (compilation_context.partitioning.partitioner) {
+            .gspmd => "mhlo.sharding",
+            .shardy => "sdy.sharding",
         };
 
         input_attributes[i].appendAssumeCapacity(.named(compilation_context.mlir_ctx, name, attr));
     }
 
     for (output_info.shapes, output_info.shardings, 0..) |shape, sharding, i| {
-        const attr_str = try compilation_context.partitioning.tensorShardingAttr(compilation_context.arena.allocator(), shape, sharding);
-
-        const name, const attr = switch (compilation_context.partitioning.partitioner) {
-            .gspmd => .{ "mhlo.sharding", mlir.stringAttribute(compilation_context.mlir_ctx, attr_str) },
-            .shardy => .{ "sdy.sharding", try mlir.Attribute.parse(compilation_context.mlir_ctx, attr_str) },
+        const attr = try compilation_context.partitioning.tensorShardingAttr(compilation_context.arena.allocator(), compilation_context.mlir_ctx, shape, sharding);
+        const name = switch (compilation_context.partitioning.partitioner) {
+            .gspmd => "mhlo.sharding",
+            .shardy => "sdy.sharding",
         };
 
         output_attributes[i].appendAssumeCapacity(.named(compilation_context.mlir_ctx, name, attr));

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -1305,8 +1305,8 @@ fn manualComputationInternal(
                 .results = .{ .flat = global_result_types },
                 .blocks = &.{manual_block},
                 .attributes = &.{
-                    .named(ctx.mlir_ctx, "in_shardings", in_shardings_attr),
-                    .named(ctx.mlir_ctx, "out_shardings", out_shardings_attr),
+                    .named(ctx.mlir_ctx, "in_shardings", in_shardings_attr.asAttr()),
+                    .named(ctx.mlir_ctx, "out_shardings", out_shardings_attr.asAttr()),
                     .named(ctx.mlir_ctx, "manual_axes", manual_axes_attr.asAttr()),
                 },
                 .verify = true,

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -1251,12 +1251,9 @@ fn manualComputationInternal(
                 local_output_shapes[i] = ctx.partitioning.localShapeForShape(output_shape) catch unreachable;
             }
 
-            const in_shardings_str = ctx.partitioning.sdyPerValueShardingAttr(allocator, input_shapes) catch unreachable;
-            const out_shardings_str = ctx.partitioning.sdyPerValueShardingAttr(allocator, outputs) catch unreachable;
-            const manual_axes_str = ctx.partitioning.sdyManualAxesAttr(allocator, input_shapes, outputs) catch unreachable;
-            const in_shardings_attr = mlir.Attribute.parse(ctx.mlir_ctx, in_shardings_str) catch unreachable;
-            const out_shardings_attr = mlir.Attribute.parse(ctx.mlir_ctx, out_shardings_str) catch unreachable;
-            const manual_axes_attr = mlir.Attribute.parse(ctx.mlir_ctx, manual_axes_str) catch unreachable;
+            const in_shardings_attr = ctx.partitioning.sdyPerValueShardingAttr(allocator, ctx.mlir_ctx, input_shapes) catch unreachable;
+            const out_shardings_attr = ctx.partitioning.sdyPerValueShardingAttr(allocator, ctx.mlir_ctx, outputs) catch unreachable;
+            const manual_axes_attr = ctx.partitioning.sdyManualAxesAttr(allocator, ctx.mlir_ctx, input_shapes, outputs) catch unreachable;
 
             const block_types = allocator.alloc(*const mlir.Type, inputs.len) catch unreachable;
             const block_locs = allocator.alloc(*const mlir.Location, inputs.len) catch unreachable;
@@ -1310,7 +1307,7 @@ fn manualComputationInternal(
                 .attributes = &.{
                     .named(ctx.mlir_ctx, "in_shardings", in_shardings_attr),
                     .named(ctx.mlir_ctx, "out_shardings", out_shardings_attr),
-                    .named(ctx.mlir_ctx, "manual_axes", manual_axes_attr),
+                    .named(ctx.mlir_ctx, "manual_axes", manual_axes_attr.asAttr()),
                 },
                 .verify = true,
                 .location = .unknown(ctx.mlir_ctx),
@@ -1324,7 +1321,7 @@ fn manualComputationInternal(
         },
         .gspmd => blk: {
             const manual_sharding = "{manual}";
-            const output_shardings = allocator.alloc([]const u8, outputs.len) catch unreachable;
+            const output_shardings = allocator.alloc(*const mlir.Attribute, outputs.len) catch unreachable;
             const local_input_shapes = allocator.alloc(Shape, inputs.len) catch unreachable;
             const local_output_shapes = allocator.alloc(Shape, outputs.len) catch unreachable;
 
@@ -1333,7 +1330,7 @@ fn manualComputationInternal(
             }
             for (outputs, 0..) |output_shape, i| {
                 local_output_shapes[i] = ctx.partitioning.localShapeForShape(output_shape) catch unreachable;
-                output_shardings[i] = ctx.partitioning.tensorShardingAttr(allocator, output_shape, null) catch unreachable;
+                output_shardings[i] = ctx.partitioning.tensorShardingAttr(allocator, ctx.mlir_ctx, output_shape, null) catch unreachable;
             }
 
             const local_input_values = allocator.alloc(*const mlir.Value, inputs.len) catch unreachable;
@@ -1389,7 +1386,7 @@ fn manualComputationInternal(
                         .has_side_effect = false,
                         .backend_config = .{ .original = "" },
                         .additional_attributes = &.{
-                            .named(ctx.mlir_ctx, "mhlo.sharding", mlir.stringAttribute(ctx.mlir_ctx, output_shardings[i])),
+                            .named(ctx.mlir_ctx, "mhlo.sharding", output_shardings[i]),
                         },
                     },
                     .unknown(ctx.mlir_ctx),

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -146,8 +146,7 @@ pub const Tensor = struct {
         const ctx = CompilationContext.current();
         const partitioned_shape = self._shape.withPartitioning(axes_);
 
-        const attr = ctx.partitioning.tensorShardingAttr(ctx.allocator, partitioned_shape, null) catch unreachable;
-        defer ctx.allocator.free(attr);
+        const attr = ctx.partitioning.tensorShardingAttr(ctx.allocator, ctx.mlir_ctx, partitioned_shape, null) catch unreachable;
 
         const op_result = switch (ctx.partitioning.partitioner) {
             .shardy => blk: {
@@ -155,7 +154,7 @@ pub const Tensor = struct {
                     .operands = .{ .flat = &.{self.value()} },
                     .results = .{ .flat = &.{self.value().type_()} },
                     .attributes = &.{
-                        .named(ctx.mlir_ctx, "sharding", mlir.Attribute.parse(ctx.mlir_ctx, attr) catch unreachable),
+                        .named(ctx.mlir_ctx, "sharding", attr),
                     },
                 }).appendTo(currentBlock());
                 break :blk op.result(0);
@@ -170,7 +169,7 @@ pub const Tensor = struct {
                         .has_side_effect = false,
                         .backend_config = .{ .original = "" },
                         .additional_attributes = &.{
-                            .named(ctx.mlir_ctx, "mhlo.sharding", mlir.stringAttribute(ctx.mlir_ctx, attr)),
+                            .named(ctx.mlir_ctx, "mhlo.sharding", attr),
                         },
                     },
                     .unknown(ctx.mlir_ctx),


### PR DESCRIPTION
Add bindings to shardy dialect,
remove the string generation code from zml.Sharding, and replace it with mlir calls.