### PR TITLE
zml/Sharding: Reduce Placement size by allocating shards on the stack.

### DIFF
--- a/examples/sharding/main.zig
+++ b/examples/sharding/main.zig
@@ -231,9 +231,16 @@ pub fn main(init: std.process.Init) !void {
     var input_buf = try createSequenceBuffer(allocator, io, platform, input_shape, sharding, 1000.0);
     defer input_buf.deinit();
 
-    log.info("input placement: {f}", .{input_buf.placement()});
-    log.info("weight placement: {f}", .{w_buf.placement()});
-    log.info("bias placement: {f}", .{b_buf.placement()});
+    var input_placement = try input_buf.placement(allocator);
+    defer input_placement.deinit(allocator);
+    var w_placement = try w_buf.placement(allocator);
+    defer w_placement.deinit(allocator);
+    var b_placement = try b_buf.placement(allocator);
+    defer b_placement.deinit(allocator);
+
+    log.info("input placement: {f}", .{input_placement});
+    log.info("weight placement: {f}", .{w_placement});
+    log.info("bias placement: {f}", .{b_placement});
 
     var exe_args = try exe.args(allocator);
     defer exe_args.deinit(allocator);

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -103,8 +103,9 @@ pub const Partitioning = struct {
 
     pub fn localShapeForShape(self: Partitioning, shape: Shape) !Shape {
         const sharding = try self.selectSharding(shape);
-        const placement = try Placement.init(sharding, shape);
-        return placement.shards.get(0).shape.withDefaultPartitioning();
+        var shards = Placement.shardIterator(sharding, shape);
+        const shard = (try shards.next()) orelse return error.InvalidPhysicalMesh;
+        return shard.shape.withDefaultPartitioning();
     }
 
     pub fn numPartitionsForLogicalAxis(self: Partitioning, shape: Shape, logical_axis: anytype) !i64 {
@@ -1766,7 +1767,7 @@ pub const Placement = struct {
             try writer.writeAll("]");
         }
     };
-    pub const Shards = stdx.BoundedArray(Shard, Platform.MAX_NUM_DEVICES);
+    pub const Shards = []Shard;
 
     const AxisSplit = struct {
         product: i64,
@@ -1794,71 +1795,106 @@ pub const Placement = struct {
         }
     };
 
+    pub const ShardIterator = struct {
+        sharding: Sharding,
+        shape: Shape,
+        ordered_devices: Devices,
+        index: usize = 0,
+
+        pub fn count(self: *const ShardIterator) usize {
+            return self.ordered_devices.len;
+        }
+
+        pub fn next(self: *ShardIterator) !?Shard {
+            if (self.index >= self.ordered_devices.len) return null;
+            defer self.index += 1;
+
+            return try shardForDevice(self.sharding, self.shape, self.ordered_devices.get(self.index));
+        }
+    };
+
     sharding: Sharding,
     shape: Shape,
     shards: Shards,
 
+    pub fn shardIterator(sharding: Sharding, shape: Shape) ShardIterator {
+        return .{
+            .sharding = sharding,
+            .shape = shape,
+            .ordered_devices = sharding.data.devicesInCanonicalOrder(),
+        };
+    }
+
+    /// Caller owns `shards` and must call `deinit` with the same allocator.
     pub fn init(
+        allocator: std.mem.Allocator,
         sharding: Sharding,
         shape: Shape,
     ) !Placement {
         const ordered_devices = sharding.data.devicesInCanonicalOrder();
-        var shards: Shards = .empty;
+        const shards = try allocator.alloc(Shard, ordered_devices.len);
+        errdefer allocator.free(shards);
 
-        for (ordered_devices.constSlice()) |d| {
-            if (d.coords.len == 0) return error.MissingDeviceCoords;
-
-            shards.appendAssumeCapacity(.{
-                .device_id = d.id,
-                .device_coords = d.coords,
-                .shape = undefined, // Calculated below
-                .global_shape = shape,
-                .slices = .empty,
-            });
+        for (ordered_devices.constSlice(), 0..) |d, i| {
+            shards[i] = try shardForDevice(sharding, shape, d);
         }
 
-        var self: Placement = .{
+        return .{
             .sharding = sharding,
             .shape = shape,
             .shards = shards,
         };
+    }
 
-        for (self.shards.slice()) |*s| {
-            var used_axes: std.EnumSet(PhysicalAxisTag) = .empty;
+    pub fn deinit(self: *Placement, allocator: std.mem.Allocator) void {
+        allocator.free(self.shards);
+    }
 
-            for (0..shape.rank()) |ax| {
-                const axis_index: u8 = @intCast(ax);
-                const slice = try self.sliceForDevice(s.device_coords.constSlice(), &used_axes, axis_index);
-                s.slices.appendAssumeCapacity(slice);
-            }
+    fn shardForDevice(sharding: Sharding, shape: Shape, device: Device) !Shard {
+        if (device.coords.len == 0) return error.MissingDeviceCoords;
 
-            s.shape = blk: {
-                var sh = shape;
-                for (s.slices.constSlice()) |slice| {
-                    sh = sh.set(slice.axis, slice.size);
-                }
-                break :blk sh;
-            };
+        var shard: Shard = .{
+            .device_id = device.id,
+            .device_coords = device.coords,
+            .shape = undefined,
+            .global_shape = shape,
+            .slices = .empty,
+        };
+        var used_axes: std.EnumSet(PhysicalAxisTag) = .empty;
+
+        for (0..shape.rank()) |ax| {
+            const axis_index: u8 = @intCast(ax);
+            const slice = try sliceForDevice(sharding, shape, shard.device_coords.constSlice(), &used_axes, axis_index);
+            shard.slices.appendAssumeCapacity(slice);
         }
 
-        return self;
+        shard.shape = blk: {
+            var sh = shape;
+            for (shard.slices.constSlice()) |slice| {
+                sh = sh.set(slice.axis, slice.size);
+            }
+            break :blk sh;
+        };
+
+        return shard;
     }
 
     fn sliceForDevice(
-        self: *Placement,
+        sharding: Sharding,
+        shape: Shape,
         device_coords: []const usize,
         used_axes: *std.EnumSet(PhysicalAxisTag),
         axis_index: u8,
     ) !Slice1d {
-        const dim = self.shape.dim(axis_index);
-        const spec = self.shape.partition(axis_index);
+        const dim = shape.dim(axis_index);
+        const spec = shape.partition(axis_index);
 
         switch (spec) {
             .axis => |logical_tag| {
-                const binding = self.sharding.data.binding(logical_tag) orelse return error.MissingLogicalBinding;
+                const binding = sharding.data.binding(logical_tag) orelse return error.MissingLogicalBinding;
 
                 // Calculate the split based on the physical coordinates of the current device
-                const plan = try self.calculateSplit(dim, binding, device_coords, used_axes);
+                const plan = try calculateSplit(sharding, dim, binding, device_coords, used_axes);
 
                 const size = @divExact(dim, plan.product);
                 const start = plan.linearIndex() * size;
@@ -1874,7 +1910,7 @@ pub const Placement = struct {
     }
 
     fn calculateSplit(
-        self: *Placement,
+        sharding: Sharding,
         dim: i64,
         binding: []const PhysicalAxisTag,
         device_coords: []const usize,
@@ -1884,16 +1920,16 @@ pub const Placement = struct {
 
         for (binding) |p_tag| {
             // Expand the physical tag: check if it's a target for folded source axes
-            if (self.sharding.data.foldSources(p_tag)) |sources| {
+            if (sharding.data.foldSources(p_tag)) |sources| {
                 for (sources) |src| {
                     if (used_axes.contains(src)) continue;
-                    self.addPhysicalToSplit(&plan, src, device_coords);
+                    addPhysicalToSplit(sharding, &plan, src, device_coords);
                     used_axes.insert(src);
                 }
             } else {
                 // Standard case: directly bound, not part of an explicit fold
                 if (used_axes.contains(p_tag)) continue;
-                self.addPhysicalToSplit(&plan, p_tag, device_coords);
+                addPhysicalToSplit(sharding, &plan, p_tag, device_coords);
                 used_axes.insert(p_tag);
             }
         }
@@ -1906,8 +1942,8 @@ pub const Placement = struct {
     }
 
     /// Extract coordinate data from the physical mesh for a specific axis.
-    fn addPhysicalToSplit(self: *Placement, plan: *AxisSplit, tag: PhysicalAxisTag, device_coords: []const usize) void {
-        const physical = self.sharding.data.physical;
+    fn addPhysicalToSplit(sharding: Sharding, plan: *AxisSplit, tag: PhysicalAxisTag, device_coords: []const usize) void {
+        const physical = sharding.data.physical;
         const info = physical.axisInfo(tag) orelse return;
         const depth = physical.axis_traversal.depth(tag) orelse return;
         const coord = device_coords[depth];
@@ -1916,17 +1952,45 @@ pub const Placement = struct {
     }
 
     pub fn format(self: Placement, writer: *std.Io.Writer) !void {
-        try writer.print("Placement(shape={f} shards={d})\n", .{ self.shape, self.shards.len });
+        const Iterator = struct {
+            shards: []const Shard,
+            index: usize = 0,
+
+            fn count(it: @This()) usize {
+                return it.shards.len;
+            }
+
+            fn next(it: *@This()) !?Shard {
+                if (it.index >= it.shards.len) return null;
+                defer it.index += 1;
+
+                return it.shards[it.index];
+            }
+        };
+        return formatFromShardSource(self.shape, Iterator{ .shards = self.shards }, writer);
+    }
+
+    pub fn formatShards(sharding: Sharding, shape: Shape, writer: *std.Io.Writer) std.Io.Writer.Error!void {
+        return formatFromShardSource(shape, shardIterator(sharding, shape), writer);
+    }
+
+    fn formatFromShardSource(shape: Shape, shards_: anytype, writer: *std.Io.Writer) std.Io.Writer.Error!void {
+        var shards = shards_;
+        const first_shard = shards.next() catch |err| {
+            return formatShardError(shape, shards.count(), err, writer);
+        };
+
+        try writer.print("Placement(shape={f} shards={d})\n", .{ shape, shards.count() });
 
         try writer.writeAll("Axis partitioning summary:\n");
-        for (0..self.shape.rank()) |ax| {
-            const dim = self.shape.dim(ax);
-            const spec = self.shape.partition(ax);
-            const axis_label = self.shape.debugTag(ax);
+        for (0..shape.rank()) |ax| {
+            const dim = shape.dim(ax);
+            const spec = shape.partition(ax);
+            const axis_label = shape.debugTag(ax);
 
             var shard_size: i64 = dim;
-            if (self.shards.len > 0) {
-                for (self.shards.constSlice()[0].slices.constSlice()) |s| {
+            if (first_shard) |shard| {
+                for (shard.slices.constSlice()) |s| {
                     if (s.axis == ax) {
                         shard_size = s.size;
                         break;
@@ -1946,9 +2010,27 @@ pub const Placement = struct {
         }
 
         try writer.writeAll("Per-shard placement:\n");
-        for (self.shards.constSlice(), 0..) |shard, i| {
-            try writer.print("└─ Shard[{d}] {f}\n", .{ i, shard });
+        var shard_index: usize = 0;
+        if (first_shard) |shard| {
+            try writer.print("└─ Shard[{d}] {f}\n", .{ shard_index, shard });
+            shard_index += 1;
         }
+        while (shards.next() catch |err| {
+            try writer.print("└─ Shard[{d}] error={s}\n", .{ shard_index, @errorName(err) });
+            return;
+        }) |shard| : (shard_index += 1) {
+            try writer.print("└─ Shard[{d}] {f}\n", .{ shard_index, shard });
+        }
+    }
+
+    fn formatShardError(
+        shape: Shape,
+        shard_count: usize,
+        err: anyerror,
+        writer: *std.Io.Writer,
+    ) std.Io.Writer.Error!void {
+        try writer.print("Placement(shape={f} shards={d})\n", .{ shape, shard_count });
+        try writer.print("Shard placement error: {s}\n", .{@errorName(err)});
     }
 };
 
@@ -2026,15 +2108,16 @@ const ShardingTest = struct {
 
         // Verify Placement logic / Error
         if (s.expect_error) |err| {
-            try std.testing.expectError(err, Placement.init(.{ .data = &sharding }, s.shape));
+            try std.testing.expectError(err, Placement.init(self.allocator, .{ .data = &sharding }, s.shape));
             return;
         }
 
         // Verify Shard Slices (Math)
         if (s.expected_shards.len > 0) {
-            const placement = try Placement.init(.{ .data = &sharding }, s.shape);
+            var placement = try Placement.init(self.allocator, .{ .data = &sharding }, s.shape);
+            defer placement.deinit(self.allocator);
             try std.testing.expectEqual(s.expected_shards.len, placement.shards.len);
-            for (s.expected_shards, placement.shards.constSlice()) |expected, actual| {
+            for (s.expected_shards, placement.shards) |expected, actual| {
                 try std.testing.expectEqual(expected.device_id, actual.device_id);
                 for (expected.slices, actual.slices.constSlice()) |exp_slice, actual_slice| {
                     try std.testing.expectEqual(exp_slice[0], actual_slice.start);

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -84,7 +84,7 @@ pub const Buffer = struct {
     }
 
     pub fn format(self: Buffer, writer: *std.Io.Writer) !void {
-        try writer.print("{f}", .{self.placement()});
+        try Sharding.Placement.formatShards(self._sharding, self._shape, writer);
     }
 
     /// Copies the content of the given buffer from host memory to the accelerator memory.
@@ -102,11 +102,15 @@ pub const Buffer = struct {
             ._sharding = sharding.resolve(platform),
             ._shards = .empty,
         };
+        errdefer for (res._shards.slice()) |shard| {
+            shard.deinit(platform.pjrt_api);
+        };
 
         const buffer_type = pjrtx.bufferTypeFromDtype(sh.dtype());
         const slice = Slice.init(sh, data_);
 
-        for (res.placement().shards.constSlice()) |shard| {
+        var shard_iter = Sharding.Placement.shardIterator(res._sharding, res._shape);
+        while (try shard_iter.next()) |shard| {
             const sub_slice = shard.shardSlice(slice);
             var default_layout: ?pjrt.DefaultMemoryLayout = null;
             const layout: pjrt.MemoryLayout = switch (platform.target) {
@@ -214,7 +218,8 @@ pub const Buffer = struct {
             shard.deinit(platform.pjrt_api);
         };
 
-        for (res.placement().shards.constSlice()) |shard| {
+        var shard_iter = Sharding.Placement.shardIterator(res._sharding, res._shape);
+        while (try shard_iter.next()) |shard| {
             var default_layout: ?pjrt.DefaultMemoryLayout = null;
             const layout: pjrt.MemoryLayout = switch (platform.target) {
                 .tpu => blk: {
@@ -274,7 +279,9 @@ pub const Buffer = struct {
     pub fn toSlice(self: Buffer, io: std.Io, slice: Slice) !void {
         stdx.debug.assert(self._shape.eql(slice.shape), "Buffer shape {f} doesn't match destination slice {f}", .{ self._shape, slice.shape });
 
-        for (self.placement().shards.constSlice(), 0..) |shard, shard_index| {
+        var shard_iter = Sharding.Placement.shardIterator(self._sharding, self._shape);
+        var shard_index: usize = 0;
+        while (try shard_iter.next()) |shard| : (shard_index += 1) {
             const sub_slice = shard.shardSlice(slice);
             if (!sub_slice.isContiguous()) return error.NonContiguousShardRead;
 
@@ -298,7 +305,9 @@ pub const Buffer = struct {
         const slice = try Slice.alloc(allocator, self.shape());
         errdefer slice.free(allocator);
 
-        for (self.placement().shards.constSlice(), 0..) |shard, shard_index| {
+        var shard_iter = Sharding.Placement.shardIterator(self._sharding, self._shape);
+        var shard_index: usize = 0;
+        while (try shard_iter.next()) |shard| : (shard_index += 1) {
             const sub_slice = shard.shardSlice(slice);
 
             var shard_slice = try Slice.alloc(allocator, sub_slice.shape);
@@ -318,14 +327,15 @@ pub const Buffer = struct {
     pub fn byteSize(self: Buffer) usize {
         var byte_size: usize = 0;
 
-        for (self.placement().shards.constSlice()) |shard| {
+        var shard_iter = Sharding.Placement.shardIterator(self._sharding, self._shape);
+        while (shard_iter.next() catch unreachable) |shard| {
             byte_size += shard.shape.byteSize();
         }
 
         return byte_size;
     }
 
-    pub fn placement(self: Buffer) Sharding.Placement {
-        return Sharding.Placement.init(self._sharding, self._shape) catch unreachable;
+    pub fn placement(self: Buffer, allocator: std.mem.Allocator) !Sharding.Placement {
+        return Sharding.Placement.init(allocator, self._sharding, self._shape);
     }
 };

--- a/zml/io.zig
+++ b/zml/io.zig
@@ -628,7 +628,7 @@ pub const DirectMemoryWriter = struct {
         }
 
         fn collectRawSegments(self: *StreamPlanner) !void {
-            for (self.placement.shards.constSlice(), 0..) |shard, writer_index| {
+            for (self.placement.shards, 0..) |shard, writer_index| {
                 try self.appendShardSegments(shard, writer_index);
             }
         }
@@ -788,7 +788,8 @@ pub const DirectMemoryWriter = struct {
         sharding: Sharding,
         buffer: *Buffer,
     ) !DirectMemoryWriter {
-        const placement = try Placement.init(sharding, shape);
+        var placement = try Placement.init(allocator, sharding, shape);
+        defer placement.deinit(allocator);
         var shard_writers = try allocator.alloc(DirectShardWriter, placement.shards.len);
         errdefer allocator.free(shard_writers);
 
@@ -798,7 +799,7 @@ pub const DirectMemoryWriter = struct {
         };
 
         var pjrt_buffers: Buffer.Shards = .empty;
-        for (placement.shards.constSlice(), 0..) |shard, i| {
+        for (placement.shards, 0..) |shard, i| {
             defer initialized += 1;
 
             const device_index = shard.platformDeviceIndex(platform) orelse return error.UnknownShardDevice;


### PR DESCRIPTION
`Placement` is 27KiB big, it led to stack allocation failure with gigantic struct sizes (~400KiB) in llmd. So changing the shards to be allocated on the heap with functions to avoid allocations when we don't need it (`format`, etc.).