### PR TITLE
zml/moe : Moe backend triton zig, qwen3_5_moe model

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -448,6 +448,56 @@
         ]
       }
     },
+    "@@aspect_rules_py+//uv/private/tomltool:extension.bzl%tomltool": {
+      "general": {
+        "bzlTransitiveDigest": "9BC6q6vdlG+lqF9L13wVxxakVkZBx8buKPFIndN6mHk=",
+        "usagesDigest": "tQ76lH+Nn5OlAFLvBbnfvnCzNIiwGgY6tOumYZXH44w=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "toml2json_aarch64_osx_libsystem": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "url": "https://github.com/dzbarsky/toml2json/releases/download/v0.0.4/toml2json_darwin_arm64",
+              "sha256": "9adc44d976e8f5baf5a6d613ceb3db6e5f56b2e22e75ac56521fdce62f227d88",
+              "executable": true
+            }
+          },
+          "toml2json_x86_64_osx_libsystem": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "url": "https://github.com/dzbarsky/toml2json/releases/download/v0.0.4/toml2json_darwin_amd64",
+              "sha256": "425bac4015394fd9840fabcd52ac60fc796a9c10655b36c57e36ffb7dc9f3dd4",
+              "executable": true
+            }
+          },
+          "toml2json_aarch64_linux_gnu": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "url": "https://github.com/dzbarsky/toml2json/releases/download/v0.0.4/toml2json_linux_arm64",
+              "sha256": "be8376c8e3232a242eae0d187f741a475498a949b942361a9af6e95072ef5670",
+              "executable": true
+            }
+          },
+          "toml2json_x86_64_linux_gnu": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "url": "https://github.com/dzbarsky/toml2json/releases/download/v0.0.4/toml2json_linux_amd64",
+              "sha256": "f3dd54fabf2d27d0c027b0421860e5d9d909080be1613f0ffd87057633b65e9a",
+              "executable": true
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "aspect_rules_py+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
       "general": {
         "bzlTransitiveDigest": "MePriaXmQNSqUfE+YQvEtzBc2bU1mjITINIffFiZYgo=",
@@ -476,6 +526,258 @@
             "aspect_tools_telemetry+",
             "bazel_skylib",
             "bazel_skylib+"
+          ]
+        ]
+      }
+    },
+    "@@cel-spec+//:extensions.bzl%non_module_dependencies": {
+      "general": {
+        "bzlTransitiveDigest": "VN89nCHLUuqo5KktrpNZqv8O+QKrrsGIqdoLPn91hhY=",
+        "usagesDigest": "HFQJtQrL9nKaFZEjgwaHVMHALMW+cafu696xy7J4ueM=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_google_googleapis": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "bd8e735d881fb829751ecb1a77038dda4a8d274c45490cb9fcf004583ee10571",
+              "strip_prefix": "googleapis-07c27163ac591955d736f3057b1619ece66f5b99",
+              "urls": [
+                "https://github.com/googleapis/googleapis/archive/07c27163ac591955d736f3057b1619ece66f5b99.tar.gz"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "cel-spec+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@cel-spec+//:googleapis_ext.bzl%googleapis_ext": {
+      "general": {
+        "bzlTransitiveDigest": "65z4sd8o73L2a8X2Pd3yAjn73l9HBG45JVnVY2DUbzI=",
+        "usagesDigest": "Ek7VfZ+tuyRBx/1h5wcmtnW9EGpOb0dkXUwBluZbD8k=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_google_googleapis_imports": {
+            "repoRuleId": "@@cel-spec++non_module_dependencies+com_google_googleapis//:repository_rules.bzl%switched_rules",
+            "attributes": {
+              "rules": {
+                "proto_library_with_info": [
+                  "",
+                  ""
+                ],
+                "moved_proto_library": [
+                  "",
+                  ""
+                ],
+                "java_proto_library": [
+                  "",
+                  ""
+                ],
+                "java_grpc_library": [
+                  "",
+                  ""
+                ],
+                "java_gapic_library": [
+                  "",
+                  ""
+                ],
+                "java_gapic_test": [
+                  "",
+                  ""
+                ],
+                "java_gapic_assembly_gradle_pkg": [
+                  "",
+                  ""
+                ],
+                "py_proto_library": [
+                  "",
+                  ""
+                ],
+                "py_grpc_library": [
+                  "",
+                  ""
+                ],
+                "py_gapic_library": [
+                  "",
+                  ""
+                ],
+                "py_test": [
+                  "",
+                  ""
+                ],
+                "py_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "py_import": [
+                  "",
+                  ""
+                ],
+                "go_proto_library": [
+                  "",
+                  ""
+                ],
+                "go_library": [
+                  "",
+                  ""
+                ],
+                "go_test": [
+                  "",
+                  ""
+                ],
+                "go_gapic_library": [
+                  "",
+                  ""
+                ],
+                "go_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "cc_proto_library": [
+                  "native.cc_proto_library",
+                  ""
+                ],
+                "cc_grpc_library": [
+                  "",
+                  ""
+                ],
+                "cc_gapic_library": [
+                  "",
+                  ""
+                ],
+                "php_proto_library": [
+                  "",
+                  "php_proto_library"
+                ],
+                "php_grpc_library": [
+                  "",
+                  "php_grpc_library"
+                ],
+                "php_gapic_library": [
+                  "",
+                  "php_gapic_library"
+                ],
+                "php_gapic_assembly_pkg": [
+                  "",
+                  "php_gapic_assembly_pkg"
+                ],
+                "nodejs_gapic_library": [
+                  "",
+                  "typescript_gapic_library"
+                ],
+                "nodejs_gapic_assembly_pkg": [
+                  "",
+                  "typescript_gapic_assembly_pkg"
+                ],
+                "ruby_proto_library": [
+                  "",
+                  ""
+                ],
+                "ruby_grpc_library": [
+                  "",
+                  ""
+                ],
+                "ruby_ads_gapic_library": [
+                  "",
+                  ""
+                ],
+                "ruby_cloud_gapic_library": [
+                  "",
+                  ""
+                ],
+                "ruby_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "csharp_proto_library": [
+                  "",
+                  ""
+                ],
+                "csharp_grpc_library": [
+                  "",
+                  ""
+                ],
+                "csharp_gapic_library": [
+                  "",
+                  ""
+                ],
+                "csharp_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ]
+              }
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "cel-spec+",
+            "com_google_googleapis",
+            "cel-spec++non_module_dependencies+com_google_googleapis"
+          ]
+        ]
+      }
+    },
+    "@@envoy_api+//bazel:repositories.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "JQHl7KCG4m+2+/1IddYzhdiav5qs2iUe+gkg5f+kUPA=",
+        "usagesDigest": "OP2p9QPxt4WFY/lah8Iecqt6SOUwZHs89hYRyaV+rSg=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "prometheus_metrics_model": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/prometheus/client_model/archive/v0.6.1.tar.gz"
+              ],
+              "sha256": "b9b690bc35d80061f255faa7df7621eae39fe157179ccd78ff6409c3b004f05e",
+              "strip_prefix": "client_model-0.6.1",
+              "build_file_content": "\nload(\"@envoy_api//bazel:api_build_system.bzl\", \"api_cc_py_proto_library\")\nload(\"@io_bazel_rules_go//proto:def.bzl\", \"go_proto_library\")\n\napi_cc_py_proto_library(\n    name = \"client_model\",\n    srcs = [\n        \"io/prometheus/client/metrics.proto\",\n    ],\n    visibility = [\"//visibility:public\"],\n)\n\ngo_proto_library(\n    name = \"client_model_go_proto\",\n    importpath = \"github.com/prometheus/client_model/go\",\n    proto = \":client_model\",\n    visibility = [\"//visibility:public\"],\n)\n"
+            }
+          },
+          "com_github_bufbuild_buf": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/bufbuild/buf/releases/download/v1.49.0/buf-Linux-x86_64.tar.gz"
+              ],
+              "sha256": "ee8da9748249f7946d79191e36469ce7bc3b8ba80019bff1fa4289a44cbc23bf",
+              "strip_prefix": "buf",
+              "build_file_content": "\npackage(\n    default_visibility = [\"//visibility:public\"],\n)\n\nfilegroup(\n    name = \"buf\",\n    srcs = [\n        \"@com_github_bufbuild_buf//:bin/buf\",\n    ],\n    tags = [\"manual\"], # buf is downloaded as a linux binary; tagged manual to prevent build for non-linux users\n)\n"
+            }
+          },
+          "envoy_toolshed": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/envoyproxy/toolshed/archive/bazel-v0.2.2.tar.gz"
+              ],
+              "sha256": "443fe177aba0cef8c17b7a48905c925c67b09005b10dd70ff12cd9f729a72d51",
+              "strip_prefix": "toolshed-bazel-v0.2.2/bazel"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "envoy_api+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "envoy_api+",
+            "envoy_api",
+            "envoy_api+"
           ]
         ]
       }
@@ -645,6 +947,126 @@
           }
         },
         "recordedRepoMappingEntries": []
+      }
+    },
+    "@@rules_apple+//apple:apple.bzl%provisioning_profile_repository_extension": {
+      "general": {
+        "bzlTransitiveDigest": "uPXHPr6/YdHK89/x69cJN1hdhUF74hBsmCHaOkor2Fg=",
+        "usagesDigest": "vsJl8Rw5NL+5Ag2wdUDoTeRF/5klkXO8545Iy7U1Q08=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_provisioning_profiles": {
+            "repoRuleId": "@@rules_apple+//apple/internal:local_provisioning_profiles.bzl%provisioning_profile_repository",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "apple_support+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "bazel_tools",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_apple+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_apple+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_apple+",
+            "build_bazel_apple_support",
+            "apple_support+"
+          ],
+          [
+            "rules_apple+",
+            "build_bazel_rules_swift",
+            "rules_swift+"
+          ],
+          [
+            "rules_cc+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_cc+",
+            "cc_compatibility_proxy",
+            "rules_cc++compatibility_proxy+cc_compatibility_proxy"
+          ],
+          [
+            "rules_cc+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_cc++compatibility_proxy+cc_compatibility_proxy",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_swift+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_swift+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_swift+",
+            "build_bazel_apple_support",
+            "apple_support+"
+          ],
+          [
+            "rules_swift+",
+            "build_bazel_rules_swift",
+            "rules_swift+"
+          ],
+          [
+            "rules_swift+",
+            "build_bazel_rules_swift_local_config",
+            "rules_swift++non_module_deps+build_bazel_rules_swift_local_config"
+          ]
+        ]
+      }
+    },
+    "@@rules_apple+//apple:extensions.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "fe3Htkk5VXHdsIrdLtxsT4oUgADmqgmxwx83bja4UqY=",
+        "usagesDigest": "M3VqFpeTCo4qmrNKGZw0dxBHvTYDrfV3cscGzlSAhQ4=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "xctestrunner": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/google/xctestrunner/archive/b7698df3d435b6491b4b4c0f9fc7a63fbed5e3a6.tar.gz"
+              ],
+              "strip_prefix": "xctestrunner-b7698df3d435b6491b4b4c0f9fc7a63fbed5e3a6",
+              "sha256": "ae3a063c985a8633cb7eb566db21656f8db8eb9a0edb8c182312c7f0db53730d"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_apple+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
       }
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
@@ -931,6 +1353,80 @@
         ]
       }
     },
+    "@@rules_perl+//perl:extensions.bzl%perl_repositories": {
+      "general": {
+        "bzlTransitiveDigest": "hVM1gWzR35NfpY87MWdNF1xPgjhXCgJv3lHedzj33TY=",
+        "usagesDigest": "qSSNDdCNVxNhY36wMndEAFacdhR0ooLTmumfad0km9s=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "perl_darwin_arm64": {
+            "repoRuleId": "@@rules_perl+//perl:repo.bzl%perl_download",
+            "attributes": {
+              "strip_prefix": "perl-darwin-arm64",
+              "sha256": "285769f3c50c339fb59a3987b216ae3c5c573b95babe6875a1ef56fb178433da",
+              "urls": [
+                "https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-darwin-arm64.tar.xz"
+              ]
+            }
+          },
+          "perl_darwin_amd64": {
+            "repoRuleId": "@@rules_perl+//perl:repo.bzl%perl_download",
+            "attributes": {
+              "strip_prefix": "perl-darwin-amd64",
+              "sha256": "63bc5ee36f5394d71c50cca6cafdd333ee58f9eaa40bca63c85f9bd06f2c1fd6",
+              "urls": [
+                "https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-darwin-amd64.tar.xz"
+              ]
+            }
+          },
+          "perl_linux_amd64": {
+            "repoRuleId": "@@rules_perl+//perl:repo.bzl%perl_download",
+            "attributes": {
+              "strip_prefix": "perl-linux-amd64",
+              "sha256": "3bdffa9d7a3f97c0207314637b260ba5115b1d0829f97e3e2e301191a4d4d076",
+              "urls": [
+                "https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-linux-amd64.tar.xz"
+              ]
+            }
+          },
+          "perl_linux_arm64": {
+            "repoRuleId": "@@rules_perl+//perl:repo.bzl%perl_download",
+            "attributes": {
+              "strip_prefix": "perl-linux-arm64",
+              "sha256": "6fa4ece99e790ecbc2861f6ecb7b52694c01c2eeb215b4370f16a3b12d952117",
+              "urls": [
+                "https://github.com/skaji/relocatable-perl/releases/download/5.36.0.1/perl-linux-arm64.tar.xz"
+              ]
+            }
+          },
+          "perl_windows_x86_64": {
+            "repoRuleId": "@@rules_perl+//perl:repo.bzl%perl_download",
+            "attributes": {
+              "strip_prefix": "",
+              "sha256": "aeb973da474f14210d3e1a1f942dcf779e2ae7e71e4c535e6c53ebabe632cc98",
+              "urls": [
+                "https://mirror.bazel.build/strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.zip",
+                "https://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_perl+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_perl+",
+            "rules_perl",
+            "rules_perl+"
+          ]
+        ]
+      }
+    },
     "@@rules_python+//python/uv:uv.bzl%uv": {
       "general": {
         "bzlTransitiveDigest": "LM8+g04lV+afYP67YcE7wenTJMrNqvF5u/ZnOctwctY=",
@@ -1099,6 +1595,165 @@
             "rules_python+",
             "platforms",
             "platforms"
+          ]
+        ]
+      }
+    },
+    "@@rules_swift+//swift:extensions.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "vwewHB1JdoOb38MyyeRQPIdGOkEKD52YNUYgGwmeOy8=",
+        "usagesDigest": "mhACFnrdMv9Wi0Mt67bxocJqviRkDSV+Ee5Mqdj5akA=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_github_apple_swift_protobuf": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-protobuf/archive/1.20.2.tar.gz"
+              ],
+              "sha256": "3fb50bd4d293337f202d917b6ada22f9548a0a0aed9d9a4d791e6fbd8a246ebb",
+              "strip_prefix": "swift-protobuf-1.20.2/",
+              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_protobuf/BUILD.overlay"
+            }
+          },
+          "com_github_grpc_grpc_swift": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/grpc/grpc-swift/archive/1.16.0.tar.gz"
+              ],
+              "sha256": "58b60431d0064969f9679411264b82e40a217ae6bd34e17096d92cc4e47556a5",
+              "strip_prefix": "grpc-swift-1.16.0/",
+              "build_file": "@@rules_swift+//third_party:com_github_grpc_grpc_swift/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_docc_symbolkit": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-docc-symbolkit/archive/refs/tags/swift-5.10-RELEASE.tar.gz"
+              ],
+              "sha256": "de1d4b6940468ddb53b89df7aa1a81323b9712775b0e33e8254fa0f6f7469a97",
+              "strip_prefix": "swift-docc-symbolkit-swift-5.10-RELEASE",
+              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_docc_symbolkit/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-nio/archive/2.42.0.tar.gz"
+              ],
+              "sha256": "e3304bc3fb53aea74a3e54bd005ede11f6dc357117d9b1db642d03aea87194a0",
+              "strip_prefix": "swift-nio-2.42.0/",
+              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_nio/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_http2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-nio-http2/archive/1.26.0.tar.gz"
+              ],
+              "sha256": "f0edfc9d6a7be1d587e5b403f2d04264bdfae59aac1d74f7d974a9022c6d2b25",
+              "strip_prefix": "swift-nio-http2-1.26.0/",
+              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_nio_http2/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_transport_services": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-nio-transport-services/archive/1.15.0.tar.gz"
+              ],
+              "sha256": "f3498dafa633751a52b9b7f741f7ac30c42bcbeb3b9edca6d447e0da8e693262",
+              "strip_prefix": "swift-nio-transport-services-1.15.0/",
+              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_nio_transport_services/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_extras": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-nio-extras/archive/1.4.0.tar.gz"
+              ],
+              "sha256": "4684b52951d9d9937bb3e8ccd6b5daedd777021ef2519ea2f18c4c922843b52b",
+              "strip_prefix": "swift-nio-extras-1.4.0/",
+              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_nio_extras/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_log": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-log/archive/1.4.4.tar.gz"
+              ],
+              "sha256": "48fe66426c784c0c20031f15dc17faf9f4c9037c192bfac2f643f65cb2321ba0",
+              "strip_prefix": "swift-log-1.4.4/",
+              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_log/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_ssl": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-nio-ssl/archive/2.23.0.tar.gz"
+              ],
+              "sha256": "4787c63f61dd04d99e498adc3d1a628193387e41efddf8de19b8db04544d016d",
+              "strip_prefix": "swift-nio-ssl-2.23.0/",
+              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_nio_ssl/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_collections": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-collections/archive/1.0.4.tar.gz"
+              ],
+              "sha256": "d9e4c8a91c60fb9c92a04caccbb10ded42f4cb47b26a212bc6b39cc390a4b096",
+              "strip_prefix": "swift-collections-1.0.4/",
+              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_collections/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_atomics": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/apple/swift-atomics/archive/1.1.0.tar.gz"
+              ],
+              "sha256": "1bee7f469f7e8dc49f11cfa4da07182fbc79eab000ec2c17bfdce468c5d276fb",
+              "strip_prefix": "swift-atomics-1.1.0/",
+              "build_file": "@@rules_swift+//third_party:com_github_apple_swift_atomics/BUILD.overlay"
+            }
+          },
+          "build_bazel_rules_swift_index_import": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@rules_swift+//third_party:build_bazel_rules_swift_index_import/BUILD.overlay",
+              "canonical_id": "index-import-5.8",
+              "urls": [
+                "https://github.com/MobileNativeFoundation/index-import/releases/download/5.8.0.1/index-import.tar.gz"
+              ],
+              "sha256": "28c1ffa39d99e74ed70623899b207b41f79214c498c603915aef55972a851a15"
+            }
+          },
+          "build_bazel_rules_swift_local_config": {
+            "repoRuleId": "@@rules_swift+//swift/internal:swift_autoconfiguration.bzl%swift_autoconfiguration",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_swift+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_swift+",
+            "build_bazel_rules_swift",
+            "rules_swift+"
           ]
         ]
       }

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -480,6 +480,173 @@
         ]
       }
     },
+    "@@googleapis+//:extensions.bzl%switched_rules": {
+      "general": {
+        "bzlTransitiveDigest": "JLpojYeGHLdgnwSUuQWOrtkL9UMygBUUEFJZh7ASlmA=",
+        "usagesDigest": "66rLsrgz6YqDpU0pD+02mTGNxYxhb/of6Fh0ulHzjdE=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_google_googleapis_imports": {
+            "repoRuleId": "@@googleapis+//:repository_rules.bzl%switched_rules",
+            "attributes": {
+              "rules": {
+                "proto_library_with_info": [
+                  "",
+                  ""
+                ],
+                "moved_proto_library": [
+                  "",
+                  ""
+                ],
+                "java_proto_library": [
+                  "",
+                  ""
+                ],
+                "java_grpc_library": [
+                  "",
+                  ""
+                ],
+                "java_gapic_library": [
+                  "",
+                  ""
+                ],
+                "java_gapic_test": [
+                  "",
+                  ""
+                ],
+                "java_gapic_assembly_gradle_pkg": [
+                  "",
+                  ""
+                ],
+                "py_proto_library": [
+                  "",
+                  ""
+                ],
+                "py_grpc_library": [
+                  "",
+                  ""
+                ],
+                "py_gapic_library": [
+                  "",
+                  ""
+                ],
+                "py_test": [
+                  "",
+                  ""
+                ],
+                "py_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "py_import": [
+                  "",
+                  ""
+                ],
+                "go_proto_library": [
+                  "",
+                  ""
+                ],
+                "go_grpc_library": [
+                  "",
+                  ""
+                ],
+                "go_library": [
+                  "",
+                  ""
+                ],
+                "go_test": [
+                  "",
+                  ""
+                ],
+                "go_gapic_library": [
+                  "",
+                  ""
+                ],
+                "go_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "cc_proto_library": [
+                  "",
+                  ""
+                ],
+                "cc_grpc_library": [
+                  "",
+                  ""
+                ],
+                "cc_gapic_library": [
+                  "",
+                  ""
+                ],
+                "php_proto_library": [
+                  "",
+                  "php_proto_library"
+                ],
+                "php_grpc_library": [
+                  "",
+                  "php_grpc_library"
+                ],
+                "php_gapic_library": [
+                  "",
+                  "php_gapic_library"
+                ],
+                "php_gapic_assembly_pkg": [
+                  "",
+                  "php_gapic_assembly_pkg"
+                ],
+                "nodejs_gapic_library": [
+                  "",
+                  "typescript_gapic_library"
+                ],
+                "nodejs_gapic_assembly_pkg": [
+                  "",
+                  "typescript_gapic_assembly_pkg"
+                ],
+                "ruby_proto_library": [
+                  "",
+                  ""
+                ],
+                "ruby_grpc_library": [
+                  "",
+                  ""
+                ],
+                "ruby_ads_gapic_library": [
+                  "",
+                  ""
+                ],
+                "ruby_cloud_gapic_library": [
+                  "",
+                  ""
+                ],
+                "ruby_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "csharp_proto_library": [
+                  "",
+                  ""
+                ],
+                "csharp_grpc_library": [
+                  "",
+                  ""
+                ],
+                "csharp_gapic_library": [
+                  "",
+                  ""
+                ],
+                "csharp_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ]
+              }
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
         "bzlTransitiveDigest": "AEsQvKwdstptzt98AO1bJYfoWpPUn2upx53ra6o/Rc8=",

--- a/examples/llm/models.zig
+++ b/examples/llm/models.zig
@@ -9,6 +9,7 @@ pub const parseConfig = common.parseConfig;
 pub const lfm2 = @import("models/lfm2.zig");
 pub const llama = @import("models/llama.zig");
 pub const qwen3_5 = @import("models/qwen3_5.zig");
+pub const qwen3_5_moe = @import("models/qwen3_5_moe.zig");
 
 const log = std.log.scoped(.llm);
 
@@ -16,6 +17,7 @@ pub const ModelType = enum {
     lfm2,
     llama,
     qwen3_5,
+    qwen3_5_moe,
 };
 
 const RawConfig = struct {
@@ -26,6 +28,7 @@ pub const LoadedModel = union(ModelType) {
     lfm2: lfm2.LoadedModel,
     llama: llama.LoadedModel,
     qwen3_5: qwen3_5.LoadedModel,
+    qwen3_5_moe: qwen3_5_moe.LoadedModel,
 
     pub fn load(
         allocator: std.mem.Allocator,
@@ -41,6 +44,7 @@ pub const LoadedModel = union(ModelType) {
             .lfm2 => .{ .lfm2 = try lfm2.LoadedModel.init(allocator, io, repo, store, generation) },
             .llama => .{ .llama = try llama.LoadedModel.init(allocator, io, repo, store, generation) },
             .qwen3_5 => .{ .qwen3_5 = try qwen3_5.LoadedModel.init(allocator, io, repo, store, generation) },
+            .qwen3_5_moe => .{ .qwen3_5_moe = try qwen3_5_moe.LoadedModel.init(allocator, io, repo, store, generation) },
         };
     }
 
@@ -55,6 +59,7 @@ pub const LoadedModel = union(ModelType) {
             .lfm2 => |*m| .{ .lfm2 = try m.loadBuffers(allocator, io, platform, store, progress, shardings) },
             .llama => |*m| .{ .llama = try m.loadBuffers(allocator, io, platform, store, progress, shardings) },
             .qwen3_5 => |*m| .{ .qwen3_5 = try m.loadBuffers(allocator, io, platform, store, progress, shardings) },
+            .qwen3_5_moe => |*m| .{ .qwen3_5_moe = try m.loadBuffers(allocator, io, platform, store, progress, shardings) },
         };
     }
 
@@ -70,6 +75,10 @@ pub const LoadedModel = union(ModelType) {
             },
             .qwen3_5 => |*loaded_model| switch (buffers.*) {
                 .qwen3_5 => |*loaded_buffers| loaded_model.unloadBuffers(loaded_buffers, allocator),
+                else => unreachable,
+            },
+            .qwen3_5_moe => |*loaded_model| switch (buffers.*) {
+                .qwen3_5_moe => |*loaded_buffers| loaded_model.unloadBuffers(loaded_buffers, allocator),
                 else => unreachable,
             },
         }
@@ -113,6 +122,15 @@ pub const LoadedModel = union(ModelType) {
                 seqlen,
                 progress,
             ) },
+            .qwen3_5_moe => |*m| .{ .qwen3_5_moe = try m.compile(
+                allocator,
+                io,
+                platform,
+                backend,
+                shardings,
+                seqlen,
+                progress,
+            ) },
         };
         return .{
             .inner = inner,
@@ -126,6 +144,7 @@ pub const CompiledModel = struct {
         lfm2: lfm2.inference.CompiledModel,
         llama: llama.inference.CompiledModel,
         qwen3_5: qwen3_5.inference.CompiledModel,
+        qwen3_5_moe: qwen3_5_moe.inference.CompiledModel,
     };
 
     inner: Inner,
@@ -136,6 +155,7 @@ pub const CompiledModel = struct {
             .lfm2 => |*b| b.deinit(),
             .llama => |*b| b.deinit(),
             .qwen3_5 => |*b| b.deinit(),
+            .qwen3_5_moe => |*b| b.deinit(),
         }
     }
 
@@ -181,6 +201,17 @@ pub const CompiledModel = struct {
                 ) },
                 .seqlen = self.seqlen,
             },
+            .qwen3_5_moe => |*compiled| .{
+                .inner = .{ .qwen3_5_moe = try qwen3_5_moe.Session.init(
+                    allocator,
+                    io,
+                    platform,
+                    tokenizer,
+                    compiled,
+                    &model_buffers.qwen3_5_moe,
+                ) },
+                .seqlen = self.seqlen,
+            },
         };
     }
 };
@@ -189,6 +220,7 @@ pub const Buffers = union(ModelType) {
     lfm2: lfm2.Buffers,
     llama: llama.Buffers,
     qwen3_5: qwen3_5.Buffers,
+    qwen3_5_moe: qwen3_5_moe.Buffers,
 };
 
 pub const Session = struct {
@@ -196,6 +228,7 @@ pub const Session = struct {
         lfm2: lfm2.Session,
         llama: llama.Session,
         qwen3_5: qwen3_5.Session,
+        qwen3_5_moe: qwen3_5_moe.Session,
     };
 
     inner: Inner,

--- a/examples/llm/models/qwen3_5/model.zig
+++ b/examples/llm/models/qwen3_5/model.zig
@@ -671,7 +671,7 @@ pub const GatedDeltaNet = struct {
         RmsNormGated.unloadBuffers(&self.norm);
     }
 
-    fn recurrent_gated_delta_rule(query: zml.Tensor, key: zml.Tensor, value: zml.Tensor, g: zml.Tensor, beta: zml.Tensor, initial_state: ?zml.Tensor) struct { zml.Tensor, zml.Tensor } {
+    fn recurrentGatedDeltaRule(query: zml.Tensor, key: zml.Tensor, value: zml.Tensor, g: zml.Tensor, beta: zml.Tensor, initial_state: ?zml.Tensor) struct { zml.Tensor, zml.Tensor } {
         const scale: f32 = 1.0 / @sqrt(@as(f32, @floatFromInt(query.dim(.khd))));
         const query_norm = zml.nn.normalizeL2(query.rename(.{ .kh = .vh }), 1e-6);
         const key_norm = zml.nn.normalizeL2(key.rename(.{ .kh = .vh }), 1e-6);
@@ -782,7 +782,7 @@ pub const GatedDeltaNet = struct {
         const query_for_rule = if (self.qk_head_repetition == 1) query else query.stutter1d(@intCast(query.axis(.kh)), @intCast(self.qk_head_repetition));
         const key_for_rule = if (self.qk_head_repetition == 1) key else key.stutter1d(@intCast(key.axis(.kh)), @intCast(self.qk_head_repetition));
 
-        const core_attn_out, const last_recurrent_state = recurrent_gated_delta_rule(
+        const core_attn_out, const last_recurrent_state = recurrentGatedDeltaRule(
             query_for_rule,
             key_for_rule,
             value,

--- a/examples/llm/models/qwen3_5_moe.zig
+++ b/examples/llm/models/qwen3_5_moe.zig
@@ -1,0 +1,11 @@
+pub const inference = @import("qwen3_5_moe/inference.zig");
+pub const CompilationParameters = inference.CompilationParameters;
+pub const CompilationOptions = inference.CompilationParameters;
+pub const CompiledModel = inference.CompiledModel;
+pub const model = @import("qwen3_5_moe/model.zig");
+pub const Config = model.Config;
+pub const Buffers = model.Buffers;
+pub const Model = model.Model;
+pub const LoadedModel = model.LoadedModel;
+pub const session = @import("qwen3_5_moe/session.zig");
+pub const Session = session.Session;

--- a/examples/llm/models/qwen3_5_moe/inference.zig
+++ b/examples/llm/models/qwen3_5_moe/inference.zig
@@ -1,0 +1,464 @@
+const std = @import("std");
+
+const zml = @import("zml");
+
+const common = @import("../common.zig");
+const model = @import("model.zig");
+
+const log = std.log.scoped(.qwen3_5_moe);
+
+const CompileModelResult = struct {
+    prefill_embedding_exe: zml.Exe,
+    decode_embedding_exe: zml.Exe,
+    prefill_full_layer_exe: ?zml.Exe,
+    decode_full_layer_exe: ?zml.Exe,
+    prefill_linear_layer_exe: ?zml.Exe,
+    decode_linear_layer_exe: ?zml.Exe,
+    prefill_sampling_exe: zml.Exe,
+    decode_sampling_exe: zml.Exe,
+};
+
+pub const CompilationParameters = struct {
+    kv_cache: model.KvCache,
+    rng: zml.Tensor.Rng,
+    prefill_moe_metadata: zml.moe.Metadata,
+    decode_moe_metadata: zml.moe.Metadata,
+    moe_parameters: zml.moe.Parameters,
+    seqlen: u32,
+    shardings: common.Shardings,
+    xla_dump_to: ?[]const u8,
+
+    pub fn init(mdl: model.Model, config: model.Config, seqlen: u32, moe_backend: zml.moe.Backend, shardings: common.Shardings) CompilationParameters {
+        const dtype = mdl.text_model.embed_tokens.weight.dtype();
+        return .{
+            .kv_cache = .init(config, 1, seqlen, dtype, .f32),
+            .rng = .init(),
+            .prefill_moe_metadata = initMoeMetadata(mdl, @intCast(seqlen), 1, moe_backend),
+            .decode_moe_metadata = initMoeMetadata(mdl, 1, 1, moe_backend),
+            .moe_parameters = .init(.fromBackend(moe_backend, config.text_config.num_experts_per_tok, zml.moe.triton.Parameters.ActivationMode.silu)),
+            .seqlen = seqlen,
+            .shardings = shardings,
+            .xla_dump_to = "/home/ubuntu/xla_dump",
+        };
+    }
+};
+
+pub const CompilationOptions = CompilationParameters;
+
+pub const CompiledModel = struct {
+    loaded_model: *const model.LoadedModel,
+    prefill_embedding_exe: zml.Exe,
+    decode_embedding_exe: zml.Exe,
+    prefill_full_layer_exe: ?zml.Exe,
+    decode_full_layer_exe: ?zml.Exe,
+    prefill_linear_layer_exe: ?zml.Exe,
+    decode_linear_layer_exe: ?zml.Exe,
+    prefill_sampling_exe: zml.Exe,
+    decode_sampling_exe: zml.Exe,
+    params: CompilationParameters,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *const zml.Platform,
+        loaded_model: *const model.LoadedModel,
+        qwen_model: model.Model,
+        parameters: CompilationParameters,
+        progress: *std.Progress.Node,
+    ) !CompiledModel {
+        const compile_result = try compileModel(allocator, io, platform, qwen_model, parameters, progress);
+        return .{
+            .loaded_model = loaded_model,
+            .prefill_embedding_exe = compile_result.prefill_embedding_exe,
+            .decode_embedding_exe = compile_result.decode_embedding_exe,
+            .prefill_full_layer_exe = compile_result.prefill_full_layer_exe,
+            .decode_full_layer_exe = compile_result.decode_full_layer_exe,
+            .prefill_linear_layer_exe = compile_result.prefill_linear_layer_exe,
+            .decode_linear_layer_exe = compile_result.decode_linear_layer_exe,
+            .prefill_sampling_exe = compile_result.prefill_sampling_exe,
+            .decode_sampling_exe = compile_result.decode_sampling_exe,
+            .params = parameters,
+        };
+    }
+
+    pub fn deinit(self: *CompiledModel) void {
+        self.prefill_embedding_exe.deinit();
+        self.decode_embedding_exe.deinit();
+        if (self.prefill_full_layer_exe) |exe| exe.deinit();
+        if (self.decode_full_layer_exe) |exe| exe.deinit();
+        if (self.prefill_linear_layer_exe) |exe| exe.deinit();
+        if (self.decode_linear_layer_exe) |exe| exe.deinit();
+        self.prefill_sampling_exe.deinit();
+        self.decode_sampling_exe.deinit();
+    }
+};
+
+pub const Inference = CompiledModel;
+
+fn compileSelfAttnLayerExe(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    platform: *const zml.Platform,
+    mdl: model.TransformerLayer,
+    hidden: zml.Tensor,
+    token_index: zml.Tensor,
+    cache: model.KvCache.SelfAttnCache,
+    config: model.Config,
+    moe_metadata: zml.moe.Metadata,
+    moe_parameters: zml.moe.Parameters,
+    shardings: []const zml.Sharding,
+    xla_dump_to: ?[]const u8,
+    progress: *std.Progress.Node,
+    label: []const u8,
+) !zml.Exe {
+    progress.increaseEstimatedTotalItems(1);
+    const compiling_label = try std.fmt.allocPrint(allocator, "Compiling {s}...", .{label});
+    defer allocator.free(compiling_label);
+    var node = progress.start(compiling_label, 1);
+    defer node.end();
+
+    const now: std.Io.Timestamp = .now(io, .awake);
+    defer log.info("Compiled {s} [{f}]", .{ label, now.untilNow(io, .awake) });
+
+    return platform.compile(allocator, io, mdl, .forwardSelfAttn, .{ hidden, token_index, cache, config, moe_metadata, moe_parameters }, .{
+        .shardings = shardings,
+        .xla_dump_to = xla_dump_to,
+    });
+}
+
+fn compileLinearAttnLayerExe(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    platform: *const zml.Platform,
+    mdl: model.TransformerLayer,
+    hidden: zml.Tensor,
+    token_index: zml.Tensor,
+    cache: model.KvCache.GatedDeltaNetCache,
+    config: model.Config,
+    moe_metadata: zml.moe.Metadata,
+    moe_parameters: zml.moe.Parameters,
+    shardings: []const zml.Sharding,
+    xla_dump_to: ?[]const u8,
+    progress: *std.Progress.Node,
+    label: []const u8,
+) !zml.Exe {
+    progress.increaseEstimatedTotalItems(1);
+    const compiling_label = try std.fmt.allocPrint(allocator, "Compiling {s}...", .{label});
+    defer allocator.free(compiling_label);
+    var node = progress.start(compiling_label, 1);
+    defer node.end();
+
+    const now: std.Io.Timestamp = .now(io, .awake);
+    defer log.info("Compiled {s} [{f}]", .{ label, now.untilNow(io, .awake) });
+
+    return platform.compile(allocator, io, mdl, .forwardLinearAttn, .{ hidden, token_index, cache, config, moe_metadata, moe_parameters }, .{
+        .shardings = shardings,
+        .xla_dump_to = xla_dump_to,
+    });
+}
+
+fn findFirstLayerIndex(layer_types: []const model.LayerType, target: model.LayerType) ?usize {
+    for (layer_types, 0..) |layer_type, index| {
+        if (layer_type == target) return index;
+    }
+    return null;
+}
+
+fn compileModel(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    platform: *const zml.Platform,
+    qwen35_model: model.Model,
+    parameters: CompilationParameters,
+    progress: *std.Progress.Node,
+) !CompileModelResult {
+    const now: std.Io.Timestamp = .now(io, .awake);
+    const all_shardings = parameters.shardings.all();
+    const prefill_len: usize = @intCast(parameters.seqlen);
+    defer log.info("Compiled model [{f}]", .{now.untilNow(io, .awake)});
+    log.info("Compiling model for platform {any} with prefill length {d}...", .{ platform.target, prefill_len });
+
+    const prefill_tokens = zml.Tensor.init(.{ .b = 1, .s = prefill_len }, .u32);
+    const decode_tokens = zml.Tensor.init(.{ .b = 1, .s = 1 }, .u32);
+    const prefill_hidden = zml.Tensor.init(.{ .b = 1, .s = prefill_len, .d = qwen35_model.config.text_config.hidden_size }, qwen35_model.text_model.embed_tokens.weight.dtype());
+    const decode_hidden = zml.Tensor.init(.{ .b = 1, .s = 1, .d = qwen35_model.config.text_config.hidden_size }, qwen35_model.text_model.embed_tokens.weight.dtype());
+    const token_index = zml.Tensor.init(.{}, .u32);
+    const self_attn_cache: model.KvCache.SelfAttnCache = .{
+        .k = parameters.kv_cache.self_attn.k,
+        .v = parameters.kv_cache.self_attn.v,
+        .layer_index = zml.Tensor.init(.{}, .u32),
+    };
+    const linear_attn_cache: model.KvCache.GatedDeltaNetCache = .{
+        .conv_state = parameters.kv_cache.gated_delta_net.conv_state,
+        .recurrent_state = parameters.kv_cache.gated_delta_net.recurrent_state,
+        .layer_index = zml.Tensor.init(.{}, .u32),
+    };
+
+    var prefill_embedding_future = try io.concurrent(struct {
+        fn call(
+            allocator_: std.mem.Allocator,
+            io_: std.Io,
+            platform_: *const zml.Platform,
+            model_: zml.nn.TokenEmbedding,
+            prefill_tokens_: zml.Tensor,
+            shardings_: []const zml.Sharding,
+            progress_: *std.Progress.Node,
+        ) !zml.Exe {
+            progress_.increaseEstimatedTotalItems(1);
+            var node_ = progress_.start("Compiling prefill embedding...", 1);
+            defer node_.end();
+            const now_: std.Io.Timestamp = .now(io_, .awake);
+            defer log.info("Compiled prefill embedding [{f}]", .{now_.untilNow(io_, .awake)});
+            return platform_.compile(allocator_, io_, model_, .forward, .{prefill_tokens_}, .{ .shardings = shardings_ });
+        }
+    }.call, .{ allocator, io, platform, qwen35_model.text_model.embed_tokens, prefill_tokens, &all_shardings, progress });
+    errdefer if (prefill_embedding_future.cancel(io)) |v| {
+        v.deinit();
+    } else |_| {};
+
+    var decode_embedding_future = try io.concurrent(struct {
+        fn call(
+            allocator_: std.mem.Allocator,
+            io_: std.Io,
+            platform_: *const zml.Platform,
+            model_: zml.nn.TokenEmbedding,
+            decode_tokens_: zml.Tensor,
+            shardings_: []const zml.Sharding,
+            progress_: *std.Progress.Node,
+        ) !zml.Exe {
+            progress_.increaseEstimatedTotalItems(1);
+            var node_ = progress_.start("Compiling decode embedding...", 1);
+            defer node_.end();
+            const now_: std.Io.Timestamp = .now(io_, .awake);
+            defer log.info("Compiled decode embedding [{f}]", .{now_.untilNow(io_, .awake)});
+            return platform_.compile(allocator_, io_, model_, .forward, .{decode_tokens_}, .{ .shardings = shardings_ });
+        }
+    }.call, .{ allocator, io, platform, qwen35_model.text_model.embed_tokens, decode_tokens, &all_shardings, progress });
+    errdefer if (decode_embedding_future.cancel(io)) |v| {
+        v.deinit();
+    } else |_| {};
+
+    const prefill_embedding_exe = try prefill_embedding_future.await(io);
+    const decode_embedding_exe = try decode_embedding_future.await(io);
+
+    const full_layer_index = findFirstLayerIndex(qwen35_model.config.text_config.layer_types, .full_attention) orelse return error.MissingFullAttentionLayer;
+    const linear_layer_index = findFirstLayerIndex(qwen35_model.config.text_config.layer_types, .linear_attention) orelse return error.MissingLinearAttentionLayer;
+    const full_layer_model = qwen35_model.text_model.layers[full_layer_index];
+    const linear_layer_model = qwen35_model.text_model.layers[linear_layer_index];
+
+    var prefill_full_layer_future = try io.concurrent(struct {
+        fn call(
+            allocator_: std.mem.Allocator,
+            io_: std.Io,
+            platform_: *const zml.Platform,
+            layer_model_: model.TransformerLayer,
+            hidden_: zml.Tensor,
+            token_index_: zml.Tensor,
+            cache_: model.KvCache.SelfAttnCache,
+            config_: model.Config,
+            moe_metadata_: zml.moe.Metadata,
+            moe_parameters_: zml.moe.Parameters,
+            shardings_: []const zml.Sharding,
+            xla_dump_to_: ?[]const u8,
+            progress_: *std.Progress.Node,
+        ) !zml.Exe {
+            return compileSelfAttnLayerExe(allocator_, io_, platform_, layer_model_, hidden_, token_index_, cache_, config_, moe_metadata_, moe_parameters_, shardings_, xla_dump_to_, progress_, "prefill full-attention layer...");
+        }
+    }.call, .{ allocator, io, platform, full_layer_model, prefill_hidden, token_index, self_attn_cache, qwen35_model.config, parameters.prefill_moe_metadata, parameters.moe_parameters, &all_shardings, parameters.xla_dump_to, progress });
+    errdefer if (prefill_full_layer_future.cancel(io)) |v| v.deinit() else |_| {};
+
+    var decode_full_layer_future = try io.concurrent(struct {
+        fn call(
+            allocator_: std.mem.Allocator,
+            io_: std.Io,
+            platform_: *const zml.Platform,
+            layer_model_: model.TransformerLayer,
+            hidden_: zml.Tensor,
+            token_index_: zml.Tensor,
+            cache_: model.KvCache.SelfAttnCache,
+            config_: model.Config,
+            moe_metadata_: zml.moe.Metadata,
+            moe_parameters_: zml.moe.Parameters,
+            shardings_: []const zml.Sharding,
+            xla_dump_to_: ?[]const u8,
+            progress_: *std.Progress.Node,
+        ) !zml.Exe {
+            return compileSelfAttnLayerExe(allocator_, io_, platform_, layer_model_, hidden_, token_index_, cache_, config_, moe_metadata_, moe_parameters_, shardings_, xla_dump_to_, progress_, "decode full-attention layer...");
+        }
+    }.call, .{ allocator, io, platform, full_layer_model, decode_hidden, token_index, self_attn_cache, qwen35_model.config, parameters.decode_moe_metadata, parameters.moe_parameters, &all_shardings, parameters.xla_dump_to, progress });
+    errdefer if (decode_full_layer_future.cancel(io)) |v| v.deinit() else |_| {};
+
+    var prefill_full_layer_exe: ?zml.Exe = null;
+    errdefer if (prefill_full_layer_exe) |exe| exe.deinit();
+    var decode_full_layer_exe: ?zml.Exe = null;
+    errdefer if (decode_full_layer_exe) |exe| exe.deinit();
+    prefill_full_layer_exe = try prefill_full_layer_future.await(io);
+    decode_full_layer_exe = try decode_full_layer_future.await(io);
+
+    var prefill_linear_layer_future = try io.concurrent(struct {
+        fn call(
+            allocator_: std.mem.Allocator,
+            io_: std.Io,
+            platform_: *const zml.Platform,
+            layer_model_: model.TransformerLayer,
+            hidden_: zml.Tensor,
+            token_index_: zml.Tensor,
+            cache_: model.KvCache.GatedDeltaNetCache,
+            config_: model.Config,
+            moe_metadata_: zml.moe.Metadata,
+            moe_parameters_: zml.moe.Parameters,
+            shardings_: []const zml.Sharding,
+            xla_dump_to_: ?[]const u8,
+            progress_: *std.Progress.Node,
+        ) !zml.Exe {
+            return compileLinearAttnLayerExe(allocator_, io_, platform_, layer_model_, hidden_, token_index_, cache_, config_, moe_metadata_, moe_parameters_, shardings_, xla_dump_to_, progress_, "prefill linear-attention layer...");
+        }
+    }.call, .{ allocator, io, platform, linear_layer_model, prefill_hidden, token_index, linear_attn_cache, qwen35_model.config, parameters.prefill_moe_metadata, parameters.moe_parameters, &all_shardings, parameters.xla_dump_to, progress });
+    errdefer if (prefill_linear_layer_future.cancel(io)) |v| v.deinit() else |_| {};
+
+    var decode_linear_layer_future = try io.concurrent(struct {
+        fn call(
+            allocator_: std.mem.Allocator,
+            io_: std.Io,
+            platform_: *const zml.Platform,
+            layer_model_: model.TransformerLayer,
+            hidden_: zml.Tensor,
+            token_index_: zml.Tensor,
+            cache_: model.KvCache.GatedDeltaNetCache,
+            config_: model.Config,
+            moe_metadata_: zml.moe.Metadata,
+            moe_parameters_: zml.moe.Parameters,
+            shardings_: []const zml.Sharding,
+            xla_dump_to_: ?[]const u8,
+            progress_: *std.Progress.Node,
+        ) !zml.Exe {
+            return compileLinearAttnLayerExe(allocator_, io_, platform_, layer_model_, hidden_, token_index_, cache_, config_, moe_metadata_, moe_parameters_, shardings_, xla_dump_to_, progress_, "decode linear-attention layer...");
+        }
+    }.call, .{ allocator, io, platform, linear_layer_model, decode_hidden, token_index, linear_attn_cache, qwen35_model.config, parameters.decode_moe_metadata, parameters.moe_parameters, &all_shardings, parameters.xla_dump_to, progress });
+    errdefer if (decode_linear_layer_future.cancel(io)) |v| v.deinit() else |_| {};
+
+    var prefill_linear_layer_exe: ?zml.Exe = null;
+    errdefer if (prefill_linear_layer_exe) |exe| exe.deinit();
+    var decode_linear_layer_exe: ?zml.Exe = null;
+    errdefer if (decode_linear_layer_exe) |exe| exe.deinit();
+
+    prefill_linear_layer_exe = try prefill_linear_layer_future.await(io);
+    decode_linear_layer_exe = try decode_linear_layer_future.await(io);
+
+    var prefill_sampling_future = try io.concurrent(struct {
+        fn call(
+            allocator_: std.mem.Allocator,
+            io_: std.Io,
+            platform_: *const zml.Platform,
+            sampler_: model.Sampler,
+            prefill_hidden_: zml.Tensor,
+            rng_: zml.Tensor.Rng,
+            shardings_: []const zml.Sharding,
+            progress_: *std.Progress.Node,
+        ) !zml.Exe {
+            progress_.increaseEstimatedTotalItems(1);
+            var node_ = progress_.start("Compiling prefill sampling...", 1);
+            defer node_.end();
+            const now_: std.Io.Timestamp = .now(io_, .awake);
+            defer log.info("Compiled prefill sampling [{f}]", .{now_.untilNow(io_, .awake)});
+            return platform_.compile(allocator_, io_, sampler_, .sampleTokens, .{ prefill_hidden_, rng_, null }, .{ .shardings = shardings_ });
+        }
+    }.call, .{ allocator, io, platform, qwen35_model.text_model.sampler(), prefill_hidden, parameters.rng, &all_shardings, progress });
+    errdefer if (prefill_sampling_future.cancel(io)) |v| {
+        v.deinit();
+    } else |_| {};
+    const prefill_sampling_exe = try prefill_sampling_future.await(io);
+
+    var decode_sampling_future = try io.concurrent(struct {
+        fn call(
+            allocator_: std.mem.Allocator,
+            io_: std.Io,
+            platform_: *const zml.Platform,
+            sampler_: model.Sampler,
+            decode_hidden_: zml.Tensor,
+            rng_: zml.Tensor.Rng,
+            token_index_: zml.Tensor,
+            shardings_: []const zml.Sharding,
+            progress_: *std.Progress.Node,
+        ) !zml.Exe {
+            progress_.increaseEstimatedTotalItems(1);
+            var node_ = progress_.start("Compiling decode sampling...", 1);
+            defer node_.end();
+            const now_: std.Io.Timestamp = .now(io_, .awake);
+            defer log.info("Compiled decode sampling [{f}]", .{now_.untilNow(io_, .awake)});
+            return platform_.compile(allocator_, io_, sampler_, .sampleTokens, .{ decode_hidden_, rng_, token_index_ }, .{ .shardings = shardings_ });
+        }
+    }.call, .{ allocator, io, platform, qwen35_model.text_model.sampler(), decode_hidden, parameters.rng, token_index, &all_shardings, progress });
+    errdefer if (decode_sampling_future.cancel(io)) |v| {
+        v.deinit();
+    } else |_| {};
+
+    const decode_sampling_exe = try decode_sampling_future.await(io);
+
+    return .{
+        .prefill_embedding_exe = prefill_embedding_exe,
+        .decode_embedding_exe = decode_embedding_exe,
+        .prefill_full_layer_exe = prefill_full_layer_exe,
+        .decode_full_layer_exe = decode_full_layer_exe,
+        .prefill_linear_layer_exe = prefill_linear_layer_exe,
+        .decode_linear_layer_exe = decode_linear_layer_exe,
+        .prefill_sampling_exe = prefill_sampling_exe,
+        .decode_sampling_exe = decode_sampling_exe,
+    };
+}
+
+fn initMoeMetadata(qwen_model: model.Model, token_len: usize, batch_size: u32, backend: zml.moe.Backend) zml.moe.Metadata {
+    if (qwen_model.config.text_config.num_experts_per_tok == null) {
+        return .init(.fromBackend(backend));
+    }
+
+    var w1_zero_bias_shape: ?zml.Shape = null;
+    var w2_zero_bias_shape: ?zml.Shape = null;
+    var first_out_shape: ?zml.Shape = null;
+    var second_out_shape: ?zml.Shape = null;
+
+    const num_experts_per_tok = qwen_model.config.text_config.num_experts_per_tok.?;
+    const num_experts = qwen_model.config.text_config.num_experts.?;
+
+    for (qwen_model.text_model.layers) |layer| {
+        const gate_up_shape = zml.Shape.init(.{
+            .expert = num_experts,
+            .out = layer.moe.shared_expert.gate_proj.weight.dim(.dout),
+        }, .bf16);
+        const down_shape = zml.Shape.init(.{
+            .expert = num_experts,
+            .out = layer.moe.shared_expert.gate_proj.weight.dim(.d),
+        }, .bf16);
+        const first_out = zml.Shape.init(.{
+            .total_tokens = batch_size * token_len * num_experts_per_tok,
+            .out = layer.moe.shared_expert.gate_proj.weight.dim(.dout) * 2,
+        }, .bf16);
+        const second_out = zml.Shape.init(.{
+            .token = batch_size * token_len,
+            .topk = num_experts_per_tok,
+            .out = layer.moe.shared_expert.down_proj.weight.dim(.d),
+        }, .bf16);
+
+        if (w1_zero_bias_shape == null) {
+            w1_zero_bias_shape = gate_up_shape;
+            w2_zero_bias_shape = down_shape;
+            first_out_shape = first_out;
+            second_out_shape = second_out;
+            continue;
+        }
+
+        if (!w1_zero_bias_shape.?.eql(gate_up_shape) or !w2_zero_bias_shape.?.eql(down_shape) or !first_out_shape.?.eql(first_out) or !second_out_shape.?.eql(second_out)) {
+            log.warn("MoE bias shapes differ across layers; using shapes from the first layer", .{});
+            break;
+        }
+    }
+
+    return switch (backend) {
+        .triton => .init(.{
+            .triton = .{
+                .w1_zero_bias_shape = w1_zero_bias_shape,
+                .w2_zero_bias_shape = w2_zero_bias_shape,
+            },
+        }),
+    };
+}

--- a/examples/llm/models/qwen3_5_moe/model.zig
+++ b/examples/llm/models/qwen3_5_moe/model.zig
@@ -908,7 +908,7 @@ pub const GatedDeltaNet = struct {
         RmsNormGated.unloadBuffers(&self.norm);
     }
 
-    fn recurrent_gated_delta_rule(query: zml.Tensor, key: zml.Tensor, value: zml.Tensor, g: zml.Tensor, beta: zml.Tensor, initial_state: ?zml.Tensor) struct { zml.Tensor, zml.Tensor } {
+    fn recurrentGatedDeltaRule(query: zml.Tensor, key: zml.Tensor, value: zml.Tensor, g: zml.Tensor, beta: zml.Tensor, initial_state: ?zml.Tensor) struct { zml.Tensor, zml.Tensor } {
         const scale: f32 = 1.0 / @sqrt(@as(f32, @floatFromInt(query.dim(.khd))));
         const query_norm = zml.nn.normalizeL2(query.rename(.{ .kh = .vh }), 1e-6);
         const key_norm = zml.nn.normalizeL2(key.rename(.{ .kh = .vh }), 1e-6);
@@ -1022,7 +1022,7 @@ pub const GatedDeltaNet = struct {
         const query_for_rule = if (self.qk_head_repetition == 1) query else query.stutter1d(@intCast(query.axis(.kh)), @intCast(self.qk_head_repetition));
         const key_for_rule = if (self.qk_head_repetition == 1) key else key.stutter1d(@intCast(key.axis(.kh)), @intCast(self.qk_head_repetition));
 
-        const core_attn_out, const last_recurrent_state = recurrent_gated_delta_rule(
+        const core_attn_out, const last_recurrent_state = recurrentGatedDeltaRule(
             query_for_rule,
             key_for_rule,
             value,

--- a/examples/llm/models/qwen3_5_moe/model.zig
+++ b/examples/llm/models/qwen3_5_moe/model.zig
@@ -1,0 +1,1376 @@
+const std = @import("std");
+
+const zml = @import("zml");
+const CompilationContext = zml.module.CompilationContext;
+
+const stdx = zml.stdx;
+
+const common = @import("../common.zig");
+const inference = @import("inference.zig");
+
+const log = std.log.scoped(.qwen3_5);
+
+pub const Config = struct {
+    text_config: TextConfig,
+};
+
+pub const TextConfig = struct {
+    // General
+    num_hidden_layers: i64,
+    layer_types: []const LayerType,
+    hidden_size: i64,
+    max_position_embeddings: i64,
+    rms_norm_eps: f32,
+    // Self attention
+    head_dim: i64,
+    num_attention_heads: i64,
+    num_key_value_heads: i64,
+    rope_parameters: RopeParameters,
+    // Linear attention
+    linear_conv_kernel_dim: i64,
+    linear_key_head_dim: i64,
+    linear_num_key_heads: i64,
+    linear_num_value_heads: i64,
+    linear_value_head_dim: i64,
+    // MoE
+    num_experts: ?i64 = null,
+    num_experts_per_tok: ?u32 = null,
+};
+
+// Each layer uses either: full attention (SelfAttn) or linear attention (GatedDeltaNet).
+pub const LayerType = enum {
+    linear_attention,
+    full_attention,
+};
+
+pub const RopeParameters = struct {
+    mrope_section: [3]i64,
+    partial_rotary_factor: f32,
+    rope_theta: f32,
+};
+
+fn kvHeadsAreReplicated(axis_size: i64, model_partitions: i64) bool {
+    return axis_size > 0 and axis_size < model_partitions and @rem(model_partitions, axis_size) == 0;
+}
+
+fn partitionProjectedKv(tensor: zml.Tensor, replicate_kv_heads: bool) zml.Tensor {
+    return if (replicate_kv_heads)
+        tensor.withPartitioning(.{ .s = .replicated, .h = .replicated, .hd = .replicated })
+    else
+        tensor.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
+}
+
+fn partitionCachedKv(tensor: zml.Tensor, replicate_kv_heads: bool) zml.Tensor {
+    return if (replicate_kv_heads)
+        tensor.rename(.{ .s = .k }).withPartitioning(.{ .k = .replicated, .h = .replicated, .hd = .replicated })
+    else
+        tensor.rename(.{ .s = .k }).withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated });
+}
+
+pub const LoadedModel = struct {
+    inner: Model,
+    parsed_config: std.json.Parsed(Config),
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        repo: std.Io.Dir,
+        store: zml.io.TensorStore.View,
+        generation: common.GenerationOptions,
+    ) !LoadedModel {
+        const parsed_config = try common.parseConfig(Config, allocator, io, repo);
+        errdefer parsed_config.deinit();
+
+        const options: Model.GenOptions = .{
+            .sampling_strategy = generation.sampling_strategy,
+            .max_seq_len = parsed_config.value.text_config.max_position_embeddings,
+        };
+
+        return .{
+            .inner = try .init(allocator, store, parsed_config.value, options),
+            .parsed_config = parsed_config,
+        };
+    }
+
+    pub fn deinit(self: *LoadedModel, allocator: std.mem.Allocator) void {
+        self.inner.deinit(allocator);
+        self.parsed_config.deinit();
+    }
+
+    pub fn loadBuffers(
+        self: *LoadedModel,
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *const zml.Platform,
+        store: *zml.io.TensorStore,
+        progress: *std.Progress.Node,
+        shardings: common.Shardings,
+    ) !Buffers {
+        progress.increaseEstimatedTotalItems(store.view().count());
+        const now: std.Io.Timestamp = .now(io, .awake);
+        var total_bytes: usize = 0;
+        defer {
+            const took = now.untilNow(io, .awake);
+            const bytes_per_sec: u64 = @intFromFloat(
+                @as(f64, @floatFromInt(total_bytes)) /
+                    (@as(f64, @floatFromInt(took.nanoseconds)) / std.time.ns_per_s),
+            );
+            log.info("Loaded weights [{Bi:.2}, {f}, {Bi:.2}/s]", .{ total_bytes, took, bytes_per_sec });
+        }
+
+        const all_shardings = shardings.all();
+        var buffers = try zml.io.load(Model, &self.inner, allocator, io, platform, store, .{
+            .dma_chunks = 32,
+            .dma_chunk_size = 128 * zml.MiB,
+            .progress = progress,
+            .shardings = &all_shardings,
+            .parallelism = 16,
+            .total_bytes = &total_bytes,
+        });
+        errdefer TextModel.unloadBuffers(&buffers.text_model, allocator);
+        return buffers;
+    }
+
+    pub fn unloadBuffers(self: *const LoadedModel, buffers: *Buffers, allocator: std.mem.Allocator) void {
+        _ = self;
+        TextModel.unloadBuffers(&buffers.text_model, allocator);
+    }
+
+    pub fn compile(
+        self: *const LoadedModel,
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *const zml.Platform,
+        backend: zml.attention.attention.Backend,
+        shardings: common.Shardings,
+        seqlen: usize,
+        progress: *std.Progress.Node,
+    ) !inference.CompiledModel {
+        _ = backend;
+        const moe_dtype = self.inner.text_model.layers[0].moe.gate_up_proj.dtype();
+        log.info("Moe dtype : {}", .{moe_dtype});
+        const moe_backend = try zml.moe.Backend.auto(platform, moe_dtype);
+        const params = inference.CompilationParameters.init(self.inner, self.parsed_config.value, @intCast(seqlen), moe_backend, shardings);
+        return inference.CompiledModel.init(allocator, io, platform, self, self.inner, params, progress);
+    }
+};
+
+pub const Buffers = zml.Bufferized(Model);
+
+pub const Model = struct {
+    pub const GenOptions = struct { sampling_strategy: zml.nn.SamplingStrategy = .{}, max_seq_len: i64 };
+
+    pub const SpecialTokens = struct {
+        im_start_token_id: u32,
+        im_end_token_id: u32,
+        end_of_text_token_id: u32,
+    };
+
+    text_model: TextModel,
+
+    config: Config,
+    special_tokens: SpecialTokens = .{
+        .im_start_token_id = 248045,
+        .im_end_token_id = 248046,
+        .end_of_text_token_id = 248044,
+    },
+
+    pub fn init(allocator: std.mem.Allocator, store: zml.io.TensorStore.View, config: Config, gen_options: GenOptions) !Model {
+        // For some Qwen3.5 versions, the output projection lm_head has a standalone weight tensor, while for others it's the same as the input embedding layer
+        return .{
+            .text_model = try .init(allocator, store.withPrefix("model.language_model"), config, gen_options),
+            .config = config,
+        };
+    }
+
+    pub fn deinit(self: Model, allocator: std.mem.Allocator) void {
+        self.text_model.deinit(allocator);
+    }
+
+    pub fn load(
+        self: *const Model,
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *const zml.Platform,
+        store: *zml.io.TensorStore,
+        shardings: []const zml.Sharding,
+        progress: *std.Progress.Node,
+    ) !zml.Bufferized(Model) {
+        progress.increaseEstimatedTotalItems(store.view().count());
+        const now: std.Io.Timestamp = .now(io, .awake);
+        var total_bytes: usize = 0;
+        defer {
+            const took = now.untilNow(io, .awake);
+            const bytes_per_sec: u64 = @intFromFloat(@as(f64, @floatFromInt(total_bytes)) / (@as(f64, @floatFromInt(took.nanoseconds)) / std.time.ns_per_s));
+            log.info("Loaded weights [{Bi:.2}, {f}, {Bi:.2}/s]", .{ total_bytes, took, bytes_per_sec });
+        }
+        return zml.io.load(Model, self, allocator, io, platform, store, .{
+            .dma_chunks = 32,
+            .dma_chunk_size = 128 * zml.MiB,
+            .progress = progress,
+            .shardings = shardings,
+            .parallelism = 16,
+            .total_bytes = &total_bytes,
+        });
+    }
+
+    pub fn unloadBuffers(self: *zml.Bufferized(Model), allocator: std.mem.Allocator) void {
+        TextModel.unloadBuffers(&self.text_model, allocator);
+    }
+    pub fn forward(
+        self: Model,
+        tokens_: zml.Tensor,
+        token_index: zml.Tensor,
+        kv_cache: KvCache,
+        rng: zml.Tensor.Rng,
+        moe_metadata: zml.moe.Metadata,
+        moe_parameters: zml.moe.Parameters,
+    ) struct { zml.Tensor, KvCache, zml.Tensor.Rng } {
+        const tokens = tokens_.withPartialTags(.{.s});
+        const new_tokens, const updated_kv_cache, const new_rng = self.text_model.forward(tokens, token_index, kv_cache, self.config, rng, moe_metadata, moe_parameters);
+        return .{ new_tokens.convert(tokens.dtype()).reuseBuffer(tokens), updated_kv_cache, new_rng };
+    }
+};
+
+//========================Text model========================
+
+// Use this intermediate struct to compile sampleTokens without taking the whole TextModel as input
+pub const Sampler = struct {
+    norm: RmsNorm,
+    lm_head: zml.nn.Linear,
+    gen_options: Model.GenOptions,
+
+    pub fn sampleTokens(
+        self: Sampler,
+        out: zml.Tensor,
+        rng: zml.Tensor.Rng,
+        token_index: ?zml.Tensor,
+    ) struct { zml.Tensor, zml.Tensor.Rng, ?zml.Tensor } {
+        const x = self.norm.forward(out);
+        const logits = self.lm_head.forward(x.withPartialTags(.{.d})).rename(.{ .dout = .voc });
+        const next_tokens, const new_rng = zml.nn.sampleTokens(logits, self.gen_options.sampling_strategy, rng);
+        if (token_index) |token_idx| {
+            return .{ next_tokens.convert(.u32), new_rng, token_idx.addConstant(1) };
+        }
+        return .{ next_tokens.convert(.u32), new_rng, null };
+    }
+};
+
+pub const TextModel = struct {
+    embed_tokens: zml.nn.TokenEmbedding,
+    layers: []TransformerLayer,
+    norm: RmsNorm,
+    lm_head: zml.nn.Linear,
+    gen_options: Model.GenOptions,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        store: zml.io.TensorStore.View,
+        config: Config,
+        gen_options: Model.GenOptions,
+    ) !TextModel {
+        const lm_head_prefix = if (store.root().hasKey("lm_head.weight")) "lm_head" else "model.language_model.embed_tokens";
+
+        const layers = try allocator.alloc(TransformerLayer, @intCast(config.text_config.num_hidden_layers));
+        errdefer allocator.free(layers);
+
+        for (layers, 0..) |*layer, i| {
+            errdefer for (layers[0..i]) |previous_layer| previous_layer.deinit(allocator);
+            layer.* = try .init(allocator, store.withPrefix("layers").withLayer(i), config, i);
+        }
+
+        return .{
+            .embed_tokens = .{ .weight = store.createTensor("embed_tokens.weight", .{ .voc, .d }, .{ .voc = .replicated, .d = .model }) },
+            .layers = layers,
+            .norm = RmsNorm.init(store.withPrefix("norm"), config.text_config.rms_norm_eps),
+            .lm_head = .init(store.root().withPrefix(lm_head_prefix).createTensor("weight", .{ .dout, .d }, .{ .dout = .model, .d = .replicated }), null, .d),
+            .gen_options = gen_options,
+        };
+    }
+
+    pub fn deinit(self: TextModel, allocator: std.mem.Allocator) void {
+        for (self.layers) |layer| {
+            layer.deinit(allocator);
+        }
+        allocator.free(self.layers);
+    }
+
+    pub fn unloadBuffers(self: *zml.Bufferized(TextModel), allocator: std.mem.Allocator) void {
+        self.embed_tokens.weight.deinit();
+        for (self.layers) |*layer| {
+            TransformerLayer.unloadBuffers(layer, allocator);
+        }
+        allocator.free(self.layers);
+        RmsNorm.unloadBuffers(&self.norm);
+        self.lm_head.weight.deinit();
+    }
+
+    pub fn sampler(self: TextModel) Sampler {
+        return .{
+            .norm = self.norm,
+            .lm_head = self.lm_head,
+            .gen_options = self.gen_options,
+        };
+    }
+
+    pub fn forward(
+        self: TextModel,
+        tokens: zml.Tensor,
+        token_index: zml.Tensor,
+        kv_cache: KvCache,
+        config: Config,
+        rng: zml.Tensor.Rng,
+        moe_metadata: zml.moe.Metadata,
+        moe_parameters: zml.moe.Parameters,
+    ) struct { zml.Tensor, KvCache, zml.Tensor.Rng } {
+        var hidden_states = self.embed_tokens.weight.gather(.{ .voc = tokens }, .{});
+
+        var updated_kv_cache = kv_cache;
+        for (self.layers, 0..) |layer, i| {
+            hidden_states, updated_kv_cache = layer.forward(hidden_states, token_index, updated_kv_cache.atLayer(i), config, moe_metadata, moe_parameters);
+        }
+
+        const new_tokens, const new_rng = self.sampleTokens(hidden_states, rng);
+        return .{ new_tokens, updated_kv_cache.reuseBuffer(kv_cache), new_rng };
+    }
+
+    pub fn sampleTokens(
+        self: TextModel,
+        out: zml.Tensor,
+        rng: zml.Tensor.Rng,
+        token_index: ?zml.Tensor,
+    ) struct { zml.Tensor, zml.Tensor.Rng, ?zml.Tensor } {
+        return self.sampler().sampleTokens(out, rng, token_index);
+    }
+};
+
+pub const TransformerLayer = struct {
+    const Attn = union(enum) {
+        self_attn: SelfAttn,
+        linear_attn: GatedDeltaNet,
+    };
+
+    input_layernorm: RmsNorm,
+    attn: Attn,
+    moe: Moe,
+    post_attention_layernorm: RmsNorm,
+
+    pub fn init(allocator: std.mem.Allocator, store: zml.io.TensorStore.View, config: Config, layer_index: usize) !TransformerLayer {
+        const is_full_attention = config.text_config.layer_types[layer_index] == .full_attention;
+        return .{
+            .input_layernorm = RmsNorm.init(store.withPrefix("input_layernorm"), config.text_config.rms_norm_eps),
+            .attn = if (is_full_attention)
+                .{ .self_attn = try .init(store.withPrefix("self_attn"), config) }
+            else
+                .{ .linear_attn = .init(store.withPrefix("linear_attn"), config) },
+            .moe = try .init(allocator, store.withPrefix("mlp"), config),
+            .post_attention_layernorm = RmsNorm.init(store.withPrefix("post_attention_layernorm"), config.text_config.rms_norm_eps),
+        };
+    }
+
+    pub fn deinit(self: TransformerLayer, allocator: std.mem.Allocator) void {
+        self.moe.deinit(allocator);
+    }
+
+    pub fn unloadBuffers(self: *zml.Bufferized(TransformerLayer), allocator: std.mem.Allocator) void {
+        RmsNorm.unloadBuffers(&self.input_layernorm);
+        switch (self.attn) {
+            .self_attn => |*self_attn| SelfAttn.unloadBuffers(self_attn),
+            .linear_attn => |*linear_attn| GatedDeltaNet.unloadBuffers(linear_attn),
+        }
+        Moe.unloadBuffers(&self.moe, allocator);
+        RmsNorm.unloadBuffers(&self.post_attention_layernorm);
+    }
+
+    pub fn forwardSelfAttn(
+        self: TransformerLayer,
+        x0: zml.Tensor,
+        token_index: zml.Tensor,
+        kv_cache: KvCache.SelfAttnCache,
+        config: Config,
+        moe_metadata: zml.moe.Metadata,
+        moe_parameters: zml.moe.Parameters,
+    ) struct { zml.Tensor, KvCache.SelfAttnCache } {
+        _ = config;
+        const residual0 = x0;
+        const normalized_x0 = self.input_layernorm.forward(x0);
+
+        const self_attn = switch (self.attn) {
+            .self_attn => |self_attn| self_attn,
+            .linear_attn => unreachable,
+        };
+        const attention_output, const updated_kv_cache = self_attn.forward(normalized_x0, token_index, kv_cache);
+
+        const x1 = attention_output.add(residual0);
+        const residual1 = x1;
+        const normalized_hidden = self.post_attention_layernorm.forward(x1);
+
+        const moe_output = self.moe.forward(normalized_hidden, moe_metadata, moe_parameters);
+
+        return .{ moe_output.add(residual1).reuseBuffer(x0), updated_kv_cache };
+    }
+
+    pub fn forwardLinearAttn(
+        self: TransformerLayer,
+        x0: zml.Tensor,
+        token_index: zml.Tensor,
+        kv_cache: KvCache.GatedDeltaNetCache,
+        config: Config,
+        moe_metadata: zml.moe.Metadata,
+        moe_parameters: zml.moe.Parameters,
+    ) struct { zml.Tensor, KvCache.GatedDeltaNetCache } {
+        _ = config;
+        _ = token_index;
+        const residual0 = x0;
+        const normalized_x0 = self.input_layernorm.forward(x0);
+
+        const linear_attn = switch (self.attn) {
+            .linear_attn => |linear_attn| linear_attn,
+            .self_attn => unreachable,
+        };
+        const attention_output, const updated_kv_cache = linear_attn.forward(normalized_x0, kv_cache);
+
+        const x1 = attention_output.add(residual0);
+        const residual1 = x1;
+        const normalized_hidden = self.post_attention_layernorm.forward(x1);
+
+        const moe_output = self.moe.forward(normalized_hidden, moe_metadata, moe_parameters);
+
+        return .{ moe_output.add(residual1).reuseBuffer(x0), updated_kv_cache };
+    }
+
+    pub fn forward(
+        self: TransformerLayer,
+        x0: zml.Tensor,
+        token_index: zml.Tensor,
+        kv_cache: KvCache.LayerView,
+        config: Config,
+        moe_metadata: zml.moe.Metadata,
+        moe_parameters: zml.moe.Parameters,
+    ) struct { zml.Tensor, KvCache } {
+        _ = config;
+        const residual0 = x0;
+        const normalized_x0 = self.input_layernorm.forward(x0);
+
+        var attention_output: zml.Tensor = undefined;
+        var updated_kv_cache: KvCache = kv_cache.parent;
+        switch (self.attn) {
+            .self_attn => |*self_attn| {
+                const result = self_attn.forward(normalized_x0, token_index, kv_cache.cache.self_attn);
+                attention_output = result[0];
+                updated_kv_cache.self_attn = result[1];
+            },
+            .linear_attn => |*linear_attn| {
+                const result = linear_attn.forward(normalized_x0, kv_cache.cache.linear_attn);
+                attention_output = result[0];
+                updated_kv_cache.gated_delta_net = result[1];
+            },
+        }
+
+        const x1 = attention_output.add(residual0);
+        const residual1 = x1;
+        const normalized_hidden = self.post_attention_layernorm.forward(x1);
+
+        const moe_output = self.moe.forward(normalized_hidden, moe_metadata, moe_parameters);
+
+        return .{ moe_output.add(residual1), updated_kv_cache };
+    }
+};
+
+pub const SelfAttn = struct {
+    q_proj: zml.nn.Linear,
+    q_proj_scale: ?zml.Tensor,
+    k_proj: zml.nn.Linear,
+    k_proj_scale: ?zml.Tensor,
+    v_proj: zml.nn.Linear,
+    v_proj_scale: ?zml.Tensor,
+
+    q_norm: RmsNorm,
+    k_norm: RmsNorm,
+
+    num_heads: i64,
+    num_kv_heads: i64,
+    head_dim: i64,
+    rotary_dim: i64,
+    rotary_embed: TextRotaryEmbedding,
+    o_proj: zml.nn.Linear,
+
+    o_proj_scale: ?zml.Tensor,
+
+    fn initProj(store: zml.io.TensorStore.View, partitions: anytype, bias_partitions: anytype) zml.nn.Linear {
+        return .init(
+            store.createTensor("weight", .{ .dout, .d }, partitions),
+            store.maybeCreateTensor("bias", .{.dout}, bias_partitions),
+            .d,
+        );
+    }
+
+    pub fn init(store: zml.io.TensorStore.View, config: Config) !SelfAttn {
+        const rotary_dim: i64 = @intFromFloat(@as(f32, @floatFromInt(config.text_config.head_dim)) *
+            config.text_config.rope_parameters.partial_rotary_factor);
+        return .{
+            .q_proj = initProj(store.withPrefix("q_proj"), .{ .dout = .model, .d = .replicated }, .{ .dout = .model }),
+            .q_proj_scale = null,
+            .k_proj = initProj(store.withPrefix("k_proj"), .{ .dout = .model, .d = .replicated }, .{ .dout = .model }),
+            .k_proj_scale = null,
+            .v_proj = initProj(store.withPrefix("v_proj"), .{ .dout = .model, .d = .replicated }, .{ .dout = .model }),
+            .v_proj_scale = null,
+            .o_proj = initProj(store.withPrefix("o_proj"), .{ .dout = .replicated, .d = .model }, .{ .dout = .replicated }),
+            .o_proj_scale = null,
+            .q_norm = RmsNorm.init(store.withPrefix("q_norm"), config.text_config.rms_norm_eps),
+            .k_norm = RmsNorm.init(store.withPrefix("k_norm"), config.text_config.rms_norm_eps),
+            .num_heads = config.text_config.num_attention_heads,
+            .num_kv_heads = config.text_config.num_key_value_heads,
+            .head_dim = config.text_config.head_dim,
+            .rotary_dim = rotary_dim,
+            .rotary_embed = .init(rotary_dim, config.text_config.rope_parameters.rope_theta, config.text_config.rope_parameters.mrope_section),
+        };
+    }
+
+    pub fn unloadBuffers(self: *zml.Bufferized(SelfAttn)) void {
+        self.q_proj.weight.deinit();
+        if (self.q_proj.bias) |*bias| bias.deinit();
+        if (self.q_proj_scale) |*scale| scale.deinit();
+        self.k_proj.weight.deinit();
+        if (self.k_proj.bias) |*bias| bias.deinit();
+        if (self.k_proj_scale) |*scale| scale.deinit();
+        self.v_proj.weight.deinit();
+        if (self.v_proj.bias) |*bias| bias.deinit();
+        if (self.v_proj_scale) |*scale| scale.deinit();
+        self.o_proj.weight.deinit();
+        if (self.o_proj.bias) |*bias| bias.deinit();
+        if (self.o_proj_scale) |*scale| scale.deinit();
+        RmsNorm.unloadBuffers(&self.q_norm);
+        RmsNorm.unloadBuffers(&self.k_norm);
+    }
+
+    fn projectQAndGate(self: SelfAttn, x: zml.Tensor) struct { zml.Tensor, zml.Tensor } {
+        const q_proj = self.q_proj.forward(x)
+            .splitAxis(.dout, .{ .h = self.num_heads, .hd = 2 * self.head_dim });
+        const q, var gate = q_proj.chunkExact(.hd, 2);
+        gate = gate.merge(.{ .d_out_proj = .{ .h, .hd } });
+        return .{ q, gate };
+    }
+
+    fn projectKV(self: SelfAttn, x: zml.Tensor) struct { zml.Tensor, zml.Tensor } {
+        const num_kv_heads = if (self.num_kv_heads > 0) self.num_kv_heads else self.num_heads;
+        const k = self.k_proj.forward(x)
+            .splitAxis(.dout, .{ .h = num_kv_heads, .hd = self.head_dim });
+        const v = self.v_proj.forward(x)
+            .splitAxis(.dout, .{ .h = num_kv_heads, .hd = self.head_dim });
+        return .{ k, v };
+    }
+
+    pub fn forward(
+        self: SelfAttn,
+        x: zml.Tensor,
+        token_index: zml.Tensor,
+        kv_cache: KvCache.SelfAttnCache,
+    ) struct { zml.Tensor, KvCache.SelfAttnCache } {
+        const model_partitions = zml.module.CompilationContext.current().partitioning.numPartitionsForLogicalAxis(self.q_proj.weight.shape(), .model) catch unreachable;
+        const replicate_kv_heads = kvHeadsAreReplicated(self.num_kv_heads, model_partitions);
+        const x_qkv = x.withPartitioning(.{ .d = .replicated });
+
+        var q, var gate = self.projectQAndGate(x_qkv);
+        var k, var v = self.projectKV(x_qkv);
+        q = q.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
+        gate = gate.withPartitioning(.{ .s = .replicated, .d_out_proj = .model });
+        k = partitionProjectedKv(k, replicate_kv_heads);
+        v = partitionProjectedKv(v, replicate_kv_heads);
+        q = self.q_norm.forward(q.rename(.{ .hd = .d })).rename(.{ .d = .hd });
+        k = self.k_norm.forward(k.rename(.{ .hd = .d })).rename(.{ .d = .hd });
+
+        const dtype = q.dtype();
+        const position_ids = zml.Tensor.arange(.{ .end = x.dim(.s) }, .i64)
+            .withTags(.{.s}).insertAxes(.s, .{.b}).broad(zml.Shape.init(.{ .b = x.dim(.b), .s = x.dim(.s) }, .i64))
+            .add(token_index.convert(.i64).broad(zml.Shape.init(.{ .b = x.dim(.b), .s = x.dim(.s) }, .i64)));
+
+        const cos, const sin = self.rotary_embed.getCosAndSin(position_ids, dtype);
+        q = self.rotary_embed.applyRope(q, cos, sin);
+        k = self.rotary_embed.applyRope(k, cos, sin);
+        q = q.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
+        k = partitionProjectedKv(k, replicate_kv_heads);
+        v = partitionProjectedKv(v, replicate_kv_heads);
+
+        const new_kv_cache = kv_cache.update(k, v, token_index.convert(.u32));
+        k = new_kv_cache.keys().convert(dtype);
+        v = new_kv_cache.values().convert(dtype);
+        q = q.rename(.{ .s = .q }).withPartitioning(.{ .q = .replicated, .h = .model, .hd = .replicated });
+        k = partitionCachedKv(k, replicate_kv_heads);
+        v = partitionCachedKv(v, replicate_kv_heads);
+
+        const attn_output = zml.attention.attention.attention(
+            q,
+            k,
+            v,
+            token_index,
+            zml.attention.attention.Metadata.init(.fromBackend(.vanilla, x.dim(.s), self.num_heads)),
+            zml.attention.attention.Parameters.init(.fromBackend(.vanilla)),
+        ).withPartitioning(.{ .q = .replicated, .h = .model, .hd = .replicated }).rename(.{ .q = .s }).merge(.{ .d_out_proj = .{ .h, .hd } });
+
+        const gated_output = attn_output.mul(gate.sigmoid());
+        const projected_output = self.o_proj.forward(gated_output.rename(.{ .d_out_proj = .d })).rename(.{ .dout = .d }).withPartitioning(.{ .d = .replicated });
+
+        return .{ projected_output, new_kv_cache };
+    }
+};
+
+pub const Mlp = struct {
+    up_proj: zml.nn.Linear,
+    up_proj_scale: ?zml.Tensor,
+    gate_proj: zml.nn.Linear,
+    gate_proj_scale: ?zml.Tensor,
+    down_proj: zml.nn.Linear,
+    down_proj_scale: ?zml.Tensor,
+
+    pub fn init(store: zml.io.TensorStore.View) Mlp {
+        return .{
+            .up_proj = .init(
+                store.withPrefix("up_proj").createTensor("weight", .{ .dout, .d }, .{ .dout = .model, .d = .replicated }),
+                store.withPrefix("up_proj").maybeCreateTensor("bias", .{.dout}, .{ .dout = .model }),
+                .d,
+            ),
+            .up_proj_scale = null,
+            .gate_proj = .init(
+                store.withPrefix("gate_proj").createTensor("weight", .{ .dout, .d }, .{ .dout = .model, .d = .replicated }),
+                store.withPrefix("gate_proj").maybeCreateTensor("bias", .{.dout}, .{ .dout = .model }),
+                .d,
+            ),
+            .gate_proj_scale = null,
+            .down_proj = .init(
+                store.withPrefix("down_proj").createTensor("weight", .{ .dout, .d }, .{ .dout = .replicated, .d = .model }),
+                store.withPrefix("down_proj").maybeCreateTensor("bias", .{.d}, .{ .d = .replicated }),
+                .d,
+            ),
+            .down_proj_scale = null,
+        };
+    }
+
+    pub fn unloadBuffers(self: *zml.Bufferized(Mlp)) void {
+        self.up_proj.weight.deinit();
+        if (self.up_proj.bias) |*bias| bias.deinit();
+        if (self.up_proj_scale) |*scale| scale.deinit();
+        self.gate_proj.weight.deinit();
+        if (self.gate_proj.bias) |*bias| bias.deinit();
+        if (self.gate_proj_scale) |*scale| scale.deinit();
+        self.down_proj.weight.deinit();
+        if (self.down_proj.bias) |*bias| bias.deinit();
+        if (self.down_proj_scale) |*scale| scale.deinit();
+    }
+
+    pub fn forward(self: Mlp, x: zml.Tensor) zml.Tensor {
+        const up_projed = self.up_proj.forward(x);
+        const gate = self.gate_proj.forward(x);
+        const hidden = gate.silu().mul(up_projed).rename(.{ .dout = .d });
+
+        const output = self.down_proj.forward(hidden);
+        return output;
+    }
+};
+
+const Router = struct {
+    router: zml.nn.Linear,
+    num_experts_per_tok: u32,
+
+    pub fn init(store: zml.io.TensorStore.View, num_experts_per_tok: u32) Router {
+        return .{
+            .router = .init(
+                store.createTensor("weight", .{ .expert, .d }, .{ .expert = .replicated, .d = .replicated }),
+                store.maybeCreateTensor("bias", .{.expert}, .{ .expert = .replicated }),
+                .d,
+            ),
+            .num_experts_per_tok = num_experts_per_tok,
+        };
+    }
+
+    pub fn unloadBuffers(self: *zml.Bufferized(Router)) void {
+        self.router.weight.deinit();
+        if (self.router.bias) |*bias| bias.deinit();
+    }
+
+    pub fn forward(self: Router, x: zml.Tensor) struct { zml.Tensor, zml.Tensor } {
+        const router_logits = self.router.forward(x).convert(.f32);
+        const routing = router_logits.topK(.{ .top_expert = .expert }, self.num_experts_per_tok, .{});
+        const topk_ids = routing.indices.convert(.i32);
+        const router_scores = routing.values.softmax(.top_expert);
+        return .{ router_scores, topk_ids };
+    }
+};
+
+pub const Moe = struct {
+    shared_expert: Mlp,
+    shared_expert_gate: zml.nn.Linear,
+    gate_up_proj: zml.Tensor,
+    down_proj: zml.Tensor,
+    router: Router,
+
+    pub fn init(allocator: std.mem.Allocator, store: zml.io.TensorStore.View, config: Config) !Moe {
+        _ = allocator;
+        const experts_store = store.withPrefix("experts");
+        const gate_up_proj_tensor = experts_store.createTensor(
+            "gate_up_proj",
+            .{ .expert, .dout, .d },
+            .{ .expert = .replicated, .dout = .model, .d = .replicated },
+        );
+        const down_proj_tensor = experts_store.createTensor(
+            "down_proj",
+            .{ .expert, .d, .dout },
+            .{ .expert = .replicated, .d = .replicated, .dout = .model },
+        );
+
+        return .{
+            .shared_expert = Mlp.init(store.withPrefix("shared_expert")),
+            .shared_expert_gate = .init(
+                store.withPrefix("shared_expert_gate").createTensor("weight", .{ .dout, .d }, .{ .dout = .model, .d = .replicated }),
+                store.withPrefix("shared_expert_gate").maybeCreateTensor("bias", .{.dout}, .{ .dout = .model }),
+                .d,
+            ),
+            .gate_up_proj = gate_up_proj_tensor,
+            .down_proj = down_proj_tensor,
+            .router = Router.init(store.withPrefix("gate"), config.text_config.num_experts_per_tok.?),
+        };
+    }
+
+    pub fn deinit(self: Moe, allocator: std.mem.Allocator) void {
+        _ = self;
+        _ = allocator;
+    }
+
+    pub fn forward(self: Moe, x: zml.Tensor, moe_metadata: zml.moe.Metadata, moe_parameters: zml.moe.Parameters) zml.Tensor {
+        const routing_scores, const topk_ids = self.router.forward(x);
+
+        const moe_output = zml.moe.forwardMoe(
+            x,
+            topk_ids,
+            routing_scores,
+            self.gate_up_proj,
+            null,
+            null,
+            self.down_proj,
+            null,
+            null,
+            moe_metadata,
+            moe_parameters,
+        ) catch |err| stdx.debug.panic("moe backend failed: {}", .{err});
+
+        const shared_gate = self.shared_expert_gate.forward(x).sigmoid().broad(x.shape());
+        const shared = self.shared_expert.forward(x).mul(shared_gate);
+
+        return moe_output.add(shared);
+    }
+
+    pub fn unloadBuffers(self: *zml.Bufferized(Moe), allocator: std.mem.Allocator) void {
+        _ = allocator;
+        Mlp.unloadBuffers(&self.shared_expert);
+        self.shared_expert_gate.weight.deinit();
+        if (self.shared_expert_gate.bias) |*bias| bias.deinit();
+        self.gate_up_proj.deinit();
+        self.down_proj.deinit();
+        Router.unloadBuffers(&self.router);
+    }
+};
+
+pub const TextRotaryEmbedding = struct {
+    rope_opts: zml.nn.RopeOpts,
+    rotary_dim: i64,
+    mrope_section: [3]i64,
+
+    pub fn init(rotary_dim: i64, theta: f32, mrope_section: [3]i64) TextRotaryEmbedding {
+        return .{
+            .rope_opts = .{
+                .layout = .sequential,
+                .scaling = .{ .default = .{ .rope_theta = theta } },
+            },
+            .rotary_dim = rotary_dim,
+            .mrope_section = mrope_section,
+        };
+    }
+
+    pub fn getCosAndSin(self: TextRotaryEmbedding, position_ids: zml.Tensor, dtype: zml.DataType) struct { zml.Tensor, zml.Tensor } {
+        const inv_freq = zml.nn.invFreq(self.rotary_dim, self.rope_opts).withTags(.{.hd});
+
+        const freqs_t = position_ids.convert(.f32).outer(inv_freq);
+
+        const emb = zml.Tensor.concatenate(&.{ freqs_t, freqs_t }, -1);
+        const cos = emb.cos().convert(dtype);
+        const sin = emb.sin().convert(dtype);
+
+        return .{ cos, sin };
+    }
+
+    pub fn getCosAndSinInterleaved(self: TextRotaryEmbedding, position_ids: zml.Tensor, dtype: zml.DataType) struct { zml.Tensor, zml.Tensor } { // To be used later in image extension
+        const stacked_position_ids = zml.Tensor.stack(&.{ position_ids, position_ids, position_ids }, 0, .g).convert(.f32);
+        const inv_freq = zml.nn.InvFreq(self.rotary_dim, self.rope_opts).withTags(.{.hd});
+
+        var freqs = stacked_position_ids.outer(inv_freq);
+        var freqs_t, var freqs_h, var freqs_w = freqs.chunkExact(.g, 3);
+        freqs_t = freqs_t.squeeze(.g);
+        freqs_h = freqs_h.squeeze(.g);
+        freqs_w = freqs_w.squeeze(.g);
+
+        const h_indices = zml.Tensor.iota(zml.Shape.init(.{ .h = self.mrope_section[1] }, .i32), .h).scale(3).addConstant(1);
+        const w_indices = zml.Tensor.iota(zml.Shape.init(.{ .h = self.mrope_section[2] }, .i32), .h).scale(3).addConstant(2);
+
+        const h_input = freqs_h.gather(.{ .dh = h_indices }, .{ .indices_are_sorted = true });
+        const w_input = freqs_w.gather(.{ .dh = w_indices }, .{ .indices_are_sorted = true });
+        freqs_t = freqs_t.scatterSlices(.{ .dh = h_indices }, h_input, .{ .update_fn = zml.Tensor.ScatterOpts.override });
+        freqs = freqs_t.scatterSlices(.{ .dh = w_indices }, w_input, .{ .update_fn = zml.Tensor.ScatterOpts.override });
+
+        const emb = zml.Tensor.concatenate(&.{ freqs, freqs }, -1);
+        const cos = emb.cos().convert(dtype);
+        const sin = emb.sin().convert(dtype);
+
+        return .{ cos, sin };
+    }
+
+    fn rotateHalf(x: zml.Tensor) zml.Tensor {
+        const half_dim = @divExact(x.dim(-1), 2);
+        const x1 = x.slice1d(-1, .{ .start = 0, .end = half_dim });
+        const x2 = x.slice1d(-1, .{ .start = half_dim, .end = x.dim(-1) });
+        return zml.Tensor.concatenate(&.{ x2.negate(), x1 }, -1);
+    }
+
+    pub fn applyRope(self: TextRotaryEmbedding, x: zml.Tensor, cos: zml.Tensor, sin: zml.Tensor) zml.Tensor {
+        const x_rot = x.slice1d(-1, .{ .start = 0, .end = self.rotary_dim });
+        const x_pass = x.slice1d(-1, .{ .start = self.rotary_dim, .end = x.dim(-1) });
+
+        const cos_x = cos.insertAxes(.hd, .{.h}).broad(x_rot.shape());
+        const sin_x = sin.insertAxes(.hd, .{.h}).broad(x_rot.shape());
+
+        const rotated = x_rot.mul(cos_x).add(rotateHalf(x_rot).mul(sin_x));
+
+        return zml.Tensor.concatenate(&.{ rotated, x_pass }, -1);
+    }
+};
+
+pub const GatedDeltaNet = struct {
+    in_proj_qkv: zml.nn.Linear,
+    in_proj_qkv_scale: ?zml.Tensor,
+    in_proj_z: zml.nn.Linear,
+    in_proj_z_scale: ?zml.Tensor,
+    in_proj_b: zml.nn.Linear,
+    in_proj_a: zml.nn.Linear,
+    out_proj: zml.nn.Linear,
+    out_proj_scale: ?zml.Tensor,
+    conv1d_weight: zml.Tensor,
+    dt_bias: zml.Tensor,
+    aLog: zml.Tensor,
+    norm: RmsNormGated,
+
+    num_k_heads: i64,
+    num_v_heads: i64,
+    qk_head_repetition: i64,
+    head_k_dim: i64,
+    head_v_dim: i64,
+    conv_kernel_size: i64,
+
+    fn initProj(store: zml.io.TensorStore.View, partitions: anytype) zml.nn.Linear {
+        return .init(store.createTensor("weight", .{ .dout, .d }, partitions), null, .d);
+    }
+
+    pub fn init(store: zml.io.TensorStore.View, config: Config) GatedDeltaNet {
+        const qk_head_repetition =
+            @divExact(config.text_config.linear_num_value_heads, config.text_config.linear_num_key_heads);
+        return .{
+            .in_proj_qkv = initProj(store.withPrefix("in_proj_qkv"), .{ .dout = .model, .d = .replicated }),
+            .in_proj_qkv_scale = null,
+            .in_proj_z = initProj(store.withPrefix("in_proj_z"), .{ .dout = .model, .d = .replicated }),
+            .in_proj_z_scale = null,
+            .in_proj_b = initProj(store.withPrefix("in_proj_b"), .{ .dout = .model, .d = .replicated }),
+            .in_proj_a = initProj(store.withPrefix("in_proj_a"), .{ .dout = .model, .d = .replicated }),
+            .out_proj = initProj(store.withPrefix("out_proj"), .{ .dout = .replicated, .d = .model }),
+            .out_proj_scale = null,
+            .conv1d_weight = store.withPrefix("conv1d").createTensor("weight", .{ .out, .in, .kernel_size }, .{ .out = .model, .in = .replicated, .kernel_size = .replicated }),
+            .dt_bias = store.createTensor("dt_bias", .{.vh}, .{ .vh = .model }),
+            .aLog = store.createTensor("A_log", .{.vh}, .{ .vh = .model }),
+            .norm = RmsNormGated.init(store.withPrefix("norm"), config.text_config.rms_norm_eps),
+            .num_k_heads = config.text_config.linear_num_key_heads,
+            .num_v_heads = config.text_config.linear_num_value_heads,
+            .qk_head_repetition = qk_head_repetition,
+            .head_k_dim = config.text_config.linear_key_head_dim,
+            .head_v_dim = config.text_config.linear_value_head_dim,
+            .conv_kernel_size = config.text_config.linear_conv_kernel_dim,
+        };
+    }
+
+    pub fn unloadBuffers(self: *zml.Bufferized(GatedDeltaNet)) void {
+        self.in_proj_qkv.weight.deinit();
+        if (self.in_proj_qkv_scale) |*scale| scale.deinit();
+        self.in_proj_z.weight.deinit();
+        if (self.in_proj_z_scale) |*scale| scale.deinit();
+        self.in_proj_b.weight.deinit();
+        self.in_proj_a.weight.deinit();
+        self.out_proj.weight.deinit();
+        if (self.out_proj_scale) |*scale| scale.deinit();
+        self.conv1d_weight.deinit();
+        self.dt_bias.deinit();
+        self.aLog.deinit();
+        RmsNormGated.unloadBuffers(&self.norm);
+    }
+
+    fn recurrent_gated_delta_rule(query: zml.Tensor, key: zml.Tensor, value: zml.Tensor, g: zml.Tensor, beta: zml.Tensor, initial_state: ?zml.Tensor) struct { zml.Tensor, zml.Tensor } {
+        const scale: f32 = 1.0 / @sqrt(@as(f32, @floatFromInt(query.dim(.khd))));
+        const query_norm = zml.nn.normalizeL2(query.rename(.{ .kh = .vh }), 1e-6);
+        const key_norm = zml.nn.normalizeL2(key.rename(.{ .kh = .vh }), 1e-6);
+
+        const query_f32, const key_f32, const value_f32, const alpha_f32, const beta_f32 = .{
+            query_norm.convert(.f32).scale(scale).rename(.{ .vh = .h, .khd = .k }),
+            key_norm.convert(.f32).rename(.{ .vh = .h, .khd = .k }),
+            value.convert(.f32).rename(.{ .vh = .h, .vhd = .v }),
+            g.convert(.f32).exp().rename(.{ .vh = .h }),
+            beta.convert(.f32).rename(.{ .vh = .h }),
+        };
+
+        const initial_recurrent_state = if (initial_state) |state|
+            state.convert(.f32).transpose(.{ .b, .vh, .vhd, .khd }).rename(.{ .vh = .h, .vhd = .v, .khd = .k })
+        else
+            zml.Tensor.constant(zml.DataType.zero(.f32)).broad(zml.Shape.init(.{
+                .b = value.dim(.b),
+                .h = value.dim(.vh),
+                .v = value.dim(.vhd),
+                .k = query.dim(.khd),
+            }, .f32));
+
+        const result = zml.nn.GatedDeltaNet.forward(
+            query_f32,
+            key_f32,
+            value_f32,
+            alpha_f32,
+            beta_f32,
+            .{ .s = initial_recurrent_state },
+        );
+
+        return .{
+            result.outputs.rename(.{ .h = .vh, .v = .vhd }).convert(query.dtype()),
+            result.state.s.transpose(.{ .b, .h, .k, .v }).rename(.{ .h = .vh, .k = .khd, .v = .vhd }),
+        };
+    }
+
+    fn buildUpdatedConvState(input: zml.Tensor, left_pad: i64) zml.Tensor {
+        const copy_len = @min(input.dim(.s), left_pad);
+        const tail = input.slice1d(.s, .{ .start = input.dim(.s) - copy_len, .end = input.dim(.s) });
+        if (copy_len == left_pad) return tail;
+
+        const padding_shape = zml.Shape.init(.{ .b = input.dim(.b), .s = left_pad - copy_len, .mix = input.dim(.mix) }, input.dtype());
+        const padding = zml.Tensor.constant(input.dtype().zero()).broad(padding_shape);
+        return zml.Tensor.concatenate(&.{ padding, tail }, .s);
+    }
+
+    pub fn forward(self: GatedDeltaNet, x: zml.Tensor, cache: KvCache.GatedDeltaNetCache) struct { zml.Tensor, KvCache.GatedDeltaNetCache } {
+        const key_dim = self.num_k_heads * self.head_k_dim;
+        const value_dim = self.num_v_heads * self.head_v_dim;
+        const conv_dim = 2 * key_dim + value_dim;
+        const left_pad = self.conv_kernel_size - 1;
+
+        const x_in = x.withPartitioning(.{ .d = .replicated });
+        const projected_qkv = self.in_proj_qkv.forward(x_in)
+            .rename(.{ .dout = .mix }).withPartitioning(.{ .s = .replicated, .mix = .model });
+        const use_cached_state = x.dim(.s) == 1 and left_pad > 0;
+        const conv_input = if (use_cached_state)
+            zml.Tensor.concatenate(&.{ cache.convState(), projected_qkv }, .s)
+        else
+            projected_qkv;
+
+        const kernel = self.conv1d_weight;
+        var mixed_qkv = zml.Tensor.conv1d(
+            conv_input,
+            kernel,
+            .{
+                .padding = &.{ left_pad, 0 },
+                .input_batch_dimension = 0,
+                .input_feature_dimension = 2,
+                .input_spatial_dimensions = 1,
+                .kernel_output_feature_dimension = 0,
+                .kernel_input_feature_dimension = 1,
+                .kernel_spatial_dimensions = 2,
+                .output_batch_dimension = 0,
+                .output_feature_dimension = 2,
+                .output_spatial_dimensions = 1,
+                .feature_group_count = conv_dim,
+            },
+        )
+            .silu();
+
+        if (use_cached_state) {
+            mixed_qkv = mixed_qkv.slice1d(.s, .{ .start = mixed_qkv.dim(.s) - 1, .end = mixed_qkv.dim(.s) });
+        }
+        mixed_qkv = mixed_qkv.withPartitioning(.{ .s = .replicated, .mix = .model });
+
+        const z = self.in_proj_z.forward(x_in)
+            .splitAxis(.dout, .{ .vh = self.num_v_heads, .vhd = self.head_v_dim })
+            .withPartitioning(.{ .s = .replicated, .vh = .model, .vhd = .replicated });
+        const b = self.in_proj_b.forward(x_in).rename(.{ .dout = .vh }).withPartitioning(.{ .s = .replicated, .vh = .model });
+        const a = self.in_proj_a.forward(x_in).rename(.{ .dout = .vh }).withPartitioning(.{ .s = .replicated, .vh = .model });
+
+        const query = mixed_qkv
+            .slice1d(.mix, .{ .start = 0, .end = key_dim })
+            .splitAxis(.mix, .{ .kh = self.num_k_heads, .khd = self.head_k_dim })
+            .withPartitioning(.{ .s = .replicated, .kh = .model, .khd = .replicated });
+        const key = mixed_qkv
+            .slice1d(.mix, .{ .start = key_dim, .end = 2 * key_dim })
+            .splitAxis(.mix, .{ .kh = self.num_k_heads, .khd = self.head_k_dim })
+            .withPartitioning(.{ .s = .replicated, .kh = .model, .khd = .replicated });
+        const value = mixed_qkv
+            .slice1d(.mix, .{ .start = 2 * key_dim, .end = 2 * key_dim + value_dim })
+            .splitAxis(.mix, .{ .vh = self.num_v_heads, .vhd = self.head_v_dim })
+            .withPartitioning(.{ .s = .replicated, .vh = .model, .vhd = .replicated });
+
+        const beta = b.sigmoid();
+        const aLog_type = self.aLog.dtype();
+        const g = self.aLog.broad(a.shape()).exp().mul(softplus(a.convert(aLog_type).add(self.dt_bias.convert(aLog_type).broad(a.shape())))).negate();
+
+        const query_for_rule = if (self.qk_head_repetition == 1) query else query.stutter1d(@intCast(query.axis(.kh)), @intCast(self.qk_head_repetition));
+        const key_for_rule = if (self.qk_head_repetition == 1) key else key.stutter1d(@intCast(key.axis(.kh)), @intCast(self.qk_head_repetition));
+
+        const core_attn_out, const last_recurrent_state = recurrent_gated_delta_rule(
+            query_for_rule,
+            key_for_rule,
+            value,
+            g,
+            beta,
+            if (use_cached_state) cache.recurrentState() else null,
+        );
+
+        const core_attn_out_normed = self.norm
+            .forward(
+                core_attn_out.rename(.{ .vhd = .d }),
+                z.rename(.{ .vhd = .d }),
+            )
+            .rename(.{ .d = .vhd })
+            .withPartitioning(.{ .s = .replicated, .vh = .model, .vhd = .replicated });
+
+        const output = self.out_proj.forward(core_attn_out_normed.merge(.{ .d = .{ .vh, .vhd } }))
+            .rename(.{ .dout = .d }).withPartitioning(.{ .d = .replicated });
+        const updated_cache = cache.update(
+            buildUpdatedConvState(conv_input, left_pad),
+            last_recurrent_state,
+        );
+        return .{ output, updated_cache };
+    }
+};
+
+pub const RmsNorm = struct {
+    weight: zml.Tensor,
+    eps: f32 = 1e-6,
+
+    pub fn init(store: zml.io.TensorStore.View, eps: f32) RmsNorm {
+        return .{ .weight = store.createTensor("weight", .{.d}, .{ .d = .replicated }), .eps = eps };
+    }
+
+    pub fn unloadBuffers(self: *zml.Bufferized(RmsNorm)) void {
+        self.weight.deinit();
+    }
+
+    pub fn forward(self: RmsNorm, x: zml.Tensor) zml.Tensor {
+        const x_f32 = x.convert(.f32);
+        const weight_f32 = self.weight.convert(.f32);
+
+        const normalized = zml.nn.rmsNorm(x_f32, .d, self.eps);
+        return normalized.mul(weight_f32.broad(x.shape())).add(normalized).convert(x.dtype());
+    }
+};
+
+pub const RmsNormGated = struct {
+    weight: zml.Tensor,
+    eps: f32 = 1e-6,
+
+    pub fn init(store: zml.io.TensorStore.View, eps: f32) RmsNormGated {
+        return .{ .weight = store.createTensor("weight", .{.d}, .{ .d = .replicated }), .eps = eps };
+    }
+
+    pub fn unloadBuffers(self: *zml.Bufferized(RmsNormGated)) void {
+        self.weight.deinit();
+    }
+
+    pub fn forward(self: RmsNormGated, x: zml.Tensor, gate: zml.Tensor) zml.Tensor {
+        const x_f32 = x.convert(.f32);
+        const gate_f32 = gate.convert(.f32);
+
+        const normalized = zml.nn.rmsNorm(x_f32, .d, self.eps);
+        const output = normalized.mul(self.weight.broad(x.shape()));
+
+        const gated_output = output.mul(gate_f32.silu());
+        return gated_output.convert(x.dtype());
+    }
+};
+
+pub const KvCache = struct {
+    layer_types: []const LayerType,
+    self_attn: SelfAttnCache,
+    gated_delta_net: GatedDeltaNetCache,
+
+    pub const SelfAttnCache = struct {
+        k: zml.Tensor,
+        v: zml.Tensor,
+        layer_index: zml.Tensor,
+
+        pub fn init(config: Config, batch_dim: i64, max_seq_len: i64, dtype: zml.DataType) SelfAttnCache {
+            const num_self_attn_layers = countLayers(config.text_config.layer_types, .full_attention);
+            const kv_shape = zml.Shape.init(.{
+                .b = batch_dim,
+                .layer = num_self_attn_layers,
+                .s = max_seq_len,
+                .h = config.text_config.num_key_value_heads,
+                .hd = config.text_config.head_dim,
+            }, dtype);
+            const sharded_kv_shape = kv_shape.withPartitioning(.{ .h = .model });
+            return .{
+                .k = .fromShape(sharded_kv_shape),
+                .v = .fromShape(sharded_kv_shape),
+                .layer_index = .init(.{}, .u32),
+            };
+        }
+
+        pub fn initBuffer(self: SelfAttnCache, io: std.Io, platform: *const zml.Platform, sharding: zml.Sharding) !zml.Bufferized(SelfAttnCache) {
+            return .{
+                .k = try zml.Buffer.uninitialized(io, platform, self.k.shape(), sharding, .{}),
+                .v = try zml.Buffer.uninitialized(io, platform, self.v.shape(), sharding, .{}),
+                .layer_index = try zml.Buffer.scalar(io, platform, 0, .u32),
+            };
+        }
+
+        pub fn deinitBuffer(self: *zml.Bufferized(SelfAttnCache)) void {
+            self.k.deinit();
+            self.v.deinit();
+            self.layer_index.deinit();
+        }
+
+        pub fn keys(self: SelfAttnCache) zml.Tensor {
+            return self.k.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = self.layer_index, .len = 1 } }).squeeze(.layer);
+        }
+
+        pub fn values(self: SelfAttnCache) zml.Tensor {
+            return self.v.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = self.layer_index, .len = 1 } }).squeeze(.layer);
+        }
+
+        pub fn update(self: SelfAttnCache, new_k: zml.Tensor, new_v: zml.Tensor, token_index: ?zml.Tensor) SelfAttnCache {
+            const k_shape = self.k.shape().drop(.layer);
+            var layer = self.layer_index;
+            layer = if (token_index) |idx| layer.broad(idx.shape()) else layer;
+
+            return if (token_index) |idx| .{
+                .k = self.k.scatterSlices(
+                    .{ .layer = layer, .s = idx },
+                    new_k.convert(self.k.dtype()).transpose(k_shape),
+                    .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override },
+                ).reuseBuffer(self.k),
+                .v = self.v.scatterSlices(
+                    .{ .layer = layer, .s = idx },
+                    new_v.convert(self.v.dtype()).transpose(k_shape),
+                    .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override },
+                ).reuseBuffer(self.v),
+                .layer_index = self.layer_index,
+            } else .{
+                .k = self.k.scatterSlices(
+                    .{ .layer = layer },
+                    new_k.convert(self.k.dtype()).transpose(k_shape),
+                    .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override },
+                ).reuseBuffer(self.k),
+                .v = self.v.scatterSlices(
+                    .{ .layer = layer },
+                    new_v.convert(self.v.dtype()).transpose(k_shape),
+                    .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override },
+                ).reuseBuffer(self.v),
+                .layer_index = self.layer_index,
+            };
+        }
+
+        pub fn atLayer(self: SelfAttnCache, layer_index: usize) SelfAttnCache {
+            return .{
+                .k = self.k,
+                .v = self.v,
+                .layer_index = zml.Tensor.scalar(layer_index, .u32),
+            };
+        }
+
+        pub fn reuseBuffer(self: SelfAttnCache, other: SelfAttnCache) SelfAttnCache {
+            return .{
+                .k = self.k.reuseBuffer(other.k),
+                .v = self.v.reuseBuffer(other.v),
+                .layer_index = self.layer_index.reuseBuffer(other.layer_index),
+            };
+        }
+    };
+
+    pub const GatedDeltaNetCache = struct {
+        conv_state: zml.Tensor,
+        recurrent_state: zml.Tensor,
+        layer_index: zml.Tensor,
+
+        pub fn init(config: Config, batch_dim: i64, conv_dtype: zml.DataType, recurrent_dtype: zml.DataType) GatedDeltaNetCache {
+            const num_linear_attn_layers = countLayers(config.text_config.layer_types, .linear_attention);
+            const conv_dim = 2 * config.text_config.linear_num_key_heads * config.text_config.linear_key_head_dim + config.text_config.linear_num_value_heads * config.text_config.linear_value_head_dim;
+            const conv_state_shape = zml.Shape.init(.{
+                .b = batch_dim,
+                .layer = num_linear_attn_layers,
+                .s = config.text_config.linear_conv_kernel_dim - 1,
+                .mix = conv_dim,
+            }, conv_dtype);
+            const recurrent_state_shape = zml.Shape.init(.{
+                .b = batch_dim,
+                .layer = num_linear_attn_layers,
+                .vh = config.text_config.linear_num_value_heads,
+                .khd = config.text_config.linear_key_head_dim,
+                .vhd = config.text_config.linear_value_head_dim,
+            }, recurrent_dtype);
+            const sharded_conv_state_shape = conv_state_shape.withPartitioning(.{ .mix = .model });
+            const sharded_recurrent_state_shape = recurrent_state_shape.withPartitioning(.{ .vh = .model });
+            return .{
+                .conv_state = .fromShape(sharded_conv_state_shape),
+                .recurrent_state = .fromShape(sharded_recurrent_state_shape),
+                .layer_index = .init(.{}, .u32),
+            };
+        }
+
+        pub fn initBuffer(self: GatedDeltaNetCache, io: std.Io, platform: *const zml.Platform, sharding: zml.Sharding) !zml.Bufferized(GatedDeltaNetCache) {
+            return .{
+                .conv_state = try zml.Buffer.uninitialized(io, platform, self.conv_state.shape(), sharding, .{}),
+                .recurrent_state = try zml.Buffer.uninitialized(io, platform, self.recurrent_state.shape(), sharding, .{}),
+                .layer_index = try zml.Buffer.scalar(io, platform, 0, .u32),
+            };
+        }
+
+        pub fn deinitBuffer(self: *zml.Bufferized(GatedDeltaNetCache)) void {
+            self.conv_state.deinit();
+            self.recurrent_state.deinit();
+            self.layer_index.deinit();
+        }
+
+        pub fn convState(self: GatedDeltaNetCache) zml.Tensor {
+            return self.conv_state.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = self.layer_index, .len = 1 } }).squeeze(.layer);
+        }
+
+        pub fn recurrentState(self: GatedDeltaNetCache) zml.Tensor {
+            return self.recurrent_state.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = self.layer_index, .len = 1 } }).squeeze(.layer);
+        }
+
+        pub fn update(self: GatedDeltaNetCache, new_conv_state: ?zml.Tensor, new_recurrent_state: ?zml.Tensor) GatedDeltaNetCache {
+            const conv_state = if (new_conv_state) |state|
+                self.conv_state.scatterSlices(
+                    .{ .layer = self.layer_index },
+                    state.convert(self.conv_state.dtype()).transpose(self.conv_state.shape().drop(.layer)),
+                    .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override },
+                ).reuseBuffer(self.conv_state)
+            else
+                self.conv_state;
+
+            const recurrent_state = if (new_recurrent_state) |state|
+                self.recurrent_state.scatterSlices(
+                    .{ .layer = self.layer_index },
+                    state.convert(self.recurrent_state.dtype()).transpose(self.recurrent_state.shape().drop(.layer)),
+                    .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override },
+                ).reuseBuffer(self.recurrent_state)
+            else
+                self.recurrent_state;
+
+            return .{
+                .conv_state = conv_state,
+                .recurrent_state = recurrent_state,
+                .layer_index = self.layer_index,
+            };
+        }
+
+        pub fn atLayer(self: GatedDeltaNetCache, layer_index: usize) GatedDeltaNetCache {
+            return .{
+                .conv_state = self.conv_state,
+                .recurrent_state = self.recurrent_state,
+                .layer_index = zml.Tensor.scalar(layer_index, .u32),
+            };
+        }
+
+        pub fn reuseBuffer(self: GatedDeltaNetCache, other: GatedDeltaNetCache) GatedDeltaNetCache {
+            return .{
+                .conv_state = self.conv_state.reuseBuffer(other.conv_state),
+                .recurrent_state = self.recurrent_state.reuseBuffer(other.recurrent_state),
+                .layer_index = self.layer_index.reuseBuffer(other.layer_index),
+            };
+        }
+    };
+
+    pub fn init(
+        config: Config,
+        batch_dim: i64,
+        max_seq_len: i64,
+        cache_dtype: zml.DataType,
+        recurrent_dtype: zml.DataType,
+    ) KvCache {
+        return .{
+            .layer_types = config.text_config.layer_types,
+            .self_attn = SelfAttnCache.init(config, batch_dim, max_seq_len, cache_dtype),
+            .gated_delta_net = GatedDeltaNetCache.init(config, batch_dim, cache_dtype, recurrent_dtype),
+        };
+    }
+
+    pub fn initBuffer(self: KvCache, io: std.Io, platform: *const zml.Platform, sharding: zml.Sharding) !zml.Bufferized(KvCache) {
+        return .{
+            .self_attn = try self.self_attn.initBuffer(io, platform, sharding),
+            .gated_delta_net = try self.gated_delta_net.initBuffer(io, platform, sharding),
+        };
+    }
+
+    pub fn deinitBuffer(self: *zml.Bufferized(KvCache)) void {
+        SelfAttnCache.deinitBuffer(&self.self_attn);
+        GatedDeltaNetCache.deinitBuffer(&self.gated_delta_net);
+    }
+
+    pub const LayerView = struct {
+        parent: KvCache,
+        cache: union(enum) {
+            self_attn: SelfAttnCache,
+            linear_attn: GatedDeltaNetCache,
+        },
+    };
+
+    pub fn atLayer(self: KvCache, layer_index: usize) LayerView {
+        return switch (getDenseIndex(self.layer_types, layer_index)) {
+            .full_attention => |dense_index| .{
+                .parent = self,
+                .cache = .{ .self_attn = self.self_attn.atLayer(dense_index.layer_dense_index) },
+            },
+            .linear_attention => |dense_index| .{
+                .parent = self,
+                .cache = .{ .linear_attn = self.gated_delta_net.atLayer(dense_index.layer_dense_index) },
+            },
+        };
+    }
+
+    pub fn reuseBuffer(self: KvCache, other: KvCache) KvCache {
+        return .{
+            .layer_types = self.layer_types,
+            .self_attn = self.self_attn.reuseBuffer(other.self_attn),
+            .gated_delta_net = self.gated_delta_net.reuseBuffer(other.gated_delta_net),
+        };
+    }
+
+    fn countLayers(layer_types: []const LayerType, layer_type: LayerType) i64 {
+        var count: i64 = 0;
+        for (layer_types) |registered_layer_type| {
+            if (registered_layer_type == layer_type) count += 1;
+        }
+        return count;
+    }
+
+    fn getDenseIndex(layer_types: []const LayerType, layer_index: usize) union(enum) {
+        full_attention: struct { layer_dense_index: usize },
+        linear_attention: struct { layer_dense_index: usize },
+    } {
+        var self_attn_layer_index: usize = 0;
+        var linear_attn_layer_index: usize = 0;
+        for (layer_types[0..layer_index]) |layer_type| {
+            switch (layer_type) {
+                .full_attention => self_attn_layer_index += 1,
+                .linear_attention => linear_attn_layer_index += 1,
+            }
+        }
+        return switch (layer_types[layer_index]) {
+            .full_attention => .{ .full_attention = .{ .layer_dense_index = self_attn_layer_index } },
+            .linear_attention => .{ .linear_attention = .{ .layer_dense_index = linear_attn_layer_index } },
+        };
+    }
+};
+
+//========================Utils========================
+
+fn softplus(x: zml.Tensor) zml.Tensor {
+    return x.exp().addConstant(1).log();
+}

--- a/examples/llm/models/qwen3_5_moe/session.zig
+++ b/examples/llm/models/qwen3_5_moe/session.zig
@@ -1,0 +1,459 @@
+const std = @import("std");
+
+const zml = @import("zml");
+
+const inference = @import("inference.zig");
+const model = @import("model.zig");
+
+const LayerIndexBuffer = union(enum) {
+    self_attn: zml.Buffer,
+    linear_attn: zml.Buffer,
+};
+
+pub const Session = struct {
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    platform: *const zml.Platform,
+    model_buffers: *model.Buffers,
+    compiled_model: *const inference.CompiledModel,
+    kv_cache_buffers: zml.Bufferized(model.KvCache),
+    prefill_moe_metadata_buffers: zml.Bufferized(zml.moe.Metadata),
+    decode_moe_metadata_buffers: zml.Bufferized(zml.moe.Metadata),
+    rng_buffers: zml.Bufferized(zml.Tensor.Rng),
+    layer_index_buffers: []LayerIndexBuffer,
+    decode_token_index_buffer: zml.Buffer,
+    self_attn_layers_caches: []zml.Bufferized(model.KvCache.SelfAttnCache),
+    linear_attn_layers_caches: []zml.Bufferized(model.KvCache.GatedDeltaNetCache),
+    step_token_slice: zml.Slice,
+    generated_token_slice: zml.Slice,
+    tokenizer: zml.tokenizer.Tokenizer,
+    seqlen: u32,
+    eos_token_id: u32,
+    special_tokens: model.Model.SpecialTokens,
+    think_start: ?u32,
+    think_end: ?u32,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *const zml.Platform,
+        tokenizer: zml.tokenizer.Tokenizer,
+        compiled_model: *const inference.CompiledModel,
+        model_buffers: *model.Buffers,
+    ) !Session {
+        const shardings = compiled_model.params.shardings;
+        var kv_cache_buffers = try compiled_model.params.kv_cache.initBuffer(io, platform, shardings.model);
+        errdefer model.KvCache.deinitBuffer(&kv_cache_buffers);
+
+        var prefill_moe_metadata_buffers = try compiled_model.params.prefill_moe_metadata.initBuffer(io, platform);
+        errdefer zml.moe.Metadata.deinitBuffer(&prefill_moe_metadata_buffers);
+
+        var decode_moe_metadata_buffers = try compiled_model.params.decode_moe_metadata.initBuffer(io, platform);
+        errdefer zml.moe.Metadata.deinitBuffer(&decode_moe_metadata_buffers);
+
+        const seed: u128 = @intCast(std.Io.Clock.now(.real, io).toNanoseconds());
+        var rng_buffers = try zml.Tensor.Rng.initBuffer(io, platform, .replicated, seed);
+        errdefer zml.Tensor.Rng.deinitBuffer(&rng_buffers);
+
+        const layer_types = compiled_model.loaded_model.inner.config.text_config.layer_types;
+        var layer_index_buffers = try allocator.alloc(LayerIndexBuffer, compiled_model.loaded_model.inner.text_model.layers.len);
+        errdefer {
+            for (layer_index_buffers) |*layer_index_buffer| {
+                switch (layer_index_buffer.*) {
+                    .self_attn => |*buffer| buffer.deinit(),
+                    .linear_attn => |*buffer| buffer.deinit(),
+                }
+            }
+            allocator.free(layer_index_buffers);
+        }
+
+        var self_attn_layer_index: usize = 0;
+        var linear_attn_layer_index: usize = 0;
+        for (layer_types, 0..) |layer_type, layer_index| {
+            switch (layer_type) {
+                .full_attention => {
+                    const layer_index_buffer = try zml.Buffer.scalar(io, platform, @as(u32, @intCast(self_attn_layer_index)), .u32);
+                    layer_index_buffers[layer_index] = .{ .self_attn = layer_index_buffer };
+                    self_attn_layer_index += 1;
+                },
+                .linear_attention => {
+                    const layer_index_buffer = try zml.Buffer.scalar(io, platform, @as(u32, @intCast(linear_attn_layer_index)), .u32);
+                    layer_index_buffers[layer_index] = .{ .linear_attn = layer_index_buffer };
+                    linear_attn_layer_index += 1;
+                },
+            }
+        }
+
+        var decode_token_index_buffer = try zml.Buffer.scalar(io, platform, @as(u32, 0), .u32);
+        errdefer decode_token_index_buffer.deinit();
+
+        var self_attn_layers_caches = try allocator.alloc(zml.Bufferized(model.KvCache.SelfAttnCache), self_attn_layer_index);
+        errdefer allocator.free(self_attn_layers_caches);
+
+        var linear_attn_layers_caches = try allocator.alloc(zml.Bufferized(model.KvCache.GatedDeltaNetCache), linear_attn_layer_index);
+        errdefer allocator.free(linear_attn_layers_caches);
+
+        var self_attn_cache_index: usize = 0;
+        var linear_attn_cache_index: usize = 0;
+        for (layer_types, 0..) |layer_type, layer_index| {
+            switch (layer_type) {
+                .full_attention => {
+                    const layer_index_buffer = switch (layer_index_buffers[layer_index]) {
+                        .self_attn => |buffer| buffer,
+                        .linear_attn => unreachable,
+                    };
+                    self_attn_layers_caches[self_attn_cache_index] = .{
+                        .k = kv_cache_buffers.self_attn.k,
+                        .v = kv_cache_buffers.self_attn.v,
+                        .layer_index = layer_index_buffer,
+                    };
+                    self_attn_cache_index += 1;
+                },
+                .linear_attention => {
+                    const layer_index_buffer = switch (layer_index_buffers[layer_index]) {
+                        .linear_attn => |buffer| buffer,
+                        .self_attn => unreachable,
+                    };
+                    linear_attn_layers_caches[linear_attn_cache_index] = .{
+                        .conv_state = kv_cache_buffers.gated_delta_net.conv_state,
+                        .recurrent_state = kv_cache_buffers.gated_delta_net.recurrent_state,
+                        .layer_index = layer_index_buffer,
+                    };
+                    linear_attn_cache_index += 1;
+                },
+            }
+        }
+
+        return .{
+            .allocator = allocator,
+            .io = io,
+            .platform = platform,
+            .model_buffers = model_buffers,
+            .compiled_model = compiled_model,
+            .kv_cache_buffers = kv_cache_buffers,
+            .prefill_moe_metadata_buffers = prefill_moe_metadata_buffers,
+            .decode_moe_metadata_buffers = decode_moe_metadata_buffers,
+            .rng_buffers = rng_buffers,
+            .layer_index_buffers = layer_index_buffers,
+            .decode_token_index_buffer = decode_token_index_buffer,
+            .self_attn_layers_caches = self_attn_layers_caches,
+            .linear_attn_layers_caches = linear_attn_layers_caches,
+            .step_token_slice = try .alloc(allocator, zml.Shape.init(.{ .b = 1, .s = 1 }, .u32)),
+            .generated_token_slice = try .alloc(allocator, zml.Shape.init(.{ .b = 1, .s = 1 }, .u32)),
+            .tokenizer = tokenizer,
+            .seqlen = compiled_model.params.seqlen,
+            .eos_token_id = compiled_model.loaded_model.inner.special_tokens.end_of_text_token_id,
+            .special_tokens = compiled_model.loaded_model.inner.special_tokens,
+            .think_start = tokenizer.tokenId("<think>"),
+            .think_end = tokenizer.tokenId("</think>"),
+        };
+    }
+
+    pub fn deinit(self: *Session) void {
+        model.KvCache.deinitBuffer(&self.kv_cache_buffers);
+        zml.moe.Metadata.deinitBuffer(&self.prefill_moe_metadata_buffers);
+        zml.moe.Metadata.deinitBuffer(&self.decode_moe_metadata_buffers);
+        zml.Tensor.Rng.deinitBuffer(&self.rng_buffers);
+        self.decode_token_index_buffer.deinit();
+        for (self.layer_index_buffers) |*layer_index_buffer| {
+            switch (layer_index_buffer.*) {
+                .self_attn => |*buffer| buffer.deinit(),
+                .linear_attn => |*buffer| buffer.deinit(),
+            }
+        }
+        self.allocator.free(self.layer_index_buffers);
+        self.allocator.free(self.self_attn_layers_caches);
+        self.allocator.free(self.linear_attn_layers_caches);
+        self.step_token_slice.free(self.allocator);
+        self.generated_token_slice.free(self.allocator);
+    }
+
+    pub fn tokenizePrompt(self: *const Session, allocator: std.mem.Allocator, prompt: []const u8) ![]const u32 {
+        return tokenizeChatPrompt(allocator, self.tokenizer, prompt, self.special_tokens, true);
+    }
+
+    pub fn tokenizeTurn(self: *const Session, allocator: std.mem.Allocator, prompt: []const u8) ![]const u32 {
+        return tokenizeChatPrompt(allocator, self.tokenizer, prompt, self.special_tokens, false);
+    }
+
+    fn storeSelfAttnLayerCache(
+        self: *Session,
+        dense_layer_index: usize,
+        layer_index: usize,
+        layer_cache: zml.Bufferized(model.KvCache.SelfAttnCache),
+    ) void {
+        self.kv_cache_buffers.self_attn.k = layer_cache.k;
+        self.kv_cache_buffers.self_attn.v = layer_cache.v;
+        self.self_attn_layers_caches[dense_layer_index] = layer_cache;
+        self.layer_index_buffers[layer_index] = .{ .self_attn = layer_cache.layer_index };
+    }
+
+    fn storeLinearAttnLayerCache(
+        self: *Session,
+        dense_layer_index: usize,
+        layer_index: usize,
+        layer_cache: zml.Bufferized(model.KvCache.GatedDeltaNetCache),
+    ) void {
+        self.kv_cache_buffers.gated_delta_net.conv_state = layer_cache.conv_state;
+        self.kv_cache_buffers.gated_delta_net.recurrent_state = layer_cache.recurrent_state;
+        self.linear_attn_layers_caches[dense_layer_index] = layer_cache;
+        self.layer_index_buffers[layer_index] = .{ .linear_attn = layer_cache.layer_index };
+    }
+
+    pub fn runPrefill(self: *Session, all_tokens: []const u32) !void {
+        const hidden_size = self.compiled_model.loaded_model.inner.config.text_config.hidden_size;
+        const model_dtype = self.compiled_model.loaded_model.inner.text_model.embed_tokens.weight.dtype();
+
+        const prefill_tokens_shape = zml.Shape.init(.{ .b = 1, .s = self.seqlen }, .u32);
+        const prefill_hidden_shape = zml.Shape.init(.{ .b = 1, .s = self.seqlen, .d = hidden_size }, model_dtype);
+
+        const prefill_tokens_slice = try zml.Slice.alloc(self.allocator, prefill_tokens_shape);
+        defer prefill_tokens_slice.free(self.allocator);
+        @memset(prefill_tokens_slice.items(u32), 0);
+        @memcpy(prefill_tokens_slice.items(u32)[0..all_tokens.len], all_tokens);
+
+        const replicated_sharding: zml.Sharding = .replicated;
+
+        var prefill_tokens_buffer = try zml.Buffer.fromSlice(self.io, self.platform, prefill_tokens_slice, replicated_sharding);
+        defer prefill_tokens_buffer.deinit();
+
+        var prefill_token_index_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, 0), .u32);
+        defer prefill_token_index_buffer.deinit();
+
+        var prefill_hidden_buffer = try zml.Buffer.uninitialized(self.io, self.platform, prefill_hidden_shape, replicated_sharding, .{});
+        defer prefill_hidden_buffer.deinit();
+
+        var embedding_prefill_args = try self.compiled_model.prefill_embedding_exe.args(self.allocator);
+        defer embedding_prefill_args.deinit(self.allocator);
+        var embedding_prefill_results = try self.compiled_model.prefill_embedding_exe.results(self.allocator);
+        defer embedding_prefill_results.deinit(self.allocator);
+
+        embedding_prefill_args.set(.{ self.model_buffers.text_model.embed_tokens, prefill_tokens_buffer });
+        self.compiled_model.prefill_embedding_exe.call(embedding_prefill_args, &embedding_prefill_results);
+        embedding_prefill_results.fill(.{&prefill_hidden_buffer});
+
+        var prefill_full_layer_args: ?zml.Exe.Arguments = if (self.compiled_model.prefill_full_layer_exe) |exe| try exe.args(self.allocator) else null;
+        defer if (prefill_full_layer_args) |*args| args.deinit(self.allocator);
+        var prefill_full_layer_results: ?zml.Exe.Results = if (self.compiled_model.prefill_full_layer_exe) |exe| try exe.results(self.allocator) else null;
+        defer if (prefill_full_layer_results) |*results| results.deinit(self.allocator);
+
+        var prefill_linear_layer_args: ?zml.Exe.Arguments = if (self.compiled_model.prefill_linear_layer_exe) |exe| try exe.args(self.allocator) else null;
+        defer if (prefill_linear_layer_args) |*args| args.deinit(self.allocator);
+        var prefill_linear_layer_results: ?zml.Exe.Results = if (self.compiled_model.prefill_linear_layer_exe) |exe| try exe.results(self.allocator) else null;
+        defer if (prefill_linear_layer_results) |*results| results.deinit(self.allocator);
+
+        var self_attn_cache_index: usize = 0;
+        var linear_attn_cache_index: usize = 0;
+
+        for (self.model_buffers.text_model.layers, 0..) |layer_weights, i| {
+            switch (self.layer_index_buffers[i]) {
+                .self_attn => {
+                    const exe = self.compiled_model.prefill_full_layer_exe orelse unreachable;
+                    self.self_attn_layers_caches[self_attn_cache_index].k = self.kv_cache_buffers.self_attn.k;
+                    self.self_attn_layers_caches[self_attn_cache_index].v = self.kv_cache_buffers.self_attn.v;
+                    prefill_full_layer_args.?.set(.{ layer_weights, prefill_hidden_buffer, prefill_token_index_buffer, self.self_attn_layers_caches[self_attn_cache_index], self.compiled_model.loaded_model.inner.config, self.prefill_moe_metadata_buffers });
+                    exe.call(prefill_full_layer_args.?, &prefill_full_layer_results.?);
+                    prefill_full_layer_results.?.fill(.{ &prefill_hidden_buffer, &self.kv_cache_buffers.self_attn });
+                    self_attn_cache_index += 1;
+                },
+                .linear_attn => {
+                    const exe = self.compiled_model.prefill_linear_layer_exe orelse unreachable;
+                    self.linear_attn_layers_caches[linear_attn_cache_index].conv_state = self.kv_cache_buffers.gated_delta_net.conv_state;
+                    self.linear_attn_layers_caches[linear_attn_cache_index].recurrent_state = self.kv_cache_buffers.gated_delta_net.recurrent_state;
+                    prefill_linear_layer_args.?.set(.{ layer_weights, prefill_hidden_buffer, prefill_token_index_buffer, self.linear_attn_layers_caches[linear_attn_cache_index], self.compiled_model.loaded_model.inner.config, self.prefill_moe_metadata_buffers });
+                    exe.call(prefill_linear_layer_args.?, &prefill_linear_layer_results.?);
+                    prefill_linear_layer_results.?.fill(.{ &prefill_hidden_buffer, &self.kv_cache_buffers.gated_delta_net });
+                    linear_attn_cache_index += 1;
+                },
+            }
+        }
+
+        var sampling_prefill_args = try self.compiled_model.prefill_sampling_exe.args(self.allocator);
+        defer sampling_prefill_args.deinit(self.allocator);
+        var sampling_prefill_results = try self.compiled_model.prefill_sampling_exe.results(self.allocator);
+        defer sampling_prefill_results.deinit(self.allocator);
+
+        sampling_prefill_args.set(.{ .{
+            .norm = self.model_buffers.text_model.norm,
+            .lm_head = self.model_buffers.text_model.lm_head,
+            .gen_options = self.compiled_model.loaded_model.inner.text_model.gen_options,
+        }, prefill_hidden_buffer, self.rng_buffers });
+        self.compiled_model.prefill_sampling_exe.call(sampling_prefill_args, &sampling_prefill_results);
+        sampling_prefill_results.fill(.{ &prefill_tokens_buffer, &self.rng_buffers });
+
+        try prefill_tokens_buffer.toSlice(self.io, prefill_tokens_slice);
+        const generated_token = prefill_tokens_slice.items(u32)[all_tokens.len - 1];
+        self.generated_token_slice.items(u32)[0] = generated_token;
+    }
+
+    pub fn runDecode(self: *Session, all_tokens: *std.ArrayList(u32), stdout: *std.Io.Writer) !void {
+        var decoder = try self.tokenizer.decoder();
+        defer decoder.deinit();
+
+        const out_tokens_buffer: []u8 = try self.allocator.alloc(u8, 1024);
+        defer self.allocator.free(out_tokens_buffer);
+
+        const hidden_size = self.compiled_model.loaded_model.inner.config.text_config.hidden_size;
+        const model_dtype = self.compiled_model.loaded_model.inner.text_model.embed_tokens.weight.dtype();
+
+        const decode_hidden_shape = zml.Shape.init(.{ .b = 1, .s = 1, .d = hidden_size }, model_dtype);
+        const replicated_sharding: zml.Sharding = .replicated;
+
+        var embedding_decode_args = try self.compiled_model.decode_embedding_exe.args(self.allocator);
+        defer embedding_decode_args.deinit(self.allocator);
+        var embedding_decode_results = try self.compiled_model.decode_embedding_exe.results(self.allocator);
+        defer embedding_decode_results.deinit(self.allocator);
+
+        var decode_full_layer_args: ?zml.Exe.Arguments = if (self.compiled_model.decode_full_layer_exe) |exe| try exe.args(self.allocator) else null;
+        defer if (decode_full_layer_args) |*args| args.deinit(self.allocator);
+        var decode_full_layer_results: ?zml.Exe.Results = if (self.compiled_model.decode_full_layer_exe) |exe| try exe.results(self.allocator) else null;
+        defer if (decode_full_layer_results) |*results| results.deinit(self.allocator);
+
+        var decode_linear_layer_args: ?zml.Exe.Arguments = if (self.compiled_model.decode_linear_layer_exe) |exe| try exe.args(self.allocator) else null;
+        defer if (decode_linear_layer_args) |*args| args.deinit(self.allocator);
+        var decode_linear_layer_results: ?zml.Exe.Results = if (self.compiled_model.decode_linear_layer_exe) |exe| try exe.results(self.allocator) else null;
+        defer if (decode_linear_layer_results) |*results| results.deinit(self.allocator);
+
+        var sampling_decode_args = try self.compiled_model.decode_sampling_exe.args(self.allocator);
+        defer sampling_decode_args.deinit(self.allocator);
+        var sampling_decode_results = try self.compiled_model.decode_sampling_exe.results(self.allocator);
+        defer sampling_decode_results.deinit(self.allocator);
+
+        var decode_hidden_buffer = try zml.Buffer.uninitialized(self.io, self.platform, decode_hidden_shape, replicated_sharding, .{});
+        defer decode_hidden_buffer.deinit();
+
+        var current_token_buffer = try zml.Buffer.fromSlice(self.io, self.platform, self.generated_token_slice, replicated_sharding);
+        defer current_token_buffer.deinit();
+
+        var token_index_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, @intCast(all_tokens.items.len)), .u32);
+        defer token_index_buffer.deinit();
+
+        var self_attn_layer_index: usize = 0;
+        var linear_attn_layer_index: usize = 0;
+
+        generation: while (true) {
+            const token_id = self.generated_token_slice.items(u32)[0];
+            if (token_id == self.eos_token_id) break :generation;
+
+            const token = try decoder.feedOne(token_id, out_tokens_buffer);
+            if (self.think_start) |think_start| if (token_id == think_start) {
+                try stdout.writeAll("\x1b[2m");
+            };
+            try stdout.writeAll(token);
+            if (self.think_end) |think_end| if (token_id == think_end) {
+                try stdout.writeAll("\x1b[0m");
+            };
+            try stdout.flush();
+
+            try all_tokens.append(self.allocator, token_id);
+            if (all_tokens.items.len >= self.seqlen) break :generation;
+
+            self_attn_layer_index = 0;
+            linear_attn_layer_index = 0;
+
+            embedding_decode_args.set(.{ self.model_buffers.text_model.embed_tokens, current_token_buffer });
+            self.compiled_model.decode_embedding_exe.call(embedding_decode_args, &embedding_decode_results);
+            embedding_decode_results.fill(.{&decode_hidden_buffer});
+
+            for (self.model_buffers.text_model.layers, 0..) |layer_weights, layer_index| {
+                switch (self.layer_index_buffers[layer_index]) {
+                    .self_attn => {
+                        const exe = self.compiled_model.decode_full_layer_exe orelse unreachable;
+                        self.self_attn_layers_caches[self_attn_layer_index].k = self.kv_cache_buffers.self_attn.k;
+                        self.self_attn_layers_caches[self_attn_layer_index].v = self.kv_cache_buffers.self_attn.v;
+
+                        decode_full_layer_args.?.set(.{
+                            layer_weights,
+                            decode_hidden_buffer,
+                            token_index_buffer,
+                            self.self_attn_layers_caches[self_attn_layer_index],
+                            self.compiled_model.loaded_model.inner.config,
+                            self.decode_moe_metadata_buffers,
+                        });
+
+                        exe.call(decode_full_layer_args.?, &decode_full_layer_results.?);
+                        decode_full_layer_results.?.fill(.{ &decode_hidden_buffer, &self.kv_cache_buffers.self_attn });
+
+                        self_attn_layer_index += 1;
+                    },
+                    .linear_attn => {
+                        const exe = self.compiled_model.decode_linear_layer_exe orelse unreachable;
+
+                        self.linear_attn_layers_caches[linear_attn_layer_index].conv_state = self.kv_cache_buffers.gated_delta_net.conv_state;
+                        self.linear_attn_layers_caches[linear_attn_layer_index].recurrent_state = self.kv_cache_buffers.gated_delta_net.recurrent_state;
+
+                        decode_linear_layer_args.?.set(.{
+                            layer_weights,
+                            decode_hidden_buffer,
+                            token_index_buffer,
+                            self.linear_attn_layers_caches[linear_attn_layer_index],
+                            self.compiled_model.loaded_model.inner.config,
+                            self.decode_moe_metadata_buffers,
+                        });
+
+                        exe.call(decode_linear_layer_args.?, &decode_linear_layer_results.?);
+                        decode_linear_layer_results.?.fill(.{ &decode_hidden_buffer, &self.kv_cache_buffers.gated_delta_net });
+
+                        linear_attn_layer_index += 1;
+                    },
+                }
+            }
+
+            sampling_decode_args.set(.{ .{
+                .norm = self.model_buffers.text_model.norm,
+                .lm_head = self.model_buffers.text_model.lm_head,
+                .gen_options = self.compiled_model.loaded_model.inner.text_model.gen_options,
+            }, decode_hidden_buffer, self.rng_buffers, token_index_buffer });
+            self.compiled_model.decode_sampling_exe.call(sampling_decode_args, &sampling_decode_results);
+            sampling_decode_results.fill(.{ &current_token_buffer, &self.rng_buffers, &token_index_buffer });
+
+            try current_token_buffer.toSlice(self.io, self.generated_token_slice);
+        }
+
+        try stdout.writeAll(try decoder.finalize(out_tokens_buffer));
+        try stdout.flush();
+    }
+};
+
+fn tokenizeChatPrompt(allocator: std.mem.Allocator, tokenizer: zml.tokenizer.Tokenizer, prompt: []const u8, special_tokens: model.Model.SpecialTokens, is_first_turn: bool) ![]const u32 {
+    var encoder = try tokenizer.encoder();
+    defer encoder.deinit();
+
+    const im_start = tokenizer.tokenId("<|im_start|>") orelse special_tokens.im_start_token_id;
+    const im_end = tokenizer.tokenId("<|im_end|>") orelse special_tokens.im_end_token_id;
+
+    var tokens: std.ArrayList(u32) = try .initCapacity(allocator, prompt.len + 32);
+    if (!is_first_turn) {
+        try tokens.append(allocator, im_end);
+        const newline = try encoder.encodeAlloc(allocator, "\n");
+        try tokens.appendSlice(allocator, newline);
+        allocator.free(newline);
+    }
+
+    try tokens.append(allocator, im_start);
+    const user = try encoder.encodeAlloc(allocator, "user\n");
+    try tokens.appendSlice(allocator, user);
+    allocator.free(user);
+    const prompt_encoded = try encoder.encodeAlloc(allocator, prompt);
+    try tokens.appendSlice(allocator, prompt_encoded);
+    allocator.free(prompt_encoded);
+    try tokens.append(allocator, im_end);
+    const newline = try encoder.encodeAlloc(allocator, "\n");
+    try tokens.appendSlice(allocator, newline);
+    allocator.free(newline);
+    try tokens.append(allocator, im_start);
+    const assistant = try encoder.encodeAlloc(allocator, "assistant\n");
+    try tokens.appendSlice(allocator, assistant);
+    allocator.free(assistant);
+    const think = try encoder.encodeAlloc(allocator, "<think>\n");
+    try tokens.appendSlice(allocator, think);
+    allocator.free(think);
+
+    return tokens.toOwnedSlice(allocator);
+}
+
+fn encodeSingleToken(encoder: *zml.tokenizer.Tokenizer.Encoder, text: []const u8) !u32 {
+    const encoded = try encoder.encode(text);
+    if (encoded.len != 1) return error.InvalidTokenizerEncoding;
+    return encoded[0];
+}

--- a/third_party/zls/zls_write_build_config.bzl
+++ b/third_party/zls/zls_write_build_config.bzl
@@ -97,6 +97,7 @@ def _zls_write_build_config_impl(ctx):
             name = "c",
             canonical_name = "c",
             zigtoolchaininfo = zigtoolchaininfo,
+            global_args = global_args,
             cc_infos = [cc_info],
         )
 

--- a/zml/BUILD.bazel
+++ b/zml/BUILD.bazel
@@ -64,6 +64,9 @@ cc_library(
 zig_library(
     name = "zml",
     tags = ["manual"],
+    data = [
+        "moe/triton_kernels/config.json",
+    ],
     srcs = [
         "attention.zig",
         "attention/attention.zig",
@@ -74,6 +77,9 @@ zig_library(
         "attention/tpu_attention.zig",
         "attention/triton_attention.zig",
         "attention/triton_kernels/unified_attention.zig",
+        "moe/moe.zig",
+        "moe/triton.zig",
+        "moe/triton_kernels/triton_kernels.zig",
         "kernel.zig",
         "buffer.zig",
         "constants.zig",

--- a/zml/moe/moe.zig
+++ b/zml/moe/moe.zig
@@ -1,0 +1,135 @@
+const std = @import("std");
+const zml = @import("../zml.zig");
+pub const triton = @import("triton.zig");
+
+pub const triton_kernels = @import("triton_kernels/triton_kernels.zig");
+
+pub const Backend = enum {
+    // Could select a more specific name like "triton_sm90_bf16"
+    triton,
+
+    pub fn auto(platform: *const zml.Platform, weights_dtype: zml.DataType) !Backend {
+        return switch (platform.target) {
+            .cuda => b: {
+                const first_device = platform.pjrt_client.devices(platform.pjrt_api)[0];
+                if (zml.platform.cuda.tryGetComputeCapabilities(platform, first_device)) |cc| {
+                    if (std.mem.eql(u8, cc, "9.0") or
+                        std.mem.eql(u8, cc, "10.0"))
+                    {
+                        break :b switch (weights_dtype) {
+                            .bf16, .f16, .f8e4m3fn => .triton,
+                            else => error.UnsupportedDataType,
+                        };
+                    }
+                    break :b error.UnsupportedComputeCapability;
+                }
+                break :b error.UnsupportedComputeCapability;
+            },
+            else => error.UnimplementedMoEBackend,
+        };
+    }
+
+    pub fn load(backend: Backend, allocator: std.mem.Allocator) !void {
+        _ = allocator;
+        return switch (backend) {
+            .triton => {},
+        };
+    }
+
+    pub fn register(backend: Backend, platform: *zml.Platform) !void {
+        _ = platform;
+        return switch (backend) {
+            .triton => {},
+        };
+    }
+};
+
+pub const Parameters = union(Backend) {
+    triton: triton.Parameters,
+
+    pub const InitOptions = union(Backend) {
+        triton: triton.Parameters.InitOptions,
+
+        pub fn fromBackend(backend: Backend, num_experts_per_tok: ?u32, activation: triton.Parameters.ActivationMode) InitOptions {
+            return switch (backend) {
+                .triton => .{ .triton = .{ .num_experts_per_tok = num_experts_per_tok.?, .activation = activation } },
+            };
+        }
+    };
+
+    pub fn init(opts: InitOptions) Parameters {
+        return switch (opts) {
+            .triton => |v| .{ .triton = triton.Parameters.init(v) },
+        };
+    }
+};
+
+pub const Metadata = union(Backend) {
+    triton: triton.Metadata,
+
+    pub const InitOptions = union(Backend) {
+        triton: triton.Metadata.InitOptions,
+
+        pub fn fromBackend(backend: Backend) InitOptions {
+            return switch (backend) {
+                .triton => .{ .triton = .{} },
+            };
+        }
+    };
+
+    pub fn init(opts: InitOptions) Metadata {
+        return switch (opts) {
+            .triton => |v| .{ .triton = triton.Metadata.init(v) },
+        };
+    }
+
+    pub fn initBuffer(self: Metadata, io: std.Io, platform: *const zml.Platform) !zml.Bufferized(Metadata) {
+        return switch (self) {
+            .triton => |metadata| .{ .triton = try metadata.initBuffer(io, platform) },
+        };
+    }
+
+    pub fn deinitBuffer(self: *zml.Bufferized(Metadata)) void {
+        switch (self.*) {
+            .triton => |*metadata| triton.deinitBuffer(metadata),
+        }
+    }
+};
+
+pub fn forwardMoe(
+    input: zml.Tensor,
+    topk_ids: zml.Tensor,
+    topk_weights: zml.Tensor,
+    weights_gate_up: zml.Tensor,
+    scales_gate_up: ?zml.Tensor,
+    bias_gate_up: ?zml.Tensor,
+    weights_down: zml.Tensor,
+    scales_down: ?zml.Tensor,
+    bias_down: ?zml.Tensor,
+    metadata: Metadata,
+    parameters: Parameters,
+) !zml.Tensor {
+    return switch (parameters) {
+        .triton => b: {
+            const triton_metadata = switch (metadata) {
+                .triton => |v| v,
+            };
+
+            break :b try triton.fusedExpertsImpl(
+                input,
+                weights_gate_up,
+                weights_down,
+                topk_weights,
+                topk_ids,
+                triton_metadata,
+                .{
+                    .activation = parameters.triton.activation,
+                    .w1_scale = scales_gate_up,
+                    .w2_scale = scales_down,
+                    .w1_bias = bias_gate_up,
+                    .w2_bias = bias_down,
+                },
+            );
+        },
+    };
+}

--- a/zml/moe/triton.zig
+++ b/zml/moe/triton.zig
@@ -564,6 +564,15 @@ fn getLaunchConfigJsonPath(allocator: std.mem.Allocator) ![]const u8 {
     return try allocator.dupe(u8, config_json);
 }
 
+const JsonConfigFields = struct {
+    BLOCK_SIZE_M: i64,
+    BLOCK_SIZE_N: i64,
+    BLOCK_SIZE_K: i64,
+    GROUP_SIZE_M: i64,
+    num_warps: i64,
+    num_stages: i64,
+};
+
 fn applyJsonTokenConfig(opts: Options, num_tokens: i64) !Options {
     var out = opts;
     if (!opts.dynamic_launch_by_num_tokens) return out;
@@ -578,47 +587,38 @@ fn applyJsonTokenConfig(opts: Options, num_tokens: i64) !Options {
     defer file.close(io);
     var reader = file.reader(io, &.{});
     const config_json = try reader.interface.readAlloc(allocator, try file.length(io));
-    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, config_json, .{});
 
-    if (parsed.value != .object) return error.InvalidLaunchConfigShape;
+    const parsed = try std.json.parseFromSlice(
+        std.json.ArrayHashMap(JsonConfigFields),
+        allocator,
+        config_json,
+        .{},
+    );
+    defer parsed.deinit();
 
-    var it = parsed.value.object.iterator();
-    var best_m: ?i64 = null;
     var best_diff: u64 = std.math.maxInt(u64);
-    var best_config: ?std.json.Value = null;
+    var best_m: ?i64 = null;
+    var best_config: ?JsonConfigFields = null;
 
+    var it = parsed.value.map.iterator();
     while (it.next()) |entry| {
-        const m = std.fmt.parseInt(i64, entry.key_ptr.*, 10) catch continue;
-        if (entry.value_ptr.* != .object) continue;
+        const m = try std.fmt.parseInt(i64, entry.key_ptr.*, 10);
 
-        const diff: u64 = if (m >= num_tokens)
-            @intCast(m - num_tokens)
-        else
-            @intCast(num_tokens - m);
-
+        const diff: u64 = @intCast(@abs(m - num_tokens));
         if (best_m == null or diff < best_diff or (diff == best_diff and m < best_m.?)) {
             best_m = m;
-            best_diff = diff;
             best_config = entry.value_ptr.*;
+            best_diff = diff;
         }
     }
 
-    if (best_config == null) return error.NoMatchingLaunchConfig;
-
-    const cfg = best_config.?.object;
-    const block_size_m = cfg.get("BLOCK_SIZE_M") orelse return error.MissingLaunchConfigField;
-    const block_size_n = cfg.get("BLOCK_SIZE_N") orelse return error.MissingLaunchConfigField;
-    const block_size_k = cfg.get("BLOCK_SIZE_K") orelse return error.MissingLaunchConfigField;
-    const group_size_m = cfg.get("GROUP_SIZE_M") orelse return error.MissingLaunchConfigField;
-    const num_warps = cfg.get("num_warps") orelse return error.MissingLaunchConfigField;
-    const num_stages = cfg.get("num_stages") orelse return error.MissingLaunchConfigField;
-
-    out.block_size_m = block_size_m.integer;
-    out.block_size_n = block_size_n.integer;
-    out.block_size_k = block_size_k.integer;
-    out.group_size_m = group_size_m.integer;
-    out.num_warps = num_warps.integer;
-    out.num_stages = num_stages.integer;
+    const cfg = best_config orelse return error.NoMatchingLaunchConfig;
+    out.block_size_m = cfg.BLOCK_SIZE_M;
+    out.block_size_n = cfg.BLOCK_SIZE_N;
+    out.block_size_k = cfg.BLOCK_SIZE_K;
+    out.group_size_m = cfg.GROUP_SIZE_M;
+    out.num_warps = cfg.num_warps;
+    out.num_stages = cfg.num_stages;
 
     return out;
 }

--- a/zml/moe/triton.zig
+++ b/zml/moe/triton.zig
@@ -579,15 +579,12 @@ fn applyJsonTokenConfig(opts: Options, num_tokens: i64) !Options {
 
     const compilation_context = zml.module.CompilationContext.current();
     const io = compilation_context.io;
-    const allocator = compilation_context.arena.allocator();
+    const allocator = compilation_context.allocator;
 
     const config_path = try getLaunchConfigJsonPath(allocator);
-    const cwd = std.Io.Dir.cwd();
-    var file = try cwd.openFile(io, config_path, .{ .mode = .read_only });
-    defer file.close(io);
-    var reader = file.reader(io, &.{});
-    const config_json = try reader.interface.readAlloc(allocator, try file.length(io));
-
+    defer allocator.free(config_path);
+    const config_json = try std.Io.Dir.cwd().readFileAlloc(io, config_path, allocator, .unlimited);
+    defer allocator.free(config_json);
     const parsed = try std.json.parseFromSlice(
         std.json.ArrayHashMap(JsonConfigFields),
         allocator,

--- a/zml/moe/triton.zig
+++ b/zml/moe/triton.zig
@@ -1,0 +1,657 @@
+const std = @import("std");
+
+const stdx = @import("stdx");
+
+const zml = @import("../zml.zig");
+const DataType = zml.DataType;
+const Tensor = zml.Tensor;
+const Shape = zml.Shape;
+const bazel = @import("bazel");
+const bazel_builtin = @import("bazel_builtin");
+
+const tri = zml.kernel.triton;
+const DType = tri.DType;
+
+const kernels = @import("triton_kernels/triton_kernels.zig");
+
+const toDType = tri.from;
+
+const log = std.log.scoped(.moe_triton);
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+pub const Options = struct {
+    inplace: bool = false,
+    activation: Parameters.ActivationMode = .silu,
+    apply_router_weight_on_input: bool = false,
+    use_fp8_w8a8: bool = false,
+    use_int8_w8a8: bool = false,
+    use_int8_w8a16: bool = false,
+    use_int4_w4a16: bool = false,
+    ocp_mx_scheme: ?[]const u8 = null,
+    per_channel_quant: bool = false,
+    global_num_experts: i64 = -1,
+    expert_map: ?Tensor = null,
+    w1_scale: ?Tensor = null,
+    w2_scale: ?Tensor = null,
+    w1_zp: ?Tensor = null,
+    w2_zp: ?Tensor = null,
+    a1_scale: ?Tensor = null,
+    a2_scale: ?Tensor = null,
+    block_shape: ?[]const i64 = null,
+    w1_bias: ?Tensor = null,
+    w2_bias: ?Tensor = null,
+    block_size_m: i64 = 16,
+    block_size_n: i64 = 64,
+    block_size_k: i64 = 32,
+    group_size_m: i64 = 1,
+    num_warps: i64 = 8,
+    num_stages: i64 = 4,
+    dynamic_launch_by_num_tokens: bool = true,
+};
+
+pub const Parameters = struct {
+    num_experts_per_tok: u32,
+    activation: ActivationMode,
+
+    pub const ActivationMode = enum {
+        silu,
+        relu,
+    };
+
+    pub const InitOptions = struct {
+        num_experts_per_tok: u32,
+        activation: ActivationMode,
+    };
+
+    pub fn init(opts: InitOptions) Parameters {
+        return .{
+            .num_experts_per_tok = opts.num_experts_per_tok,
+            .activation = opts.activation,
+        };
+    }
+};
+
+pub const Metadata = struct {
+    w1_zero_bias: ?Tensor = null,
+    w2_zero_bias: ?Tensor = null,
+
+    pub const InitOptions = struct {
+        w1_zero_bias_shape: ?Shape = null,
+        w2_zero_bias_shape: ?Shape = null,
+    };
+
+    pub fn init(opts: InitOptions) Metadata {
+        return .{
+            .w1_zero_bias = if (opts.w1_zero_bias_shape) |shape| Tensor.fromShape(shape) else null,
+            .w2_zero_bias = if (opts.w2_zero_bias_shape) |shape| Tensor.fromShape(shape) else null,
+        };
+    }
+
+    pub fn initBuffer(self: Metadata, io: std.Io, platform: *const zml.Platform) !zml.Bufferized(Metadata) {
+        const replicated_sharding = platform.replicated_sharding;
+        return .{
+            .w1_zero_bias = if (self.w1_zero_bias) |tensor| try initZeroBiasBuffer(io, platform, replicated_sharding, tensor.shape()) else null,
+            .w2_zero_bias = if (self.w2_zero_bias) |tensor| try initZeroBiasBuffer(io, platform, replicated_sharding, tensor.shape()) else null,
+        };
+    }
+};
+
+pub fn deinitBuffer(bufferized: *zml.Bufferized(Metadata)) void {
+    if (bufferized.w1_zero_bias) |*buffer| buffer.deinit();
+    if (bufferized.w2_zero_bias) |*buffer| buffer.deinit();
+}
+
+fn initZeroBiasBuffer(io: std.Io, platform: *const zml.Platform, sharding: zml.Sharding, shape: Shape) !zml.Buffer {
+    var zero_slice: zml.Slice = try .alloc(std.heap.c_allocator, shape);
+    defer zero_slice.free(std.heap.c_allocator);
+    @memset(zero_slice.data(), 0);
+    return zml.Buffer.fromSlice(io, platform, zero_slice, sharding);
+}
+
+// =============================================================================
+// Top-level entry point
+// =============================================================================
+
+pub fn fusedExpertsImpl(
+    hidden_states: Tensor,
+    w1: Tensor,
+    w2: Tensor,
+    topk_weights: Tensor,
+    topk_ids: Tensor,
+    metadata: Metadata,
+    opts: Options,
+) !Tensor {
+    try validateOptions(opts);
+    const options = applyJsonTokenConfig(opts, hidden_states.dim(0)) catch |err| fallback: {
+        log.warn("Failed to load MoE launch config from JSON ({}), falling back to built-in token heuristic", .{err});
+        break :fallback applyDefaultTokenConfig(opts, hidden_states.dim(0), w1.dim(0));
+    };
+    const b = hidden_states.dim(.b);
+    const s = hidden_states.dim(.s);
+
+    const hidden = hidden_states.reshape(.{ .token = b * s, .in = hidden_states.dim(.d) }).withTags(.{ .token, .in });
+    const gate_up = w1.withTags(.{ .expert, .out, .in });
+    const down = w2.withTags(.{ .expert, .out, .mid });
+    const weights = topk_weights.reshape(.{ .token = b * s, .in = topk_weights.dim(.top_expert) }).withTags(.{ .token, .topk });
+    const ids = topk_ids.reshape(.{ .token = b * s, .in = topk_ids.dim(.top_expert) }).withTags(.{ .token, .topk });
+
+    try validateInputs(hidden, gate_up, down, weights, ids);
+
+    const block_size_m = options.block_size_m;
+    const num_experts = gate_up.dim(.expert);
+    const num_assignments = hidden.dim(.token) * ids.dim(.topk);
+    const sparsity_factor: i64 = 4;
+    const naive_block_assignment = num_assignments * sparsity_factor <= num_experts;
+
+    const max_num_tokens_padded = if (naive_block_assignment)
+        num_assignments * block_size_m
+    else if (num_assignments < num_experts)
+        num_assignments * block_size_m
+    else
+        num_assignments + num_experts * (block_size_m - 1);
+
+    const sorted_token_ids, const expert_ids, const num_tokens_post_padded = if (naive_block_assignment) blk: {
+        log.info("Using naive block assignment for MoE kernels. Num assignments: {d}, Num experts: {d}", .{ num_assignments, num_experts });
+        const naive_sorted_ids = Tensor.zeroes(Shape.init(.{ .g = 1 }, .i32));
+        const naive_expert_ids = ids.reshape(.{ .g = num_assignments });
+        const naive_num_tokens_post_padded = Tensor.constant(.{ .i32 = @as(i32, @intCast(max_num_tokens_padded)) }).reshape(.{1});
+        break :blk .{ naive_sorted_ids, naive_expert_ids, naive_num_tokens_post_padded };
+    } else alignBlockSize(ids, num_experts, block_size_m);
+
+    var hidden_quant = hidden;
+    var a_scale = opts.a1_scale orelse Tensor.scalar(1.0, .f32);
+
+    if (gate_up.dtype() == .f8e4m3fn) {
+        hidden_quant, a_scale = quantizePerTokenGroupFp8(hidden, fp8ActivationGroupSize(hidden));
+    }
+
+    const first_cfg = makeFusedMoeConfig(
+        hidden_quant,
+        gate_up,
+        options,
+        naive_block_assignment,
+        ids.dim(.topk),
+        false,
+        false,
+        .bf16,
+    );
+
+    const b_bias_1 =
+        opts.w1_bias orelse
+        metadata.w1_zero_bias orelse
+        Tensor.zeroes(Shape.init(.{ .expert = gate_up.dim(.expert), .out = gate_up.dim(.out) }, .bf16));
+
+    const b_scale_1 = opts.w1_scale orelse Tensor.scalar(1.0, .f32);
+
+    const first_out = callFusedMoe(
+        hidden_quant,
+        gate_up,
+        b_bias_1,
+        a_scale,
+        b_scale_1,
+        weights,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        first_cfg,
+        options,
+        max_num_tokens_padded,
+        num_assignments,
+        Shape.init(.{ .token = num_assignments, .out = gate_up.dim(.out) }, .bf16),
+    );
+
+    const activated = switch (opts.activation) {
+        .silu => b: {
+            const gate, const up = zml.nn.splitRealImg(first_out, .sequential);
+            break :b gate.silu().mul(up);
+        },
+        .relu => first_out.relu().powByConst(2),
+    };
+
+    var activated_quant = activated;
+    a_scale = opts.a2_scale orelse Tensor.scalar(1.0, .f32);
+    if (down.dtype() == .f8e4m3fn) {
+        activated_quant, a_scale = quantizePerTokenGroupFp8(activated, fp8ActivationGroupSize(activated));
+    }
+
+    const second_cfg = makeFusedMoeConfig(
+        activated_quant,
+        down,
+        options,
+        naive_block_assignment,
+        1,
+        true,
+        false,
+        .bf16,
+    );
+
+    const b_bias_2 =
+        opts.w2_bias orelse
+        metadata.w2_zero_bias orelse
+        Tensor.zeroes(Shape.init(.{ .expert = down.dim(.expert), .out = down.dim(.out) }, .bf16));
+
+    const b_scale_2 = opts.w2_scale orelse Tensor.scalar(1.0, .f32);
+
+    const second_out = callFusedMoe(
+        activated_quant,
+        down,
+        b_bias_2,
+        a_scale,
+        b_scale_2,
+        weights,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        second_cfg,
+        options,
+        max_num_tokens_padded,
+        num_assignments,
+        Shape.init(.{ .token = b * s, .topk = ids.dim(.topk), .out = down.dim(.out) }, .bf16),
+    );
+
+    const output = second_out.sum(.topk).squeeze(.topk);
+
+    return output.reshape(.{ .b = b, .token = s, .out = down.dim(.out) });
+}
+
+/// Build the inputs tuple for FusedMoe and invoke it via `K.call(...)`.
+fn callFusedMoe(
+    a: Tensor,
+    b: Tensor,
+    b_bias: Tensor,
+    a_scale: Tensor,
+    b_scale: Tensor,
+    topk_weights: Tensor,
+    sorted_token_ids: Tensor,
+    expert_ids: Tensor,
+    num_tokens_post_padded: Tensor,
+    cfg: kernels.FusedMoe.Cfg,
+    options: Options,
+    max_num_tokens_padded: i64,
+    num_valid_tokens: i64,
+    output_shape: Shape,
+) Tensor {
+    const block_size_m: i64 = @intCast(cfg.block_size_m);
+    const block_size_n: i64 = @intCast(cfg.block_size_n);
+    const m_tokens = a.dim(0);
+    const em_effective = if (m_tokens < block_size_m)
+        @min(max_num_tokens_padded, num_valid_tokens * block_size_m)
+    else
+        max_num_tokens_padded;
+    const grid_x =
+        (std.math.divCeil(i64, em_effective, block_size_m) catch unreachable) *
+        (std.math.divCeil(i64, b.dim(1), block_size_n) catch unreachable);
+
+    const stride_asm: i64 = if (cfg.b_scale_dtype != null and a_scale.rank() == 2) a_scale.dim(1) else 0;
+    const stride_ask: i64 = if (cfg.b_scale_dtype != null and a_scale.rank() == 2) 1 else 0;
+    const stride_bse: i64 = if (cfg.b_scale_dtype != null and b_scale.rank() == 3)
+        b_scale.dim(1) * b_scale.dim(2)
+    else
+        0;
+    const stride_bsk: i64 = if (cfg.b_scale_dtype != null and b_scale.rank() == 3) 1 else 0;
+    const stride_bsn: i64 = if (cfg.b_scale_dtype != null and b_scale.rank() == 3) b_scale.dim(2) else 0;
+
+    return kernels.FusedMoe.Kernel.call(
+        .{
+            .a_ptr = a,
+            .b_ptr = b,
+            .b_bias_ptr = b_bias,
+            .a_scale_ptr = a_scale,
+            .b_scale_ptr = b_scale,
+            .topk_weights_ptr = topk_weights,
+            .sorted_token_ids_ptr = sorted_token_ids,
+            .expert_ids_ptr = expert_ids,
+            .num_tokens_post_padded_ptr = num_tokens_post_padded,
+            .N_ptr = Tensor.constant(.{ .i64 = b.dim(1) }).reshape(.{1}),
+            .K_ptr = Tensor.constant(.{ .i64 = b.dim(2) }).reshape(.{1}),
+            .EM_ptr = Tensor.constant(.{ .i64 = em_effective }).reshape(.{1}),
+            .num_valid_tokens_ptr = Tensor.constant(.{ .i64 = num_valid_tokens }).reshape(.{1}),
+            .stride_am_ptr = Tensor.constant(.{ .i64 = a.dim(1) }).reshape(.{1}),
+            .stride_be_ptr = Tensor.constant(.{ .i64 = b.dim(1) * b.dim(2) }).reshape(.{1}),
+            .stride_bn_ptr = Tensor.constant(.{ .i64 = b.dim(2) }).reshape(.{1}),
+            .stride_cm_ptr = Tensor.constant(.{ .i64 = b.dim(.out) }).reshape(.{1}),
+            .stride_asm_ptr = Tensor.constant(.{ .i64 = stride_asm }).reshape(.{1}),
+            .stride_ask_ptr = Tensor.constant(.{ .i64 = stride_ask }).reshape(.{1}),
+            .stride_bse_ptr = Tensor.constant(.{ .i64 = stride_bse }).reshape(.{1}),
+            .stride_bsk_ptr = Tensor.constant(.{ .i64 = stride_bsk }).reshape(.{1}),
+            .stride_bsn_ptr = Tensor.constant(.{ .i64 = stride_bsn }).reshape(.{1}),
+            .stride_bbe_ptr = Tensor.constant(.{ .i64 = 0 }).reshape(.{1}),
+            .stride_bbn_ptr = Tensor.constant(.{ .i64 = 0 }).reshape(.{1}),
+        },
+        .{ .c = output_shape },
+        .{
+            .cfg = cfg,
+            .grid = .{ @intCast(grid_x), 1, 1 },
+            .num_warps = @intCast(options.num_warps),
+            .num_stages = @intCast(options.num_stages),
+        },
+    ).c;
+}
+
+fn alignBlockSize(topk_ids: Tensor, num_experts: i64, block_size_m: i64) struct { Tensor, Tensor, Tensor } {
+    log.info("Using triton kernels to sort and align tokens to experts with block size {d}", .{block_size_m});
+    const topk_ids_ = topk_ids.withTags(.{ .token, .topk }).convert(.i32);
+    const num_tokens = topk_ids_.dim(.token);
+    const topk = topk_ids_.dim(.topk);
+    const num_assignments = num_tokens * topk;
+    const max_num_tokens_padded = if (num_assignments < num_experts)
+        num_assignments * block_size_m
+    else
+        num_assignments + num_experts * (block_size_m - 1);
+    const max_num_m_blocks = std.math.divCeil(i64, max_num_tokens_padded, block_size_m) catch unreachable;
+    const warp_size: i64 = 32;
+    const padded_num_experts = (std.math.divCeil(i64, num_experts, warp_size) catch unreachable) * warp_size;
+    const sort_block_size: i64 = 256;
+    const sort_grid_x: i64 = @min(std.math.divCeil(i64, num_assignments, sort_block_size) catch unreachable, 65535);
+
+    const flat_experts = topk_ids_.reshape(.{ .g = num_assignments });
+    var cumsums = Tensor.zeroes(Shape.init(.{ .g = num_experts + 1 }, .i32));
+    var expert_ids = Tensor.zeroes(Shape.init(.{ .g = max_num_m_blocks }, .i32));
+    var sorted_token_ids = Tensor.zeroes(Shape.init(.{ .g = max_num_tokens_padded }, .i32));
+    var num_tokens_post_padded = Tensor.zeroes(Shape.init(.{ .g = 1 }, .i32));
+
+    {
+        const align_outs = kernels.MoeAlignBlockSize.Kernel.call(
+            .{
+                .topk_ids_ptr = flat_experts,
+                .sorted_token_ids_ptr = sorted_token_ids,
+                .expert_ids_ptr = expert_ids,
+                .num_tokens_post_pad_ptr = num_tokens_post_padded,
+                .cumsum_ptr = cumsums,
+            },
+            .{
+                .sorted_token_ids = sorted_token_ids.shape(),
+                .expert_ids = expert_ids.shape(),
+                .num_tokens_post_pad = num_tokens_post_padded.shape(),
+                .cumsum = cumsums.shape(),
+            },
+            .{
+                .cfg = .{
+                    .numel = @intCast(num_assignments),
+                    .num_experts = @intCast(num_experts),
+                    .padded_num_experts = @intCast(padded_num_experts),
+                    .max_num_tokens_padded = @intCast(max_num_tokens_padded),
+                    .max_num_m_blocks = @intCast(max_num_m_blocks),
+                    .block_size_m = @intCast(block_size_m),
+                    .hist_block = 256,
+                },
+                .grid = .{ 2, 1, 1 },
+                .num_stages = 1,
+                .num_warps = 8,
+                .output_operand_aliases = &.{
+                    .{ .output_index = 0, .operand_index = 1 },
+                    .{ .output_index = 1, .operand_index = 2 },
+                    .{ .output_index = 2, .operand_index = 3 },
+                    .{ .output_index = 3, .operand_index = 4 },
+                },
+            },
+        );
+        sorted_token_ids = align_outs.sorted_token_ids;
+        expert_ids = align_outs.expert_ids;
+        num_tokens_post_padded = align_outs.num_tokens_post_pad;
+        cumsums = align_outs.cumsum;
+    }
+
+    {
+        const sort_outs = kernels.CountAndSortExpertTokens.Kernel.call(
+            .{
+                .topk_ids_ptr = flat_experts,
+                .sorted_token_ids_ptr = sorted_token_ids,
+                .cumsum_ptr = cumsums,
+            },
+            .{
+                .sorted_token_ids = sorted_token_ids.shape(),
+                .cumsum = cumsums.shape(),
+            },
+            .{
+                .cfg = .{
+                    .numel = @intCast(num_assignments),
+                    .num_experts = @intCast(num_experts),
+                    .sort_block_size = @intCast(sort_block_size),
+                },
+                .grid = .{ @intCast(sort_grid_x), 1, 1 },
+                .num_stages = 1,
+                .num_warps = 4,
+                .output_operand_aliases = &.{
+                    .{ .output_index = 0, .operand_index = 1 },
+                    .{ .output_index = 1, .operand_index = 2 },
+                },
+            },
+        );
+        sorted_token_ids = sort_outs.sorted_token_ids;
+        cumsums = sort_outs.cumsum;
+    }
+
+    return .{ sorted_token_ids, expert_ids, num_tokens_post_padded };
+}
+
+fn quantizePerTokenGroupFp8(x: Tensor, group_size: i64) struct { Tensor, Tensor } {
+    stdx.debug.assert(x.rank() == 2, "expected a rank-2 activation matrix, got {f}", .{x.shape()});
+    stdx.debug.assert(@mod(x.dim(1), group_size) == 0, "activation width must be divisible by group size {d}, got {d}", .{ group_size, x.dim(1) });
+
+    const groups_per_row = @divExact(x.dim(1), group_size);
+    const quantized = Tensor.zeroes(Shape.init(.{ .token = x.dim(0), .feature = x.dim(1) }, .f8e4m3fn));
+    const scales = Tensor.zeroes(Shape.init(.{ .token = x.dim(0), .group = groups_per_row }, .bf16));
+
+    const outs = kernels.PerTokenGroupQuantFp8.Kernel.call(
+        .{
+            .y_ptr = x,
+            .group_size_ptr = Tensor.constant(.{ .i64 = group_size }).reshape(.{1}),
+            .y_num_columns_ptr = Tensor.constant(.{ .i64 = x.dim(1) }).reshape(.{1}),
+            .y_row_stride_ptr = Tensor.constant(.{ .i64 = x.dim(1) }).reshape(.{1}),
+            .eps_ptr = Tensor.scalar(1e-6, .f32),
+        },
+        .{ .y_q = quantized.shape(), .y_s = scales.shape() },
+        .{
+            .cfg = .{
+                .input_dtype = toDType(x.dtype()),
+                .output_dtype = .f8e4m3fn,
+                .scale_dtype = .bf16,
+                .block = @intCast(group_size),
+                .fp8_min = -448.0,
+                .fp8_max = 448.0,
+                .use_ue8m0 = false,
+            },
+            .grid = .{ @intCast(x.dim(0) * groups_per_row), 1, 1 },
+            .num_stages = 1,
+            .num_warps = 1,
+        },
+    );
+
+    return .{ outs.y_q, outs.y_s };
+}
+
+// =============================================================================
+// Config / validation helpers
+// =============================================================================
+
+fn makeFusedMoeConfig(
+    a: Tensor,
+    b: Tensor,
+    opts: Options,
+    naive_block_assignment: bool,
+    top_k: i64,
+    mul_routed_weight: bool,
+    has_bias: bool,
+    output_dtype: DataType,
+) kernels.FusedMoe.Cfg {
+    var use_fp8 = opts.use_fp8_w8a8;
+    if (b.dtype() == .f8e4m3fn) use_fp8 = true;
+    return .{
+        .a_dtype = toDType(a.dtype()),
+        .b_dtype = toDType(b.dtype()),
+        .c_dtype = toDType(output_dtype),
+        .a_scale_dtype = if (use_fp8) .bf16 else null,
+        .b_scale_dtype = if (use_fp8) .bf16 else null,
+        .b_bias_dtype = null,
+        .topk_weights_dtype = null,
+        .block_size_m = @intCast(opts.block_size_m),
+        .block_size_n = @intCast(opts.block_size_n),
+        .block_size_k = @intCast(opts.block_size_k),
+        .group_size_m = @intCast(opts.group_size_m),
+        .top_k = @intCast(top_k),
+        .naive_block_assignment = naive_block_assignment,
+        .mul_routed_weight = mul_routed_weight,
+        .compute_type = .bf16,
+        .use_fp8_w8a8 = use_fp8,
+        .use_int8_w8a8 = false,
+        .use_int8_w8a16 = false,
+        .per_channel_quant = false,
+        .has_bias = has_bias,
+    };
+}
+
+const DefaultTokenBucket = struct {
+    tokens: i64,
+    block_size_m: i64,
+    block_size_n: i64,
+    block_size_k: i64,
+    group_size_m: i64,
+    num_warps: i64,
+    num_stages: i64,
+};
+
+fn applyDefaultTokenConfig(opts: Options, num_tokens: i64, num_experts: i64) Options {
+    var out = opts;
+    if (!opts.dynamic_launch_by_num_tokens) return out;
+
+    // General default policy for NVIDIA bf16/fp16 and fp8 per-tensor.
+    // Tile sizes scale with batch size: small batches are more memory-bound,
+    // while larger batches benefit from wider M/N tiles and more warps.
+    if (num_tokens <= 32) {
+        out.block_size_m = 16;
+    } else if (num_tokens <= 96) {
+        out.block_size_m = 32;
+    } else if (num_tokens <= 512) {
+        out.block_size_m = 64;
+    } else {
+        out.block_size_m = 128;
+    }
+
+    out.block_size_n = if (num_tokens <= 64) 64 else 128;
+    out.block_size_k = if (opts.use_fp8_w8a8 or num_tokens <= 64) 128 else 64;
+
+    const tokens_per_expert = @divFloor(num_tokens, @max(num_experts, 1));
+    out.group_size_m = if (tokens_per_expert > 128) 16 else 1;
+    out.num_warps = if (num_tokens <= 128) 4 else 8;
+    out.num_stages = if (num_tokens <= 32) 4 else 3;
+
+    return out;
+}
+
+fn getLaunchConfigJsonPath(allocator: std.mem.Allocator) ![]const u8 {
+    const runfiles = bazel.runfiles(bazel_builtin.current_repository) catch |err| {
+        log.err("Failed to initialize runfiles for MoE launch config: {}", .{err});
+        return err;
+    };
+
+    var config_path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const config_path =
+        runfiles.rlocation("zml/zml/moe/triton_kernels/config.json", &config_path_buf) catch null orelse
+        runfiles.rlocation("zml/zml/moe/triton/triton_kernels/config.json", &config_path_buf) catch |err| {
+            log.err("Failed to resolve MoE launch config in runfiles: {}", .{err});
+            return err;
+        };
+
+    const config_json = config_path orelse {
+        log.warn("MoE launch config is missing from runfiles at both zml/zml/moe/triton_kernels/config.json and zml/zml/moe/triton/triton_kernels/config.json", .{});
+        return error.MissingLaunchConfigRunfile;
+    };
+
+    return try allocator.dupe(u8, config_json);
+}
+
+fn applyJsonTokenConfig(opts: Options, num_tokens: i64) !Options {
+    var out = opts;
+    if (!opts.dynamic_launch_by_num_tokens) return out;
+
+    const compilation_context = zml.module.CompilationContext.current();
+    const io = compilation_context.io;
+    const allocator = compilation_context.arena.allocator();
+
+    const config_path = try getLaunchConfigJsonPath(allocator);
+    const cwd = std.Io.Dir.cwd();
+    var file = try cwd.openFile(io, config_path, .{ .mode = .read_only });
+    defer file.close(io);
+    var reader = file.reader(io, &.{});
+    const config_json = try reader.interface.readAlloc(allocator, try file.length(io));
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, config_json, .{});
+
+    if (parsed.value != .object) return error.InvalidLaunchConfigShape;
+
+    var it = parsed.value.object.iterator();
+    var best_m: ?i64 = null;
+    var best_diff: u64 = std.math.maxInt(u64);
+    var best_config: ?std.json.Value = null;
+
+    while (it.next()) |entry| {
+        const m = std.fmt.parseInt(i64, entry.key_ptr.*, 10) catch continue;
+        if (entry.value_ptr.* != .object) continue;
+
+        const diff: u64 = if (m >= num_tokens)
+            @intCast(m - num_tokens)
+        else
+            @intCast(num_tokens - m);
+
+        if (best_m == null or diff < best_diff or (diff == best_diff and m < best_m.?)) {
+            best_m = m;
+            best_diff = diff;
+            best_config = entry.value_ptr.*;
+        }
+    }
+
+    if (best_config == null) return error.NoMatchingLaunchConfig;
+
+    const cfg = best_config.?.object;
+    const block_size_m = cfg.get("BLOCK_SIZE_M") orelse return error.MissingLaunchConfigField;
+    const block_size_n = cfg.get("BLOCK_SIZE_N") orelse return error.MissingLaunchConfigField;
+    const block_size_k = cfg.get("BLOCK_SIZE_K") orelse return error.MissingLaunchConfigField;
+    const group_size_m = cfg.get("GROUP_SIZE_M") orelse return error.MissingLaunchConfigField;
+    const num_warps = cfg.get("num_warps") orelse return error.MissingLaunchConfigField;
+    const num_stages = cfg.get("num_stages") orelse return error.MissingLaunchConfigField;
+
+    out.block_size_m = block_size_m.integer;
+    out.block_size_n = block_size_n.integer;
+    out.block_size_k = block_size_k.integer;
+    out.group_size_m = group_size_m.integer;
+    out.num_warps = num_warps.integer;
+    out.num_stages = num_stages.integer;
+
+    return out;
+}
+
+fn fp8ActivationGroupSize(x: Tensor) i64 {
+    const group_size: i64 = 128;
+    stdx.debug.assert(@mod(x.dim(1), group_size) == 0, "FP8 activation width must be divisible by {d}, got {d}", .{ group_size, x.dim(1) });
+    return group_size;
+}
+
+fn validateOptions(opts: Options) !void {
+    if (opts.inplace) return error.Unimplemented;
+    if (opts.activation != .silu and opts.activation != .relu) return error.UnsupportedActivation;
+    if (opts.apply_router_weight_on_input) return error.UnsupportedOption;
+    if (opts.use_fp8_w8a8 or opts.use_int8_w8a8 or opts.use_int8_w8a16 or opts.use_int4_w4a16) return error.UnsupportedQuantization;
+    if (opts.ocp_mx_scheme != null or opts.per_channel_quant) return error.UnsupportedOption;
+    if (opts.global_num_experts != -1) return error.UnsupportedOption;
+    if (opts.expert_map != null) return error.UnsupportedOption;
+    if (opts.w1_zp != null or opts.w2_zp != null) return error.UnsupportedOption;
+    if (opts.a1_scale != null or opts.a2_scale != null or opts.block_shape != null) return error.UnsupportedOption;
+    if (opts.w1_bias != null or opts.w2_bias != null) return error.UnsupportedOption;
+}
+
+fn validateInputs(hidden: Tensor, gate_up: Tensor, down: Tensor, weights: Tensor, ids: Tensor) !void {
+    if (hidden.dtype() != .bf16) return error.UnsupportedType;
+    if (gate_up.dtype() != .bf16 and gate_up.dtype() != .f8e4m3fn) return error.UnsupportedType;
+    if (down.dtype() != .bf16 and down.dtype() != .f8e4m3fn) return error.UnsupportedType;
+    if (weights.dtype() != .f32 and weights.dtype() != .bf16) return error.UnsupportedType;
+    if (ids.dtype() != .i32) return error.UnsupportedType;
+    if (hidden.dim(.in) != gate_up.dim(.in)) return error.InvalidShape;
+    if (@rem(gate_up.dim(.out), 2) != 0) return error.InvalidShape;
+    if (down.dim(.mid) != @divFloor(gate_up.dim(.out), 2)) return error.InvalidShape;
+    if (ids.dim(.token) != hidden.dim(.token) or weights.dim(.token) != hidden.dim(.token)) return error.InvalidShape;
+    if (ids.dim(.topk) != weights.dim(.topk)) return error.InvalidShape;
+    if (gate_up.dim(.expert) != down.dim(.expert)) return error.InvalidShape;
+}

--- a/zml/moe/triton_kernels/config.json
+++ b/zml/moe/triton_kernels/config.json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "512": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 4
+    }
+}

--- a/zml/moe/triton_kernels/triton_kernels.zig
+++ b/zml/moe/triton_kernels/triton_kernels.zig
@@ -1,3 +1,10 @@
+//! Triton MoE kernel declarations — direct ports of the `@triton.jit`
+//! functions in `triton_kernels/moe.py`. Each kernel here is a
+//! `tri.Kernel(...)` declaration with its own inline config struct (no
+//! defaults — every field is required at call time). Production callers
+//! invoke these via `K.call(inputs, outputs, opts)`; offline tooling reaches the TTIR
+//! string via `K.emit(allocator, ctx, cfg)`.
+
 const std = @import("std");
 
 const zml = @import("../../zml.zig");
@@ -8,10 +15,18 @@ const DType = tri.DType;
 
 const log = std.log.scoped(.moe_triton);
 
+/// Floor to a multiple of 16 — matches the Python `(v // 16) * 16` guards
+/// that keep dynamic strides aligned for tt.load/store.
 fn blockFloor16(v: Value) Value {
     return v.div(16).mul(16);
 }
 
+// =============================================================================
+// per_token_group_quant_fp8
+// =============================================================================
+
+/// Direct port of Python `per_token_group_quant_fp8` — per-token-group
+/// float8 quantization.
 pub const PerTokenGroupQuantFp8 = struct {
     pub const Cfg = struct {
         input_dtype: DType,
@@ -103,6 +118,14 @@ pub const PerTokenGroupQuantFp8 = struct {
     }
 };
 
+// =============================================================================
+// write_zeros_to_output — helper called by FusedMoe
+// =============================================================================
+
+/// Direct port of Python `write_zeros_to_output`. Stores a masked zero-tile
+/// for blocks whose expert is `-1` (no expert assigned). `stride_cn` is
+/// hardcoded to 1 (contiguous last dim), so the N-axis offset is just
+/// `offs_cn` itself.
 fn writeZerosToOutput(
     b: *Builder,
     c_ptr: Value,
@@ -138,6 +161,12 @@ fn writeZerosToOutput(
     b.storeOpts(c_ptrs, accumulator, .{ .mask = token_mask_full.bitAnd(offs_cn_lt_full) });
 }
 
+// =============================================================================
+// fused_moe_kernel
+// =============================================================================
+
+/// Direct port of Python `fused_moe_kernel`. Bf16 / no-quant / no-bias path
+/// only — errors out for the feature flags that aren't implemented yet.
 pub const FusedMoe = struct {
     pub const Cfg = struct {
         a_dtype: DType,
@@ -261,9 +290,9 @@ pub const FusedMoe = struct {
         const pid_m_block = pid_m.mul(block_size_m);
         const num_tokens_post_padded = num_tokens_post_padded_i32.to(.i64);
         const out_of_range = pid_m_block.ge(num_tokens_post_padded);
-	
+
         b.returnIfOpts(out_of_range, .{}, .{ .inline_return = true });
-	
+
         const offs_token = if (cfg.naive_block_assignment)
             b.select(
                 offs.eq(0),
@@ -411,6 +440,13 @@ pub const FusedMoe = struct {
     }
 };
 
+// =============================================================================
+// moe_align_block_size_kernel
+// =============================================================================
+
+/// Direct port of Python `moe_align_block_size_kernel`. pid==0 runs the
+/// histogram + cumsum + block-to-expert assignment pass; pid==1 fills
+/// sorted_token_ids with NUMEL.
 pub const MoeAlignBlockSize = struct {
     pub const Cfg = struct {
         numel: usize,
@@ -533,6 +569,13 @@ pub const MoeAlignBlockSize = struct {
     }
 };
 
+// =============================================================================
+// count_and_sort_expert_tokens_kernel
+// =============================================================================
+
+/// Direct port of Python `count_and_sort_expert_tokens_kernel`. Each program
+/// atomically bumps `cumsum[expert]`, writing its block's token offsets into
+/// `sorted_token_ids` at the returned rank.
 pub const CountAndSortExpertTokens = struct {
     pub const Cfg = struct {
         numel: usize,

--- a/zml/moe/triton_kernels/triton_kernels.zig
+++ b/zml/moe/triton_kernels/triton_kernels.zig
@@ -261,7 +261,9 @@ pub const FusedMoe = struct {
         const pid_m_block = pid_m.mul(block_size_m);
         const num_tokens_post_padded = num_tokens_post_padded_i32.to(.i64);
         const out_of_range = pid_m_block.ge(num_tokens_post_padded);
-        b.returnIf(out_of_range, .{});
+	
+        b.returnIfOpts(out_of_range, .{}, .{ .inline_return = true });
+	
         const offs_token = if (cfg.naive_block_assignment)
             b.select(
                 offs.eq(0),
@@ -282,6 +284,7 @@ pub const FusedMoe = struct {
 
         // Python: if off_experts == -1: write_zeros_to_output(...); return
         var dead_ret = b.openReturnIf(is_dead);
+        dead_ret.inline_return = true;
         {
             writeZerosToOutput(
                 b,
@@ -450,6 +453,7 @@ pub const MoeAlignBlockSize = struct {
 
         // if pid == 1: fill sorted_token_ids with NUMEL; return
         var fill_branch = b.openReturnIf(pid.eq(1));
+        fill_branch.inline_return = true;
         {
             var fill_loop = b.openFor(0, max_num_tokens_padded, hist_block, .{});
             {

--- a/zml/moe/triton_kernels/triton_kernels.zig
+++ b/zml/moe/triton_kernels/triton_kernels.zig
@@ -1,0 +1,605 @@
+const std = @import("std");
+
+const zml = @import("../../zml.zig");
+const tri = zml.kernel.triton;
+const Builder = tri.Builder;
+const Value = tri.Value;
+const DType = tri.DType;
+
+const log = std.log.scoped(.moe_triton);
+
+fn blockFloor16(v: Value) Value {
+    return v.div(16).mul(16);
+}
+
+pub const PerTokenGroupQuantFp8 = struct {
+    pub const Cfg = struct {
+        input_dtype: DType,
+        output_dtype: DType,
+        scale_dtype: DType,
+        block: usize,
+        fp8_min: f32,
+        fp8_max: f32,
+        use_ue8m0: bool,
+    };
+    pub const Kernel = tri.Kernel(Cfg, .{
+        .name = "per_token_group_quant_fp8",
+        .inputs = &.{ "y_ptr", "group_size_ptr", "y_num_columns_ptr", "y_row_stride_ptr", "eps_ptr" },
+        .outputs = &.{ "y_q", "y_s" },
+        .run = run,
+    });
+    fn run(b: *Builder, cfg: Cfg) tri.FinishError!void {
+        const a = try b.declareArgs(.{
+            .y_ptr = .{ .ptr = cfg.input_dtype },
+            .group_size_ptr = .{ .ptr = .i64 },
+            .y_num_columns_ptr = .{ .ptr = .i64 },
+            .y_row_stride_ptr = .{ .ptr = .i64 },
+            .eps_ptr = .{ .ptr = .f32 },
+            .y_q_ptr = .{ .ptr = cfg.output_dtype },
+            .y_s_ptr = .{ .ptr = cfg.scale_dtype },
+        });
+
+        const block: i64 = @intCast(cfg.block);
+        const out_dt = cfg.output_dtype;
+        const scale_dt = cfg.scale_dtype;
+
+        const group_size = b.load(a.group_size_ptr);
+        const y_num_columns = b.load(a.y_num_columns_ptr);
+        const y_row_stride = b.load(a.y_row_stride_ptr);
+        const eps = b.load(a.eps_ptr);
+
+        const groups_per_row = y_num_columns.div(group_size);
+        // g_id is i32 from `tl.program_id`; the i64 promotion only happens
+        // inside the `(row|row_g_id).to(tl.int64)` casts in the Python source.
+        // y_s_ptr_shifted reuses the raw i32 `g_id` directly (no extsi).
+        const pid_i32 = b.programId(.x);
+        const g_id = pid_i32.to(.i64);
+
+        // y_ptr += (g_id // groups_per_row) * y_row_stride + (g_id % groups_per_row) * group_size
+        // Python emit order: divsi, remsi, muli (row * stride), muli (row_g_id * group_size), addi.
+        const row = g_id.div(groups_per_row);
+        const row_g_id = g_id.rem(groups_per_row);
+        const row_off = row.mul(y_row_stride);
+        const grp_off = row_g_id.mul(group_size);
+        const y_ptr_shifted = a.y_ptr.addPtr(row_off.add(grp_off));
+        const y_q_ptr_shifted = a.y_q_ptr.addPtr(g_id.mul(group_size));
+        // y_s_ptr += g_id (raw i32, no cast — matches `y_s_ptr += g_id` in Python).
+        const y_s_ptr_shifted = a.y_s_ptr.addPtr(pid_i32);
+
+        // cols = arange(0, BLOCK) — i64 for both pointer offsets and mask
+        // comparison against the i64 `group_size` (matches Python's
+        // `cols < group_size` after Triton's auto-promotion).
+        const cols_i32 = b.arange(0, block, .i32);
+        const cols_i64 = cols_i32.to(.i64);
+        const mask = cols_i64.lt(group_size);
+
+        // Python: `tl.load(y_ptr + cols, mask=mask, other=0.0)` — explicit
+        // 3-operand form. Use `.other` to materialize the const-zero tensor
+        // (without it, `tt.load` is 2-operand and Python's emit doesn't match).
+        const y_load_ptrs = y_ptr_shifted.addPtr(cols_i64);
+        const y_other = b.zeros(&.{block}, cfg.input_dtype);
+        const y = b.loadOpts(y_load_ptrs, .{ .mask = mask, .other = y_other }).to(.f32);
+
+        // _absmax = max(tl.max(tl.abs(y)), eps) — `b.max(...).maximum(eps)`
+        // resolves to `arith.maxnumf` (matches Python's `tl.maximum`).
+        const absmax = b.max(b.absf(y)).maximum(eps);
+
+        // scale_raw = _absmax * (1.0 / fp8_max)
+        const scale_raw = absmax.mul(1.0 / cfg.fp8_max);
+        const y_s = if (cfg.use_ue8m0) b.exp2(b.ceil(b.log2(scale_raw))) else scale_raw;
+
+        // y_q = clamp(y / y_s, fp8_min, fp8_max).to(output_dtype)
+        const y_div = y.div(y_s);
+        const clamped = b.clampf(
+            y_div,
+            b.splat(cfg.fp8_min, &.{block}),
+            b.splat(cfg.fp8_max, &.{block}),
+        );
+        const y_q = clamped.to(out_dt);
+
+        const y_q_ptrs = y_q_ptr_shifted.addPtr(cols_i64);
+        b.storeOpts(y_q_ptrs, y_q, .{ .mask = mask });
+        b.store(y_s_ptr_shifted, y_s.to(scale_dt));
+    }
+};
+
+fn writeZerosToOutput(
+    b: *Builder,
+    c_ptr: Value,
+    stride_cm: Value,
+    pid_n: Value,
+    n: Value,
+    offs_token: Value,
+    token_mask: Value,
+    block_size_m: i64,
+    block_size_n: i64,
+    compute_type: DType,
+) void {
+    const accumulator = b.zeros(&.{ block_size_m, block_size_n }, compute_type);
+    const offs_cn = pid_n.mul(block_size_n).add(b.arange(0, block_size_n, .i64));
+
+    // c_ptrs in two addptrs to match Python's `c_ptr + cm[:, None] + cn[None, :]`
+    // left-to-right evaluation. `stride_cm * offs_token[:, None]` puts the
+    // splatted stride on the LHS of arith.muli (Python source order).
+    const offs_token_col = b.expandDims(offs_token, 1);
+    const cm_col = stride_cm.mul(offs_token_col);
+    const c_ptrs_col = b.splat(c_ptr, &.{ block_size_m, 1 }).addPtr(cm_col);
+    const offs_cn_row = b.expandDims(offs_cn, 0);
+    const c_ptrs_2d = b.broadcastTo(c_ptrs_col, &.{ block_size_m, block_size_n });
+    const cn_off_2d = b.broadcastTo(offs_cn_row, &.{ block_size_m, block_size_n });
+    const c_ptrs = c_ptrs_2d.addPtr(cn_off_2d);
+
+    // c_mask: Python emit order — expand_dims, splat, cmpi, broadcast, broadcast, andi.
+    const token_mask_col = b.expandDims(token_mask, 1);
+    const n_splat = b.splat(n, &.{ 1, block_size_n });
+    const offs_cn_lt_2d = offs_cn_row.lt(n_splat);
+    const token_mask_full = b.broadcastTo(token_mask_col, &.{ block_size_m, block_size_n });
+    const offs_cn_lt_full = b.broadcastTo(offs_cn_lt_2d, &.{ block_size_m, block_size_n });
+    b.storeOpts(c_ptrs, accumulator, .{ .mask = token_mask_full.bitAnd(offs_cn_lt_full) });
+}
+
+pub const FusedMoe = struct {
+    pub const Cfg = struct {
+        a_dtype: DType,
+        b_dtype: DType,
+        c_dtype: DType,
+        a_scale_dtype: ?DType,
+        b_scale_dtype: ?DType,
+        b_bias_dtype: ?DType,
+        topk_weights_dtype: ?DType,
+        block_size_m: usize,
+        block_size_n: usize,
+        block_size_k: usize,
+        group_size_m: usize,
+        top_k: usize,
+        naive_block_assignment: bool,
+        mul_routed_weight: bool,
+        compute_type: DType,
+        // Validation flags — the kernel rejects configs that set any of
+        // these to true (the body only implements the bf16 / no-quant /
+        // no-bias path).
+        use_fp8_w8a8: bool,
+        use_int8_w8a8: bool,
+        use_int8_w8a16: bool,
+        per_channel_quant: bool,
+        has_bias: bool,
+    };
+    pub const Kernel = tri.Kernel(Cfg, .{
+        .name = "fused_moe_kernel",
+        .inputs = &.{
+            "a_ptr",            "b_ptr",                "b_bias_ptr",           "a_scale_ptr",                "b_scale_ptr",
+            "topk_weights_ptr", "sorted_token_ids_ptr", "expert_ids_ptr",       "num_tokens_post_padded_ptr", "N_ptr",
+            "K_ptr",            "EM_ptr",               "num_valid_tokens_ptr", "stride_am_ptr",              "stride_be_ptr",
+            "stride_bn_ptr",    "stride_cm_ptr",        "stride_asm_ptr",       "stride_ask_ptr",             "stride_bse_ptr",
+            "stride_bsk_ptr",   "stride_bsn_ptr",       "stride_bbe_ptr",       "stride_bbn_ptr",
+        },
+        .outputs = &.{"c"},
+        .run = run,
+    });
+    fn run(b: *Builder, cfg: Cfg) tri.FinishError!void {
+        if (cfg.use_fp8_w8a8 or cfg.use_int8_w8a8 or cfg.use_int8_w8a16 or cfg.has_bias or cfg.per_channel_quant) {
+            log.err("fused_moe_kernel: unsupported config (fp8/int8/bias/per_channel)", .{});
+            return error.InvalidMlir;
+        }
+
+        const a = try b.declareArgs(.{
+            .a_ptr = .{ .ptr = cfg.a_dtype },
+            .b_ptr = .{ .ptr = cfg.b_dtype },
+            .b_bias_ptr = .{ .ptr = cfg.b_bias_dtype orelse cfg.c_dtype },
+            .a_scale_ptr = .{ .ptr = cfg.a_scale_dtype orelse .f32 },
+            .b_scale_ptr = .{ .ptr = cfg.b_scale_dtype orelse .f32 },
+            .topk_weights_ptr = .{ .ptr = cfg.topk_weights_dtype orelse .f32 },
+            .sorted_token_ids_ptr = .{ .ptr = .i32 },
+            .expert_ids_ptr = .{ .ptr = .i32 },
+            .num_tokens_post_padded_ptr = .{ .ptr = .i32 },
+            .N_ptr = .{ .ptr = .i64 },
+            .K_ptr = .{ .ptr = .i64 },
+            .EM_ptr = .{ .ptr = .i64 },
+            .num_valid_tokens_ptr = .{ .ptr = .i64 },
+            .stride_am_ptr = .{ .ptr = .i64 },
+            .stride_be_ptr = .{ .ptr = .i64 },
+            .stride_bn_ptr = .{ .ptr = .i64 },
+            .stride_cm_ptr = .{ .ptr = .i64 },
+            .stride_asm_ptr = .{ .ptr = .i64 },
+            .stride_ask_ptr = .{ .ptr = .i64 },
+            .stride_bse_ptr = .{ .ptr = .i64 },
+            .stride_bsk_ptr = .{ .ptr = .i64 },
+            .stride_bsn_ptr = .{ .ptr = .i64 },
+            .stride_bbe_ptr = .{ .ptr = .i64 },
+            .stride_bbn_ptr = .{ .ptr = .i64 },
+            .c_ptr = .{ .ptr = cfg.c_dtype },
+        });
+
+        const block_size_m: i64 = @intCast(cfg.block_size_m);
+        const block_size_n: i64 = @intCast(cfg.block_size_n);
+        const block_size_k: i64 = @intCast(cfg.block_size_k);
+        const group_size_m: i64 = @intCast(cfg.group_size_m);
+        const top_k: i64 = @intCast(cfg.top_k);
+        const compute_type = cfg.compute_type;
+
+        // Runtime scalars — load all first, then floor to multiples of 16
+        // (Python loads them as a group then runs the // 16 * 16 sequence).
+        const n_raw = b.load(a.N_ptr);
+        const k_raw = b.load(a.K_ptr);
+        const em_raw = b.load(a.EM_ptr);
+        const num_valid_tokens = b.load(a.num_valid_tokens_ptr);
+        const stride_am_raw = b.load(a.stride_am_ptr);
+        const stride_be_raw = b.load(a.stride_be_ptr);
+        const stride_bn_raw = b.load(a.stride_bn_ptr);
+        const stride_cm_raw = b.load(a.stride_cm_ptr);
+        const n_block = blockFloor16(n_raw);
+        const k_block = blockFloor16(k_raw);
+        const em_block = blockFloor16(em_raw);
+        const stride_am_block = blockFloor16(stride_am_raw);
+        const stride_be_block = blockFloor16(stride_be_raw);
+        const stride_bn_block = blockFloor16(stride_bn_raw);
+        const stride_cm_block = blockFloor16(stride_cm_raw);
+        // stride_ak / stride_bk / stride_cn are all 1 in this port — the A/B/C
+        // inner dimension is contiguous, so those mul-by-1 terms are elided.
+
+        // pid grouping. Python keeps `pid` as i32 and lets the divsi auto-
+        // promote at the use site — emit the cdivs first, then extsi at the
+        // first i64 use. Manual order keeps `extsi pid` after the cdivs in TTIR.
+        const pid_i32 = b.programId(.x);
+        const num_pid_m = em_block.cdiv(block_size_m);
+        const num_pid_n = n_block.cdiv(block_size_n);
+        const num_pid_in_group = num_pid_n.mul(group_size_m);
+        const pid = pid_i32.to(.i64);
+        const group_id = pid.div(num_pid_in_group);
+        const first_pid_m = group_id.mul(group_size_m);
+        const gsm_actual = num_pid_m.sub(first_pid_m).minimum(group_size_m);
+        const pid_mod_in_group = pid.rem(num_pid_in_group);
+        const pid_m = first_pid_m.add(pid_mod_in_group.rem(gsm_actual));
+        const pid_n = pid_mod_in_group.div(gsm_actual);
+
+        // Python source order: arange first, then load + early-return.
+        // Match emit order so the make_range op lands before the cf.cond_br.
+        const offs = b.arange(0, block_size_m, .i64);
+        // Order: load (i32), muli, extsi (Python emits the muli before the
+        // i32→i64 extsi at the cmpi).
+        const num_tokens_post_padded_i32 = b.load(a.num_tokens_post_padded_ptr);
+        const pid_m_block = pid_m.mul(block_size_m);
+        const num_tokens_post_padded = num_tokens_post_padded_i32.to(.i64);
+        const out_of_range = pid_m_block.ge(num_tokens_post_padded);
+        b.returnIf(out_of_range, .{});
+        const offs_token = if (cfg.naive_block_assignment)
+            b.select(
+                offs.eq(0),
+                pid_m.splatTo(&.{block_size_m}),
+                num_valid_tokens.splatTo(&.{block_size_m}),
+            )
+        else off: {
+            const ids_ptrs = a.sorted_token_ids_ptr
+                .addPtr(pid_m.mul(block_size_m).add(offs));
+            break :off b.load(ids_ptrs).to(.i64);
+        };
+        const token_mask = offs_token.lt(num_valid_tokens);
+
+        // off_experts = expert_ids[pid_m].to(i64). pid_m is i64; Python's
+        // `expert_ids_ptr + pid_m` keeps the offset as i64.
+        const off_experts = b.load(a.expert_ids_ptr.addPtr(pid_m)).to(.i64);
+        const is_dead = off_experts.eq(-1);
+
+        // Python: if off_experts == -1: write_zeros_to_output(...); return
+        var dead_ret = b.openReturnIf(is_dead);
+        {
+            writeZerosToOutput(
+                b,
+                a.c_ptr,
+                stride_cm_block,
+                pid_n,
+                n_block,
+                offs_token,
+                token_mask,
+                block_size_m,
+                block_size_n,
+                compute_type,
+            );
+            dead_ret.yieldReturn(.{});
+        }
+
+        // CSE `pid_n * BLOCK_SIZE_N` so it reuses across offs_bn / offs_cn.
+        const pid_n_block_n = pid_n.mul(block_size_n);
+        const offs_bn = pid_n_block_n.add(b.arange(0, block_size_n, .i64)).rem(n_block);
+
+        // offs_k stays i32 through expand_dims; extsi to i64 happens on the 2D form.
+        const offs_k_i32 = b.arange(0, block_size_k, .i32);
+
+        // a_ptrs: `offs_token[:, None] // top_k * stride_am + offs_k[None, :]`.
+        // (stride_ak == 1 here, so `* stride_ak` folds away.) Build with explicit
+        // broadcastTo to match Python's emit shape.
+        const offs_token_col = b.expandDims(offs_token, 1);
+        const am_col = offs_token_col.div(top_k).mul(stride_am_block);
+        const offs_k_row = b.expandDims(offs_k_i32, 0).to(.i64);
+        const am_term = b.broadcastTo(am_col, &.{ block_size_m, block_size_k });
+        const ak_term = b.broadcastTo(offs_k_row, &.{ block_size_m, block_size_k });
+        const a_ptrs_init = a.a_ptr.addPtr(am_term.add(ak_term));
+
+        // b_ptrs: `b_ptr + off_experts * stride_be` (scalar addptr) THEN
+        // `+ (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)` (2D
+        // addptr) — matches Python's left-to-right evaluation. Defer extsi
+        // for offs_k to after offs_bn's expand_dims/mul (Python emit order).
+        const b_ptr_shifted = a.b_ptr.addPtr(off_experts.mul(stride_be_block));
+        const offs_k_col_i32 = b.expandDims(offs_k_i32, 1);
+        const offs_bn_row = b.expandDims(offs_bn, 0);
+        const bn_row = offs_bn_row.mul(stride_bn_block);
+        const offs_k_col = offs_k_col_i32.to(.i64);
+        const bk_term = b.broadcastTo(offs_k_col, &.{ block_size_k, block_size_n });
+        const bn_term = b.broadcastTo(bn_row, &.{ block_size_k, block_size_n });
+        const b_ptrs_init = b_ptr_shifted.addPtr(bk_term.add(bn_term));
+
+        const acc_init = b.zeros(&.{ block_size_m, block_size_n }, .f32);
+
+        // Loop bounds stay i64 because `k_block` is i64. iter_args order
+        // matches Python's TTIR (a_ptrs, b_ptrs, accumulator).
+        const num_k_iters = k_block.cdiv(block_size_k);
+        var loop = b.openFor(@as(i64, 0), num_k_iters, @as(i64, 1), .{ a_ptrs_init, b_ptrs_init, acc_init });
+        {
+            const k_iter = loop.iv;
+            const a_ptrs = loop.carried[0];
+            const b_ptrs = loop.carried[1];
+            const acc = loop.carried[2];
+
+            const k_remaining = k_block.sub(k_iter.mul(block_size_k));
+
+            // mask_a = token_mask[:, None] & (offs_k[None, :] < k_remaining).
+            const token_mask_col_a = b.expandDims(token_mask, 1);
+            const offs_k_row_a = b.expandDims(offs_k_i32, 0).to(.i64);
+            const offs_k_lt_a = offs_k_row_a.lt(b.splat(k_remaining, &.{ 1, block_size_k }));
+            const token_mask_full_a = b.broadcastTo(token_mask_col_a, &.{ block_size_m, block_size_k });
+            const offs_k_lt_a_full = b.broadcastTo(offs_k_lt_a, &.{ block_size_m, block_size_k });
+            const mask_a = token_mask_full_a.bitAnd(offs_k_lt_a_full);
+
+            const a_val = b.loadOpts(a_ptrs, .{
+                .mask = mask_a,
+                .other = b.zeros(&.{ block_size_m, block_size_k }, cfg.a_dtype),
+            });
+
+            // mask_b = offs_k[:, None] < k_remaining (broadcast to KxN).
+            const offs_k_col_b = b.expandDims(offs_k_i32, 1).to(.i64);
+            const offs_k_lt_b = offs_k_col_b.lt(b.splat(k_remaining, &.{ block_size_k, 1 }));
+            const mask_b = b.broadcastTo(offs_k_lt_b, &.{ block_size_k, block_size_n });
+
+            const b_val = b.loadOpts(b_ptrs, .{
+                .mask = mask_b,
+                .other = b.zeros(&.{ block_size_k, block_size_n }, cfg.b_dtype),
+            });
+
+            const new_acc = b.dotOpts(a_val, b_val, acc, .{
+                .input_precision = .tf32,
+                .max_num_imprecise_acc = 0,
+            });
+
+            // BLOCK_SIZE_K is `tl.constexpr` → i32 dense splat (stride_ak == 1).
+            const bsk_i32: i32 = @intCast(cfg.block_size_k);
+            const new_a_ptrs = a_ptrs.addPtr(b.splat(bsk_i32, &.{ block_size_m, block_size_k }));
+            const new_b_ptrs = b_ptrs.addPtr(b.splat(bsk_i32, &.{ block_size_k, block_size_n }));
+
+            loop.yield(.{ new_a_ptrs, new_b_ptrs, new_acc });
+        }
+        var accumulator = loop.results[2];
+
+        if (cfg.mul_routed_weight) {
+            const tw_dtype = cfg.topk_weights_dtype orelse .f32;
+            const tw_other = b.zeros(&.{block_size_m}, tw_dtype);
+            const tw = b.loadOpts(a.topk_weights_ptr.addPtr(offs_token), .{ .mask = token_mask, .other = tw_other });
+            accumulator = accumulator.mul(tw.expandDims(1));
+        }
+
+        accumulator = accumulator.to(compute_type);
+
+        // c_ptrs: two addptrs to match Python's `c_ptr + cm[:, None] + cn[None, :]`
+        // left-to-right eval. `stride_cm * offs_token[:, None]` puts the splatted
+        // stride on the LHS of arith.muli (Python source order).
+        const offs_cn = pid_n_block_n.add(b.arange(0, block_size_n, .i64));
+        const offs_token_col_c = b.expandDims(offs_token, 1);
+        const cm_col = stride_cm_block.mul(offs_token_col_c);
+        const c_ptrs_col = b.splat(a.c_ptr, &.{ block_size_m, 1 }).addPtr(cm_col);
+        const offs_cn_row = b.expandDims(offs_cn, 0);
+        const c_ptrs_2d = b.broadcastTo(c_ptrs_col, &.{ block_size_m, block_size_n });
+        const c_ptrs = c_ptrs_2d.addPtr(b.broadcastTo(offs_cn_row, &.{ block_size_m, block_size_n }));
+
+        // c_mask = token_mask[:, None] & (offs_cn[None, :] < n_block).
+        const token_mask_col_c = b.expandDims(token_mask, 1);
+        const offs_cn_lt_2d = offs_cn_row.lt(b.splat(n_block, &.{ 1, block_size_n }));
+        const token_mask_full_c = b.broadcastTo(token_mask_col_c, &.{ block_size_m, block_size_n });
+        const offs_cn_lt_full = b.broadcastTo(offs_cn_lt_2d, &.{ block_size_m, block_size_n });
+        b.storeOpts(c_ptrs, accumulator, .{ .mask = token_mask_full_c.bitAnd(offs_cn_lt_full) });
+    }
+};
+
+pub const MoeAlignBlockSize = struct {
+    pub const Cfg = struct {
+        numel: usize,
+        num_experts: usize,
+        padded_num_experts: usize,
+        max_num_tokens_padded: usize,
+        max_num_m_blocks: usize,
+        block_size_m: usize,
+        hist_block: usize,
+    };
+    pub const Kernel = tri.Kernel(Cfg, .{
+        .name = "moe_align_block_size_kernel",
+        .inputs = &.{ "topk_ids_ptr", "sorted_token_ids_ptr", "expert_ids_ptr", "num_tokens_post_pad_ptr", "cumsum_ptr" },
+        .outputs = &.{ "sorted_token_ids", "expert_ids", "num_tokens_post_pad", "cumsum" },
+        .run = run,
+    });
+    fn run(b: *Builder, cfg: Cfg) tri.FinishError!void {
+        const a = try b.declareArgs(.{
+            .topk_ids_ptr = .{ .ptr = .i32 },
+            .sorted_token_ids_ptr = .{ .ptr = .i32 },
+            .expert_ids_ptr = .{ .ptr = .i32 },
+            .num_tokens_post_pad_ptr = .{ .ptr = .i32 },
+            .cumsum_ptr = .{ .ptr = .i32 },
+            .out0_ptr = .{ .ptr = .i32 },
+            .out1_ptr = .{ .ptr = .i32 },
+            .out2_ptr = .{ .ptr = .i32 },
+            .out3_ptr = .{ .ptr = .i32 },
+        });
+
+        const block_size_m: i32 = @intCast(cfg.block_size_m);
+        const numel: i32 = @intCast(cfg.numel);
+        const num_experts: i32 = @intCast(cfg.num_experts);
+        const padded_num_experts: i64 = @intCast(cfg.padded_num_experts);
+        const max_num_tokens_padded: i32 = @intCast(cfg.max_num_tokens_padded);
+        const max_num_m_blocks: i64 = @intCast(cfg.max_num_m_blocks);
+        const hist_block: i64 = @intCast(cfg.hist_block);
+
+        const pid = b.programId(.x);
+        const fill_offs = b.arange(0, hist_block, .i32);
+
+        // if pid == 1: fill sorted_token_ids with NUMEL; return
+        var fill_branch = b.openReturnIf(pid.eq(1));
+        {
+            var fill_loop = b.openFor(0, max_num_tokens_padded, hist_block, .{});
+            {
+                const offs = fill_loop.iv.add(fill_offs);
+                const mask = offs.lt(max_num_tokens_padded);
+                b.storeOpts(
+                    a.sorted_token_ids_ptr.addPtr(offs),
+                    b.splat(numel, &.{hist_block}),
+                    .{ .mask = mask },
+                );
+                fill_loop.yield(.{});
+            }
+            fill_branch.yieldReturn(.{});
+        }
+
+        // pid != 1: histogram + cumsum + block assignment.
+        const expert_offs = b.arange(0, padded_num_experts, .i32);
+        const token_offs = b.arange(0, hist_block, .i32);
+        const expert_mask = expert_offs.lt(num_experts);
+        const counts_init = b.zeros(&.{padded_num_experts}, .i32);
+
+        var hist_loop = b.openFor(0, numel, hist_block, .{counts_init});
+        {
+            const offs = hist_loop.iv.add(token_offs);
+            const mask = offs.lt(numel);
+            const expert_vals = b.loadOpts(a.topk_ids_ptr.addPtr(offs), .{
+                .mask = mask,
+                .other = b.splat(num_experts, &.{hist_block}),
+            });
+            const valid = mask.bitAnd(expert_vals.lt(num_experts));
+            const h = b.histogramOpts(expert_vals, padded_num_experts, .{ .mask = valid });
+            hist_loop.yield(.{hist_loop.carried[0].add(h)});
+        }
+        const counts = hist_loop.results[0];
+
+        // padded_counts = where(expert_mask, cdiv(counts, BLOCK_SIZE_M) * BLOCK_SIZE_M, 0)
+        const padded_counts = b.select(
+            expert_mask,
+            counts.cdiv(block_size_m).mul(block_size_m),
+            b.zeros(&.{padded_num_experts}, .i32),
+        );
+        const padded_cumsum = b.cumsumOpts(padded_counts, .{ .axis = 0 });
+        const starts = padded_cumsum.sub(padded_counts);
+        const total_tokens_post_pad = b.sumOpts(padded_counts, .{ .axis = 0 });
+
+        b.storeOpts(a.cumsum_ptr.addPtr(expert_offs), starts, .{ .mask = expert_mask });
+        b.store(a.cumsum_ptr.addPtr(num_experts), total_tokens_post_pad);
+        b.store(a.num_tokens_post_pad_ptr, total_tokens_post_pad);
+
+        const block_offs = b.arange(0, hist_block, .i32);
+        var assign_loop = b.openFor(0, max_num_m_blocks, hist_block, .{});
+        {
+            const block_ids = assign_loop.iv.add(block_offs);
+            const block_mask = block_ids.lt(@as(i32, @intCast(max_num_m_blocks)));
+            const block_offsets = block_ids.mul(block_size_m);
+            const block_expert_init = b.full(&.{hist_block}, -1, .i32);
+
+            var exp_loop = b.openFor(0, num_experts, 1, .{block_expert_init});
+            {
+                const e_iv = exp_loop.iv;
+                const start_v = b.load(a.cumsum_ptr.addPtr(e_iv));
+                const end_v = b.load(a.cumsum_ptr.addPtr(e_iv.add(1)));
+                const in_range = block_mask
+                    .bitAnd(block_offsets.ge(start_v))
+                    .bitAnd(block_offsets.lt(end_v));
+                exp_loop.yield(.{
+                    b.select(in_range, e_iv.splatTo(&.{hist_block}), exp_loop.carried[0]),
+                });
+            }
+            b.storeOpts(
+                a.expert_ids_ptr.addPtr(block_ids),
+                exp_loop.results[0],
+                .{ .mask = block_mask },
+            );
+            assign_loop.yield(.{});
+        }
+    }
+};
+
+pub const CountAndSortExpertTokens = struct {
+    pub const Cfg = struct {
+        numel: usize,
+        num_experts: usize,
+        sort_block_size: usize,
+    };
+    pub const Kernel = tri.Kernel(Cfg, .{
+        .name = "count_and_sort_expert_tokens_kernel",
+        .inputs = &.{ "topk_ids_ptr", "sorted_token_ids_ptr", "cumsum_ptr" },
+        .outputs = &.{ "sorted_token_ids", "cumsum" },
+        .run = run,
+    });
+    fn run(b: *Builder, cfg: Cfg) tri.FinishError!void {
+        const a = try b.declareArgs(.{
+            .topk_ids_ptr = .{ .ptr = .i32 },
+            .sorted_token_ids_ptr = .{ .ptr = .i32 },
+            .cumsum_ptr = .{ .ptr = .i32 },
+            .out0_ptr = .{ .ptr = .i32 },
+            .out1_ptr = .{ .ptr = .i32 },
+        });
+
+        const block: i64 = @intCast(cfg.sort_block_size);
+        const numel: i32 = @intCast(cfg.numel);
+        const num_experts: i32 = @intCast(cfg.num_experts);
+        const block_i32: i32 = @intCast(block);
+
+        const pid = b.programId(.x);
+        const num_progs = b.numPrograms(.x);
+        const token_offs = b.makeRange(0, block);
+
+        const token_start_init = pid.mul(block_i32);
+
+        // while token_start < NUMEL:
+        var w = b.openWhile(.{token_start_init}, .{b.scalarTy(.i32)});
+        {
+            const ts = w.before_carried[0];
+            w.yieldBefore(ts.lt(numel), .{ts});
+        }
+        {
+            const ts = w.after_carried[0];
+
+            // offs = ts + token_offs; mask = offs < NUMEL
+            const offs = ts.add(token_offs);
+            const mask = offs.lt(numel);
+
+            // expert_vals = load(topk_ids + offs, mask=mask, other=NUM_EXPERTS)
+            const topk_ptrs = a.topk_ids_ptr.addPtr(offs);
+            const expert_vals = b.loadOpts(topk_ptrs, .{
+                .mask = mask,
+                .other = b.splat(num_experts, &.{block}),
+            });
+            const valid = mask.bitAnd(expert_vals.lt(num_experts));
+
+            // rank = atomic_add(cumsum + expert_vals, 1, mask=valid, sem="relaxed")
+            const cumsum_ptrs = a.cumsum_ptr.addPtr(expert_vals);
+            const rank = b.atomicRmwOpts(.add, cumsum_ptrs, b.ones(&.{block}, .i32), .{
+                .mask = valid,
+                .sem = .relaxed,
+                .scope = .gpu,
+            });
+
+            // store(sorted_token_ids + rank, offs, mask=valid)
+            const sorted_ptrs = a.sorted_token_ids_ptr.addPtr(rank);
+            b.storeOpts(sorted_ptrs, offs, .{ .mask = valid });
+
+            // token_start += num_programs * BLOCK_SIZE
+            // Compute step INSIDE the loop body (Python's source position).
+            // It's loop-invariant, so XLA's LICM hoists it out — the hoisted
+            // op-order then matches Python's IR (splats before step).
+            const step = num_progs.mul(block_i32);
+            w.yieldAfter(.{ts.add(step)});
+        }
+    }
+};

--- a/zml/zml.zig
+++ b/zml/zml.zig
@@ -30,6 +30,7 @@ pub const meta = @import("meta.zig");
 pub const mlir = @import("mlirx.zig");
 pub const module = @import("module.zig");
 pub const CompilationOptions = module.CompilationOptions;
+pub const moe = @import("moe/moe.zig");
 pub const nn = @import("nn.zig");
 pub const ops = @import("ops.zig");
 pub const pjrtx = @import("pjrtx.zig");


### PR DESCRIPTION
### Overview
Context: Modern models utilize a MLP called Mixture of Experts (MoE). In a MoE, the MLP is organized into "experts," where specific sub-tensors are specialized to process particular linguistic patterns or elements. During inference, the hidden states of each token are routed to the most relevant experts, ensuring that matrix multiplications (matmul) are performed only on the active parameters.

Problem: Due to the sparse and dynamic nature of MoE where token assignment is determined at runtime via routing, treating an MoE layer as a standard matmul results in significant performance degradation. Standard kernels are not optimized for the irregular memory access patterns in sparse routing.

Approach: MoE is implemented as a primitive in the ZML operation set. The generic MoE Backend is designed to support various specialized kernels tailored to specific hardware and weight precisions. The primary implementation currently features a Triton MoE backend optimized for NVIDIA Hopper architecture using BF16 and FP8 weights. This implementation is utilized in the Qwen 3.5 MoE model.

### Features
**Generic MoE Backend (zml/moe/moe.zig)**
- Integrate specialized MoE backends (e.g., Triton).
- Select the optimal backend based on hardware and precision.
- Implements essential utilities and structures for registration, parameter loading, and metadata management.
- The forwardMoe() function acts as the entry point to invoke the appropriate backend.

**Triton MoE Backend (zml/moe/triton.zig)**
- Generates TTIR (Triton Intermediate Representation) at compile time.
- Leverages Triton's custom calls exposed via XLA.
Execution Flow:
1. Select the optimal configuration for the fused MoE kernel.
2. Determine token distribution: use naive assignment if the distribution is sparse; otherwise, sort and align tokens for efficiency.
3. Quantization: quantize activations if using FP8 weights.
4. Fused Kernel: execute the fused MoE kernel for the gate and up-projection layers.
5. Post-Processing: split the output and apply the activation function.
6. Quantization : re-quantize activations for the next stage if required by the FP8 path.
7. Fused Kernel: execute the fused MoE kernel for the down-projection layer.
8. Aggregation: sum the Top-K results for each token.

Qwen 3.5 MoE
- Fully utilizes the Triton MoE backend.
- BF16 weights implementation (also tested with FP8 but not implemented here)