### PR TITLE
zml/testing: resolve type of forward in testLayer()

### DIFF
--- a/zml/testing.zig
+++ b/zml/testing.zig
@@ -296,7 +296,7 @@ pub fn testLayer(
     defer arena.deinit();
 
     const forward = @field(@TypeOf(layer), @tagName(func));
-    const ArgsT = stdx.meta.Tail(stdx.meta.FnArgs(forward));
+    const ArgsT = stdx.meta.Tail(std.meta.ArgsTuple(@TypeOf(forward)));
 
     var args: ArgsT = undefined;
 


### PR DESCRIPTION
Key Changes:
- use Zig native std to resolve type of `forward` in testLayer()

---

Change made in response to the following error:

```
zml/testing.zig:299:43: error: root source file struct 'meta' has no member named 'FnArgs'
    const ArgsT = stdx.meta.Tail(stdx.meta.FnArgs(forward));
                                 ~~~~~~~~~^~~~~~~
stdx/meta.zig:1:1: note: struct declared here
```