### PR TITLE
workspace: use latest version of upstreamable rules_zig

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -78,6 +78,8 @@ common          --@rules_zig//zig/settings:use_cc_common_link=true
 # Zig self hosted backend is too fragile for now
 common          --@rules_zig//zig/settings:zigopt=-fllvm
 
+common          --@rules_zig//zig/settings:use_standalone_translate_c=True
+
 common          --@llvm//config:experimental_stub_libgcc_s=true
 
 common          --macos_minimum_os=13.0

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,8 +1,26 @@
 load("//third_party/zls:zls_completion.bzl", "zls_completion")
+load("@rules_zig//zig/translate-c:toolchain.bzl", "translate_c_toolchain")
 
 alias(
     name = "translate-c",
     actual = "@translate-c//:translate-c",
+    visibility = ["//visibility:public"],
+)
+
+translate_c_toolchain(
+    name = "translate_c_toolchain_impl",
+    runtime_modules = [
+        "@translate-c//:c_builtins",
+        "@translate-c//:helpers",
+    ],
+    translate_c = "@translate-c//:translate-c",
+)
+
+toolchain(
+    name = "translate_c_toolchain",
+    target_settings = ["@rules_zig//zig/config/use_standalone_translate_c:enabled"],
+    toolchain = ":translate_c_toolchain_impl",
+    toolchain_type = "@rules_zig//zig/translate-c:toolchain_type",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,7 +30,7 @@ bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "rules_zig", version = "0.12.2")
 git_override(
     module_name = "rules_zig",
-    commit = "b65a2bb460b9dbcbcc3231ba648c3c1a266c4eb5",
+    commit = "6e9d876037ecb01ce4354c9c9e0c93e026e84e37", # upstreamable-20260515.1
     remote = "https://github.com/zml/rules_zig.git",
 )
 
@@ -65,7 +65,6 @@ use_repo(
 zig = use_extension("@rules_zig//zig:extensions.bzl", "zig")
 zig.index(file = "//bazel:zig_index.json")
 zig.toolchain(
-    translate_c = "@translate-c",
     zig_version = "0.16.0",
 )
 zig.mirrors(urls = [
@@ -89,6 +88,7 @@ use_repo(zig, "zig_toolchains")
 register_toolchains("@rules_zig//zig/target:all")
 
 register_toolchains("@zig_toolchains//:all")
+register_toolchains("//:translate_c_toolchain")
 ###
 
 ### LLVM Bootstrapped toolchains

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -22,12 +22,12 @@
     "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
     "https://bcr.bazel.build/modules/apple_support/1.17.1/MODULE.bazel": "655c922ab1209978a94ef6ca7d9d43e940cd97d9c172fb55f94d91ac53f8610b",
     "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
-    "https://bcr.bazel.build/modules/apple_support/2.2.0/MODULE.bazel": "5e32bc42e413a4544df7afee7fa4c7aff73e670a44e56e8e45ce1954332034ad",
-    "https://bcr.bazel.build/modules/apple_support/2.2.0/source.json": "368bf1de5dace2a411e792e6df2ea5384eb8db3899680ed51b37eb48b88fd8ac",
+    "https://bcr.bazel.build/modules/apple_support/2.5.4/MODULE.bazel": "964e9268b37edb64e9a0fa525e5b5e535ba56bf63cadc68375f92e69fcb734f6",
+    "https://bcr.bazel.build/modules/apple_support/2.5.4/source.json": "df85e46410ff71c4006a13dbdeeeee488feba563be78f3a9ed8497c1fb93fb5d",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.14.0/MODULE.bazel": "2b31ffcc9bdc8295b2167e07a757dbbc9ac8906e7028e5170a3708cecaac119f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.19.3/MODULE.bazel": "253d739ba126f62a5767d832765b12b59e9f8d2bc88cc1572f4a73e46eb298ca",
-    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.21.2/MODULE.bazel": "276347663a25b0d5bd6cad869252bea3e160c4d980e764b15f3bae7f80b30624",
-    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.21.2/source.json": "f42051fa42629f0e59b7ac2adf0a55749144b11f1efcd8c697f0ee247181e526",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.22.5/MODULE.bazel": "004ba890363d05372a97248c37205ae64b6fa31047629cd2c0895a9d0c7779e8",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.22.5/source.json": "ac2c3213df8f985785f1d0aeb7f0f73d5324e6e67d593d9b9470fb74a25d4a9b",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.7.2/MODULE.bazel": "780d1a6522b28f5edb7ea09630748720721dfe27690d65a2d33aa7509de77e07",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.8.1/MODULE.bazel": "812d2dd42f65dca362152101fbec418029cc8fd34cbad1a2fde905383d705838",
     "https://bcr.bazel.build/modules/aspect_rules_py/1.8.4/MODULE.bazel": "4ab4a78e9d65cf15e755807f7ae504655e1771cefd7c3343ad34dbbb625b9564",
@@ -179,7 +179,8 @@
     "https://bcr.bazel.build/modules/opentracing-cpp/1.6.0/MODULE.bazel": "b3925269f63561b8b880ae7cf62ccf81f6ece55b62cd791eda9925147ae116ec",
     "https://bcr.bazel.build/modules/opentracing-cpp/1.6.0/source.json": "da1cb1add160f5e5074b7272e9db6fd8f1b3336c15032cd0a653af9d2f484aed",
     "https://bcr.bazel.build/modules/package_metadata/0.0.2/MODULE.bazel": "fb8d25550742674d63d7b250063d4580ca530499f045d70748b1b142081ebb92",
-    "https://bcr.bazel.build/modules/package_metadata/0.0.2/source.json": "e53a759a72488d2c0576f57491ef2da0cf4aab05ac0997314012495935531b73",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.3/MODULE.bazel": "77890552ecea9e284b5424c9de827a58099348763a4359e975c359a83d4faa83",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.3/source.json": "742075a428ad12a3fa18a69014c2f57f01af910c6d9d18646c990200853e641a",
     "https://bcr.bazel.build/modules/patchelf/0.18.0.bcr.1/MODULE.bazel": "35320668481400503dea7c75313473b9ffd6dea4e7ba583b96a896199b0088d5",
     "https://bcr.bazel.build/modules/patchelf/0.18.0.bcr.1/source.json": "d877d271ef5d531407885322054c99c7f0617a9a85ff99c0a70f4ced7f13e13a",
     "https://bcr.bazel.build/modules/pcre2/10.45/MODULE.bazel": "9bdc838aa2e21be030d7181385e45a5c87b14575bb7ff35d10b5be3d56913bed",
@@ -193,7 +194,8 @@
     "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
     "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
     "https://bcr.bazel.build/modules/platforms/1.0.0/MODULE.bazel": "f05feb42b48f1b3c225e4ccf351f367be0371411a803198ec34a389fb22aa580",
-    "https://bcr.bazel.build/modules/platforms/1.0.0/source.json": "f4ff1fd412e0246fd38c82328eb209130ead81d62dcd5a9e40910f867f733d96",
+    "https://bcr.bazel.build/modules/platforms/1.1.0/MODULE.bazel": "1c0c09f5bdcf4b3f924720d2478a3711cb39f4977019ca5988685e5b7e18b3d2",
+    "https://bcr.bazel.build/modules/platforms/1.1.0/source.json": "fcf351c47596c939140ab0d333dfdd08ed1ea6ce33c2fe70c12493a301cf1344",
     "https://bcr.bazel.build/modules/prometheus-cpp/1.2.4/MODULE.bazel": "0fbe5dcff66311947a3f6b86ebc6a6d9328e31a28413ca864debc4a043f371e5",
     "https://bcr.bazel.build/modules/prometheus-cpp/1.3.0.bcr.1/MODULE.bazel": "116ad46e97c1d2aeb020fe2899a342a7e703574ce7c0faf7e4810f938c974a9a",
     "https://bcr.bazel.build/modules/prometheus-cpp/1.3.0.bcr.1/source.json": "e813cce2d450708cfcb26e309c5172583a7440776edf354e83e6788c768e5cca",
@@ -1135,7 +1137,7 @@
     },
     "@@rules_oci+//oci:extensions.bzl%oci": {
       "general": {
-        "bzlTransitiveDigest": "rM01g4kd1EG6Z+4iqFqd+ZkaNCU9oVCGJf+Kg9jgr5k=",
+        "bzlTransitiveDigest": "7oR14uSSRXhIDozspnn5ya0JWJlnqcG+JmT5yO1BsLw=",
         "usagesDigest": "JLbamplho20rviuebatMGqnQnaoj32ewCzLuRVusGoU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1760,11 +1762,11 @@
     },
     "@@rules_zig+//zig:extensions.bzl%zig": {
       "general": {
-        "bzlTransitiveDigest": "xx2lb1ba6RcnnXdfUyaxI5j2wFLM03GTQfTv2UUie3Q=",
-        "usagesDigest": "3YLtfwSfkXudL3+Coim7hrTFktQHln4CiUbszoYuRzE=",
+        "bzlTransitiveDigest": "mBSDTk+QEb2UlXBSWQWCw8A/tUSarS8PCSbhFYCkotc=",
+        "usagesDigest": "TA6Tzd8UNrxyL67PtNy0LKhpR1wAStj+mb2UDC/QiyI=",
         "recordedFileInputs": {
           "@@//bazel/zig_index.json": "2e3b4b83f1add5d3ca12fd05797c04c38af21d86c7fc7c1a9b356560141a4797",
-          "@@rules_zig+//zig/private/versions.json": "6eb85ebaee72c4e6fbc82d8ad73f69e0899d839b70a7e19caa792ab6a5fa0c36"
+          "@@rules_zig+//zig/private/versions.json": "3e4e370dee9c3f3fdc8bfc7a600e76743278fde40815eead5d0bcda3aec3e2bd"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1787,12 +1789,24 @@
                 "https://zig.karearl.com/zig",
                 "https://pkg.earth/zig",
                 "https://fs.liujiacai.net/zigbuilds",
-                "https://ziglang.org/builds/"
+                "https://ziglang.org/builds/",
+                "https://pkg.machengine.org/zig",
+                "https://zigmirror.hryx.net/zig",
+                "https://zig.linus.dev/zig",
+                "https://zig.squirl.dev",
+                "https://zig.florent.dev",
+                "https://zig.mirror.mschae23.de/zig",
+                "https://zigmirror.meox.dev",
+                "https://ziglang.freetls.fastly.net",
+                "https://zig.tilok.dev",
+                "https://zig-mirror.tsimnet.eu/zig",
+                "https://zig.karearl.com/zig",
+                "https://pkg.earth/zig",
+                "https://fs.liujiacai.net/zigbuilds"
               ],
               "sha256": "ea4b09bfb22ec6f6c6ceac57ab63efb6b46e17ab08d21f69f3a48b38e1534f17",
               "zig_version": "0.16.0",
-              "platform": "aarch64-linux",
-              "translate_c": "@@+non_module_deps+translate-c//:translate-c"
+              "platform": "aarch64-linux"
             }
           },
           "zig_0.16.0_aarch64-macos": {
@@ -1813,12 +1827,24 @@
                 "https://zig.karearl.com/zig",
                 "https://pkg.earth/zig",
                 "https://fs.liujiacai.net/zigbuilds",
-                "https://ziglang.org/builds/"
+                "https://ziglang.org/builds/",
+                "https://pkg.machengine.org/zig",
+                "https://zigmirror.hryx.net/zig",
+                "https://zig.linus.dev/zig",
+                "https://zig.squirl.dev",
+                "https://zig.florent.dev",
+                "https://zig.mirror.mschae23.de/zig",
+                "https://zigmirror.meox.dev",
+                "https://ziglang.freetls.fastly.net",
+                "https://zig.tilok.dev",
+                "https://zig-mirror.tsimnet.eu/zig",
+                "https://zig.karearl.com/zig",
+                "https://pkg.earth/zig",
+                "https://fs.liujiacai.net/zigbuilds"
               ],
               "sha256": "b23d70deaa879b5c2d486ed3316f7eaa53e84acf6fc9cc747de152450d401489",
               "zig_version": "0.16.0",
-              "platform": "aarch64-macos",
-              "translate_c": "@@+non_module_deps+translate-c//:translate-c"
+              "platform": "aarch64-macos"
             }
           },
           "zig_0.16.0_aarch64-windows": {
@@ -1839,12 +1865,24 @@
                 "https://zig.karearl.com/zig",
                 "https://pkg.earth/zig",
                 "https://fs.liujiacai.net/zigbuilds",
-                "https://ziglang.org/builds/"
+                "https://ziglang.org/builds/",
+                "https://pkg.machengine.org/zig",
+                "https://zigmirror.hryx.net/zig",
+                "https://zig.linus.dev/zig",
+                "https://zig.squirl.dev",
+                "https://zig.florent.dev",
+                "https://zig.mirror.mschae23.de/zig",
+                "https://zigmirror.meox.dev",
+                "https://ziglang.freetls.fastly.net",
+                "https://zig.tilok.dev",
+                "https://zig-mirror.tsimnet.eu/zig",
+                "https://zig.karearl.com/zig",
+                "https://pkg.earth/zig",
+                "https://fs.liujiacai.net/zigbuilds"
               ],
               "sha256": "aee38316ee4111717900f45dd3130145c39289e105541d737eb8c5ed653c78ef",
               "zig_version": "0.16.0",
-              "platform": "aarch64-windows",
-              "translate_c": "@@+non_module_deps+translate-c//:translate-c"
+              "platform": "aarch64-windows"
             }
           },
           "zig_0.16.0_x86_64-linux": {
@@ -1865,12 +1903,24 @@
                 "https://zig.karearl.com/zig",
                 "https://pkg.earth/zig",
                 "https://fs.liujiacai.net/zigbuilds",
-                "https://ziglang.org/builds/"
+                "https://ziglang.org/builds/",
+                "https://pkg.machengine.org/zig",
+                "https://zigmirror.hryx.net/zig",
+                "https://zig.linus.dev/zig",
+                "https://zig.squirl.dev",
+                "https://zig.florent.dev",
+                "https://zig.mirror.mschae23.de/zig",
+                "https://zigmirror.meox.dev",
+                "https://ziglang.freetls.fastly.net",
+                "https://zig.tilok.dev",
+                "https://zig-mirror.tsimnet.eu/zig",
+                "https://zig.karearl.com/zig",
+                "https://pkg.earth/zig",
+                "https://fs.liujiacai.net/zigbuilds"
               ],
               "sha256": "70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00",
               "zig_version": "0.16.0",
-              "platform": "x86_64-linux",
-              "translate_c": "@@+non_module_deps+translate-c//:translate-c"
+              "platform": "x86_64-linux"
             }
           },
           "zig_0.16.0_x86_64-macos": {
@@ -1891,12 +1941,24 @@
                 "https://zig.karearl.com/zig",
                 "https://pkg.earth/zig",
                 "https://fs.liujiacai.net/zigbuilds",
-                "https://ziglang.org/builds/"
+                "https://ziglang.org/builds/",
+                "https://pkg.machengine.org/zig",
+                "https://zigmirror.hryx.net/zig",
+                "https://zig.linus.dev/zig",
+                "https://zig.squirl.dev",
+                "https://zig.florent.dev",
+                "https://zig.mirror.mschae23.de/zig",
+                "https://zigmirror.meox.dev",
+                "https://ziglang.freetls.fastly.net",
+                "https://zig.tilok.dev",
+                "https://zig-mirror.tsimnet.eu/zig",
+                "https://zig.karearl.com/zig",
+                "https://pkg.earth/zig",
+                "https://fs.liujiacai.net/zigbuilds"
               ],
               "sha256": "0387557ed1877bc6a2e1802c8391953baddba76081876301c522f52977b52ba7",
               "zig_version": "0.16.0",
-              "platform": "x86_64-macos",
-              "translate_c": "@@+non_module_deps+translate-c//:translate-c"
+              "platform": "x86_64-macos"
             }
           },
           "zig_0.16.0_x86_64-windows": {
@@ -1917,12 +1979,24 @@
                 "https://zig.karearl.com/zig",
                 "https://pkg.earth/zig",
                 "https://fs.liujiacai.net/zigbuilds",
-                "https://ziglang.org/builds/"
+                "https://ziglang.org/builds/",
+                "https://pkg.machengine.org/zig",
+                "https://zigmirror.hryx.net/zig",
+                "https://zig.linus.dev/zig",
+                "https://zig.squirl.dev",
+                "https://zig.florent.dev",
+                "https://zig.mirror.mschae23.de/zig",
+                "https://zigmirror.meox.dev",
+                "https://ziglang.freetls.fastly.net",
+                "https://zig.tilok.dev",
+                "https://zig-mirror.tsimnet.eu/zig",
+                "https://zig.karearl.com/zig",
+                "https://pkg.earth/zig",
+                "https://fs.liujiacai.net/zigbuilds"
               ],
               "sha256": "68659eb5f1e4eb1437a722f1dd889c5a322c9954607f5edcf337bc3684a75a7e",
               "zig_version": "0.16.0",
-              "platform": "x86_64-windows",
-              "translate_c": "@@+non_module_deps+translate-c//:translate-c"
+              "platform": "x86_64-windows"
             }
           },
           "zig_toolchains": {
@@ -1978,11 +2052,6 @@
           }
         },
         "recordedRepoMappingEntries": [
-          [
-            "",
-            "translate-c",
-            "+non_module_deps+translate-c"
-          ],
           [
             "rules_zig+",
             "bazel_skylib",

--- a/third_party/arocc/repo.bzl
+++ b/third_party/arocc/repo.bzl
@@ -5,5 +5,5 @@ def repo():
         name = "arocc",
         remote = "https://github.com/Vexu/arocc.git",
         commit = "5f5a050569a95ecc40a426f0c3666ae7ef987ede",
-        build_file = "//third_party/arocc:arocc.bazel",
+        build_file = Label("//third_party/arocc:arocc.bazel"),
     )

--- a/third_party/translate-c/repo.bzl
+++ b/third_party/translate-c/repo.bzl
@@ -5,5 +5,5 @@ def repo():
         name = "translate-c",
         remote = "https://codeberg.org/ziglang/translate-c",
         commit = "46b5609b5ac4c0a896217d1d984f3ae50e4810b5",
-        build_file = "//third_party/translate-c:translate-c.bazel",
+        build_file = Label("//third_party/translate-c:translate-c.bazel"),
     )

--- a/third_party/translate-c/translate-c.bazel
+++ b/third_party/translate-c/translate-c.bazel
@@ -1,17 +1,19 @@
-load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_library")
+load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_configure_binary", "zig_library")
 
 zig_library(
     name = "c_builtins",
     main = "lib/c_builtins.zig",
+    visibility = ["//visibility:public"],
 )
 
 zig_library(
     name = "helpers",
     main = "lib/helpers.zig",
+    visibility = ["//visibility:public"],
 )
 
 zig_binary(
-    name = "translate-c",
+    name = "translate-c_raw",
     data = glob(["lib/**/*.zig"]),
     srcs = glob(["src/**/*.zig"]),
     main = "src/main.zig",
@@ -21,5 +23,18 @@ zig_binary(
         ":helpers",
         "@arocc//:aro",
     ],
+    visibility = ["//visibility:public"],
+)
+
+# TODO(cerisier): Generate 1 translate-c toolchain per target platform
+# So that the choice of doing this for a given platform is given to users.
+#
+# Right now we do this because the arocc source code has the same support
+# for platforms than the official zig compiler and in the case of using a
+# custom zig version with support for newer chips, arocc cannot be built.
+zig_configure_binary(
+    name = "translate-c",
+    actual = ":translate-c_raw",
+    bootstrapped = 0,
     visibility = ["//visibility:public"],
 )

--- a/third_party/uucode/config-storage-module.patch
+++ b/third_party/uucode/config-storage-module.patch
@@ -1,0 +1,33 @@
+diff --git a/src/config.zig b/src/config.zig
+index 2cadab4..aa46c5d 100644
+--- a/src/config.zig
++++ b/src/config.zig
+@@ -1,5 +1,5 @@
+ const std = @import("std");
+-const storage = @import("storage.zig");
++pub const storage = @import("storage.zig");
+ const multi_slice = @import("multi_slice.zig");
+ pub const quirks = @import("quirks.zig");
+ pub const components = @import("components.zig");
+diff --git a/src/generate.zig b/src/generate.zig
+index 6f4dcf5..8ef1d83 100644
+--- a/src/generate.zig
++++ b/src/generate.zig
+@@ -1,7 +1,7 @@
+ const std = @import("std");
+-const storage = @import("storage.zig");
+ const config = @import("config.zig");
+ const build_config = @import("build_config");
++const storage = config.storage;
+ const inlineAssert = config.quirks.inlineAssert;
+ 
+ pub const std_options: std.Options = .{
+@@ -339,7 +339,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
+         \\const std = @import("std");
+         \\const config = @import("config.zig");
+         \\const types = config.types;
+-        \\const storage = @import("storage.zig");
++        \\const storage = config.storage;
+         \\const build_config = @import("build_config");
+         \\
+         \\pub const get_components = build_config.get_components;

--- a/third_party/uucode/repo.bzl
+++ b/third_party/uucode/repo.bzl
@@ -3,6 +3,7 @@ def _uucode_repo_impl(ctx):
         url = "https://github.com/jacobsandlund/uucode/archive/{}.tar.gz".format(ctx.attr.commit),
         stripPrefix = "uucode-{}".format(ctx.attr.commit),
     )
+    ctx.patch(ctx.attr.config_storage_patch, strip = 1)
 
     ctx.symlink(ctx.attr.build_config, "build_config.zig")
     ctx.symlink(ctx.attr.build_file, "BUILD.bazel")
@@ -13,6 +14,7 @@ _uucode_repo = repository_rule(
         "commit": attr.string(mandatory = True),
         "build_config": attr.label(mandatory = True, allow_single_file = True),
         "build_file": attr.label(mandatory = True, allow_single_file = True),
+        "config_storage_patch": attr.label(mandatory = True, allow_single_file = True),
     },
 )
 
@@ -22,4 +24,5 @@ def repo():
         commit = "f1c687f09174f9f11eda14d3e3ce497d68ab09a6",
         build_config = "//third_party/uucode:build_config.zig",
         build_file = "//third_party/uucode:uucode.bazel",
+        config_storage_patch = "//third_party/uucode:config-storage-module.patch",
     )

--- a/third_party/uucode/uucode.bazel
+++ b/third_party/uucode/uucode.bazel
@@ -11,29 +11,22 @@ zig_library(
         "src/fields.zig",
         "src/multi_slice.zig",
         "src/quirks.zig",
+        "src/storage.zig",
         "src/types.zig",
     ],
-    zigopts = ["--dep", "storage.zig=_storage_gen"],  # circular: config.zig <-> storage.zig
-)
-
-zig_library(
-    name = "_storage_gen",
-    import_name = "storage.zig",
-    main = "src/storage.zig",
-    deps = [":_config_gen"],
 )
 
 zig_library(
     name = "_build_config_gen",
     import_name = "build_config",
     main = "build_config.zig",
-    deps = [":_config_gen", ":_storage_gen"],
+    deps = [":_config_gen"],
 )
 
 zig_binary(
     name = "gen_tables",
     main = "src/generate.zig",
-    deps = [":_build_config_gen", ":_config_gen", ":_storage_gen"],
+    deps = [":_build_config_gen", ":_config_gen"],
 )
 
 genrule(
@@ -61,30 +54,23 @@ zig_library(
         "src/fields.zig",
         "src/multi_slice.zig",
         "src/quirks.zig",
+        "src/storage.zig",
     ],
     deps = [":types"],
-    zigopts = ["--dep", "storage.zig=storage"],  # circular: config.zig <-> storage.zig
-)
-
-zig_library(
-    name = "storage",
-    import_name = "storage.zig",
-    main = "src/storage.zig",
-    deps = [":config"],
 )
 
 zig_library(
     name = "build_config",
     import_name = "build_config",
     main = "build_config.zig",
-    deps = [":config", ":storage"],
+    deps = [":config"],
 )
 
 zig_library(
     name = "tables_lib",
     import_name = "tables",
     main = ":tables",
-    deps = [":build_config", ":config", ":storage"],
+    deps = [":build_config", ":config"],
 )
 
 zig_library(

--- a/third_party/zls/zls_write_runner_zig_src.bzl
+++ b/third_party/zls/zls_write_runner_zig_src.bzl
@@ -2,17 +2,30 @@
 
 load("@bazel_lib//lib:paths.bzl", "to_rlocation_path")
 
+def zig_toolchain_executable_rpath(ctx, zigtoolchaininfo):
+    if zigtoolchaininfo.zig_exe.file != None:
+        return to_rlocation_path(ctx, zigtoolchaininfo.zig_exe.file)
+    return zigtoolchaininfo.zig_exe.path
+
+def zig_toolchain_lib_rpath(ctx, zigtoolchaininfo):
+    if zigtoolchaininfo.zig_lib.file != None:
+        return to_rlocation_path(ctx, zigtoolchaininfo.zig_lib.file)
+    return zigtoolchaininfo.zig_lib.path
+
 def _zls_write_runner_zig_src_impl(ctx):
     zigtoolchaininfo = ctx.toolchains["@rules_zig//zig:toolchain_type"].zigtoolchaininfo
     zlstoolchaininfo = ctx.toolchains["//third_party/zls:toolchain_type"].zlstoolchaininfo
+
+    zig_exe_rpath = zig_toolchain_executable_rpath(ctx, zigtoolchaininfo)
+    zig_lib_rpath = zig_toolchain_lib_rpath(ctx, zigtoolchaininfo)
 
     zls_runner = ctx.outputs.out
     ctx.actions.expand_template(
         output = zls_runner,
         template = ctx.file._runner_tpl,
         substitutions = {
-            "@@__ZIG_EXE_RPATH__@@": to_rlocation_path(ctx, zigtoolchaininfo.zig_exe),
-            "@@__ZIG_LIB_RPATH__@@": to_rlocation_path(ctx, zigtoolchaininfo.zig_lib),
+            "@@__ZIG_EXE_RPATH__@@": zig_exe_rpath,
+            "@@__ZIG_LIB_RPATH__@@": zig_lib_rpath,
             "@@__ZLS_BIN_RPATH__@@": to_rlocation_path(ctx, zlstoolchaininfo.bin),
             "@@__ZLS_BUILD_RUNNER_RPATH__@@": to_rlocation_path(ctx, ctx.file.build_runner),
             "@@__GLOBAL_CACHE_PATH__@@": zigtoolchaininfo.zig_cache,


### PR DESCRIPTION
The upstreamable branch now contains only 2 minor commits. Everything else inccluding test-obj, translatec and bootstrap have been upstreamed.