### PR TITLE
tensor/zml: fix SwiGLU

### DIFF
--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1353,7 +1353,7 @@ pub const Tensor = struct {
         var gate_path = self.dot(v, tag);
         gate_path = gate_path.add(c.broad(gate_path.shape()));
 
-        return value_path.mul(sigmoid_tensor).mul(gate_path);
+        return value_path.mul(sigmoid_tensor).outer(gate_path);
     }
 
     test swiglu {
@@ -1363,9 +1363,9 @@ pub const Tensor = struct {
         const input: Tensor = .init(.{ .d = 4 }, .f32);
         const beta = 3;
         const w: Tensor = .init(.{ .c = 3, .d = 4 }, .f32);
-        const v: Tensor = .init(.{ .c = 3, .d = 4 }, .f32);
+        const v: Tensor = .init(.{ .e = 3, .d = 4 }, .f32);
         const b: Tensor = .init(.{ .c = 3 }, .f32);
-        const c: Tensor = .init(.{ .c = 3 }, .f32);
+        const c: Tensor = .init(.{ .e = 3 }, .f32);
 
         var exe = try zml.module.compile(
             std.testing.allocator,

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1349,10 +1349,64 @@ pub const Tensor = struct {
         value_path = value_path.add(b.broad(value_path.shape()));
 
         const sigmoid_tensor = value_path.scale(beta).sigmoid();
-        var gate_path = self.dot(v, tag);
 
+        var gate_path = self.dot(v, tag);
         gate_path = gate_path.add(c.broad(gate_path.shape()));
-        return value_path.mul(sigmoid_tensor).outer(gate_path);
+
+        return value_path.mul(sigmoid_tensor).mul(gate_path);
+    }
+
+    test swiglu {
+        const zml = @import("zml.zig");
+        const platform = zml.testing.env();
+
+        const input: Tensor = .init(.{ .d = 4 }, .f32);
+        const beta = 3;
+        const w: Tensor = .init(.{ .c = 3, .d = 4 }, .f32);
+        const v: Tensor = .init(.{ .c = 3, .d = 4 }, .f32);
+        const b: Tensor = .init(.{ .c = 3 }, .f32);
+        const c: Tensor = .init(.{ .c = 3 }, .f32);
+
+        var exe = try zml.module.compile(
+            std.testing.allocator,
+            std.testing.io,
+            Tensor.swiglu,
+            .{ input, beta, w, v, b, c, Shape.toTag(.d) },
+            platform,
+            .{},
+        );
+        defer exe.deinit();
+
+        var input_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, input.shape(), .replicated, std.mem.sliceAsBytes(&[4]f32{ 1, 0, 1, 2 }));
+        defer input_buffer.deinit();
+
+        var w_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, w.shape(), .replicated, std.mem.sliceAsBytes(&[3][4]f32{
+            .{ 1, 0, 2, 0 },
+            .{ 2, 1, 3, 3 },
+            .{ 1, 1, 0, 0 },
+        }));
+        defer w_buffer.deinit();
+
+        var v_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, v.shape(), .replicated, std.mem.sliceAsBytes(&[3][4]f32{
+            .{ 0, 0, 2, 1 },
+            .{ 1, 2, 1, 3 },
+            .{ 0, 0, 2, 0 },
+        }));
+        defer v_buffer.deinit();
+
+        var b_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, b.shape(), .replicated, std.mem.sliceAsBytes(&[3]f32{ 1, 1, 1 }));
+        defer b_buffer.deinit();
+
+        var c_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, c.shape(), .replicated, std.mem.sliceAsBytes(&[3]f32{ 2, 2, 2 }));
+        defer c_buffer.deinit();
+
+        var res = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Tensor.swiglu, .{ input_buffer, w_buffer, v_buffer, b_buffer, c_buffer });
+        defer res.deinit();
+
+        const output_shape = Shape.init(.{ .c = 3 }, .f32);
+        const expectation: zml.Slice = .init(output_shape, std.mem.sliceAsBytes(&[3]f32{ 23.9998, 120.0, 7.9802 }));
+
+        try zml.testing.expectClose(std.testing.io, expectation, res, .{});
     }
 
     /// Returns a Tensor containing the Gaussian Error Linear Units (GeLU) activation function applied to each element of the input Tensor.

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1344,11 +1344,15 @@ pub const Tensor = struct {
     }
 
     /// Returns a Tensor containing the SwiGLU activation function applied to the input Tensor.
-    pub fn swiglu(self: Tensor, beta: f32, w: Tensor, b: Tensor, tag: Shape.Tag) Tensor {
-        const sigmoid_tensor = self.mul(Tensor.constant(DataType.Value.init(self.dtype(), beta)).broad(.init(self._shape, self.dtype()))).sigmoid();
-        const one_minus_sigmoid_tensor = Tensor.constant(.init(self.dtype(), 1)).broad(.init(self._shape, self.dtype())).sub(sigmoid_tensor);
+    pub fn swiglu(self: Tensor, beta: f32, w: Tensor, v: Tensor, b: Tensor, c: Tensor, tag: Shape.Tag) Tensor {
+        var value_path = self.dot(w, tag);
+        value_path = value_path.add(b.broad(value_path.shape()));
 
-        return self.mul(sigmoid_tensor).add(one_minus_sigmoid_tensor.mul(w.dot(self, tag).add(b)));
+        const sigmoid_tensor = value_path.scale(beta).sigmoid();
+        var gate_path = self.dot(v, tag);
+
+        gate_path = gate_path.add(c.broad(gate_path.shape()));
+        return value_path.mul(sigmoid_tensor).outer(gate_path);
     }
 
     /// Returns a Tensor containing the Gaussian Error Linear Units (GeLU) activation function applied to each element of the input Tensor.

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1403,8 +1403,12 @@ pub const Tensor = struct {
         var res = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Tensor.swiglu, .{ input_buffer, w_buffer, v_buffer, b_buffer, c_buffer });
         defer res.deinit();
 
-        const output_shape = Shape.init(.{ .c = 3 }, .f32);
-        const expectation: zml.Slice = .init(output_shape, std.mem.sliceAsBytes(&[3]f32{ 23.9998, 120.0, 7.9802 }));
+        const output_shape = Shape.init(.{ .c = 3, .e = 3 }, .f32);
+        const expectation: zml.Slice = .init(output_shape, std.mem.sliceAsBytes(&[3][3]f32{
+            .{ 23.999856, 39.99976, 15.999904 },
+            .{ 72.000000, 120.000000, 48.000000 },
+            .{ 11.970324, 19.950540, 7.980216 },
+        }));
 
         try zml.testing.expectClose(std.testing.io, expectation, res, .{});
     }


### PR DESCRIPTION
Update SwiGLU implementation to match the SwiGLU paper.

- Formula: `(xW + b) * sigmoid(β(xW + b)), elementwise product with (xV + c)`
- Add test for SwiGLU

TODO:
- Make less opinionated, so implementation can be model specific
- concatenate W and V to do only one matmul