### PR TITLE
kernels: extend Mosaic TPU + Triton kernel DSL

### DIFF
--- a/kernels/mosaic_tpu/BUILD.bazel
+++ b/kernels/mosaic_tpu/BUILD.bazel
@@ -5,6 +5,7 @@ zig_library(
     tags = ["manual"],
     srcs = [
         "dtype.zig",
+        "pipeline.zig",
     ],
     import_name = "kernels/mosaic_tpu/builder",
     main = "builder.zig",

--- a/kernels/mosaic_tpu/builder.zig
+++ b/kernels/mosaic_tpu/builder.zig
@@ -39,6 +39,8 @@ const isFloatDtype = dtypes.isFloatDtype;
 const dtypeBitwidth = dtypes.dtypeBitwidth;
 const intBitwidth = dtypes.intBitwidth;
 
+pub const pipeline = @import("pipeline.zig");
+
 // =============================================================================
 // Value — a handle to an MLIR value inside the kernel body.
 // =============================================================================
@@ -215,6 +217,44 @@ pub const Value = struct {
     /// Absolute value (float→absf, int→absi).
     pub fn abs(self: Value) Value {
         return self.kern().abs(self);
+    }
+
+    /// Best-effort fold to an `i64` for `arith.constant` (and `addi`/`muli` of folded
+    /// operands). Returns `null` for anything else; the caller decides what to do.
+    /// TODO(raph): check if there is no better way
+    pub fn asConstantInt(self: Value) ?i64 {
+        if (self.inner.isA(mlir.OpResult) == null) return null;
+
+        const op = self.inner.owner();
+        const op_name = op.name();
+
+        if (std.mem.eql(u8, op_name, "arith.constant")) {
+            const attr = op.attributeByName("value") orelse return null;
+            const iattr = attr.isA(mlir.IntegerAttribute) orelse return null;
+            return iattr.value(i64);
+        }
+
+        if (std.mem.eql(u8, op_name, "arith.muli")) {
+            const lhs = Value{ .inner = op.operand(0), .kernel = self.kernel };
+            const rhs = Value{ .inner = op.operand(1), .kernel = self.kernel };
+            const lv = lhs.asConstantInt();
+            const rv = rhs.asConstantInt();
+            if (lv) |l| if (rv) |r| return l *% r;
+            // One side null, the other known: still folds if the known side is 0.
+            if (lv) |l| if (l == 0) return 0;
+            if (rv) |r| if (r == 0) return 0;
+            return null;
+        }
+
+        if (std.mem.eql(u8, op_name, "arith.addi")) {
+            const lhs = Value{ .inner = op.operand(0), .kernel = self.kernel };
+            const rhs = Value{ .inner = op.operand(1), .kernel = self.kernel };
+            const lv = lhs.asConstantInt() orelse return null;
+            const rv = rhs.asConstantInt() orelse return null;
+            return lv +% rv;
+        }
+
+        return null;
     }
 };
 
@@ -1644,7 +1684,7 @@ pub const Builder = struct {
         return self.emit(tpu.concatenate(self.ctx, self.innerSlice(sources), dimension, ty, self.loc()));
     }
 
-    pub fn transpose(self: *Builder, src: Value, permutation: []const i32) Value {
+    pub fn transpose(self: *Builder, src: Value, permutation: []const i64) Value {
         const in_shape = src.shape();
         std.debug.assert(permutation.len == in_shape.len);
         var out: stdx.BoundedArray(i64, mlir.ShapedType.MAX_RANK) = .empty;

--- a/kernels/mosaic_tpu/builder.zig
+++ b/kernels/mosaic_tpu/builder.zig
@@ -235,8 +235,8 @@ pub const Value = struct {
         }
 
         if (std.mem.eql(u8, op_name, "arith.muli")) {
-            const lhs = Value{ .inner = op.operand(0), .kernel = self.kernel };
-            const rhs = Value{ .inner = op.operand(1), .kernel = self.kernel };
+            const lhs: Value = .{ .inner = op.operand(0), .kernel = self.kernel };
+            const rhs: Value = .{ .inner = op.operand(1), .kernel = self.kernel };
             const lv = lhs.asConstantInt();
             const rv = rhs.asConstantInt();
             if (lv) |l| if (rv) |r| return l *% r;
@@ -247,8 +247,8 @@ pub const Value = struct {
         }
 
         if (std.mem.eql(u8, op_name, "arith.addi")) {
-            const lhs = Value{ .inner = op.operand(0), .kernel = self.kernel };
-            const rhs = Value{ .inner = op.operand(1), .kernel = self.kernel };
+            const lhs: Value = .{ .inner = op.operand(0), .kernel = self.kernel };
+            const rhs: Value = .{ .inner = op.operand(1), .kernel = self.kernel };
             const lv = lhs.asConstantInt() orelse return null;
             const rv = rhs.asConstantInt() orelse return null;
             return lv +% rv;

--- a/kernels/mosaic_tpu/pipeline.zig
+++ b/kernels/mosaic_tpu/pipeline.zig
@@ -1,0 +1,871 @@
+//! Zig port of `pltpu.emit_pipeline` (jax/_src/pallas/mosaic/pipeline.py) —
+//! emits lowered `tpu`-dialect IR byte-equivalent to `pallas_call`.
+//!
+//! 1-D dynamic-bound grid; VMEM operands; `buffer_count ∈ {1,2}`;
+//! `.blocked`/`.squeezed`/one `.bounded_slice` block dim; trivial-windowing
+//! inputs peeled as sync copy; `trace_scopes`. Unsupported features panic.
+
+const std = @import("std");
+const mlir = @import("mlir");
+const dialects = @import("mlir/dialects");
+const builder = @import("builder.zig");
+
+const tpu = @import("mlir/dialects/mosaic_tpu");
+const arith = dialects.arith;
+const scf = dialects.scf;
+const memref = dialects.memref;
+
+const Builder = builder.Builder;
+const Value = builder.Value;
+const DType = builder.DType;
+const MemorySpace = builder.MemorySpace;
+const FinishError = builder.FinishError;
+
+/// `ShapedType::kDynamic` — sentinel for a `?` dim in a memref shape.
+const kDyn: i64 = std.math.minInt(i64);
+
+/// One entry of `pl.BlockSpec.block_shape`.
+pub const BlockDim = union(enum) {
+    /// `pl.Blocked(n)` — windowed dim of size `n`.
+    blocked: i64,
+    /// `pl.Squeezed()` / `None` — dim dropped in the window.
+    squeezed,
+    /// `pl.BoundedSlice(n)` — index_map returns `.slice`; `n` is the max.
+    bounded_slice: i64,
+};
+
+/// One entry returned by `pl.BlockSpec.index_map`.
+pub const BlockIndex = union(enum) {
+    /// `pl.ds(idx*block, block)` — for `.blocked`/`.squeezed` dims.
+    scalar: Value,
+    /// `pl.ds(start, size)` — for `.bounded_slice` dims.
+    slice: struct { start: Value, size: Value },
+};
+
+/// `pl.BlockSpec.index_map`. `ctx` is opaque user data (Zig has no closures).
+pub const IndexMapFn = *const fn (b: *Builder, indices: []const Value, ctx: ?*anyopaque) []const BlockIndex;
+
+/// Working window for one pipeline operand. Body must re-emit
+/// `memref_slice`/`squeeze` at each use site. `slot == null` ⇒ trivial-windowing;
+/// `buf == null` ⇒ no operand.
+pub const RefWindow = struct { buf: ?Value = null, slot: ?Value = null };
+
+/// The pipeline body — `pallas_call`'s inner kernel.
+pub const BodyFn = *const fn (b: *Builder, grid_indices: []const Value, refs: []const RefWindow, scratches: []const Value, ctx: ?*anyopaque) FinishError!void;
+
+/// `pl.BlockSpec` for one pipeline operand. `null` slot ↔ `None` spec.
+pub const PipeSpec = struct {
+    full_shape: []const i64,
+    dtype: DType,
+    /// `null` ⇒ trivial windowing (the whole array).
+    block_shape: ?[]const BlockDim = null,
+    /// `null` only allowed with trivial windowing.
+    index_map: ?IndexMapFn = null,
+    index_map_ctx: ?*anyopaque = null,
+    /// Only `.vmem` supported.
+    memory_space: MemorySpace = .vmem,
+    /// `null` ⇒ 2 (or 1 if trivial).
+    buffer_count: ?usize = null,
+    /// Tile that `_create_bounded_slice` rounds the DMA size up to.
+    bounded_slice_tiling: i32 = 1,
+    /// Pallas's `disable_bounds_checks`: skip OOB clamp, emit only `tpu.assume_multiple`.
+    bounded_slice_skip_clamp: bool = false,
+};
+
+pub const PipelineOpts = struct {
+    body: BodyFn,
+    body_ctx: ?*anyopaque = null,
+    /// Dynamic (`i32`) grid bounds. Comptime: pass `b.lift(@as(i32, N))`.
+    grid: []const Value,
+    /// One per HBM input ref (slot `null` <-> `None` spec).
+    in_specs: []const ?PipeSpec,
+    out_specs: []const ?PipeSpec,
+    trace_scopes: bool = true,
+};
+
+/// Emit `pltpu.emit_pipeline(body, grid=..., in_specs=..., out_specs=...)(*refs, scratches=...)`.
+/// `refs` = `in_refs ++ out_refs`. Emits into `b.currentBlock()`.
+pub fn emitPipeline(
+    b: *Builder,
+    refs: []const ?Value,
+    scratches: []const Value,
+    opts: PipelineOpts,
+) FinishError!void {
+    std.debug.assert(opts.grid.len >= 1);
+    if (opts.grid.len != 1) @panic("emitPipeline: only 1-D grids supported (TODO: N-D `_next_index`)");
+    const n_in = opts.in_specs.len;
+    std.debug.assert(refs.len == n_in + opts.out_specs.len);
+
+    const a = b.arena.allocator();
+
+    var brefs = std.ArrayList(BufferedRef).empty;
+    for (opts.in_specs, 0..) |maybe_spec, i| {
+        if (maybe_spec) |spec| {
+            std.debug.assert(refs[i] != null);
+            try brefs.append(a, BufferedRef.create(b, spec, .input, refs[i].?, i));
+        }
+    }
+    for (opts.out_specs, 0..) |maybe_spec, j| {
+        if (maybe_spec) |spec| {
+            std.debug.assert(refs[n_in + j] != null);
+            try brefs.append(a, BufferedRef.create(b, spec, .output, refs[n_in + j].?, n_in + j));
+        }
+    }
+
+    // Whole pipeline lives in a `tpu.region`.
+    const region_block = mlir.Block.init(&.{}, &.{});
+    b.pushBlock(region_block);
+
+    for (brefs.items) |*br| br.allocate(b);
+
+    const num_steps = opts.grid[0];
+    const c0_i32 = b.lift(@as(i32, 0));
+    const c1_i32 = b.lift(@as(i32, 1));
+    {
+        var when = b.openIf(b.cmpi(.sgt, num_steps, c0_i32));
+        {
+            for (brefs.items) |*br| if (br.is_trivial and br.buffer_type == .input) br.syncCopyIn(b);
+
+            const num_stages = blk: {
+                var m: usize = 2;
+                for (brefs.items) |br| if (br.buffer_count > m) {
+                    m = br.buffer_count;
+                };
+                break :blk m;
+            };
+            var sched0 = Scheduler.init(b, c0_i32, opts.grid, num_steps, num_stages, opts.trace_scopes);
+            for (0..num_stages - 1) |step| {
+                if (opts.trace_scopes) {
+                    var buf: [32]u8 = undefined;
+                    b.traceStart(10, std.fmt.bufPrint(&buf, "ep_initialize_{d}", .{step}) catch unreachable);
+                }
+                for (brefs.items) |*br| sched0.initializeStep(b, br, step);
+                if (opts.trace_scopes) b.traceStop();
+            }
+
+            // iter_args: each bref's slots in spec order (see appendSlotInits), then grid_idx.
+            var inits = std.ArrayList(*const mlir.Value).empty;
+            for (brefs.items) |*br| br.appendSlotInits(b, &inits, a);
+            inits.append(a, c0_i32.inner) catch unreachable;
+            const n_slots = inits.items.len - 1;
+
+            const i32_ty = b.scalarTy(.i32);
+            const block_types = a.alloc(*const mlir.Type, inits.items.len + 1) catch unreachable;
+            const block_locs = a.alloc(*const mlir.Location, inits.items.len + 1) catch unreachable;
+            for (block_types) |*t| t.* = i32_ty;
+            for (block_locs) |*l| l.* = b.loc();
+            const for_body = mlir.Block.init(block_types, block_locs);
+            b.pushBlock(for_body);
+
+            const iv: Value = .{ .inner = for_body.argument(0), .kernel = b };
+            {
+                var cur: usize = 1;
+                for (brefs.items) |*br| cur = br.bindSlotsAt(b, for_body, cur);
+                std.debug.assert(cur == n_slots + 1);
+            }
+            const grid_idx: Value = .{ .inner = for_body.argument(@intCast(n_slots + 1)), .kernel = b };
+
+            var sched = Scheduler.init(b, iv, opts.grid, num_steps, num_stages, opts.trace_scopes);
+            sched.indices_storage[0] = grid_idx;
+            sched.recomputeDerivedIndices(b);
+
+            for (brefs.items) |*br| if (br.buffer_type == .input) sched.copyIn(b, br);
+            for (brefs.items) |*br| if (br.buffer_type == .input) sched.waitIn(b, br);
+
+            // Emit slot `rem` ops BEFORE the body; body re-emits slice/squeeze per use.
+            var current_refs = a.alloc(RefWindow, refs.len) catch unreachable;
+            for (current_refs) |*r| r.* = .{};
+            for (brefs.items) |*br| {
+                if (br.is_trivial or !br.isBuffered()) {
+                    current_refs[br.spec_index] = .{ .buf = br.window_ref };
+                } else {
+                    const active = if (br.buffer_type == .output) br.copy_out_slot.? else br.wait_in_slot.?;
+                    current_refs[br.spec_index] = .{ .buf = br.window_ref, .slot = b.remui(active, b.lift(@as(i32, @intCast(br.buffer_count)))) };
+                }
+            }
+
+            if (opts.trace_scopes) b.traceStart(10, "ep_run_kernel");
+            try opts.body(b, sched.indices_storage[0..opts.grid.len], current_refs, scratches, opts.body_ctx);
+            if (opts.trace_scopes) b.traceStop();
+
+            for (brefs.items) |*br| if (br.buffer_type == .output) sched.copyOut(b, br);
+            for (brefs.items) |*br| if (br.buffer_type == .output) sched.waitOut(b, br);
+
+            for (brefs.items) |*br| if (br.buffer_type == .input) sched.advanceSlots(b, br);
+
+            var yields = std.ArrayList(*const mlir.Value).empty;
+            for (brefs.items) |*br| br.appendSlotYields(b, &yields, a);
+            const next_idx = nextIndex1D(b, grid_idx, num_steps);
+            yields.append(a, next_idx.inner) catch unreachable;
+            _ = scf.yield(b.ctx, yields.items, b.loc()).appendTo(for_body);
+            b.popBlock();
+
+            const for_op = scf.for_(b.ctx, c0_i32.inner, num_steps.inner, c1_i32.inner, inits.items, for_body, .{}, b.loc());
+            _ = for_op.appendTo(b.currentBlock());
+            var k: usize = 0;
+            for (brefs.items) |*br| k = br.readbackSlots(b, for_op, k);
+            const final_grid_idx: Value = .{ .inner = for_op.result(@intCast(n_slots)), .kernel = b };
+
+            // prev_index BEFORE Scheduler.init so its inner `subi(num_steps,1)` CSEs with `step`.
+            const final_idx = prevIndex1D(b, final_grid_idx, num_steps);
+            var sched_fin = Scheduler.init(b, b.subi(num_steps, c1_i32), opts.grid, num_steps, num_stages, opts.trace_scopes);
+            sched_fin.indices_storage[0] = final_idx;
+            sched_fin.recomputeDerivedIndices(b);
+            for (brefs.items) |*br| sched_fin.finalize(b, br);
+            for (brefs.items) |*br| if (br.is_trivial and br.buffer_type == .output) br.syncCopyOut(b);
+
+            when.yieldThen(.{});
+        }
+    }
+
+    _ = tpu.yield(b.ctx, &.{}, b.loc()).appendTo(region_block);
+    b.popBlock();
+    _ = tpu.region(b.ctx, region_block, &.{}, b.loc()).appendTo(b.currentBlock());
+}
+
+const BufferType = enum { input, output };
+
+/// VMEM double-buffer + DMA semaphores for one pipeline operand.
+const BufferedRef = struct {
+    spec: PipeSpec,
+    buffer_type: BufferType,
+    buffer_count: usize,
+    is_trivial: bool,
+    /// Index into `refs` / `current_refs`.
+    spec_index: usize,
+    src: Value,
+    /// Block shape with `.squeezed` dims removed.
+    block_compact: []const i64,
+    /// Indices into `spec.block_shape` parallel to `block_compact`.
+    block_keep: []const usize,
+
+    /// `memref<buffer_count x block_compact…, vmem>` (or full shape if trivial).
+    window_ref: Value = undefined,
+    sem_recvs: ?Value = null,
+    sem_sends: ?Value = null,
+
+    // Slot iter_arg state — see appendSlotInits for init values.
+    copy_in_slot: ?Value = null,
+    wait_in_slot: ?Value = null,
+    copy_out_slot: ?Value = null,
+    wait_out_slot: ?Value = null,
+    slot: ?Value = null,
+
+    fn create(b: *Builder, spec: PipeSpec, bt: BufferType, src: Value, spec_index: usize) BufferedRef {
+        const a = b.arena.allocator();
+        if (spec.memory_space != .vmem) @panic("emitPipeline: only VMEM operands supported");
+        const trivial = specHasTrivialWindowing(spec);
+        var bc: usize = if (spec.buffer_count) |c| c else 2;
+        if (spec.buffer_count == null and trivial) bc = 1;
+        if (bt == .output and bc > 2) @panic("emitPipeline: output buffer_count > 2 unsupported");
+
+        var keep = std.ArrayList(usize).empty;
+        var compact = std.ArrayList(i64).empty;
+        if (spec.block_shape) |bs| {
+            for (bs, 0..) |bd, di| switch (bd) {
+                .blocked => |n| {
+                    keep.append(a, di) catch unreachable;
+                    compact.append(a, n) catch unreachable;
+                },
+                .bounded_slice => |n| {
+                    keep.append(a, di) catch unreachable;
+                    compact.append(a, n) catch unreachable;
+                },
+                .squeezed => {},
+            };
+        }
+        return .{
+            .spec = spec,
+            .buffer_type = bt,
+            .buffer_count = bc,
+            .is_trivial = trivial,
+            .spec_index = spec_index,
+            .src = src,
+            .block_compact = compact.items,
+            .block_keep = keep.items,
+        };
+    }
+
+    fn isBuffered(self: *const BufferedRef) bool {
+        return self.buffer_count > 0;
+    }
+
+    fn allocate(self: *BufferedRef, b: *Builder) void {
+        const a = b.arena.allocator();
+        const vmem = MemorySpace.vmem.attribute(b.ctx);
+        const elem = self.spec.dtype.toMlir(b.ctx);
+        if (self.is_trivial) {
+            const ty = mlir.Type.memRef(elem, self.spec.full_shape, null, vmem);
+            self.window_ref = memRefAlloca(b, ty);
+        } else {
+            if (self.block_compact.len == 1) @panic("emitPipeline: 1-D flat block buffers unsupported (TODO)");
+            var shape = a.alloc(i64, self.block_compact.len + 1) catch unreachable;
+            shape[0] = @intCast(self.buffer_count);
+            @memcpy(shape[1..], self.block_compact);
+            const ty = mlir.Type.memRef(elem, shape, null, vmem);
+            self.window_ref = memRefAlloca(b, ty);
+        }
+        if (!self.is_trivial) {
+            const sem_arr_ty = dmaSemRefTy(b, self.buffer_count);
+            const sem = semAllocOp(b, sem_arr_ty);
+            if (self.buffer_type == .input) self.sem_recvs = sem else self.sem_sends = sem;
+        }
+    }
+
+    fn appendSlotInits(self: *BufferedRef, b: *Builder, out: *std.ArrayList(*const mlir.Value), a: std.mem.Allocator) void {
+        const c0 = b.lift(@as(i32, 0)).inner;
+        const c1 = b.lift(@as(i32, 1)).inner;
+        switch (self.buffer_type) {
+            .input => {
+                if (self.is_trivial) {
+                    out.append(a, c0) catch unreachable;
+                } else {
+                    out.append(a, c1) catch unreachable; // copy_in_slot: initialize_step advanced 0→1
+                    out.append(a, c0) catch unreachable;
+                }
+            },
+            .output => {
+                out.append(a, c0) catch unreachable;
+                out.append(a, c0) catch unreachable;
+            },
+        }
+    }
+
+    fn nSlots(self: *const BufferedRef) usize {
+        return switch (self.buffer_type) {
+            .input => if (self.is_trivial) 1 else 2,
+            .output => 2,
+        };
+    }
+
+    fn bindSlotsAt(self: *BufferedRef, b: *Builder, body: *mlir.Block, start: usize) usize {
+        var k = start;
+        const arg = struct {
+            fn f(b_: *Builder, body_: *mlir.Block, i: *usize) Value {
+                const v: Value = .{ .inner = body_.argument(@intCast(i.*)), .kernel = b_ };
+                i.* += 1;
+                return v;
+            }
+        }.f;
+        switch (self.buffer_type) {
+            .input => {
+                if (self.is_trivial) {
+                    self.slot = arg(b, body, &k);
+                } else {
+                    self.copy_in_slot = arg(b, body, &k);
+                    self.wait_in_slot = arg(b, body, &k);
+                }
+            },
+            .output => {
+                self.copy_out_slot = arg(b, body, &k);
+                self.wait_out_slot = arg(b, body, &k);
+            },
+        }
+        return k;
+    }
+
+    fn appendSlotYields(self: *BufferedRef, b: *Builder, out: *std.ArrayList(*const mlir.Value), a: std.mem.Allocator) void {
+        _ = b;
+        switch (self.buffer_type) {
+            .input => {
+                if (self.is_trivial) {
+                    out.append(a, self.slot.?.inner) catch unreachable;
+                } else {
+                    out.append(a, self.copy_in_slot.?.inner) catch unreachable;
+                    out.append(a, self.wait_in_slot.?.inner) catch unreachable;
+                }
+            },
+            .output => {
+                out.append(a, self.copy_out_slot.?.inner) catch unreachable;
+                out.append(a, self.wait_out_slot.?.inner) catch unreachable;
+            },
+        }
+    }
+
+    fn readbackSlots(self: *BufferedRef, b: *Builder, for_op: *mlir.Operation, start: usize) usize {
+        var k = start;
+        const take = struct {
+            fn f(b_: *Builder, op: *mlir.Operation, i: *usize) Value {
+                const v: Value = .{ .inner = op.result(@intCast(i.*)), .kernel = b_ };
+                i.* += 1;
+                return v;
+            }
+        }.f;
+        switch (self.buffer_type) {
+            .input => {
+                if (self.is_trivial) {
+                    self.slot = take(b, for_op, &k);
+                } else {
+                    self.copy_in_slot = take(b, for_op, &k);
+                    self.wait_in_slot = take(b, for_op, &k);
+                }
+            },
+            .output => {
+                self.copy_out_slot = take(b, for_op, &k);
+                self.wait_out_slot = take(b, for_op, &k);
+            },
+        }
+        return k;
+    }
+
+    fn computeIndex(self: *const BufferedRef, b: *Builder, indices: []const Value) []const BlockIndex {
+        if (self.spec.index_map) |im| return im(b, indices, self.spec.index_map_ctx);
+        @panic("emitPipeline: index_map required for non-trivial windowing");
+    }
+
+    /// Per `block_shape` dim: `{base, size?}`. `size == null` ⇒ static-full.
+    /// `static_zero_start` enables prologue shortcut (Python-int 0 start folds).
+    const DmaSlice = struct { base: []Value, size: []?Value };
+    fn getDmaSlice(self: *const BufferedRef, b: *Builder, indices: []const Value, static_zero_start: bool) DmaSlice {
+        const a = b.arena.allocator();
+        const bs = self.spec.block_shape.?;
+        const bidx = self.computeIndex(b, indices);
+        std.debug.assert(bidx.len == bs.len);
+        var base = a.alloc(Value, bs.len) catch unreachable;
+        var size = a.alloc(?Value, bs.len) catch unreachable;
+        for (bs, 0..) |bd, d| {
+            switch (bd) {
+                .squeezed => {
+                    base[d] = switch (bidx[d]) {
+                        .scalar => |v| v,
+                        .slice => @panic("emitPipeline: squeezed dim must get a scalar index"),
+                    };
+                    size[d] = null;
+                },
+                .blocked => |n| {
+                    const idx = switch (bidx[d]) {
+                        .scalar => |v| v,
+                        .slice => @panic("emitPipeline: blocked dim must get a scalar index"),
+                    };
+                    if (@mod(self.spec.full_shape[d], n) != 0) @panic("emitPipeline: non-dividing blocked dim unsupported");
+                    base[d] = if (n == 1) idx else idx.mul(@as(i32, @intCast(n)));
+                    size[d] = null;
+                },
+                .bounded_slice => {
+                    const sl = switch (bidx[d]) {
+                        .scalar => @panic("emitPipeline: bounded_slice dim must get a `.slice` index from index_map"),
+                        .slice => |s| s,
+                    };
+                    const tiling: i32 = self.spec.bounded_slice_tiling;
+                    const dim_size = self.spec.full_shape[d];
+                    base[d] = sl.start;
+                    if (self.spec.bounded_slice_skip_clamp) {
+                        size[d] = b.emit(tpu.assume_multiple(b.ctx, sl.size.inner, tiling, b.loc()));
+                        continue;
+                    }
+                    // Prologue shortcut: Python-int 0 start ⇒ `_round_up_to_nearest_multiple` folds.
+                    if (static_zero_start and sl.start.asConstantInt() == @as(?i64, 0)) {
+                        const is_oob = b.cmpi(.sgt, sl.size, b.lift(@as(i32, @intCast(dim_size))));
+                        const sz = b.select(is_oob, b.lift(@as(i32, @intCast(dim_size))), sl.size);
+                        size[d] = b.emit(tpu.assume_multiple(b.ctx, sz.inner, tiling, b.loc()));
+                        continue;
+                    }
+                    const is_oob = b.cmpi(.sgt, b.addi(sl.start, sl.size), b.lift(@as(i32, @intCast(dim_size))));
+                    const rounded = blk: {
+                        if (tiling == 1) break :blk b.subi(b.lift(@as(i32, @intCast(dim_size + 1))), sl.start);
+                        // lax sign-fixup for `jnp.remainder`.
+                        const m = b.lift(tiling);
+                        const c0 = b.lift(@as(i32, 0));
+                        const rem_arg = b.subi(b.lift(@as(i32, @intCast(dim_size))), sl.start);
+                        const r = b.remsi(rem_arg, m);
+                        const r_nz = b.cmpi(.ne, r, c0);
+                        const r_neg = b.cmpi(.slt, r, c0);
+                        const fixup = b.andi(r_neg, r_nz);
+                        const r_plus = b.addi(r, m);
+                        const floormod = b.select(fixup, r_plus, r);
+                        const round_down = b.subi(rem_arg, floormod);
+                        break :blk b.addi(round_down, m);
+                    };
+                    const sz = b.select(is_oob, rounded, sl.size);
+                    size[d] = b.emit(tpu.assume_multiple(b.ctx, sz.inner, tiling, b.loc()));
+                },
+            }
+        }
+        return .{ .base = base, .size = size };
+    }
+
+    fn sliceSrc(self: *const BufferedRef, b: *Builder, dma: DmaSlice) Value {
+        const a = b.arena.allocator();
+        const bs = self.spec.block_shape.?;
+        var base = a.alloc(Value, bs.len) catch unreachable;
+        var dyn = std.ArrayList(Value).empty;
+        var result_shape = a.alloc(i64, bs.len) catch unreachable;
+        for (bs, 0..) |bd, d| {
+            base[d] = dma.base[d];
+            if (dma.size[d]) |sz| {
+                result_shape[d] = kDyn;
+                dyn.append(a, sz) catch unreachable;
+            } else {
+                result_shape[d] = switch (bd) {
+                    .squeezed => 1,
+                    .blocked => |n| n,
+                    .bounded_slice => unreachable,
+                };
+            }
+        }
+        return b.memRefSlice(self.src, base, result_shape, dyn.items);
+    }
+
+    /// Slice `alloca[slot, 0…]` (non-squeezed dims) then squeeze the slot dim.
+    fn sliceWindowAt(self: *const BufferedRef, b: *Builder, slot: Value, dma: DmaSlice) Value {
+        const a = b.arena.allocator();
+        const bs = self.spec.block_shape.?;
+        const c0 = b.lift(@as(i32, 0));
+        const nd = 1 + self.block_compact.len;
+        var base = a.alloc(Value, nd) catch unreachable;
+        var result_shape = a.alloc(i64, nd) catch unreachable;
+        var dyn = std.ArrayList(Value).empty;
+        base[0] = slot;
+        result_shape[0] = 1;
+        for (self.block_keep, 0..) |sd, ci| {
+            base[ci + 1] = c0;
+            if (dma.size[sd]) |sz| {
+                result_shape[ci + 1] = kDyn;
+                dyn.append(a, sz) catch unreachable;
+            } else {
+                result_shape[ci + 1] = switch (bs[sd]) {
+                    .blocked => |n| n,
+                    else => unreachable,
+                };
+            }
+        }
+        const sliced = b.memRefSlice(self.window_ref, base, result_shape, dyn.items);
+        const squeezed_shape = a.alloc(i64, self.block_compact.len) catch unreachable;
+        @memcpy(squeezed_shape, result_shape[1..]);
+        return b.memRefSqueeze(sliced, squeezed_shape);
+    }
+
+    fn semAt(b: *Builder, sem_array: Value, i: Value) Value {
+        const sliced = b.memRefSlice(sem_array, &.{i}, &.{1}, &.{});
+        return b.memRefSqueeze(sliced, &.{});
+    }
+
+    fn currentRef(self: *BufferedRef, b: *Builder) Value {
+        if (self.is_trivial or !self.isBuffered()) return self.window_ref;
+        const slot = switch (self.buffer_type) {
+            .output => b.remui(self.copy_out_slot.?, b.lift(@as(i32, @intCast(self.buffer_count)))),
+            .input => b.remui(self.wait_in_slot.?, b.lift(@as(i32, @intCast(self.buffer_count)))),
+        };
+        const a = b.arena.allocator();
+        const nd = 1 + self.block_compact.len;
+        var base = a.alloc(Value, nd) catch unreachable;
+        var result_shape = a.alloc(i64, nd) catch unreachable;
+        const c0 = b.lift(@as(i32, 0));
+        base[0] = slot;
+        result_shape[0] = 1;
+        for (self.block_compact, 0..) |n, ci| {
+            base[ci + 1] = c0;
+            result_shape[ci + 1] = n;
+        }
+        const sliced = b.memRefSlice(self.window_ref, base, result_shape, &.{});
+        return b.memRefSqueeze(sliced, self.block_compact);
+    }
+
+    fn syncCopyIn(self: *BufferedRef, b: *Builder) void {
+        const blk = mlir.Block.init(&.{}, &.{});
+        b.pushBlock(blk);
+        const sem = semAllocOp(b, dmaSemRefTy(b, null));
+        b.enqueueDma(self.src, self.window_ref, sem, .{});
+        b.waitDma2(sem, self.src, self.window_ref, .{});
+        _ = tpu.yield(b.ctx, &.{}, b.loc()).appendTo(blk);
+        b.popBlock();
+        _ = tpu.region(b.ctx, blk, &.{}, b.loc()).appendTo(b.currentBlock());
+    }
+
+    fn syncCopyOut(self: *BufferedRef, b: *Builder) void {
+        const blk = mlir.Block.init(&.{}, &.{});
+        b.pushBlock(blk);
+        const sem = semAllocOp(b, dmaSemRefTy(b, null));
+        b.enqueueDma(self.window_ref, self.src, sem, .{});
+        b.waitDma2(sem, self.window_ref, self.src, .{});
+        _ = tpu.yield(b.ctx, &.{}, b.loc()).appendTo(blk);
+        b.popBlock();
+        _ = tpu.region(b.ctx, blk, &.{}, b.loc()).appendTo(b.currentBlock());
+    }
+
+    // Op order mirrors pipeline.py: copy_in/copy_out/wait_out take slot rem
+    // before get_dma_slice; wait_in does it after.
+
+    fn copyIn(self: *BufferedRef, b: *Builder, indices: []const Value, slot_cumulative: Value, static_zero_start: bool) void {
+        const slot = b.remui(slot_cumulative, b.lift(@as(i32, @intCast(self.buffer_count))));
+        const dma = self.getDmaSlice(b, indices, static_zero_start);
+        const src_sl = self.sliceSrc(b, dma);
+        const dst_sl = self.sliceWindowAt(b, slot, dma);
+        const sem = semAt(b, self.sem_recvs.?, slot);
+        b.enqueueDma(src_sl, dst_sl, sem, .{});
+    }
+
+    fn waitIn(self: *BufferedRef, b: *Builder, indices: []const Value) void {
+        const dma = self.getDmaSlice(b, indices, false);
+        const slot = b.remui(self.wait_in_slot.?, b.lift(@as(i32, @intCast(self.buffer_count))));
+        const src_sl = self.sliceSrc(b, dma);
+        const dst_sl = self.sliceWindowAt(b, slot, dma);
+        const sem = semAt(b, self.sem_recvs.?, slot);
+        b.waitDma2(sem, src_sl, dst_sl, .{});
+    }
+
+    fn copyOut(self: *BufferedRef, b: *Builder, indices: []const Value) void {
+        if (self.buffer_count == 1) @panic("emitPipeline: single-buffered output sync_copy_out unsupported (TODO)");
+        const slot = b.remui(self.copy_out_slot.?, b.lift(@as(i32, @intCast(self.buffer_count))));
+        const dma = self.getDmaSlice(b, indices, false);
+        // Pallas evaluates `src` (VMEM window) before `dst` (HBM).
+        const src_sl = self.sliceWindowAt(b, slot, dma);
+        const dst_sl = self.sliceSrc(b, dma);
+        const sem = semAt(b, self.sem_sends.?, slot);
+        b.enqueueDma(src_sl, dst_sl, sem, .{});
+    }
+
+    fn waitOut(self: *BufferedRef, b: *Builder, indices: []const Value) void {
+        if (self.buffer_count <= 1) return;
+        const slot = b.remui(self.wait_out_slot.?, b.lift(@as(i32, @intCast(self.buffer_count))));
+        const dma = self.getDmaSlice(b, indices, false);
+        const src_sl = self.sliceWindowAt(b, slot, dma);
+        const dst_sl = self.sliceSrc(b, dma);
+        const sem = semAt(b, self.sem_sends.?, slot);
+        b.waitDma2(sem, src_sl, dst_sl, .{});
+    }
+};
+
+/// Prologue/loop/epilogue copy+wait schedule.
+const Scheduler = struct {
+    step: Value,
+    grid: []const Value,
+    num_steps: Value,
+    num_stages: usize,
+    trace_scopes: bool,
+    first_step: Value,
+    last_step: Value,
+    indices_storage: [4]Value = undefined,
+    prev_storage: [4]Value = undefined,
+    next_storage: [4]Value = undefined,
+    indices_len: usize,
+
+    fn init(b: *Builder, step: Value, grid: []const Value, num_steps: Value, num_stages: usize, trace_scopes: bool) Scheduler {
+        const c0 = b.lift(@as(i32, 0));
+        const c1 = b.lift(@as(i32, 1));
+        var s = Scheduler{
+            .step = step,
+            .grid = grid,
+            .num_steps = num_steps,
+            .num_stages = num_stages,
+            .trace_scopes = trace_scopes,
+            .first_step = b.cmpi(.eq, step, c0),
+            .last_step = b.cmpi(.eq, step, b.subi(num_steps, c1)),
+            .indices_len = grid.len,
+        };
+        for (0..grid.len) |i| s.indices_storage[i] = c0;
+        s.recomputeDerivedIndices(b);
+        return s;
+    }
+
+    fn indices(self: *Scheduler) []const Value {
+        return self.indices_storage[0..self.indices_len];
+    }
+    fn prevIndices(self: *Scheduler) []const Value {
+        return self.prev_storage[0..self.indices_len];
+    }
+    fn nextIndices(self: *Scheduler) []const Value {
+        return self.next_storage[0..self.indices_len];
+    }
+
+    fn recomputeDerivedIndices(self: *Scheduler, b: *Builder) void {
+        const i = self.indices_storage[0];
+        self.prev_storage[0] = prevIndex1D(b, i, self.num_steps);
+        self.next_storage[0] = nextIndex1D(b, i, self.num_steps);
+    }
+
+    fn namedScope(self: *Scheduler, b: *Builder, name: []const u8) void {
+        if (self.trace_scopes) b.traceStart(10, name);
+    }
+    fn endScope(self: *Scheduler, b: *Builder) void {
+        if (self.trace_scopes) b.traceStop();
+    }
+
+    /// `~out_of_fetch` as `step < num_steps + (1 - buffer_count)`.
+    fn notOutOfFetch(self: *Scheduler, b: *Builder, br: *const BufferedRef) Value {
+        std.debug.assert(br.isBuffered());
+        const off: i32 = 1 - @as(i32, @intCast(br.buffer_count));
+        return b.cmpi(.slt, self.step, b.addi(self.num_steps, b.lift(off)));
+    }
+
+    fn notFirstStep(self: *Scheduler, b: *Builder) Value {
+        return b.cmpi(.ne, self.step, b.lift(@as(i32, 0)));
+    }
+
+    fn indicesDiffer(b: *Builder, br: *const BufferedRef, ai: []const Value, ci: []const Value) Value {
+        const xa = br.computeIndex(b, ai);
+        const xc = br.computeIndex(b, ci);
+        std.debug.assert(xa.len == xc.len and xa.len > 0);
+        var acc: ?Value = null;
+        for (xa, xc) |x, y| {
+            const d: Value = switch (x) {
+                .scalar => |xv| b.cmpi(.ne, xv, y.scalar),
+                .slice => |xs| b.ori(b.cmpi(.ne, xs.start, y.slice.start), b.cmpi(.ne, xs.size, y.slice.size)),
+            };
+            acc = if (acc) |p| b.ori(p, d) else d;
+        }
+        return acc.?;
+    }
+
+    fn hasChanged(self: *Scheduler, b: *Builder, br: *const BufferedRef) Value {
+        std.debug.assert(br.isBuffered() and !br.is_trivial);
+        return indicesDiffer(b, br, self.indices(), self.prevIndices());
+    }
+    fn willChangeCurrent(self: *Scheduler, b: *Builder, br: *const BufferedRef) Value {
+        std.debug.assert(br.isBuffered() and !br.is_trivial);
+        return indicesDiffer(b, br, self.indices(), self.nextIndices());
+    }
+    fn willChangeFetch(self: *Scheduler, b: *Builder, br: *const BufferedRef) Value {
+        std.debug.assert(br.isBuffered() and !br.is_trivial);
+        if (br.buffer_count < 2) return self.hasChanged(b, br);
+        std.debug.assert(br.buffer_count == 2);
+        return indicesDiffer(b, br, self.indices(), self.nextIndices());
+    }
+
+    fn advance(b: *Builder, slot: Value, pred: Value) Value {
+        return b.select(pred, b.addi(slot, b.lift(@as(i32, 1))), slot);
+    }
+
+    fn initializeStep(self: *Scheduler, b: *Builder, br: *BufferedRef, step: usize) void {
+        if (br.buffer_type != .input or !br.isBuffered() or br.is_trivial) return;
+        if (step + 1 >= br.buffer_count) return;
+        if (step != 0) @panic("emitPipeline: num_stages>2 (multi-step initialize) unsupported (TODO)");
+        // static_zero_start=true: Python-int 0 grid indices enable folds in getDmaSlice.
+        br.copyIn(b, self.indices(), b.lift(@as(i32, 0)), true);
+    }
+
+    fn copyIn(self: *Scheduler, b: *Builder, br: *BufferedRef) void {
+        if (br.is_trivial) return;
+        var pred = b.andi(self.willChangeFetch(b, br), self.notOutOfFetch(b, br));
+        if (br.isBuffered() and br.buffer_count < 2) pred = b.ori(pred, self.first_step);
+        if (br.buffer_type != .input) return;
+        {
+            var when = b.openIf(pred);
+            {
+                self.namedScope(b, "ep_copy_in");
+                br.copyIn(b, self.nextIndices(), br.copy_in_slot.?, false);
+                self.endScope(b);
+                when.yieldThen(.{});
+            }
+        }
+        br.copy_in_slot = advance(b, br.copy_in_slot.?, pred);
+    }
+
+    fn waitIn(self: *Scheduler, b: *Builder, br: *BufferedRef) void {
+        if (br.is_trivial) return;
+        const pred = b.ori(self.hasChanged(b, br), self.first_step);
+        {
+            var when = b.openIf(pred);
+            {
+                self.namedScope(b, "ep_wait_in");
+                if (br.buffer_type == .input) br.waitIn(b, self.indices());
+                self.endScope(b);
+                when.yieldThen(.{});
+            }
+        }
+    }
+
+    fn copyOut(self: *Scheduler, b: *Builder, br: *BufferedRef) void {
+        if (br.is_trivial) return;
+        const pred = b.ori(self.willChangeCurrent(b, br), self.last_step);
+        {
+            var when = b.openIf(pred);
+            {
+                self.namedScope(b, "ep_copy_out");
+                if (br.buffer_type == .output) br.copyOut(b, self.indices());
+                self.endScope(b);
+                when.yieldThen(.{});
+            }
+        }
+        br.copy_out_slot = advance(b, br.copy_out_slot.?, pred);
+    }
+
+    fn waitOut(self: *Scheduler, b: *Builder, br: *BufferedRef) void {
+        if (br.is_trivial) return;
+        const pred = b.andi(self.hasChanged(b, br), self.notFirstStep(b));
+        {
+            var when = b.openIf(pred);
+            {
+                self.namedScope(b, "ep_wait_out");
+                // copy_out was issued the previous iteration.
+                if (br.buffer_type == .output) br.waitOut(b, self.prevIndices());
+                self.endScope(b);
+                when.yieldThen(.{});
+            }
+        }
+        br.wait_out_slot = advance(b, br.wait_out_slot.?, pred);
+    }
+
+    fn finalize(self: *Scheduler, b: *Builder, br: *BufferedRef) void {
+        if (br.is_trivial or br.buffer_type != .output) return;
+        var when = b.openIf(self.last_step);
+        {
+            self.namedScope(b, "ep_finalize");
+            br.waitOut(b, self.indices());
+            self.endScope(b);
+            when.yieldThen(.{});
+        }
+    }
+
+    fn advanceSlots(self: *Scheduler, b: *Builder, br: *BufferedRef) void {
+        if (br.buffer_type != .input) return;
+        if (br.is_trivial) {
+            br.slot = advance(b, br.slot.?, self.last_step);
+        } else {
+            const pred = b.ori(self.willChangeCurrent(b, br), self.last_step);
+            br.wait_in_slot = advance(b, br.wait_in_slot.?, pred);
+        }
+    }
+};
+
+/// `verify = false`: `AutomaticAllocationScope` requirement is only satisfied
+/// once it's inside `func.func`; full verify at `Builder.finish`.
+pub fn memRefAlloca(b: *Builder, ty: *const mlir.Type) Value {
+    return b.emit(mlir.Operation.make(b.ctx, "memref.alloca", .{
+        .results = .{ .flat = &.{ty} },
+        .attributes = &.{.named(b.ctx, "operandSegmentSizes", mlir.Attribute.denseArray(b.ctx, .i32, &[2]i32{ 0, 0 }))},
+        .verify = false,
+        .location = b.loc(),
+    }));
+}
+
+pub fn semAllocOp(b: *Builder, ty: *const mlir.Type) Value {
+    return b.emit(mlir.Operation.make(b.ctx, "tpu.sem_alloc", .{
+        .results = .{ .flat = &.{ty} },
+        .verify = false,
+        .location = b.loc(),
+    }));
+}
+
+/// `pl.SemaphoreType.DMA((n,))`, or rank-0 for `n == null`.
+pub fn dmaSemRefTy(b: *Builder, n: ?usize) *const mlir.Type {
+    const shape: []const i64 = if (n) |m| &.{@intCast(m)} else &.{};
+    return mlir.Type.memRef(tpu.dmaSemaphoreType(b.ctx), shape, null, MemorySpace.semaphore_mem.attribute(b.ctx));
+}
+
+fn nextIndex1D(b: *Builder, i: Value, n: Value) Value {
+    const inc = b.addi(i, b.lift(@as(i32, 1)));
+    const carry = b.cmpi(.eq, inc, n);
+    return b.select(carry, b.lift(@as(i32, 0)), inc);
+}
+
+fn prevIndex1D(b: *Builder, i: Value, n: Value) Value {
+    const dec = b.subi(i, b.lift(@as(i32, 1)));
+    const borrow = b.cmpi(.eq, dec, b.lift(@as(i32, -1)));
+    return b.select(borrow, b.subi(n, b.lift(@as(i32, 1))), dec);
+}
+
+/// `null` block_shape, or every dim is `.blocked(full_dim)`.
+fn specHasTrivialWindowing(spec: PipeSpec) bool {
+    const bs = spec.block_shape orelse return true;
+    if (bs.len != spec.full_shape.len) return false;
+    for (bs, spec.full_shape) |bd, fs| switch (bd) {
+        .blocked => |n| if (n != fs) return false,
+        else => return false,
+    };
+    return true;
+}
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/kernels/mosaic_tpu/pipeline.zig
+++ b/kernels/mosaic_tpu/pipeline.zig
@@ -83,7 +83,7 @@ pub const PipelineOpts = struct {
     trace_scopes: bool = true,
 };
 
-/// Emit `pltpu.emit_pipeline(body, grid=..., in_specs=..., out_specs=...)(*refs, scratches=...)`.
+/// Emits `pltpu.emit_pipeline(body, grid=..., in_specs=..., out_specs=...)(*refs, scratches=...)`.
 /// `refs` = `in_refs ++ out_refs`. Emits into `b.currentBlock()`.
 pub fn emitPipeline(
     b: *Builder,
@@ -98,17 +98,17 @@ pub fn emitPipeline(
 
     const a = b.arena.allocator();
 
-    var brefs = std.ArrayList(BufferedRef).empty;
+    var brefs: std.ArrayList(BufferedRef) = try .initCapacity(a, opts.in_specs.len + opts.out_specs.len);
     for (opts.in_specs, 0..) |maybe_spec, i| {
         if (maybe_spec) |spec| {
             std.debug.assert(refs[i] != null);
-            try brefs.append(a, BufferedRef.create(b, spec, .input, refs[i].?, i));
+            brefs.appendAssumeCapacity(BufferedRef.create(b, spec, .input, refs[i].?, i));
         }
     }
     for (opts.out_specs, 0..) |maybe_spec, j| {
         if (maybe_spec) |spec| {
             std.debug.assert(refs[n_in + j] != null);
-            try brefs.append(a, BufferedRef.create(b, spec, .output, refs[n_in + j].?, n_in + j));
+            brefs.appendAssumeCapacity(BufferedRef.create(b, spec, .output, refs[n_in + j].?, n_in + j));
         }
     }
 
@@ -144,9 +144,9 @@ pub fn emitPipeline(
             }
 
             // iter_args: each bref's slots in spec order (see appendSlotInits), then grid_idx.
-            var inits = std.ArrayList(*const mlir.Value).empty;
-            for (brefs.items) |*br| br.appendSlotInits(b, &inits, a);
-            inits.append(a, c0_i32.inner) catch unreachable;
+            var inits: std.ArrayList(*const mlir.Value) = try .initCapacity(a, brefs.items.len * 2 + 1);
+            for (brefs.items) |*br| br.appendSlotInits(b, &inits);
+            inits.appendAssumeCapacity(c0_i32.inner);
             const n_slots = inits.items.len - 1;
 
             const i32_ty = b.scalarTy(.i32);
@@ -193,10 +193,10 @@ pub fn emitPipeline(
 
             for (brefs.items) |*br| if (br.buffer_type == .input) sched.advanceSlots(b, br);
 
-            var yields = std.ArrayList(*const mlir.Value).empty;
-            for (brefs.items) |*br| br.appendSlotYields(b, &yields, a);
+            var yields: std.ArrayList(*const mlir.Value) = try .initCapacity(a, brefs.items.len * 2 + 1);
+            for (brefs.items) |*br| br.appendSlotYields(b, &yields);
             const next_idx = nextIndex1D(b, grid_idx, num_steps);
-            yields.append(a, next_idx.inner) catch unreachable;
+            yields.appendAssumeCapacity(next_idx.inner);
             _ = scf.yield(b.ctx, yields.items, b.loc()).appendTo(for_body);
             b.popBlock();
 
@@ -259,17 +259,18 @@ const BufferedRef = struct {
         if (spec.buffer_count == null and trivial) bc = 1;
         if (bt == .output and bc > 2) @panic("emitPipeline: output buffer_count > 2 unsupported");
 
-        var keep = std.ArrayList(usize).empty;
-        var compact = std.ArrayList(i64).empty;
+        const block_len = if (spec.block_shape) |bs| bs.len else 0;
+        var keep = std.ArrayList(usize).initCapacity(a, block_len) catch unreachable;
+        var compact = std.ArrayList(i64).initCapacity(a, block_len) catch unreachable;
         if (spec.block_shape) |bs| {
             for (bs, 0..) |bd, di| switch (bd) {
                 .blocked => |n| {
-                    keep.append(a, di) catch unreachable;
-                    compact.append(a, n) catch unreachable;
+                    keep.appendAssumeCapacity(di);
+                    compact.appendAssumeCapacity(n);
                 },
                 .bounded_slice => |n| {
-                    keep.append(a, di) catch unreachable;
-                    compact.append(a, n) catch unreachable;
+                    keep.appendAssumeCapacity(di);
+                    compact.appendAssumeCapacity(n);
                 },
                 .squeezed => {},
             };
@@ -312,21 +313,21 @@ const BufferedRef = struct {
         }
     }
 
-    fn appendSlotInits(self: *BufferedRef, b: *Builder, out: *std.ArrayList(*const mlir.Value), a: std.mem.Allocator) void {
+    fn appendSlotInits(self: *BufferedRef, b: *Builder, out: *std.ArrayList(*const mlir.Value)) void {
         const c0 = b.lift(@as(i32, 0)).inner;
         const c1 = b.lift(@as(i32, 1)).inner;
         switch (self.buffer_type) {
             .input => {
                 if (self.is_trivial) {
-                    out.append(a, c0) catch unreachable;
+                    out.appendAssumeCapacity(c0);
                 } else {
-                    out.append(a, c1) catch unreachable; // copy_in_slot: initialize_step advanced 0→1
-                    out.append(a, c0) catch unreachable;
+                    out.appendAssumeCapacity(c1); // copy_in_slot: initialize_step advanced 0→1
+                    out.appendAssumeCapacity(c0);
                 }
             },
             .output => {
-                out.append(a, c0) catch unreachable;
-                out.append(a, c0) catch unreachable;
+                out.appendAssumeCapacity(c0);
+                out.appendAssumeCapacity(c0);
             },
         }
     }
@@ -364,20 +365,20 @@ const BufferedRef = struct {
         return k;
     }
 
-    fn appendSlotYields(self: *BufferedRef, b: *Builder, out: *std.ArrayList(*const mlir.Value), a: std.mem.Allocator) void {
+    fn appendSlotYields(self: *BufferedRef, b: *Builder, out: *std.ArrayList(*const mlir.Value)) void {
         _ = b;
         switch (self.buffer_type) {
             .input => {
                 if (self.is_trivial) {
-                    out.append(a, self.slot.?.inner) catch unreachable;
+                    out.appendAssumeCapacity(self.slot.?.inner);
                 } else {
-                    out.append(a, self.copy_in_slot.?.inner) catch unreachable;
-                    out.append(a, self.wait_in_slot.?.inner) catch unreachable;
+                    out.appendAssumeCapacity(self.copy_in_slot.?.inner);
+                    out.appendAssumeCapacity(self.wait_in_slot.?.inner);
                 }
             },
             .output => {
-                out.append(a, self.copy_out_slot.?.inner) catch unreachable;
-                out.append(a, self.wait_out_slot.?.inner) catch unreachable;
+                out.appendAssumeCapacity(self.copy_out_slot.?.inner);
+                out.appendAssumeCapacity(self.wait_out_slot.?.inner);
             },
         }
     }
@@ -488,13 +489,13 @@ const BufferedRef = struct {
         const a = b.arena.allocator();
         const bs = self.spec.block_shape.?;
         var base = a.alloc(Value, bs.len) catch unreachable;
-        var dyn = std.ArrayList(Value).empty;
+        var dyn = std.ArrayList(Value).initCapacity(a, bs.len) catch unreachable;
         var result_shape = a.alloc(i64, bs.len) catch unreachable;
         for (bs, 0..) |bd, d| {
             base[d] = dma.base[d];
             if (dma.size[d]) |sz| {
                 result_shape[d] = kDyn;
-                dyn.append(a, sz) catch unreachable;
+                dyn.appendAssumeCapacity(sz);
             } else {
                 result_shape[d] = switch (bd) {
                     .squeezed => 1,
@@ -506,7 +507,7 @@ const BufferedRef = struct {
         return b.memRefSlice(self.src, base, result_shape, dyn.items);
     }
 
-    /// Slice `alloca[slot, 0…]` (non-squeezed dims) then squeeze the slot dim.
+    /// Slices `alloca[slot, 0…]` (non-squeezed dims) then squeezes the slot dim.
     fn sliceWindowAt(self: *const BufferedRef, b: *Builder, slot: Value, dma: DmaSlice) Value {
         const a = b.arena.allocator();
         const bs = self.spec.block_shape.?;
@@ -514,14 +515,14 @@ const BufferedRef = struct {
         const nd = 1 + self.block_compact.len;
         var base = a.alloc(Value, nd) catch unreachable;
         var result_shape = a.alloc(i64, nd) catch unreachable;
-        var dyn = std.ArrayList(Value).empty;
+        var dyn = std.ArrayList(Value).initCapacity(a, self.block_keep.len) catch unreachable;
         base[0] = slot;
         result_shape[0] = 1;
         for (self.block_keep, 0..) |sd, ci| {
             base[ci + 1] = c0;
             if (dma.size[sd]) |sz| {
                 result_shape[ci + 1] = kDyn;
-                dyn.append(a, sz) catch unreachable;
+                dyn.appendAssumeCapacity(sz);
             } else {
                 result_shape[ci + 1] = switch (bs[sd]) {
                     .blocked => |n| n,
@@ -643,7 +644,7 @@ const Scheduler = struct {
     fn init(b: *Builder, step: Value, grid: []const Value, num_steps: Value, num_stages: usize, trace_scopes: bool) Scheduler {
         const c0 = b.lift(@as(i32, 0));
         const c1 = b.lift(@as(i32, 1));
-        var s = Scheduler{
+        var s: Scheduler = .{
             .step = step,
             .grid = grid,
             .num_steps = num_steps,
@@ -823,7 +824,7 @@ const Scheduler = struct {
 pub fn memRefAlloca(b: *Builder, ty: *const mlir.Type) Value {
     return b.emit(mlir.Operation.make(b.ctx, "memref.alloca", .{
         .results = .{ .flat = &.{ty} },
-        .attributes = &.{.named(b.ctx, "operandSegmentSizes", mlir.Attribute.denseArray(b.ctx, .i32, &[2]i32{ 0, 0 }))},
+        .attributes = &.{.named(b.ctx, "operandSegmentSizes", .denseArray(b.ctx, .i32, &.{ 0, 0 }))},
         .verify = false,
         .location = b.loc(),
     }));

--- a/mlir/dialects/mosaic_tpu/mosaic_tpu.zig
+++ b/mlir/dialects/mosaic_tpu/mosaic_tpu.zig
@@ -646,7 +646,7 @@ pub fn concatenate(
 pub fn transpose(
     ctx: *mlir.Context,
     src: *const mlir.Value,
-    permutation: []const i32,
+    permutation: []const i64,
     result_type: *const mlir.Type,
     location: *const mlir.Location,
 ) *mlir.Operation {
@@ -654,7 +654,7 @@ pub fn transpose(
         .operands = .{ .flat = &.{src} },
         .results = .{ .flat = &.{result_type} },
         .attributes = &.{
-            .named(ctx, "permutation", .denseArray(ctx, .i32, permutation)),
+            .named(ctx, "permutation", mlir.Attribute.denseArray(ctx, .i64, permutation)),
         },
         .location = location,
     });
@@ -1149,14 +1149,14 @@ pub fn delay(
 pub fn assume_multiple(
     ctx: *mlir.Context,
     src: *const mlir.Value,
-    multiple: i64,
+    multiple: i32,
     location: *const mlir.Location,
 ) *mlir.Operation {
     return mlir.Operation.make(ctx, "tpu.assume_multiple", .{
         .operands = .{ .flat = &.{src} },
         .results = .{ .flat = &.{src.type_()} },
         .attributes = &.{
-            .named(ctx, "multiple", .int(ctx, .i64, multiple)),
+            .named(ctx, "multiple", mlir.Attribute.int(ctx, .i32, multiple)),
         },
         .location = location,
     });
@@ -1166,11 +1166,11 @@ pub fn assume_multiple(
 // Internal helpers
 // =============================================================================
 
-/// `DenseBoolArrayAttr` is distinct from `DenseArrayAttr<bool>`; pack bools as i8.
+/// `tpu.DenseBoolArrayAttr` stores one C `int` (i32) per bool, see `mlirDenseBoolArrayGet`
 fn denseBoolArrayAttribute(ctx: *mlir.Context, values: []const bool) *const mlir.Attribute {
-    var bytes: stdx.BoundedArray(i32, 64) = .empty;
-    for (values) |b| bytes.appendAssumeCapacity(@intFromBool(b));
-    return .denseArray(ctx, .bool, bytes.constSlice());
+    var ints: stdx.BoundedArray(i32, 64) = .empty;
+    for (values) |b| ints.appendAssumeCapacity(@intFromBool(b));
+    return mlir.Attribute.denseArray(ctx, .bool, ints.constSlice());
 }
 
 test {

--- a/mlir/dialects/mosaic_tpu/mosaic_tpu.zig
+++ b/mlir/dialects/mosaic_tpu/mosaic_tpu.zig
@@ -654,7 +654,7 @@ pub fn transpose(
         .operands = .{ .flat = &.{src} },
         .results = .{ .flat = &.{result_type} },
         .attributes = &.{
-            .named(ctx, "permutation", mlir.Attribute.denseArray(ctx, .i64, permutation)),
+            .named(ctx, "permutation", .denseArray(ctx, .i64, permutation)),
         },
         .location = location,
     });
@@ -1156,7 +1156,7 @@ pub fn assume_multiple(
         .operands = .{ .flat = &.{src} },
         .results = .{ .flat = &.{src.type_()} },
         .attributes = &.{
-            .named(ctx, "multiple", mlir.Attribute.int(ctx, .i32, multiple)),
+            .named(ctx, "multiple", .int(ctx, .i32, multiple)),
         },
         .location = location,
     });
@@ -1170,7 +1170,7 @@ pub fn assume_multiple(
 fn denseBoolArrayAttribute(ctx: *mlir.Context, values: []const bool) *const mlir.Attribute {
     var ints: stdx.BoundedArray(i32, 64) = .empty;
     for (values) |b| ints.appendAssumeCapacity(@intFromBool(b));
-    return mlir.Attribute.denseArray(ctx, .bool, ints.constSlice());
+    return .denseArray(ctx, .bool, ints.constSlice());
 }
 
 test {

--- a/mlir/dialects/stablehlo/stablehlo.zig
+++ b/mlir/dialects/stablehlo/stablehlo.zig
@@ -719,6 +719,9 @@ pub fn convolution(
 }
 
 pub const CustomCallOpts = struct {
+    pub const MAX_OPERANDS = 64;
+    pub const MAX_RESULTS = 16;
+
     pub const ApiVersion = enum(i32) {
         original = 1,
         status_returning = 2,
@@ -749,8 +752,8 @@ pub const CustomCallOpts = struct {
 };
 
 pub fn custom_call(ctx: *mlir.Context, inputs: []const *const mlir.Value, result_types: []const *const mlir.Type, opts: CustomCallOpts, location: *const mlir.Location) *mlir.Operation {
-    const MAX_OPERANDS = 64;
-    const MAX_RESULTS = 16;
+    const MAX_OPERANDS = CustomCallOpts.MAX_OPERANDS;
+    const MAX_RESULTS = CustomCallOpts.MAX_RESULTS;
     const MINOR_TO_MAJOR = comptime blk: {
         var ret: [mlir.ShapedType.MAX_RANK]usize = undefined;
         for (0..ret.len) |i| {

--- a/mlir/dialects/vector.zig
+++ b/mlir/dialects/vector.zig
@@ -140,15 +140,12 @@ pub const StridedSliceArgs = struct {
     strides: []const i64,
 };
 
-// `vector.extract_strided_slice` / `insert_strided_slice` use `ArrayAttr` of
-// `IntegerAttr` for `offsets`/`sizes`/`strides` (which print as `[i, j, k]`),
-// NOT `DenseArrayAttr` (which prints as `array<i64: i, j, k>`). The verifier
-// rejects the latter — its trait checks for ArrayAttr.
+/// extract/insert_strided_slice need offsets/sizes/strides as an ArrayAttr of IntegerAttr, not a DenseArrayAttr
 fn intArrayAttribute(ctx: *mlir.Context, comptime T: type, values: []const T) *const mlir.Attribute {
     const it: mlir.IntegerTypes = comptime @field(mlir.IntegerTypes, @typeName(T));
     var buf: stdx.BoundedArray(*const mlir.Attribute, mlir.ShapedType.MAX_RANK) = .empty;
-    for (values) |v| buf.appendAssumeCapacity(mlir.Attribute.int(ctx, it, v));
-    return mlir.Attribute.array(ctx, buf.constSlice());
+    for (values) |v| buf.appendAssumeCapacity(.int(ctx, it, v));
+    return .array(ctx, buf.constSlice());
 }
 
 pub fn extract_strided_slice(

--- a/mlir/dialects/vector.zig
+++ b/mlir/dialects/vector.zig
@@ -140,6 +140,17 @@ pub const StridedSliceArgs = struct {
     strides: []const i64,
 };
 
+// `vector.extract_strided_slice` / `insert_strided_slice` use `ArrayAttr` of
+// `IntegerAttr` for `offsets`/`sizes`/`strides` (which print as `[i, j, k]`),
+// NOT `DenseArrayAttr` (which prints as `array<i64: i, j, k>`). The verifier
+// rejects the latter — its trait checks for ArrayAttr.
+fn intArrayAttribute(ctx: *mlir.Context, comptime T: type, values: []const T) *const mlir.Attribute {
+    const it: mlir.IntegerTypes = comptime @field(mlir.IntegerTypes, @typeName(T));
+    var buf: stdx.BoundedArray(*const mlir.Attribute, mlir.ShapedType.MAX_RANK) = .empty;
+    for (values) |v| buf.appendAssumeCapacity(mlir.Attribute.int(ctx, it, v));
+    return mlir.Attribute.array(ctx, buf.constSlice());
+}
+
 pub fn extract_strided_slice(
     ctx: *mlir.Context,
     src: *const mlir.Value,
@@ -151,9 +162,9 @@ pub fn extract_strided_slice(
         .operands = .{ .flat = &.{src} },
         .results = .{ .flat = &.{result_type} },
         .attributes = &.{
-            .named(ctx, "offsets", .denseArray(ctx, .i64, args.offsets)),
-            .named(ctx, "sizes", .denseArray(ctx, .i64, args.sizes)),
-            .named(ctx, "strides", .denseArray(ctx, .i64, args.strides)),
+            .named(ctx, "offsets", intArrayAttribute(ctx, i64, args.offsets)),
+            .named(ctx, "sizes", intArrayAttribute(ctx, i64, args.sizes)),
+            .named(ctx, "strides", intArrayAttribute(ctx, i64, args.strides)),
         },
         .location = location,
     });
@@ -171,8 +182,8 @@ pub fn insert_strided_slice(
         .operands = .{ .flat = &.{ src, dest } },
         .results = .{ .flat = &.{dest.type_()} },
         .attributes = &.{
-            .named(ctx, "offsets", .denseArray(ctx, .i64, offsets)),
-            .named(ctx, "strides", .denseArray(ctx, .i64, strides)),
+            .named(ctx, "offsets", intArrayAttribute(ctx, i64, offsets)),
+            .named(ctx, "strides", intArrayAttribute(ctx, i64, strides)),
         },
         .location = location,
     });

--- a/mlir/mlir.zig
+++ b/mlir/mlir.zig
@@ -1175,6 +1175,11 @@ pub const Operation = opaque {
         c.mlirOperationSetAttributeByName(self.ptr(), stringRef(name_), attribute.ptr());
     }
 
+    pub fn attributeByName(self: *const Operation, name_: []const u8) ?*const Attribute {
+        const attr = c.mlirOperationGetAttributeByName(self.ptr(), stringRef(name_));
+        return if (attr.ptr == null) null else @ptrCast(attr.ptr);
+    }
+
     pub const PrintFlags = struct {
         elide_large_elements_attrs: ?usize = null,
         debug_info: bool = false,

--- a/zml/kernel.zig
+++ b/zml/kernel.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 
+const stdx = @import("stdx");
 const dialects = @import("mlir/dialects");
 const mlir = @import("mlir");
 const mosaic_tpu_builder = @import("kernels/mosaic_tpu/builder");
@@ -36,6 +37,24 @@ fn makeKernelContext(comptime dialects_needed: []const []const u8) std.mem.Alloc
     ctx.loadAllAvailableDialects();
 
     return ctx;
+}
+
+fn resolveOutputOperandAliases(
+    aliases_opt: anytype,
+    operand_offset: i64,
+) stdx.BoundedArray(dialects.stablehlo.CustomCallOpts.OutputOperandAlias, dialects.stablehlo.CustomCallOpts.MAX_RESULTS) {
+    var out: stdx.BoundedArray(dialects.stablehlo.CustomCallOpts.OutputOperandAlias, dialects.stablehlo.CustomCallOpts.MAX_RESULTS) = .empty;
+
+    if (aliases_opt) |a| {
+        inline for (@typeInfo(@TypeOf(a)).@"struct".fields, 0..) |field, output_index| {
+            if (@field(a, field.name)) |operand| out.appendAssumeCapacity(.{
+                .output_index = @intCast(output_index),
+                .operand_index = @as(i64, @intCast(@intFromEnum(operand))) + operand_offset,
+            });
+        }
+    }
+
+    return out;
 }
 
 pub const triton = struct {
@@ -90,7 +109,7 @@ pub const triton = struct {
                 grid: [3]i32,
                 num_stages: i32,
                 num_warps: i32,
-                output_operand_aliases: @FieldType(ops.TritonOps, "output_operand_aliases") = &.{},
+                output_operand_aliases: ?ops.CustomCallOutputOperandAliases(Inputs, Outputs) = null,
                 debug: bool = false,
             };
 
@@ -119,6 +138,8 @@ pub const triton = struct {
                 var outputs_arr: [spec.outputs.len]Shape = undefined;
                 inline for (spec.outputs, 0..) |fname, i| outputs_arr[i] = @field(outputs, fname);
 
+                const aliases = resolveOutputOperandAliases(opts.output_operand_aliases, 0);
+
                 const tensor_results = ops.triton(inputs_arr, outputs_arr, .{
                     .debug = opts.debug,
                     .name = name,
@@ -126,7 +147,7 @@ pub const triton = struct {
                     .grid = opts.grid,
                     .num_stages = opts.num_stages,
                     .num_warps = opts.num_warps,
-                    .output_operand_aliases = opts.output_operand_aliases,
+                    .output_operand_aliases = aliases.constSlice(),
                 });
 
                 var results: Results = undefined;
@@ -183,6 +204,16 @@ pub const mosaic_tpu = struct {
             pub const Outputs = StructOf(spec.outputs, Shape);
             pub const Results = StructOf(spec.outputs, Tensor);
 
+            pub const CallExtras = struct {
+                vmem_limit_bytes: ?i64 = null,
+                disable_bounds_checks: ?bool = null,
+                disable_semaphore_checks: ?bool = null,
+                has_communication: ?bool = null,
+                additional_attributes: []const mlir.NamedAttribute = &.{},
+                output_operand_aliases: ?ops.CustomCallOutputOperandAliases(Inputs, Outputs) = null,
+                dynamic_grid_bounds: []const Tensor = &.{},
+            };
+
             pub const CallOpts = struct {
                 cfg: ConfigT,
                 extras: CallExtras = .{},
@@ -207,7 +238,12 @@ pub const mosaic_tpu = struct {
                     std.debug.panic("zml.kernel.mosaic_tpu.Kernel({s}).call: emit failed: {}", .{ name, err });
                 defer cur.allocator.free(ir);
 
-                const backend_config = buildBackendConfig(cur.allocator, ir, opts.extras) catch |err|
+                const backend_config = buildBackendConfig(cur.allocator, ir, .{
+                    .vmem_limit_bytes = opts.extras.vmem_limit_bytes,
+                    .disable_bounds_checks = opts.extras.disable_bounds_checks,
+                    .disable_semaphore_checks = opts.extras.disable_semaphore_checks,
+                    .has_communication = opts.extras.has_communication,
+                }) catch |err|
                     std.debug.panic("zml.kernel.mosaic_tpu.Kernel({s}).call: backend_config build failed: {}", .{ name, err });
                 defer cur.allocator.free(backend_config);
 
@@ -219,7 +255,16 @@ pub const mosaic_tpu = struct {
                     r.* = mlirx.Type.rankedTensor(cur.mlir_ctx, @field(outputs, fname));
                 }
 
-                const op = callTpuCustomCall(&values, &res_types, backend_config, opts.extras);
+                const aliases = resolveOutputOperandAliases(opts.extras.output_operand_aliases, @intCast(opts.extras.dynamic_grid_bounds.len));
+
+                const op = callTpuCustomCall(.{
+                    .inputs = &values,
+                    .result_types = &res_types,
+                    .backend_config = backend_config,
+                    .aliases = aliases.constSlice(),
+                    .dynamic_grid_bounds = opts.extras.dynamic_grid_bounds,
+                    .additional_attributes = opts.extras.additional_attributes,
+                });
 
                 var results: Results = undefined;
                 inline for (spec.outputs, 0..) |fname, i| {
@@ -230,15 +275,6 @@ pub const mosaic_tpu = struct {
             }
         };
     }
-
-    const CallExtras = struct {
-        vmem_limit_bytes: ?i64 = null,
-        disable_bounds_checks: ?bool = null,
-        disable_semaphore_checks: ?bool = null,
-        has_communication: ?bool = null,
-        additional_attributes: []const mlir.NamedAttribute = &.{},
-        output_operand_aliases: []const dialects.stablehlo.CustomCallOpts.OutputOperandAlias = &.{},
-    };
 
     const CustomCallConfig = struct {
         body: []const u8,
@@ -261,10 +297,17 @@ pub const mosaic_tpu = struct {
         scoped_memory_configs: ?[]const ScopedMemoryConfig = null,
     };
 
+    const BackendConfigOpts = struct {
+        vmem_limit_bytes: ?i64 = null,
+        disable_bounds_checks: ?bool = null,
+        disable_semaphore_checks: ?bool = null,
+        has_communication: ?bool = null,
+    };
+
     fn buildBackendConfig(
         allocator: std.mem.Allocator,
         ir: [:0]const u8,
-        extras: CallExtras,
+        opts: BackendConfigOpts,
     ) ![]u8 {
         const ctx = try newContext();
         defer ctx.deinit();
@@ -295,11 +338,11 @@ pub const mosaic_tpu = struct {
         const config = BackendConfig{
             .custom_call_config = .{
                 .body = b64,
-                .has_communication = extras.has_communication,
-                .disable_bounds_checks = extras.disable_bounds_checks,
-                .disable_semaphore_checks = extras.disable_semaphore_checks,
+                .has_communication = opts.has_communication,
+                .disable_bounds_checks = opts.disable_bounds_checks,
+                .disable_semaphore_checks = opts.disable_semaphore_checks,
             },
-            .scoped_memory_configs = if (extras.vmem_limit_bytes) |vmem|
+            .scoped_memory_configs = if (opts.vmem_limit_bytes) |vmem|
                 &.{.{ .size = vmem }}
             else
                 null,
@@ -312,24 +355,33 @@ pub const mosaic_tpu = struct {
         return try json.toOwnedSlice();
     }
 
-    fn callTpuCustomCall(
+    const TpuCustomCallArgs = struct {
         inputs: []const *const mlir.Value,
         result_types: []const *const mlir.Type,
         backend_config: []const u8,
-        extras: CallExtras,
-    ) *mlir.Operation {
+        aliases: []const dialects.stablehlo.CustomCallOpts.OutputOperandAlias,
+        dynamic_grid_bounds: []const Tensor,
+        additional_attributes: []const mlir.NamedAttribute,
+    };
+
+    fn callTpuCustomCall(args: TpuCustomCallArgs) *mlir.Operation {
         const cur = CompilationContext.current();
+
+        var all_inputs: stdx.BoundedArray(*const mlir.Value, dialects.stablehlo.CustomCallOpts.MAX_OPERANDS) = .empty;
+        for (args.dynamic_grid_bounds) |t| all_inputs.appendAssumeCapacity(t.value());
+        all_inputs.appendSliceAssumeCapacity(args.inputs);
+
         return dialects.stablehlo.custom_call(
             cur.mlir_ctx,
-            inputs,
-            result_types,
+            all_inputs.constSlice(),
+            args.result_types,
             .{
                 .call_target_name = "tpu_custom_call",
-                .backend_config = .{ .original = backend_config },
+                .backend_config = .{ .original = args.backend_config },
                 .has_side_effect = false,
                 .api_version = .original,
-                .additional_attributes = extras.additional_attributes,
-                .output_operand_aliases = extras.output_operand_aliases,
+                .additional_attributes = args.additional_attributes,
+                .output_operand_aliases = args.aliases,
             },
             .unknown(cur.mlir_ctx),
         ).appendTo(cur.currentScope().block);

--- a/zml/moe/triton.zig
+++ b/zml/moe/triton.zig
@@ -381,11 +381,11 @@ fn alignBlockSize(topk_ids: Tensor, num_experts: i64, block_size_m: i64) struct 
                 .grid = .{ 2, 1, 1 },
                 .num_stages = 1,
                 .num_warps = 8,
-                .output_operand_aliases = &.{
-                    .{ .output_index = 0, .operand_index = 1 },
-                    .{ .output_index = 1, .operand_index = 2 },
-                    .{ .output_index = 2, .operand_index = 3 },
-                    .{ .output_index = 3, .operand_index = 4 },
+                .output_operand_aliases = .{
+                    .sorted_token_ids = .sorted_token_ids_ptr,
+                    .expert_ids = .expert_ids_ptr,
+                    .num_tokens_post_pad = .num_tokens_post_pad_ptr,
+                    .cumsum = .cumsum_ptr,
                 },
             },
         );
@@ -415,9 +415,9 @@ fn alignBlockSize(topk_ids: Tensor, num_experts: i64, block_size_m: i64) struct 
                 .grid = .{ @intCast(sort_grid_x), 1, 1 },
                 .num_stages = 1,
                 .num_warps = 4,
-                .output_operand_aliases = &.{
-                    .{ .output_index = 0, .operand_index = 1 },
-                    .{ .output_index = 1, .operand_index = 2 },
+                .output_operand_aliases = .{
+                    .sorted_token_ids = .sorted_token_ids_ptr,
+                    .cumsum = .cumsum_ptr,
                 },
             },
         );

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -1071,7 +1071,7 @@ fn customCallAdditionalAttributes(ctx: *CompilationContext, opts: CustomCallOpti
     return additional_attributes;
 }
 
-fn customCallOutputOperandAliases(
+pub fn customCallOutputOperandAliases(
     comptime I: type,
     comptime O: type,
     comptime aliases: ?CustomCallOutputOperandAliases(I, O),


### PR DESCRIPTION
This PR changes the following:

- Name-based `output_operand_aliases` for MosaicTPU and Triton DSLs
- New `kernels/mosaic_tpu/pipeline.zig`, a Zig port of `pltpu.emit_pipeline`
- Some fixes to MosaicTPU