### PR TITLE
zml/moe: Add sharding for triton MoE

### DIFF
--- a/examples/llm/models/common.zig
+++ b/examples/llm/models/common.zig
@@ -14,15 +14,17 @@ pub const GenerationOptions = struct {
 
 pub const Shardings = struct {
     model: zml.Sharding,
+    experts: zml.Sharding,
 
     pub fn init(platform: *zml.Platform) !Shardings {
         return .{
             .model = try platform.registerSharding("model", .mesh(.{ .model = .high_bandwidth })),
+            .experts = try platform.registerSharding("experts", .mesh(.{ .experts = .high_bandwidth })),
         };
     }
 
-    pub fn all(self: Shardings) [1]zml.Sharding {
-        return .{self.model};
+    pub fn all(self: Shardings) [2]zml.Sharding {
+        return .{ self.model, self.experts };
     }
 };
 

--- a/examples/llm/models/lfm2/model.zig
+++ b/examples/llm/models/lfm2/model.zig
@@ -94,11 +94,12 @@ pub const LoadedModel = struct {
             log.info("Loaded weights [{Bi:.2}, {f}, {Bi:.2}/s]", .{ total_bytes, took, bytes_per_sec });
         }
 
+        const all_shardings = shardings.all();
         return zml.io.load(Model, &self.inner, allocator, io, platform, store, .{
             .dma_chunks = 32,
             .dma_chunk_size = 128 * zml.MiB,
             .progress = progress,
-            .shardings = &shardings.all(),
+            .shardings = &all_shardings,
             .parallelism = 16,
             .total_bytes = &total_bytes,
         });

--- a/examples/llm/models/lfm2_tests.zig
+++ b/examples/llm/models/lfm2_tests.zig
@@ -47,9 +47,7 @@ pub fn main(init: std.process.Init) !void {
     defer repo_model.deinit(allocator);
 
     var progress = std.Progress.start(io, .{ .root_name = args.model });
-    const shardings: common.Shardings = .{
-        .model = try platform.registerSharding("tp_mesh", .mesh(.{ .model = .high_bandwidth })),
-    };
+    const shardings: common.Shardings = try .init(platform);
 
     var model_buffers = try repo_model.loadBuffers(allocator, io, platform, &store, &progress, shardings);
     defer repo_model.unloadBuffers(&model_buffers, allocator);

--- a/examples/llm/models/llama/inference.zig
+++ b/examples/llm/models/llama/inference.zig
@@ -113,7 +113,7 @@ fn compileModel(
             platform_: *const zml.Platform,
             llama_model_: model.Model,
             parameters_: CompilationParameters,
-            shardings_: [1]zml.Sharding,
+            shardings_: []const zml.Sharding,
             progress_: *std.Progress.Node,
         ) !zml.Exe {
             progress_.increaseEstimatedTotalItems(1);
@@ -134,11 +134,11 @@ fn compileModel(
                     parameters_.prefill_attention_parameters,
                 },
                 .{
-                    .shardings = &shardings_,
+                    .shardings = shardings_,
                 },
             );
         }
-    }.call, .{ allocator, io, platform, llama_model, parameters, all_shardings, progress });
+    }.call, .{ allocator, io, platform, llama_model, parameters, &all_shardings, progress });
     var prefill_future_awaited = false;
     errdefer if (!prefill_future_awaited) if (prefill_future.cancel(io)) |v| v.deinit() else |_| {};
 

--- a/examples/llm/models/llama/model.zig
+++ b/examples/llm/models/llama/model.zig
@@ -81,11 +81,12 @@ pub const LoadedModel = struct {
             std.log.scoped(.llama).info("Loaded weights [{Bi:.2}, {f}, {Bi:.2}/s]", .{ total_bytes, took, bytes_per_sec });
         }
 
+        const all_shardings = shardings.all();
         return zml.io.load(Model, &self.inner, allocator, io, platform, store, .{
             .dma_chunks = 32,
             .dma_chunk_size = 128 * zml.MiB,
             .progress = progress,
-            .shardings = &shardings.all(),
+            .shardings = &all_shardings,
             .parallelism = 16,
             .total_bytes = &total_bytes,
         });

--- a/examples/llm/models/llama_tests.zig
+++ b/examples/llm/models/llama_tests.zig
@@ -44,9 +44,7 @@ pub fn main(init: std.process.Init) !void {
     defer repo_model.deinit(allocator);
 
     var progress = std.Progress.start(io, .{ .root_name = args.model });
-    const shardings: common.Shardings = .{
-        .model = try platform.registerSharding("tp_mesh", .mesh(.{ .model = .high_bandwidth })),
-    };
+    const shardings: common.Shardings = try .init(platform);
 
     var model_buffers = try repo_model.loadBuffers(allocator, io, platform, &store, &progress, shardings);
     defer repo_model.unloadBuffers(&model_buffers, allocator);

--- a/examples/llm/models/qwen3_5_moe/inference.zig
+++ b/examples/llm/models/qwen3_5_moe/inference.zig
@@ -30,8 +30,9 @@ pub const CompilationParameters = struct {
 
     pub fn init(mdl: model.Model, config: model.Config, seqlen: u32, moe_backend: zml.moe.Backend, shardings: common.Shardings) CompilationParameters {
         const dtype = mdl.text_model.embed_tokens.weight.dtype();
+        const model_partitions = shardings.model.numPartitionsForLogicalAxis(.model);
         return .{
-            .kv_cache = .init(config, 1, seqlen, dtype, .f32),
+            .kv_cache = .init(config, 1, seqlen, dtype, .f32, model_partitions),
             .rng = .init(),
             .prefill_moe_metadata = initMoeMetadata(mdl, @intCast(seqlen), 1, moe_backend),
             .decode_moe_metadata = initMoeMetadata(mdl, 1, 1, moe_backend),
@@ -180,8 +181,23 @@ fn compileModel(
 
     const prefill_tokens = zml.Tensor.init(.{ .b = 1, .s = prefill_len }, .u32);
     const decode_tokens = zml.Tensor.init(.{ .b = 1, .s = 1 }, .u32);
-    const prefill_hidden = zml.Tensor.init(.{ .b = 1, .s = prefill_len, .d = qwen35_model.config.text_config.hidden_size }, qwen35_model.text_model.embed_tokens.weight.dtype());
-    const decode_hidden = zml.Tensor.init(.{ .b = 1, .s = 1, .d = qwen35_model.config.text_config.hidden_size }, qwen35_model.text_model.embed_tokens.weight.dtype());
+    const hidden_dtype = qwen35_model.text_model.embed_tokens.weight.dtype();
+    const prefill_hidden: zml.Tensor = .fromShape(zml.Shape.init(
+        .{ .b = 1, .s = prefill_len, .d = qwen35_model.config.text_config.hidden_size },
+        hidden_dtype,
+    ).withPartitioning(.{
+        .b = .replicated,
+        .s = .replicated,
+        .d = .replicated,
+    }));
+    const decode_hidden: zml.Tensor = .fromShape(zml.Shape.init(
+        .{ .b = 1, .s = 1, .d = qwen35_model.config.text_config.hidden_size },
+        hidden_dtype,
+    ).withPartitioning(.{
+        .b = .replicated,
+        .s = .replicated,
+        .d = .replicated,
+    }));
     const token_index = zml.Tensor.init(.{}, .u32);
     const self_attn_cache: model.KvCache.SelfAttnCache = .{
         .k = parameters.kv_cache.self_attn.k,

--- a/examples/llm/models/qwen3_5_moe/model.zig
+++ b/examples/llm/models/qwen3_5_moe/model.zig
@@ -67,6 +67,13 @@ fn partitionCachedKv(tensor: zml.Tensor, replicate_kv_heads: bool) zml.Tensor {
         tensor.rename(.{ .s = .k }).withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated });
 }
 
+fn partitionKvCacheShape(kv_shape: zml.Shape, kv_heads: i64, model_partitions: i64) zml.Shape {
+    return if (kvHeadsAreReplicated(kv_heads, model_partitions))
+        kv_shape.withPartitioning(.{ .h = .replicated })
+    else
+        kv_shape.withPartitioning(.{ .h = .model });
+}
+
 pub const LoadedModel = struct {
     inner: Model,
     parsed_config: std.json.Parsed(Config),
@@ -392,8 +399,8 @@ pub const TransformerLayer = struct {
         moe_parameters: zml.moe.Parameters,
     ) struct { zml.Tensor, KvCache.SelfAttnCache } {
         _ = config;
-        const residual0 = x0;
-        const normalized_x0 = self.input_layernorm.forward(x0);
+        const x0_replicated = x0.withPartitioning(.{ .d = .replicated });
+        const normalized_x0 = self.input_layernorm.forward(x0_replicated);
 
         const self_attn = switch (self.attn) {
             .self_attn => |self_attn| self_attn,
@@ -401,13 +408,12 @@ pub const TransformerLayer = struct {
         };
         const attention_output, const updated_kv_cache = self_attn.forward(normalized_x0, token_index, kv_cache);
 
-        const x1 = attention_output.add(residual0);
-        const residual1 = x1;
+        const x1 = attention_output.add(x0_replicated).withPartitioning(.{ .d = .replicated });
         const normalized_hidden = self.post_attention_layernorm.forward(x1);
 
         const moe_output = self.moe.forward(normalized_hidden, moe_metadata, moe_parameters);
 
-        return .{ moe_output.add(residual1).reuseBuffer(x0), updated_kv_cache };
+        return .{ moe_output.add(x1).withPartitioning(.{ .d = .replicated }).reuseBuffer(x0), updated_kv_cache };
     }
 
     pub fn forwardLinearAttn(
@@ -421,8 +427,8 @@ pub const TransformerLayer = struct {
     ) struct { zml.Tensor, KvCache.GatedDeltaNetCache } {
         _ = config;
         _ = token_index;
-        const residual0 = x0;
-        const normalized_x0 = self.input_layernorm.forward(x0);
+        const x0_replicated = x0.withPartitioning(.{ .d = .replicated });
+        const normalized_x0 = self.input_layernorm.forward(x0_replicated);
 
         const linear_attn = switch (self.attn) {
             .linear_attn => |linear_attn| linear_attn,
@@ -430,13 +436,12 @@ pub const TransformerLayer = struct {
         };
         const attention_output, const updated_kv_cache = linear_attn.forward(normalized_x0, kv_cache);
 
-        const x1 = attention_output.add(residual0);
-        const residual1 = x1;
+        const x1 = attention_output.add(x0_replicated).withPartitioning(.{ .d = .replicated });
         const normalized_hidden = self.post_attention_layernorm.forward(x1);
 
         const moe_output = self.moe.forward(normalized_hidden, moe_metadata, moe_parameters);
 
-        return .{ moe_output.add(residual1).reuseBuffer(x0), updated_kv_cache };
+        return .{ moe_output.add(x1).withPartitioning(.{ .d = .replicated }).reuseBuffer(x0), updated_kv_cache };
     }
 
     pub fn forward(
@@ -449,8 +454,8 @@ pub const TransformerLayer = struct {
         moe_parameters: zml.moe.Parameters,
     ) struct { zml.Tensor, KvCache } {
         _ = config;
-        const residual0 = x0;
-        const normalized_x0 = self.input_layernorm.forward(x0);
+        const x0_replicated = x0.withPartitioning(.{ .d = .replicated });
+        const normalized_x0 = self.input_layernorm.forward(x0_replicated);
 
         var attention_output: zml.Tensor = undefined;
         var updated_kv_cache: KvCache = kv_cache.parent;
@@ -467,13 +472,12 @@ pub const TransformerLayer = struct {
             },
         }
 
-        const x1 = attention_output.add(residual0);
-        const residual1 = x1;
+        const x1 = attention_output.add(x0_replicated).withPartitioning(.{ .d = .replicated });
         const normalized_hidden = self.post_attention_layernorm.forward(x1);
 
         const moe_output = self.moe.forward(normalized_hidden, moe_metadata, moe_parameters);
 
-        return .{ moe_output.add(residual1), updated_kv_cache };
+        return .{ moe_output.add(x1).withPartitioning(.{ .d = .replicated }), updated_kv_cache };
     }
 };
 
@@ -710,19 +714,19 @@ pub const Moe = struct {
         const gate_up_proj_tensor = experts_store.createTensor(
             "gate_up_proj",
             .{ .expert, .dout, .d },
-            .{ .expert = .replicated, .dout = .model, .d = .replicated },
+            .{ .expert = .experts, .dout = .replicated, .d = .replicated },
         );
         const down_proj_tensor = experts_store.createTensor(
             "down_proj",
             .{ .expert, .d, .dout },
-            .{ .expert = .replicated, .d = .replicated, .dout = .model },
+            .{ .expert = .experts, .d = .replicated, .dout = .replicated },
         );
 
         return .{
             .shared_expert = Mlp.init(store.withPrefix("shared_expert")),
             .shared_expert_gate = .init(
-                store.withPrefix("shared_expert_gate").createTensor("weight", .{ .dout, .d }, .{ .dout = .model, .d = .replicated }),
-                store.withPrefix("shared_expert_gate").maybeCreateTensor("bias", .{.dout}, .{ .dout = .model }),
+                store.withPrefix("shared_expert_gate").createTensor("weight", .{ .dout, .d }, .{ .dout = .replicated, .d = .replicated }),
+                store.withPrefix("shared_expert_gate").maybeCreateTensor("bias", .{.dout}, .{ .dout = .replicated }),
                 .d,
             ),
             .gate_up_proj = gate_up_proj_tensor,
@@ -754,7 +758,7 @@ pub const Moe = struct {
         ) catch |err| stdx.debug.panic("moe backend failed: {}", .{err});
 
         const shared_gate = self.shared_expert_gate.forward(x).sigmoid().broad(x.shape());
-        const shared = self.shared_expert.forward(x).mul(shared_gate);
+        const shared = self.shared_expert.forward(x).rename(.{ .dout = .d }).mul(shared_gate);
 
         return moe_output.add(shared);
     }
@@ -1104,7 +1108,7 @@ pub const KvCache = struct {
         v: zml.Tensor,
         layer_index: zml.Tensor,
 
-        pub fn init(config: Config, batch_dim: i64, max_seq_len: i64, dtype: zml.DataType) SelfAttnCache {
+        pub fn init(config: Config, batch_dim: i64, max_seq_len: i64, dtype: zml.DataType, model_partitions: i64) SelfAttnCache {
             const num_self_attn_layers = countLayers(config.text_config.layer_types, .full_attention);
             const kv_shape = zml.Shape.init(.{
                 .b = batch_dim,
@@ -1113,7 +1117,7 @@ pub const KvCache = struct {
                 .h = config.text_config.num_key_value_heads,
                 .hd = config.text_config.head_dim,
             }, dtype);
-            const sharded_kv_shape = kv_shape.withPartitioning(.{ .h = .model });
+            const sharded_kv_shape = partitionKvCacheShape(kv_shape, config.text_config.num_key_value_heads, model_partitions);
             return .{
                 .k = .fromShape(sharded_kv_shape),
                 .v = .fromShape(sharded_kv_shape),
@@ -1293,10 +1297,11 @@ pub const KvCache = struct {
         max_seq_len: i64,
         cache_dtype: zml.DataType,
         recurrent_dtype: zml.DataType,
+        model_partitions: i64,
     ) KvCache {
         return .{
             .layer_types = config.text_config.layer_types,
-            .self_attn = SelfAttnCache.init(config, batch_dim, max_seq_len, cache_dtype),
+            .self_attn = SelfAttnCache.init(config, batch_dim, max_seq_len, cache_dtype, model_partitions),
             .gated_delta_net = GatedDeltaNetCache.init(config, batch_dim, cache_dtype, recurrent_dtype),
         };
     }

--- a/examples/llm/models/qwen3_5_moe/model.zig
+++ b/examples/llm/models/qwen3_5_moe/model.zig
@@ -49,29 +49,37 @@ pub const RopeParameters = struct {
     rope_theta: f32,
 };
 
-fn kvHeadsAreReplicated(axis_size: i64, model_partitions: i64) bool {
-    return axis_size > 0 and axis_size < model_partitions and @rem(model_partitions, axis_size) == 0;
+fn kvHeadsAreReplicated(axis_size: i64, model_partitions: i64) struct { bool, ?u32 } {
+    const is_replicated = axis_size > 0 and axis_size < model_partitions and @rem(model_partitions, axis_size) == 0;
+    const repeat_factor = if (is_replicated) @as(u32, @intCast(@divExact(model_partitions, axis_size))) else null;
+    return .{ is_replicated, repeat_factor };
 }
 
-fn partitionProjectedKv(tensor: zml.Tensor, replicate_kv_heads: bool) zml.Tensor {
+fn partitionProjectedKv(tensor: zml.Tensor, replicate_kv_heads: bool, repeat_factor: ?u32) zml.Tensor {
     return if (replicate_kv_heads)
-        tensor.withPartitioning(.{ .s = .replicated, .h = .replicated, .hd = .replicated })
+        tensor.repeat1d(.h, @as(u63, repeat_factor.?)).withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated })
     else
         tensor.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
 }
 
-fn partitionCachedKv(tensor: zml.Tensor, replicate_kv_heads: bool) zml.Tensor {
+fn partitionCachedKv(tensor: zml.Tensor, replicate_kv_heads: bool, repeat_factor: ?u32) zml.Tensor {
     return if (replicate_kv_heads)
-        tensor.rename(.{ .s = .k }).withPartitioning(.{ .k = .replicated, .h = .replicated, .hd = .replicated })
+        tensor.rename(.{ .s = .k }).repeat1d(.h, @as(u63, repeat_factor.?)).withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated })
     else
         tensor.rename(.{ .s = .k }).withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated });
 }
 
 fn partitionKvCacheShape(kv_shape: zml.Shape, kv_heads: i64, model_partitions: i64) zml.Shape {
-    return if (kvHeadsAreReplicated(kv_heads, model_partitions))
-        kv_shape.withPartitioning(.{ .h = .replicated })
-    else
-        kv_shape.withPartitioning(.{ .h = .model });
+    const is_replicated, const repeat_factor = kvHeadsAreReplicated(kv_heads, model_partitions);
+
+    if (is_replicated) {
+        const repeated_h = kv_shape.dim(.h) * @as(i64, @intCast(repeat_factor.?));
+        return kv_shape
+            .setDim(.h, repeated_h)
+            .withPartitioning(.{ .h = .model });
+    }
+
+    return kv_shape.withPartitioning(.{ .h = .model });
 }
 
 pub const LoadedModel = struct {
@@ -572,15 +580,15 @@ pub const SelfAttn = struct {
         kv_cache: KvCache.SelfAttnCache,
     ) struct { zml.Tensor, KvCache.SelfAttnCache } {
         const model_partitions = zml.module.CompilationContext.current().partitioning.numPartitionsForLogicalAxis(self.q_proj.weight.shape(), .model) catch unreachable;
-        const replicate_kv_heads = kvHeadsAreReplicated(self.num_kv_heads, model_partitions);
+        const replicate_kv_heads, const repeat_factor = kvHeadsAreReplicated(self.num_kv_heads, model_partitions);
         const x_qkv = x.withPartitioning(.{ .d = .replicated });
 
         var q, var gate = self.projectQAndGate(x_qkv);
         var k, var v = self.projectKV(x_qkv);
         q = q.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
         gate = gate.withPartitioning(.{ .s = .replicated, .d_out_proj = .model });
-        k = partitionProjectedKv(k, replicate_kv_heads);
-        v = partitionProjectedKv(v, replicate_kv_heads);
+        k = partitionProjectedKv(k, replicate_kv_heads, repeat_factor);
+        v = partitionProjectedKv(v, replicate_kv_heads, repeat_factor);
         q = self.q_norm.forward(q.rename(.{ .hd = .d })).rename(.{ .d = .hd });
         k = self.k_norm.forward(k.rename(.{ .hd = .d })).rename(.{ .d = .hd });
 
@@ -593,15 +601,15 @@ pub const SelfAttn = struct {
         q = self.rotary_embed.applyRope(q, cos, sin);
         k = self.rotary_embed.applyRope(k, cos, sin);
         q = q.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
-        k = partitionProjectedKv(k, replicate_kv_heads);
-        v = partitionProjectedKv(v, replicate_kv_heads);
+        k = partitionProjectedKv(k, replicate_kv_heads, repeat_factor);
+        v = partitionProjectedKv(v, replicate_kv_heads, repeat_factor);
 
         const new_kv_cache = kv_cache.update(k, v, token_index.convert(.u32));
         k = new_kv_cache.keys().convert(dtype);
         v = new_kv_cache.values().convert(dtype);
         q = q.rename(.{ .s = .q }).withPartitioning(.{ .q = .replicated, .h = .model, .hd = .replicated });
-        k = partitionCachedKv(k, replicate_kv_heads);
-        v = partitionCachedKv(v, replicate_kv_heads);
+        k = partitionCachedKv(k, replicate_kv_heads, repeat_factor);
+        v = partitionCachedKv(v, replicate_kv_heads, repeat_factor);
 
         const attn_output = zml.attention.attention.attention(
             q,

--- a/examples/llm/models/qwen3_5_moe/session.zig
+++ b/examples/llm/models/qwen3_5_moe/session.zig
@@ -205,7 +205,11 @@ pub const Session = struct {
         const model_dtype = self.compiled_model.loaded_model.inner.text_model.embed_tokens.weight.dtype();
 
         const prefill_tokens_shape = zml.Shape.init(.{ .b = 1, .s = self.seqlen }, .u32);
-        const prefill_hidden_shape = zml.Shape.init(.{ .b = 1, .s = self.seqlen, .d = hidden_size }, model_dtype);
+        const prefill_hidden_shape = zml.Shape.init(.{ .b = 1, .s = self.seqlen, .d = hidden_size }, model_dtype).withPartitioning(.{
+            .b = .replicated,
+            .s = .replicated,
+            .d = .replicated,
+        });
 
         const prefill_tokens_slice = try zml.Slice.alloc(self.allocator, prefill_tokens_shape);
         defer prefill_tokens_slice.free(self.allocator);
@@ -296,7 +300,11 @@ pub const Session = struct {
         const hidden_size = self.compiled_model.loaded_model.inner.config.text_config.hidden_size;
         const model_dtype = self.compiled_model.loaded_model.inner.text_model.embed_tokens.weight.dtype();
 
-        const decode_hidden_shape = zml.Shape.init(.{ .b = 1, .s = 1, .d = hidden_size }, model_dtype);
+        const decode_hidden_shape = zml.Shape.init(.{ .b = 1, .s = 1, .d = hidden_size }, model_dtype).withPartitioning(.{
+            .b = .replicated,
+            .s = .replicated,
+            .d = .replicated,
+        });
         const replicated_sharding: zml.Sharding = .replicated;
 
         var embedding_decode_args = try self.compiled_model.decode_embedding_exe.args(self.allocator);
@@ -445,9 +453,6 @@ fn tokenizeChatPrompt(allocator: std.mem.Allocator, tokenizer: zml.tokenizer.Tok
     const assistant = try encoder.encodeAlloc(allocator, "assistant\n");
     try tokens.appendSlice(allocator, assistant);
     allocator.free(assistant);
-    const think = try encoder.encodeAlloc(allocator, "<think>\n");
-    try tokens.appendSlice(allocator, think);
-    allocator.free(think);
 
     return tokens.toOwnedSlice(allocator);
 }

--- a/mlir/dialects/stablehlo/stablehlo.zig
+++ b/mlir/dialects/stablehlo/stablehlo.zig
@@ -897,7 +897,7 @@ pub fn unpin(ctx: *mlir.Context, value: *const mlir.Value, location: *const mlir
 
 pub fn partition_id(ctx: *mlir.Context, location: *const mlir.Location) *mlir.Operation {
     return mlir.Operation.make(ctx, "stablehlo.partition_id", .{
-        .results = .{ .flat = &.{.rankedTensor(&.{}, mlir.integerType(ctx, .u32))} },
+        .results = .{ .flat = &.{.rankedTensor(&.{}, .int(ctx, .u32))} },
         .location = location,
     });
 }

--- a/mlir/dialects/stablehlo/stablehlo.zig
+++ b/mlir/dialects/stablehlo/stablehlo.zig
@@ -1433,14 +1433,15 @@ pub fn channelHandle(
 
 pub fn allReduce(
     ctx: *mlir.Context,
-    input: *const mlir.Value,
+    inputs: []const *const mlir.Value,
+    result_types: []const *const mlir.Type,
     reducer_block: *mlir.Block,
     replica_groups: *const mlir.Attribute,
     channel_handle: *const mlir.Attribute,
 ) *mlir.Operation {
     return mlir.Operation.make(ctx, "stablehlo.all_reduce", .{
-        .operands = .{ .flat = &.{input} },
-        .results = .{ .flat = &.{input.type_()} },
+        .operands = .{ .variadic = &.{inputs} },
+        .results = .{ .flat = result_types },
         .blocks = &.{reducer_block},
         .attributes = &.{
             .named(ctx, "replica_groups", replica_groups),

--- a/mlir/dialects/stablehlo/stablehlo.zig
+++ b/mlir/dialects/stablehlo/stablehlo.zig
@@ -1413,3 +1413,41 @@ pub fn returns(ctx: *mlir.Context, values: []const *const mlir.Value, location: 
         .location = location,
     });
 }
+
+pub const ChannelType = enum(i64) {
+    collective = 0,
+    send_recv = 1,
+};
+
+pub fn channelHandle(
+    ctx: *mlir.Context,
+    handle: i64,
+    channel_type: ChannelType,
+) *const mlir.Attribute {
+    return @ptrCast(c.stablehloChannelHandleGet(
+        ctx.ptr(),
+        handle,
+        @intFromEnum(channel_type),
+    ).ptr);
+}
+
+pub fn allReduce(
+    ctx: *mlir.Context,
+    input: *const mlir.Value,
+    reducer_block: *mlir.Block,
+    replica_groups: *const mlir.Attribute,
+    channel_handle: *const mlir.Attribute,
+) *mlir.Operation {
+    return mlir.Operation.make(ctx, "stablehlo.all_reduce", .{
+        .operands = .{ .flat = &.{input} },
+        .results = .{ .flat = &.{input.type_()} },
+        .blocks = &.{reducer_block},
+        .attributes = &.{
+            .named(ctx, "replica_groups", replica_groups),
+            .named(ctx, "channel_handle", channel_handle),
+            .named(ctx, "use_global_device_ids", .unit(ctx)),
+        },
+        .verify = true,
+        .location = .unknown(ctx),
+    });
+}

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -97,6 +97,8 @@ pub const CompilationContext = struct {
     scopes: stdx.BoundedArray(Scope, 16) = .empty,
     manual_computation_depth: usize = 0,
 
+    channel_id: i64 = 0,
+
     threadlocal var _current: ?*CompilationContext = null;
 
     pub fn init(allocator: std.mem.Allocator, io: std.Io, platform: *const Platform, opts: CompilationOptions) CompilationContext {
@@ -180,6 +182,11 @@ pub const CompilationContext = struct {
         if (maybe_popped_scope) |*popped| {
             popped.deinit();
         }
+    }
+
+    pub fn nextChannelId(self: *CompilationContext) i64 {
+        self.channel_id += 1;
+        return self.channel_id;
     }
 };
 

--- a/zml/moe/moe.zig
+++ b/zml/moe/moe.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const zml = @import("../zml.zig");
+const stdx = zml.stdx;
 pub const triton = @import("triton.zig");
 
 pub const triton_kernels = @import("triton_kernels/triton_kernels.zig");
@@ -115,6 +116,67 @@ pub fn forwardMoe(
                 .triton => |v| v,
             };
 
+            const expert_partition = weights_gate_up.shape().partition(.expert);
+
+            if (expert_partition.eql(.init(.experts))) {
+                const expert_partitions = zml.module.CompilationContext.current().partitioning.numPartitionsForLogicalAxis(
+                    weights_gate_up.shape(),
+                    .experts,
+                ) catch unreachable;
+
+                const global_num_experts = weights_down.shape().dim(.expert) * expert_partitions;
+
+                const partial_output = zml.ops.manualComputation(
+                    .{ input, topk_ids, topk_weights, weights_gate_up, weights_down },
+                    input.shape().withPartitioning(.{ .b = .replicated, .s = .replicated, .d = .replicated }),
+                    .{
+                        .activation = parameters.triton.activation,
+                        .global_num_experts = global_num_experts,
+                        .scales_gate_up = scales_gate_up,
+                        .bias_gate_up = bias_gate_up,
+                        .scales_down = scales_down,
+                        .bias_down = bias_down,
+                    },
+                    (struct {
+                        fn body(ctx: anytype, _: std.mem.Allocator, sharded_inputs: []const zml.Tensor, output_shape: zml.Shape) zml.Tensor {
+                            const local_num_experts = sharded_inputs[3].dim(.expert);
+                            const partition_id = zml.ops.partitionId().convert(.i32);
+                            const expert_start = partition_id.scale(local_num_experts).convert(.i32);
+                            // List of global expert ids
+                            const global_expert_ids = zml.Tensor.arange(.{ .end = ctx.global_num_experts }, .i32).withTags(.{.expert});
+
+                            // Mapping of local experts to global expert ids, -1 if the global expert is not present in the local partition
+                            const local_expert_mask = global_expert_ids.cmp(.GE, expert_start)
+                                .logical(.AND, global_expert_ids.cmp(.LT, expert_start.addConstant(local_num_experts)));
+                            const expert_map = local_expert_mask.select(
+                                global_expert_ids.sub(expert_start),
+                                zml.Tensor.scalar(-1, .i32),
+                            );
+                            const local_output = triton.fusedExpertsImpl(
+                                sharded_inputs[0],
+                                sharded_inputs[3],
+                                sharded_inputs[4],
+                                sharded_inputs[2],
+                                sharded_inputs[1],
+                                .{},
+                                .{
+                                    .activation = ctx.activation,
+                                    .global_num_experts = ctx.global_num_experts,
+                                    .expert_map = expert_map,
+                                    .w1_scale = ctx.scales_gate_up,
+                                    .w2_scale = ctx.scales_down,
+                                    .w1_bias = ctx.bias_gate_up,
+                                    .w2_bias = ctx.bias_down,
+                                },
+                            ) catch |err| stdx.debug.panic("moe backend failed: {}", .{err});
+                            _ = output_shape;
+                            return local_output.reshape(sharded_inputs[0].shape().dims()).withTags(.{ .b, .s, .d });
+                        }
+                    }).body,
+                );
+                break :b zml.ops.allReduceSum(partial_output);
+            }
+
             break :b try triton.fusedExpertsImpl(
                 input,
                 weights_gate_up,
@@ -124,6 +186,7 @@ pub fn forwardMoe(
                 triton_metadata,
                 .{
                     .activation = parameters.triton.activation,
+                    .global_num_experts = weights_gate_up.dim(.expert),
                     .w1_scale = scales_gate_up,
                     .w2_scale = scales_down,
                     .w1_bias = bias_gate_up,

--- a/zml/moe/moe.zig
+++ b/zml/moe/moe.zig
@@ -174,7 +174,7 @@ pub fn forwardMoe(
                         }
                     }).body,
                 );
-                break :b zml.ops.allReduceSum(partial_output);
+                break :b zml.ops.allReduce(partial_output, zml.Tensor.add);
             }
 
             break :b try triton.fusedExpertsImpl(

--- a/zml/moe/triton.zig
+++ b/zml/moe/triton.zig
@@ -141,7 +141,11 @@ pub fn fusedExpertsImpl(
     try validateInputs(hidden, gate_up, down, weights, ids);
 
     const block_size_m = options.block_size_m;
-    const num_experts = gate_up.dim(.expert);
+    const num_experts = if (opts.global_num_experts != -1) opts.global_num_experts else gate_up.dim(.expert);
+    if (opts.expert_map) |expert_map| {
+        if (expert_map.dtype() != .i32) return error.UnsupportedType;
+        if (expert_map.rank() != 1 or expert_map.dim(.expert) != num_experts) return error.InvalidShape;
+    }
     const num_assignments = hidden.dim(.token) * ids.dim(.topk);
     const sparsity_factor: i64 = 4;
     const naive_block_assignment = num_assignments * sparsity_factor <= num_experts;
@@ -153,13 +157,18 @@ pub fn fusedExpertsImpl(
     else
         num_assignments + num_experts * (block_size_m - 1);
 
-    const sorted_token_ids, const expert_ids, const num_tokens_post_padded = if (naive_block_assignment) blk: {
+    const sorted_token_ids, const expert_ids_global, const num_tokens_post_padded = if (naive_block_assignment) blk: {
         log.info("Using naive block assignment for MoE kernels. Num assignments: {d}, Num experts: {d}", .{ num_assignments, num_experts });
         const naive_sorted_ids = Tensor.zeroes(Shape.init(.{ .g = 1 }, .i32));
         const naive_expert_ids = ids.reshape(.{ .g = num_assignments });
         const naive_num_tokens_post_padded = Tensor.constant(.{ .i32 = @as(i32, @intCast(max_num_tokens_padded)) }).reshape(.{1});
         break :blk .{ naive_sorted_ids, naive_expert_ids, naive_num_tokens_post_padded };
     } else alignBlockSize(ids, num_experts, block_size_m);
+
+    const expert_ids = if (opts.expert_map) |expert_map|
+        expert_map.gather(.{ .expert = expert_ids_global }, .{}).withTags(.{.g})
+    else
+        expert_ids_global;
 
     var hidden_quant = hidden;
     var a_scale = opts.a1_scale orelse Tensor.scalar(1.0, .f32);
@@ -632,8 +641,7 @@ fn validateOptions(opts: Options) !void {
     if (opts.apply_router_weight_on_input) return error.UnsupportedOption;
     if (opts.use_fp8_w8a8 or opts.use_int8_w8a8 or opts.use_int8_w8a16 or opts.use_int4_w4a16) return error.UnsupportedQuantization;
     if (opts.ocp_mx_scheme != null or opts.per_channel_quant) return error.UnsupportedOption;
-    if (opts.global_num_experts != -1) return error.UnsupportedOption;
-    if (opts.expert_map != null) return error.UnsupportedOption;
+    if (opts.expert_map != null and opts.global_num_experts == -1) return error.InvalidShape;
     if (opts.w1_zp != null or opts.w2_zp != null) return error.UnsupportedOption;
     if (opts.a1_scale != null or opts.a2_scale != null or opts.block_shape != null) return error.UnsupportedOption;
     if (opts.w1_bias != null or opts.w2_bias != null) return error.UnsupportedOption;

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -23,6 +23,9 @@ pub fn allReduceSum(input: Tensor) Tensor {
     const ctx = CompilationContext.current();
     const mlir_ctx = ctx.mlir_ctx;
 
+    const num_devices = ctx.partitioning.numPartitions();
+    if (num_devices <= 1) return input;
+
     const reducer_block = b: {
         const scalar_shape = Shape.init(.{}, input.dtype());
         const left: Tensor = .fromShape(scalar_shape);
@@ -51,9 +54,6 @@ pub fn allReduceSum(input: Tensor) Tensor {
         break :b block;
     };
 
-    const num_devices = ctx.partitioning.numPartitions();
-    if (num_devices <= 1) return input;
-
     var replica_group_storage: [constants.MAX_RANK]i64 = undefined;
     for (0..@intCast(num_devices)) |i| {
         replica_group_storage[i] = @intCast(i);
@@ -72,7 +72,7 @@ pub fn allReduceSum(input: Tensor) Tensor {
     );
 
     const op = dialects.stablehlo.allReduce(
-        ctx.mlir_ctx,
+        mlir_ctx,
         input.value(),
         reducer_block,
         replica_groups_attr,

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -64,23 +64,20 @@ pub fn allReduceSum(input: Tensor) Tensor {
         replica_group_slice,
     );
 
-    const channel_handle_attr = mlir.Attribute.parse(
+    const handle = ctx.nextChannelId();
+    const channel_handle_attr = dialects.stablehlo.channelHandle(
         mlir_ctx,
-        "#stablehlo.channel_handle<handle = 1, type = 1>",
-    ) catch unreachable;
+        handle,
+        .collective,
+    );
 
-    const op = mlir.Operation.make(mlir_ctx, "stablehlo.all_reduce", .{
-        .operands = .{ .flat = &.{input.value()} },
-        .results = .{ .flat = &.{input.value().type_()} },
-        .blocks = &.{reducer_block},
-        .attributes = &.{
-            .named(mlir_ctx, "replica_groups", replica_groups_attr),
-            .named(mlir_ctx, "channel_handle", channel_handle_attr),
-            .named(mlir_ctx, "use_global_device_ids", .unit(mlir_ctx)),
-        },
-        .verify = true,
-        .location = .unknown(mlir_ctx),
-    }).appendTo(ctx.currentScope().block);
+    const op = dialects.stablehlo.allReduce(
+        ctx.mlir_ctx,
+        input.value(),
+        reducer_block,
+        replica_groups_attr,
+        channel_handle_attr,
+    ).appendTo(ctx.currentScope().block);
 
     return Tensor._result(input.shape(), op.result(0));
 }

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -19,6 +19,81 @@ pub const ShapeToCustomCallBuffer = @import("pjrtx.zig").ShapeToCustomCallBuffer
 const Tensor = @import("tensor.zig").Tensor;
 pub const TensorToCustomCallBuffer = @import("pjrtx.zig").TensorToCustomCallBuffer;
 
+pub fn allReduceSum(input: Tensor) Tensor {
+    const ctx = CompilationContext.current();
+    const mlir_ctx = ctx.mlir_ctx;
+
+    const reducer_block = b: {
+        const scalar_shape = Shape.init(.{}, input.dtype());
+        const left: Tensor = .fromShape(scalar_shape);
+        const right: Tensor = .fromShape(scalar_shape);
+
+        const block_types = [_]*const mlir.Type{
+            mlirx.Type.rankedTensor(mlir_ctx, scalar_shape),
+            mlirx.Type.rankedTensor(mlir_ctx, scalar_shape),
+        };
+        const block_locs = [_]*const mlir.Location{
+            mlir.Location.unknown(mlir_ctx),
+            mlir.Location.unknown(mlir_ctx),
+        };
+        const block = mlir.Block.init(&block_types, &block_locs);
+        errdefer block.deinit();
+
+        ctx.pushBlock(block);
+        defer ctx.popBlock();
+
+        const scope = ctx.currentScope();
+        scope.id_to_argument.put(scope.arena.allocator(), left.id, 0) catch unreachable;
+        scope.id_to_argument.put(scope.arena.allocator(), right.id, 1) catch unreachable;
+
+        const sum = left.add(right);
+        _ = dialects.stablehlo.return_(mlir_ctx, sum.value(), .unknown(mlir_ctx)).appendTo(block);
+        break :b block;
+    };
+
+    const num_devices = ctx.partitioning.numPartitions();
+    if (num_devices <= 1) return input;
+
+    var replica_group_storage: [constants.MAX_RANK]i64 = undefined;
+    for (0..@intCast(num_devices)) |i| {
+        replica_group_storage[i] = @intCast(i);
+    }
+    const replica_group_slice = replica_group_storage[0..@intCast(num_devices)];
+    const replica_groups_attr = mlir.Attribute.denseElements(
+        .rankedTensor(&.{ 1, num_devices }, .int(mlir_ctx, .i64)),
+        replica_group_slice,
+    );
+
+    const channel_handle_attr = mlir.Attribute.parse(
+        mlir_ctx,
+        "#stablehlo.channel_handle<handle = 1, type = 1>",
+    ) catch unreachable;
+
+    const op = mlir.Operation.make(mlir_ctx, "stablehlo.all_reduce", .{
+        .operands = .{ .flat = &.{input.value()} },
+        .results = .{ .flat = &.{input.value().type_()} },
+        .blocks = &.{reducer_block},
+        .attributes = &.{
+            .named(mlir_ctx, "replica_groups", replica_groups_attr),
+            .named(mlir_ctx, "channel_handle", channel_handle_attr),
+            .named(mlir_ctx, "use_global_device_ids", .unit(mlir_ctx)),
+        },
+        .verify = true,
+        .location = .unknown(mlir_ctx),
+    }).appendTo(ctx.currentScope().block);
+
+    return Tensor._result(input.shape(), op.result(0));
+}
+
+pub fn partitionId() Tensor {
+    const ctx = CompilationContext.current();
+    const op = mlir.Operation.make(ctx.mlir_ctx, "stablehlo.partition_id", .{
+        .results = .{ .flat = &.{mlirx.Type.rankedTensor(ctx.mlir_ctx, Shape.scalar(.u32))} },
+        .location = .unknown(ctx.mlir_ctx),
+    }).appendTo(ctx.currentScope().block);
+    return Tensor._result(.init(.{}, .u32), op.result(0));
+}
+
 pub const ReduceArgs = struct {
     left: Tensor,
     right: Tensor,

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -19,26 +19,69 @@ pub const ShapeToCustomCallBuffer = @import("pjrtx.zig").ShapeToCustomCallBuffer
 const Tensor = @import("tensor.zig").Tensor;
 pub const TensorToCustomCallBuffer = @import("pjrtx.zig").TensorToCustomCallBuffer;
 
-pub fn allReduceSum(input: Tensor) Tensor {
+
+
+pub fn allReduce(inputs: anytype, comptime func: anytype) allReduceReturnType(@TypeOf(inputs)) {
     const ctx = CompilationContext.current();
     const mlir_ctx = ctx.mlir_ctx;
 
+    const InputsT = @TypeOf(inputs);
+    const n_inputs = switch (@typeInfo(InputsT)) {
+        .@"struct" => |struct_info| b: {
+            if (InputsT == Tensor) break :b 1;
+            if (!struct_info.is_tuple) {
+                @compileError("zml.ops.allReduce expects Tensor, tuple of Tensor, or [N]Tensor inputs");
+            }
+            break :b struct_info.fields.len;
+        },
+        .array => |array_info| b: {
+            if (array_info.child != Tensor) {
+                @compileError("zml.ops.allReduce expects [N]Tensor inputs");
+            }
+            break :b array_info.len;
+        },
+        else => @compileError("zml.ops.allReduce expects Tensor, tuple of Tensor, or [N]Tensor inputs"),
+    };
+    comptime stdx.debug.assertComptime(n_inputs > 0, "zml.ops.allReduce requires at least one input tensor", .{});
+
+    const input_tensors: [n_inputs]Tensor = switch (@typeInfo(InputsT)) {
+        .@"struct" => |struct_info| b: {
+            if (InputsT == Tensor) {
+                break :b .{inputs};
+            }
+            if (!struct_info.is_tuple) {
+                @compileError("zml.ops.allReduce expects Tensor, tuple of Tensor, or [N]Tensor inputs");
+            }
+
+            var flat_inputs: [n_inputs]Tensor = undefined;
+            meta.collectBuf((struct {
+                pub fn cb(t: Tensor) Tensor {
+                    return t;
+                }
+            }).cb, {}, &inputs, &flat_inputs);
+            break :b flat_inputs;
+        },
+        .array => inputs,
+        else => @compileError("zml.ops.allReduce expects Tensor, tuple of Tensor, or [N]Tensor inputs"),
+    };
+
     const num_devices = ctx.partitioning.numPartitions();
-    if (num_devices <= 1) return input;
+    if (num_devices <= 1) return inputs;
 
     const reducer_block = b: {
-        const scalar_shape = Shape.init(.{}, input.dtype());
-        const left: Tensor = .fromShape(scalar_shape);
-        const right: Tensor = .fromShape(scalar_shape);
+        var args: std.meta.Tuple(&[1]type{ReduceArgs} ** input_tensors.len) = undefined;
+        var block_types: [2 * input_tensors.len]*const mlir.Type = undefined;
 
-        const block_types = [_]*const mlir.Type{
-            mlirx.Type.rankedTensor(mlir_ctx, scalar_shape),
-            mlirx.Type.rankedTensor(mlir_ctx, scalar_shape),
-        };
-        const block_locs = [_]*const mlir.Location{
-            mlir.Location.unknown(mlir_ctx),
-            mlir.Location.unknown(mlir_ctx),
-        };
+        inline for (0..input_tensors.len) |i| {
+            const scalar_shape = Shape.init(.{}, input_tensors[i].dtype());
+            args[i].left = .fromShape(scalar_shape);
+            args[i].right = .fromShape(scalar_shape);
+            block_types[i] = mlirx.Type.rankedTensor(mlir_ctx, scalar_shape);
+            block_types[i + input_tensors.len] = mlirx.Type.rankedTensor(mlir_ctx, scalar_shape);
+        }
+
+        const block_locs: [2 * input_tensors.len]*const mlir.Location = @splat(mlir.Location.unknown(mlir_ctx));
+
         const block = mlir.Block.init(&block_types, &block_locs);
         errdefer block.deinit();
 
@@ -46,11 +89,30 @@ pub fn allReduceSum(input: Tensor) Tensor {
         defer ctx.popBlock();
 
         const scope = ctx.currentScope();
-        scope.id_to_argument.put(scope.arena.allocator(), left.id, 0) catch unreachable;
-        scope.id_to_argument.put(scope.arena.allocator(), right.id, 1) catch unreachable;
+        inline for (0..input_tensors.len) |i| {
+            scope.id_to_argument.put(scope.arena.allocator(), args[i].left.id, i) catch unreachable;
+            scope.id_to_argument.put(scope.arena.allocator(), args[i].right.id, i + input_tensors.len) catch unreachable;
+        }
 
-        const sum = left.add(right);
-        _ = dialects.stablehlo.return_(mlir_ctx, sum.value(), .unknown(mlir_ctx)).appendTo(block);
+        var reduced_values: [input_tensors.len]*const mlir.Value = undefined;
+        if (input_tensors.len == 1) {
+            const reduced = @call(.auto, func, .{ args[0].left, args[0].right });
+            reduced_values[0] = reduced.value();
+        } else {
+            var reduced = @call(.auto, func, args);
+            var reduced_tensors: [input_tensors.len]Tensor = undefined;
+            meta.collectBuf((struct {
+                pub fn cb(t: Tensor) Tensor {
+                    return t;
+                }
+            }).cb, {}, &reduced, &reduced_tensors);
+
+            inline for (0..input_tensors.len) |i| {
+                reduced_values[i] = reduced_tensors[i].value();
+            }
+        }
+
+        _ = dialects.stablehlo.returns(mlir_ctx, &reduced_values, .unknown(mlir_ctx)).appendTo(block);
         break :b block;
     };
 
@@ -71,15 +133,63 @@ pub fn allReduceSum(input: Tensor) Tensor {
         .collective,
     );
 
+    var input_values: [input_tensors.len]*const mlir.Value = undefined;
+    var result_types: [input_tensors.len]*const mlir.Type = undefined;
+    inline for (0..input_tensors.len) |i| {
+        input_values[i] = input_tensors[i].value();
+        result_types[i] = input_values[i].type_();
+    }
+
     const op = dialects.stablehlo.allReduce(
         mlir_ctx,
-        input.value(),
+        &input_values,
+        &result_types,
         reducer_block,
         replica_groups_attr,
         channel_handle_attr,
     ).appendTo(ctx.currentScope().block);
 
-    return Tensor._result(input.shape(), op.result(0));
+    return switch (@typeInfo(@TypeOf(inputs))) {
+        .@"struct" => |struct_info| b: {
+            if (@TypeOf(inputs) == Tensor) {
+                break :b Tensor._result(input_tensors[0].shape(), op.result(0));
+            }
+
+            var out: @TypeOf(inputs) = undefined;
+            inline for (struct_info.fields, 0..) |field, i| {
+                @field(out, field.name) = Tensor._result(input_tensors[i].shape(), op.result(i));
+            }
+            break :b out;
+        },
+        .array => |array_info| b: {
+            var out: [array_info.len]Tensor = undefined;
+            inline for (0..array_info.len) |i| {
+                out[i] = Tensor._result(input_tensors[i].shape(), op.result(i));
+            }
+            break :b out;
+        },
+        else => unreachable,
+    };
+}
+
+fn allReduceReturnType(comptime InputsT: type) type {
+    if (InputsT == Tensor) return Tensor;
+
+    return switch (@typeInfo(InputsT)) {
+        .@"struct" => |struct_info| b: {
+            if (!struct_info.is_tuple) {
+                @compileError("zml.ops.allReduce expects Tensor, tuple of Tensor or [N]Tensor inputs");
+            }
+            break :b InputsT;
+        },
+        .array => |array_info| b: {
+            if (array_info.child != Tensor) {
+                @compileError("zml.ops.allReduce expects [N]Tensor inputs");
+            }
+            break :b InputsT;
+        },
+        else => @compileError("zml.ops.allReduce expects Tensor, tuple of Tensor, or [N]Tensor inputs"),
+    };
 }
 
 pub fn partitionId() Tensor {

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -19,8 +19,6 @@ pub const ShapeToCustomCallBuffer = @import("pjrtx.zig").ShapeToCustomCallBuffer
 const Tensor = @import("tensor.zig").Tensor;
 pub const TensorToCustomCallBuffer = @import("pjrtx.zig").TensorToCustomCallBuffer;
 
-
-
 pub fn allReduce(inputs: anytype, comptime func: anytype) allReduceReturnType(@TypeOf(inputs)) {
     const ctx = CompilationContext.current();
     const mlir_ctx = ctx.mlir_ctx;


### PR DESCRIPTION
This PR introduces the sharding as expert parallelism for MoE :

- Introduce a .experts logical sharding (required to express an other semantic than TP (.model))
- Wrap the whole MoE impl into a manualComputation
- Implement a manual stableHlo all reduce sum since shardy can not infer the correct communication after a manualComputation (blackbox)
- Partition qwen 3.5 moe example with TP for the rest of the model (non MoE)