### PR TITLE
examples/llm: split Llama and Qwen 3.5 with LFM cleanup

### DIFF
--- a/examples/llm/main.zig
+++ b/examples/llm/main.zig
@@ -20,7 +20,6 @@ const Args = struct {
     topk: u32 = 4,
     backend: ?zml.attention.attention.Backend = null,
     attnd_ip: ?[]const u8 = null,
-    single: bool = false,
     profile: bool = false,
 
     pub const help =
@@ -35,8 +34,6 @@ const Args = struct {
         \\   --topk=<number>     Top-k sampling cutoff (default: 4)
         \\   --backend=<text>    Attention backend to use ([vanilla, attnd, cuda_fa2, cuda_fa3], default: auto-selection)
         \\   --attnd-ip=<addr>   Register and prefer the `attnd` backend at the provided `IP:PORT`
-        \\   --single            Create a single kernel encompassing all the layers when supported
-        \\                       (only used by LFM2 which uses multiple kernels by default)
         \\   --profile           Capture a PJRT profile for non-interactive runs and write a Perfetto trace
         \\
     ;

--- a/examples/llm/models/common.zig
+++ b/examples/llm/models/common.zig
@@ -12,6 +12,37 @@ pub const GenerationOptions = struct {
     sampling_strategy: zml.nn.SamplingStrategy = .{},
 };
 
+pub const Phase = enum {
+    prefill,
+    decode,
+
+    pub fn isPrefill(self: Phase) bool {
+        return self == .prefill;
+    }
+
+    pub fn label(self: Phase) []const u8 {
+        return @tagName(self);
+    }
+
+    pub fn startMessage(self: Phase, comptime component: []const u8) []const u8 {
+        return switch (self) {
+            .prefill => "Compiling prefill " ++ component ++ "...",
+            .decode => "Compiling decode " ++ component ++ "...",
+        };
+    }
+
+    pub fn programName(self: Phase, comptime model_name: []const u8, comptime component: []const u8) []const u8 {
+        return switch (self) {
+            .prefill => "llm_" ++ model_name ++ "_prefill_" ++ component,
+            .decode => "llm_" ++ model_name ++ "_decode_" ++ component,
+        };
+    }
+
+    pub fn logCompileDone(self: Phase, logger: anytype, comptime component: []const u8, io: std.Io, from: std.Io.Timestamp) void {
+        logger.info("Compiled {s} " ++ component ++ " [{f}]", .{ self.label(), from.untilNow(io, .awake) });
+    }
+};
+
 pub const Shardings = struct {
     model: zml.Sharding,
     experts: zml.Sharding,

--- a/examples/llm/models/common.zig
+++ b/examples/llm/models/common.zig
@@ -5,7 +5,6 @@ const zml = @import("zml");
 pub const SessionOptions = struct {
     seqlen: u32,
     backend: zml.attention.attention.Backend,
-    single: bool,
 };
 
 pub const GenerationOptions = struct {

--- a/examples/llm/models/lfm2/inference.zig
+++ b/examples/llm/models/lfm2/inference.zig
@@ -8,6 +8,7 @@ const common = @import("../common.zig");
 const model = @import("model.zig");
 
 const log = std.log.scoped(.lfm);
+const Phase = common.Phase;
 
 pub const CompilationParameters = struct {
     hidden_dim: usize,
@@ -83,8 +84,8 @@ pub const CompiledModel = struct {
         progress: *std.Progress.Node,
     ) !CompiledModel {
         if (opts.single) {
-            const prefill_exe = try compileSingleKernelExe(allocator, io, platform, mdl, opts, opts.seqlen, true, progress, opts.shardings);
-            const decode_exe = try compileSingleKernelExe(allocator, io, platform, mdl, opts, 1, false, progress, opts.shardings);
+            const prefill_exe = try compileSingleKernelExe(allocator, io, platform, mdl, opts, opts.seqlen, .prefill, progress, opts.shardings);
+            const decode_exe = try compileSingleKernelExe(allocator, io, platform, mdl, opts, 1, .decode, progress, opts.shardings);
 
             return .{
                 .loaded_model = loaded_model,
@@ -93,8 +94,8 @@ pub const CompiledModel = struct {
                 .params = opts,
             };
         } else {
-            const prefill_exe = try compileComposedKernelExe(allocator, io, platform, mdl, opts, opts.seqlen, true, progress, opts.shardings);
-            const decode_exe = try compileComposedKernelExe(allocator, io, platform, mdl, opts, 1, false, progress, opts.shardings);
+            const prefill_exe = try compileComposedKernelExe(allocator, io, platform, mdl, opts, opts.seqlen, .prefill, progress, opts.shardings);
+            const decode_exe = try compileComposedKernelExe(allocator, io, platform, mdl, opts, 1, .decode, progress, opts.shardings);
 
             return .{
                 .loaded_model = loaded_model,
@@ -175,15 +176,15 @@ fn compileSingleKernelExe(
     mdl: model.Model,
     opts: CompilationOptions,
     seqlen: u32,
-    is_prefill: bool,
+    phase: Phase,
     progress: *std.Progress.Node,
     shardings: common.Shardings,
 ) !SingleKernelExe {
     progress.increaseEstimatedTotalItems(1);
-    var node = progress.start("Compiling single kernel...", 1);
+    var node = progress.start(phase.startMessage("single kernel"), 1);
     defer node.end();
-    const now: std.Io.Timestamp = .now(io, .awake);
-    defer log.info("Compiled single kernel [{f}]", .{now.untilNow(io, .awake)});
+    const from: std.Io.Timestamp = .now(io, .awake);
+    defer phase.logCompileDone(log, "single kernel", io, from);
 
     const actual_seq_len: zml.Tensor = .init(.{}, .u32);
     const tokens: zml.Tensor = .init(.{ .batch = opts.batch_dim, .seq = seqlen }, .u32);
@@ -203,9 +204,12 @@ fn compileSingleKernelExe(
             opts.cache,
             opts.attention_metadata,
             opts.attention_parameters,
-            model.ConvParameters{ .is_prefill = is_prefill },
+            model.ConvParameters{ .is_prefill = phase.isPrefill() },
         },
-        .{ .shardings = &all_shardings },
+        .{
+            .shardings = &all_shardings,
+            .program_name = phase.programName("lfm2", "single"),
+        },
     );
 
     return .{ .exe = exe };
@@ -323,14 +327,14 @@ fn compileComposedKernelExe(
     mdl: model.Model,
     opts: CompilationOptions,
     seqlen: u32,
-    is_prefill: bool,
+    phase: Phase,
     progress: *std.Progress.Node,
     shardings: common.Shardings,
 ) !ComposedKernelExe {
-    const embed_tokens_exe = try compileEmbedTokens(allocator, io, platform, mdl.embed_tokens, opts, seqlen, progress, shardings);
-    const conv_layer_exe = try compileConvLayer(allocator, io, platform, mdl, opts, seqlen, is_prefill, progress, shardings);
-    const attn_layer_exe = try compileAttnLayer(allocator, io, platform, mdl, opts, seqlen, is_prefill, progress, shardings);
-    const lm_head_exe = try compileLmHead(allocator, io, platform, mdl, opts, seqlen, progress, shardings);
+    const embed_tokens_exe = try compileEmbedTokens(allocator, io, platform, mdl.embed_tokens, opts, seqlen, phase, progress, shardings);
+    const conv_layer_exe = try compileConvLayer(allocator, io, platform, mdl, opts, seqlen, phase, progress, shardings);
+    const attn_layer_exe = try compileAttnLayer(allocator, io, platform, mdl, opts, seqlen, phase, progress, shardings);
+    const lm_head_exe = try compileLmHead(allocator, io, platform, mdl, opts, seqlen, phase, progress, shardings);
     return .{
         .embed_tokens = embed_tokens_exe,
         .conv_layer = conv_layer_exe,
@@ -346,18 +350,22 @@ fn compileEmbedTokens(
     embed_tokens: model.TokenEmbedding,
     opts: CompilationOptions,
     seqlen: u32,
+    phase: Phase,
     progress: *std.Progress.Node,
     shardings: common.Shardings,
 ) !zml.Exe {
     progress.increaseEstimatedTotalItems(1);
-    var node = progress.start("Compiling embed_tokens...", 1);
+    var node = progress.start(phase.startMessage("embed_tokens"), 1);
     defer node.end();
-    const now: std.Io.Timestamp = .now(io, .awake);
-    defer log.info("Compiled embed_tokens [{f}]", .{now.untilNow(io, .awake)});
+    const from: std.Io.Timestamp = .now(io, .awake);
+    defer phase.logCompileDone(log, "embed_tokens", io, from);
 
     const tokens: zml.Tensor = .init(.{ .batch = opts.batch_dim, .seq = seqlen }, .u32);
     const all_shardings = shardings.all();
-    return platform.compile(allocator, io, embed_tokens, .forward, .{tokens}, .{ .shardings = &all_shardings });
+    return platform.compile(allocator, io, embed_tokens, .forward, .{tokens}, .{
+        .shardings = &all_shardings,
+        .program_name = phase.programName("lfm2", "embed_tokens"),
+    });
 }
 
 fn compileConvLayer(
@@ -367,15 +375,15 @@ fn compileConvLayer(
     mdl: model.Model,
     opts: CompilationOptions,
     seqlen: u32,
-    is_prefill: bool,
+    phase: Phase,
     progress: *std.Progress.Node,
     shardings: common.Shardings,
 ) !zml.Exe {
     progress.increaseEstimatedTotalItems(1);
-    var node = progress.start("Compiling conv layer...", 1);
+    var node = progress.start(phase.startMessage("conv layer"), 1);
     defer node.end();
-    const now: std.Io.Timestamp = .now(io, .awake);
-    defer log.info("Compiled conv layer [{f}]", .{now.untilNow(io, .awake)});
+    const from: std.Io.Timestamp = .now(io, .awake);
+    defer phase.logCompileDone(log, "conv layer", io, from);
 
     const conv_layer = for (mdl.layers) |layer| {
         if (layer.operator == .conv) break layer;
@@ -397,8 +405,11 @@ fn compileConvLayer(
         kv_cache_index,
         opts.attention_metadata,
         opts.attention_parameters,
-        model.ConvParameters{ .is_prefill = is_prefill },
-    }, .{ .shardings = &all_shardings });
+        model.ConvParameters{ .is_prefill = phase.isPrefill() },
+    }, .{
+        .shardings = &all_shardings,
+        .program_name = phase.programName("lfm2", "conv_layer"),
+    });
 }
 
 fn compileAttnLayer(
@@ -408,15 +419,15 @@ fn compileAttnLayer(
     mdl: model.Model,
     opts: CompilationOptions,
     seqlen: u32,
-    is_prefill: bool,
+    phase: Phase,
     progress: *std.Progress.Node,
     shardings: common.Shardings,
 ) !zml.Exe {
     progress.increaseEstimatedTotalItems(1);
-    var node = progress.start("Compiling attn layer...", 1);
+    var node = progress.start(phase.startMessage("attn layer"), 1);
     defer node.end();
-    const now: std.Io.Timestamp = .now(io, .awake);
-    defer log.info("Compiled attn layer [{f}]", .{now.untilNow(io, .awake)});
+    const from: std.Io.Timestamp = .now(io, .awake);
+    defer phase.logCompileDone(log, "attn layer", io, from);
 
     const attn_layer = for (mdl.layers) |layer| {
         if (layer.operator == .self_attn) break layer;
@@ -438,8 +449,11 @@ fn compileAttnLayer(
         kv_cache_index,
         opts.attention_metadata,
         opts.attention_parameters,
-        model.ConvParameters{ .is_prefill = is_prefill },
-    }, .{ .shardings = &all_shardings });
+        model.ConvParameters{ .is_prefill = phase.isPrefill() },
+    }, .{
+        .shardings = &all_shardings,
+        .program_name = phase.programName("lfm2", "attn_layer"),
+    });
 }
 
 fn compileLmHead(
@@ -449,17 +463,30 @@ fn compileLmHead(
     mdl: model.Model,
     opts: CompilationOptions,
     seqlen: u32,
+    phase: Phase,
     progress: *std.Progress.Node,
     shardings: common.Shardings,
 ) !zml.Exe {
     progress.increaseEstimatedTotalItems(1);
-    var node = progress.start("Compiling lm_head...", 1);
+    var node = progress.start(phase.startMessage("lm_head"), 1);
     defer node.end();
-    const now: std.Io.Timestamp = .now(io, .awake);
-    defer log.info("Compiled lm_head [{f}]", .{now.untilNow(io, .awake)});
+    const from: std.Io.Timestamp = .now(io, .awake);
+    defer phase.logCompileDone(log, "lm_head", io, from);
 
     const hidden: zml.Tensor = .init(.{ .batch = opts.batch_dim, .seq = seqlen, .d = opts.hidden_dim }, mdl.embed_tokens.weight.dtype());
     const tokens: zml.Tensor = .init(.{ .batch = opts.batch_dim, .seq = seqlen }, .u32);
     const all_shardings = shardings.all();
-    return platform.compile(allocator, io, mdl.lm_head, .forward, .{ hidden, mdl.embed_tokens, tokens, opts.rng }, .{ .shardings = &all_shardings });
+    return platform.compile(allocator, io, mdl.lm_head, .forward, .{ hidden, mdl.embed_tokens, tokens, opts.rng }, .{
+        .shardings = &all_shardings,
+        .program_name = phase.programName("lfm2", "lm_head"),
+    });
+}
+
+test "lfm2 phase helper emits distinct program names and labels" {
+    try std.testing.expectEqualStrings("prefill", Phase.prefill.label());
+    try std.testing.expectEqualStrings("decode", Phase.decode.label());
+    try std.testing.expectEqualStrings("llm_lfm2_prefill_single", Phase.prefill.programName("lfm2", "single"));
+    try std.testing.expectEqualStrings("llm_lfm2_decode_attn_layer", Phase.decode.programName("lfm2", "attn_layer"));
+    try std.testing.expectEqualStrings("Compiling prefill embed_tokens...", Phase.prefill.startMessage("embed_tokens"));
+    try std.testing.expectEqualStrings("Compiling decode lm_head...", Phase.decode.startMessage("lm_head"));
 }

--- a/examples/llm/models/lfm2/inference.zig
+++ b/examples/llm/models/lfm2/inference.zig
@@ -13,7 +13,6 @@ const Phase = common.Phase;
 pub const CompilationParameters = struct {
     hidden_dim: usize,
     batch_dim: usize,
-    single: bool,
     rng: zml.Tensor.Rng,
     cache: model.Cache,
     attention_metadata: attention.Metadata,
@@ -21,7 +20,7 @@ pub const CompilationParameters = struct {
     seqlen: u32,
     shardings: common.Shardings,
 
-    pub fn init(mdl: model.Model, config: model.Config, seqlen: u32, backend: attention.Backend, single: bool, shardings: common.Shardings) CompilationParameters {
+    pub fn init(mdl: model.Model, config: model.Config, seqlen: u32, backend: attention.Backend, shardings: common.Shardings) CompilationParameters {
         stdx.debug.assert(seqlen >= config.conv_L_cache, "seqlen ({}) must be at least conv_L_cache ({})", .{ seqlen, config.conv_L_cache });
         const cache: model.Cache = .{
             .kv = .init(.init(.{
@@ -40,7 +39,6 @@ pub const CompilationParameters = struct {
         };
 
         return .{
-            .single = single,
             .hidden_dim = config.hidden_size,
             .batch_dim = 1,
             .rng = .init(),
@@ -83,27 +81,12 @@ pub const CompiledModel = struct {
         opts: CompilationParameters,
         progress: *std.Progress.Node,
     ) !CompiledModel {
-        if (opts.single) {
-            const prefill_exe = try compileSingleKernelExe(allocator, io, platform, mdl, opts, opts.seqlen, .prefill, progress, opts.shardings);
-            const decode_exe = try compileSingleKernelExe(allocator, io, platform, mdl, opts, 1, .decode, progress, opts.shardings);
-
-            return .{
-                .loaded_model = loaded_model,
-                .prefill = .{ .single = prefill_exe },
-                .decode = .{ .single = decode_exe },
-                .params = opts,
-            };
-        } else {
-            const prefill_exe = try compileComposedKernelExe(allocator, io, platform, mdl, opts, opts.seqlen, .prefill, progress, opts.shardings);
-            const decode_exe = try compileComposedKernelExe(allocator, io, platform, mdl, opts, 1, .decode, progress, opts.shardings);
-
-            return .{
-                .loaded_model = loaded_model,
-                .prefill = .{ .composed = prefill_exe },
-                .decode = .{ .composed = decode_exe },
-                .params = opts,
-            };
-        }
+        return .{
+            .loaded_model = loaded_model,
+            .prefill = try KernelExe.init(allocator, io, platform, mdl, opts, opts.seqlen, .prefill, progress),
+            .decode = try KernelExe.init(allocator, io, platform, mdl, opts, 1, .decode, progress),
+            .params = opts,
+        };
     }
 
     pub fn deinit(self: *CompiledModel) void {
@@ -114,112 +97,68 @@ pub const CompiledModel = struct {
 
 pub const Inference = CompiledModel;
 
-pub const KernelExe = union(enum) {
-    single: SingleKernelExe,
+pub const KernelExe = struct {
     composed: ComposedKernelExe,
 
+    pub fn init(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *zml.Platform,
+        mdl: model.Model,
+        opts: CompilationOptions,
+        seqlen: u32,
+        phase: Phase,
+        progress: *std.Progress.Node,
+    ) !KernelExe {
+        return .{
+            .composed = try ComposedKernelExe.init(allocator, io, platform, mdl, opts, seqlen, phase, progress),
+        };
+    }
+
     pub fn deinit(self: KernelExe) void {
-        switch (self) {
-            .single => |exe| exe.deinit(),
-            .composed => |exe| exe.deinit(),
-        }
+        self.composed.deinit();
     }
 
     pub fn run(self: *const KernelExe, args: Args) !void {
-        switch (self.*) {
-            .single => |*exe| try exe.run(args),
-            .composed => |*exe| try exe.run(args),
-        }
+        try self.composed.run(args);
     }
 };
-
-pub const SingleKernelExe = struct {
-    exe: zml.Exe,
-
-    fn deinit(self: SingleKernelExe) void {
-        self.exe.deinit();
-    }
-
-    pub fn run(self: *const SingleKernelExe, args: Args) !void {
-        var exe_args = try self.exe.args(args.allocator);
-        defer exe_args.deinit(args.allocator);
-
-        var results = try self.exe.results(args.allocator);
-        defer results.deinit(args.allocator);
-
-        exe_args.set(.{
-            args.model_buffers,
-            args.tokens_buf,
-            args.tokens_pos_buf,
-            args.actual_seq_len_buf,
-            args.rng_buf,
-            args.cache_buffers,
-            args.attention_metadata_buffers,
-        });
-        self.exe.call(exe_args, &results);
-
-        var new_tokens, var new_cache, var new_rng = results.get(struct {
-            zml.Buffer,
-            zml.Bufferized(model.Cache),
-            zml.Bufferized(zml.Tensor.Rng),
-        });
-        replaceBuffer(args.tokens_buf, &new_tokens);
-        replaceCacheBuffers(args.cache_buffers, &new_cache);
-        replaceBuffer(&args.rng_buf._state, &new_rng._state);
-    }
-};
-
-fn compileSingleKernelExe(
-    allocator: std.mem.Allocator,
-    io: std.Io,
-    platform: *zml.Platform,
-    mdl: model.Model,
-    opts: CompilationOptions,
-    seqlen: u32,
-    phase: Phase,
-    progress: *std.Progress.Node,
-    shardings: common.Shardings,
-) !SingleKernelExe {
-    progress.increaseEstimatedTotalItems(1);
-    var node = progress.start(phase.startMessage("single kernel"), 1);
-    defer node.end();
-    const from: std.Io.Timestamp = .now(io, .awake);
-    defer phase.logCompileDone(log, "single kernel", io, from);
-
-    const actual_seq_len: zml.Tensor = .init(.{}, .u32);
-    const tokens: zml.Tensor = .init(.{ .batch = opts.batch_dim, .seq = seqlen }, .u32);
-    const token_position_offset: zml.Tensor = .init(.{ .batch = opts.batch_dim }, .u32);
-
-    const all_shardings = shardings.all();
-    const exe = try platform.compile(
-        allocator,
-        io,
-        mdl,
-        .forward,
-        .{
-            tokens,
-            token_position_offset,
-            actual_seq_len,
-            opts.rng,
-            opts.cache,
-            opts.attention_metadata,
-            opts.attention_parameters,
-            model.ConvParameters{ .is_prefill = phase.isPrefill() },
-        },
-        .{
-            .shardings = &all_shardings,
-            .program_name = phase.programName("lfm2", "single"),
-        },
-    );
-
-    return .{ .exe = exe };
-}
 
 pub const ComposedKernelExe = struct {
     embed_tokens: zml.Exe,
     conv_layer: zml.Exe,
     attn_layer: zml.Exe,
     lm_head: zml.Exe,
+
+    fn init(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *zml.Platform,
+        mdl: model.Model,
+        opts: CompilationOptions,
+        seqlen: u32,
+        phase: Phase,
+        progress: *std.Progress.Node,
+    ) !ComposedKernelExe {
+        const embed_tokens = try ComposedKernelExe.compileEmbedTokens(allocator, io, platform, mdl.embed_tokens, opts, seqlen, phase, progress);
+        errdefer embed_tokens.deinit();
+
+        const conv_layer = try ComposedKernelExe.compileConvLayer(allocator, io, platform, mdl, opts, seqlen, phase, progress);
+        errdefer conv_layer.deinit();
+
+        const attn_layer = try ComposedKernelExe.compileAttnLayer(allocator, io, platform, mdl, opts, seqlen, phase, progress);
+        errdefer attn_layer.deinit();
+
+        const lm_head = try ComposedKernelExe.compileLmHead(allocator, io, platform, mdl, opts, seqlen, phase, progress);
+        errdefer lm_head.deinit();
+
+        return .{
+            .embed_tokens = embed_tokens,
+            .conv_layer = conv_layer,
+            .attn_layer = attn_layer,
+            .lm_head = lm_head,
+        };
+    }
 
     fn deinit(self: ComposedKernelExe) void {
         self.embed_tokens.deinit();
@@ -232,6 +171,7 @@ pub const ComposedKernelExe = struct {
         var hidden_buf: zml.Buffer = b: {
             var exe_args = try self.embed_tokens.args(args.allocator);
             defer exe_args.deinit(args.allocator);
+
             var results = try self.embed_tokens.results(args.allocator);
             defer results.deinit(args.allocator);
 
@@ -267,226 +207,213 @@ pub const ComposedKernelExe = struct {
                 &kv_cache_index_buf,
                 args.attention_metadata_buffers,
             });
-            exe.call(exe_args, &results);
-
-            var new_hidden, var new_cache, var new_conv_cache_index, var new_kv_cache_index = results.get(struct {
-                zml.Buffer,
-                zml.Bufferized(model.Cache),
-                zml.Buffer,
-                zml.Buffer,
-            });
-            replaceBuffer(&hidden_buf, &new_hidden);
-            replaceCacheBuffers(args.cache_buffers, &new_cache);
-            replaceBuffer(&conv_cache_index_buf, &new_conv_cache_index);
-            replaceBuffer(&kv_cache_index_buf, &new_kv_cache_index);
+            ComposedKernelExe.runLayer(exe, &exe_args, &results, args.cache_buffers, &hidden_buf, &conv_cache_index_buf, &kv_cache_index_buf);
         }
 
-        {
-            var exe_args = try self.lm_head.args(args.allocator);
-            defer exe_args.deinit(args.allocator);
-            var results = try self.lm_head.results(args.allocator);
-            defer results.deinit(args.allocator);
+        var exe_args = try self.lm_head.args(args.allocator);
+        defer exe_args.deinit(args.allocator);
+        var results = try self.lm_head.results(args.allocator);
+        defer results.deinit(args.allocator);
 
-            exe_args.set(.{ args.model_buffers.lm_head, hidden_buf, args.model_buffers.embed_tokens, args.tokens_buf, args.rng_buf });
-            self.lm_head.call(exe_args, &results);
-            var new_tokens, var new_rng = results.get(struct {
-                zml.Buffer,
-                zml.Bufferized(zml.Tensor.Rng),
-            });
-            replaceBuffer(args.tokens_buf, &new_tokens);
-            replaceBuffer(&args.rng_buf._state, &new_rng._state);
+        exe_args.set(.{ args.model_buffers.lm_head, hidden_buf, args.model_buffers.embed_tokens, args.tokens_buf, args.rng_buf });
+        self.runLmHead(&exe_args, &results, args.tokens_buf, args.rng_buf);
+    }
+
+    fn runLayer(
+        exe: *const zml.Exe,
+        exe_args: *zml.exe.Exe.Arguments,
+        results: *zml.exe.Exe.Results,
+        cache_buffers: *zml.Bufferized(model.Cache),
+        hidden_buf: *zml.Buffer,
+        conv_cache_index_buf: *zml.Buffer,
+        kv_cache_index_buf: *zml.Buffer,
+    ) void {
+        exe.call(exe_args.*, results);
+
+        var new_hidden, var new_cache, var new_conv_cache_index, var new_kv_cache_index = results.get(struct {
+            zml.Buffer,
+            zml.Bufferized(model.Cache),
+            zml.Buffer,
+            zml.Buffer,
+        });
+        ComposedKernelExe.replaceBuffer(hidden_buf, &new_hidden);
+        ComposedKernelExe.replaceCacheBuffers(cache_buffers, &new_cache);
+        ComposedKernelExe.replaceBuffer(conv_cache_index_buf, &new_conv_cache_index);
+        ComposedKernelExe.replaceBuffer(kv_cache_index_buf, &new_kv_cache_index);
+    }
+
+    fn runLmHead(
+        self: *const ComposedKernelExe,
+        exe_args: *zml.exe.Exe.Arguments,
+        results: *zml.exe.Exe.Results,
+        tokens_buf: *zml.Buffer,
+        rng_buf: *zml.Bufferized(zml.Tensor.Rng),
+    ) void {
+        self.lm_head.call(exe_args.*, results);
+
+        var new_tokens, var new_rng = results.get(struct {
+            zml.Buffer,
+            zml.Bufferized(zml.Tensor.Rng),
+        });
+        ComposedKernelExe.replaceBuffer(tokens_buf, &new_tokens);
+        ComposedKernelExe.replaceBuffer(&rng_buf._state, &new_rng._state);
+    }
+
+    fn replaceCacheBuffers(dst: *zml.Bufferized(model.Cache), src: *zml.Bufferized(model.Cache)) void {
+        ComposedKernelExe.replaceBuffer(&dst.conv.state, &src.conv.state);
+        ComposedKernelExe.replaceBuffer(&dst.kv.k, &src.kv.k);
+        ComposedKernelExe.replaceBuffer(&dst.kv.v, &src.kv.v);
+    }
+
+    fn replaceBuffer(dst: *zml.Buffer, src: *zml.Buffer) void {
+        if (!ComposedKernelExe.sameBufferHandle(dst.*, src.*)) {
+            dst.deinit();
         }
+        dst.* = src.*;
+    }
+
+    fn sameBufferHandle(a: zml.Buffer, b: zml.Buffer) bool {
+        if (a._shards.len != b._shards.len) return false;
+        for (a._shards.constSlice(), b._shards.constSlice()) |a_shard, b_shard| {
+            if (a_shard != b_shard) return false;
+        }
+        return true;
+    }
+
+    fn compileEmbedTokens(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *zml.Platform,
+        embed_tokens: model.TokenEmbedding,
+        opts: CompilationOptions,
+        seqlen: u32,
+        phase: Phase,
+        progress: *std.Progress.Node,
+    ) !zml.Exe {
+        progress.increaseEstimatedTotalItems(1);
+        var node = progress.start(phase.startMessage("embed_tokens"), 1);
+        defer node.end();
+
+        const from: std.Io.Timestamp = .now(io, .awake);
+        defer phase.logCompileDone(log, "embed_tokens", io, from);
+
+        const tokens: zml.Tensor = .init(.{ .batch = opts.batch_dim, .seq = seqlen }, .u32);
+
+        return platform.compile(allocator, io, embed_tokens, .forward, .{tokens}, .{
+            .shardings = &opts.shardings.all(),
+            .program_name = phase.programName("lfm2", "embed_tokens"),
+        });
+    }
+
+    fn compileConvLayer(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *zml.Platform,
+        mdl: model.Model,
+        opts: CompilationOptions,
+        seqlen: u32,
+        phase: Phase,
+        progress: *std.Progress.Node,
+    ) !zml.Exe {
+        progress.increaseEstimatedTotalItems(1);
+        var node = progress.start(phase.startMessage("conv layer"), 1);
+        defer node.end();
+
+        const from: std.Io.Timestamp = .now(io, .awake);
+        defer phase.logCompileDone(log, "conv layer", io, from);
+
+        const conv_layer = for (mdl.layers) |layer| {
+            if (layer.operator == .conv) break layer;
+        } else unreachable;
+
+        const hidden: zml.Tensor = .init(.{ .batch = opts.batch_dim, .seq = seqlen, .d = opts.hidden_dim }, mdl.embed_tokens.weight.dtype());
+        const token_position_offset: zml.Tensor = .init(.{ .batch = opts.batch_dim }, .u32);
+        const actual_seq_len: zml.Tensor = .init(.{}, .u32);
+        const conv_cache_index: zml.Tensor = .init(.{}, .u32);
+        const kv_cache_index: zml.Tensor = .init(.{}, .u32);
+
+        return platform.compile(allocator, io, conv_layer, .forward, .{
+            hidden,
+            token_position_offset,
+            actual_seq_len,
+            opts.cache,
+            conv_cache_index,
+            kv_cache_index,
+            opts.attention_metadata,
+            opts.attention_parameters,
+            model.ConvParameters{ .is_prefill = phase.isPrefill() },
+        }, .{
+            .shardings = &opts.shardings.all(),
+            .program_name = phase.programName("lfm2", "conv_layer"),
+        });
+    }
+
+    fn compileAttnLayer(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *zml.Platform,
+        mdl: model.Model,
+        opts: CompilationOptions,
+        seqlen: u32,
+        phase: Phase,
+        progress: *std.Progress.Node,
+    ) !zml.Exe {
+        progress.increaseEstimatedTotalItems(1);
+        var node = progress.start(phase.startMessage("attn layer"), 1);
+        defer node.end();
+
+        const from: std.Io.Timestamp = .now(io, .awake);
+        defer phase.logCompileDone(log, "attn layer", io, from);
+
+        const attn_layer = for (mdl.layers) |layer| {
+            if (layer.operator == .self_attn) break layer;
+        } else unreachable;
+
+        const hidden: zml.Tensor = .init(.{ .batch = opts.batch_dim, .seq = seqlen, .d = opts.hidden_dim }, mdl.embed_tokens.weight.dtype());
+        const token_position_offset: zml.Tensor = .init(.{ .batch = opts.batch_dim }, .u32);
+        const actual_seq_len: zml.Tensor = .init(.{}, .u32);
+        const conv_cache_index: zml.Tensor = .init(.{}, .u32);
+        const kv_cache_index: zml.Tensor = .init(.{}, .u32);
+
+        return platform.compile(allocator, io, attn_layer, .forward, .{
+            hidden,
+            token_position_offset,
+            actual_seq_len,
+            opts.cache,
+            conv_cache_index,
+            kv_cache_index,
+            opts.attention_metadata,
+            opts.attention_parameters,
+            model.ConvParameters{ .is_prefill = phase.isPrefill() },
+        }, .{
+            .shardings = &opts.shardings.all(),
+            .program_name = phase.programName("lfm2", "attn_layer"),
+        });
+    }
+
+    fn compileLmHead(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *zml.Platform,
+        mdl: model.Model,
+        opts: CompilationOptions,
+        seqlen: u32,
+        phase: Phase,
+        progress: *std.Progress.Node,
+    ) !zml.Exe {
+        progress.increaseEstimatedTotalItems(1);
+        var node = progress.start(phase.startMessage("lm_head"), 1);
+        defer node.end();
+
+        const from: std.Io.Timestamp = .now(io, .awake);
+        defer phase.logCompileDone(log, "lm_head", io, from);
+
+        const hidden: zml.Tensor = .init(.{ .batch = opts.batch_dim, .seq = seqlen, .d = opts.hidden_dim }, mdl.embed_tokens.weight.dtype());
+        const tokens: zml.Tensor = .init(.{ .batch = opts.batch_dim, .seq = seqlen }, .u32);
+
+        return platform.compile(allocator, io, mdl.lm_head, .forward, .{ hidden, mdl.embed_tokens, tokens, opts.rng }, .{
+            .shardings = &opts.shardings.all(),
+            .program_name = phase.programName("lfm2", "lm_head"),
+        });
     }
 };
-
-fn replaceCacheBuffers(dst: *zml.Bufferized(model.Cache), src: *zml.Bufferized(model.Cache)) void {
-    replaceBuffer(&dst.conv.state, &src.conv.state);
-    replaceBuffer(&dst.kv.k, &src.kv.k);
-    replaceBuffer(&dst.kv.v, &src.kv.v);
-}
-
-fn replaceBuffer(dst: *zml.Buffer, src: *zml.Buffer) void {
-    if (!sameBufferHandle(dst.*, src.*)) {
-        dst.deinit();
-    }
-    dst.* = src.*;
-}
-
-fn sameBufferHandle(a: zml.Buffer, b: zml.Buffer) bool {
-    if (a._shards.len != b._shards.len) return false;
-    for (a._shards.constSlice(), b._shards.constSlice()) |a_shard, b_shard| {
-        if (a_shard != b_shard) return false;
-    }
-    return true;
-}
-
-fn compileComposedKernelExe(
-    allocator: std.mem.Allocator,
-    io: std.Io,
-    platform: *zml.Platform,
-    mdl: model.Model,
-    opts: CompilationOptions,
-    seqlen: u32,
-    phase: Phase,
-    progress: *std.Progress.Node,
-    shardings: common.Shardings,
-) !ComposedKernelExe {
-    const embed_tokens_exe = try compileEmbedTokens(allocator, io, platform, mdl.embed_tokens, opts, seqlen, phase, progress, shardings);
-    const conv_layer_exe = try compileConvLayer(allocator, io, platform, mdl, opts, seqlen, phase, progress, shardings);
-    const attn_layer_exe = try compileAttnLayer(allocator, io, platform, mdl, opts, seqlen, phase, progress, shardings);
-    const lm_head_exe = try compileLmHead(allocator, io, platform, mdl, opts, seqlen, phase, progress, shardings);
-    return .{
-        .embed_tokens = embed_tokens_exe,
-        .conv_layer = conv_layer_exe,
-        .attn_layer = attn_layer_exe,
-        .lm_head = lm_head_exe,
-    };
-}
-
-fn compileEmbedTokens(
-    allocator: std.mem.Allocator,
-    io: std.Io,
-    platform: *zml.Platform,
-    embed_tokens: model.TokenEmbedding,
-    opts: CompilationOptions,
-    seqlen: u32,
-    phase: Phase,
-    progress: *std.Progress.Node,
-    shardings: common.Shardings,
-) !zml.Exe {
-    progress.increaseEstimatedTotalItems(1);
-    var node = progress.start(phase.startMessage("embed_tokens"), 1);
-    defer node.end();
-    const from: std.Io.Timestamp = .now(io, .awake);
-    defer phase.logCompileDone(log, "embed_tokens", io, from);
-
-    const tokens: zml.Tensor = .init(.{ .batch = opts.batch_dim, .seq = seqlen }, .u32);
-    const all_shardings = shardings.all();
-    return platform.compile(allocator, io, embed_tokens, .forward, .{tokens}, .{
-        .shardings = &all_shardings,
-        .program_name = phase.programName("lfm2", "embed_tokens"),
-    });
-}
-
-fn compileConvLayer(
-    allocator: std.mem.Allocator,
-    io: std.Io,
-    platform: *zml.Platform,
-    mdl: model.Model,
-    opts: CompilationOptions,
-    seqlen: u32,
-    phase: Phase,
-    progress: *std.Progress.Node,
-    shardings: common.Shardings,
-) !zml.Exe {
-    progress.increaseEstimatedTotalItems(1);
-    var node = progress.start(phase.startMessage("conv layer"), 1);
-    defer node.end();
-    const from: std.Io.Timestamp = .now(io, .awake);
-    defer phase.logCompileDone(log, "conv layer", io, from);
-
-    const conv_layer = for (mdl.layers) |layer| {
-        if (layer.operator == .conv) break layer;
-    } else unreachable;
-
-    const hidden: zml.Tensor = .init(.{ .batch = opts.batch_dim, .seq = seqlen, .d = opts.hidden_dim }, mdl.embed_tokens.weight.dtype());
-    const token_position_offset: zml.Tensor = .init(.{ .batch = opts.batch_dim }, .u32);
-    const actual_seq_len: zml.Tensor = .init(.{}, .u32);
-    const conv_cache_index: zml.Tensor = .init(.{}, .u32);
-    const kv_cache_index: zml.Tensor = .init(.{}, .u32);
-
-    const all_shardings = shardings.all();
-    return platform.compile(allocator, io, conv_layer, .forward, .{
-        hidden,
-        token_position_offset,
-        actual_seq_len,
-        opts.cache,
-        conv_cache_index,
-        kv_cache_index,
-        opts.attention_metadata,
-        opts.attention_parameters,
-        model.ConvParameters{ .is_prefill = phase.isPrefill() },
-    }, .{
-        .shardings = &all_shardings,
-        .program_name = phase.programName("lfm2", "conv_layer"),
-    });
-}
-
-fn compileAttnLayer(
-    allocator: std.mem.Allocator,
-    io: std.Io,
-    platform: *zml.Platform,
-    mdl: model.Model,
-    opts: CompilationOptions,
-    seqlen: u32,
-    phase: Phase,
-    progress: *std.Progress.Node,
-    shardings: common.Shardings,
-) !zml.Exe {
-    progress.increaseEstimatedTotalItems(1);
-    var node = progress.start(phase.startMessage("attn layer"), 1);
-    defer node.end();
-    const from: std.Io.Timestamp = .now(io, .awake);
-    defer phase.logCompileDone(log, "attn layer", io, from);
-
-    const attn_layer = for (mdl.layers) |layer| {
-        if (layer.operator == .self_attn) break layer;
-    } else unreachable;
-
-    const hidden: zml.Tensor = .init(.{ .batch = opts.batch_dim, .seq = seqlen, .d = opts.hidden_dim }, mdl.embed_tokens.weight.dtype());
-    const token_position_offset: zml.Tensor = .init(.{ .batch = opts.batch_dim }, .u32);
-    const actual_seq_len: zml.Tensor = .init(.{}, .u32);
-    const conv_cache_index: zml.Tensor = .init(.{}, .u32);
-    const kv_cache_index: zml.Tensor = .init(.{}, .u32);
-
-    const all_shardings = shardings.all();
-    return platform.compile(allocator, io, attn_layer, .forward, .{
-        hidden,
-        token_position_offset,
-        actual_seq_len,
-        opts.cache,
-        conv_cache_index,
-        kv_cache_index,
-        opts.attention_metadata,
-        opts.attention_parameters,
-        model.ConvParameters{ .is_prefill = phase.isPrefill() },
-    }, .{
-        .shardings = &all_shardings,
-        .program_name = phase.programName("lfm2", "attn_layer"),
-    });
-}
-
-fn compileLmHead(
-    allocator: std.mem.Allocator,
-    io: std.Io,
-    platform: *zml.Platform,
-    mdl: model.Model,
-    opts: CompilationOptions,
-    seqlen: u32,
-    phase: Phase,
-    progress: *std.Progress.Node,
-    shardings: common.Shardings,
-) !zml.Exe {
-    progress.increaseEstimatedTotalItems(1);
-    var node = progress.start(phase.startMessage("lm_head"), 1);
-    defer node.end();
-    const from: std.Io.Timestamp = .now(io, .awake);
-    defer phase.logCompileDone(log, "lm_head", io, from);
-
-    const hidden: zml.Tensor = .init(.{ .batch = opts.batch_dim, .seq = seqlen, .d = opts.hidden_dim }, mdl.embed_tokens.weight.dtype());
-    const tokens: zml.Tensor = .init(.{ .batch = opts.batch_dim, .seq = seqlen }, .u32);
-    const all_shardings = shardings.all();
-    return platform.compile(allocator, io, mdl.lm_head, .forward, .{ hidden, mdl.embed_tokens, tokens, opts.rng }, .{
-        .shardings = &all_shardings,
-        .program_name = phase.programName("lfm2", "lm_head"),
-    });
-}
-
-test "lfm2 phase helper emits distinct program names and labels" {
-    try std.testing.expectEqualStrings("prefill", Phase.prefill.label());
-    try std.testing.expectEqualStrings("decode", Phase.decode.label());
-    try std.testing.expectEqualStrings("llm_lfm2_prefill_single", Phase.prefill.programName("lfm2", "single"));
-    try std.testing.expectEqualStrings("llm_lfm2_decode_attn_layer", Phase.decode.programName("lfm2", "attn_layer"));
-    try std.testing.expectEqualStrings("Compiling prefill embed_tokens...", Phase.prefill.startMessage("embed_tokens"));
-    try std.testing.expectEqualStrings("Compiling decode lm_head...", Phase.decode.startMessage("lm_head"));
-}

--- a/examples/llm/models/lfm2/model.zig
+++ b/examples/llm/models/lfm2/model.zig
@@ -120,7 +120,7 @@ pub const LoadedModel = struct {
         seqlen: usize,
         progress: *std.Progress.Node,
     ) !inference.CompiledModel {
-        const params = inference.CompilationParameters.init(self.inner, self.parsed_config.value, @intCast(seqlen), backend, false, shardings);
+        const params = inference.CompilationParameters.init(self.inner, self.parsed_config.value, @intCast(seqlen), backend, shardings);
         return inference.CompiledModel.init(allocator, io, @constCast(platform), self, self.inner, params, progress);
     }
 };
@@ -252,7 +252,7 @@ pub const TokenEmbedding = struct {
     weight: zml.Tensor,
 
     pub fn init(store: zml.io.TensorStore.View) TokenEmbedding {
-        return .{ .weight = store.createTensor("weight", .{ .voc, .d }, .replicated) };
+        return .{ .weight = store.createTensor("weight", .{ .voc, .d }, .{ .voc = .replicated, .d = .model }) };
     }
 
     pub fn forward(self: TokenEmbedding, tokens: zml.Tensor) zml.Tensor {
@@ -398,8 +398,8 @@ pub const ShortConv = struct {
     pub fn init(config: Config, store: zml.io.TensorStore.View) ShortConv {
         stdx.debug.assert(!config.conv_bias, "conv_bias is not supported.", .{});
         return .{
-            .in_proj = initLinear(store.withPrefix("in_proj"), .d),
-            .out_proj = initLinear(store.withPrefix("out_proj"), .d),
+            .in_proj = .init(store.withPrefix("in_proj").createTensor("weight", .{ .out, .d }, .{ .out = .model, .d = .replicated }), null, .d),
+            .out_proj = .init(store.withPrefix("out_proj").createTensor("weight", .{ .out, .d }, .{ .out = .replicated, .d = .model }), null, .d),
             .kernel = store.createTensor("conv.weight", .{ .out, .in, .kernel_size }, .replicated),
             .config = config,
         };
@@ -407,7 +407,7 @@ pub const ShortConv = struct {
 
     pub fn forward(self: ShortConv, input: zml.Tensor, tokens_position_offset: zml.Tensor, actual_seq_len: zml.Tensor, cache_: ConvCache, cache_index: zml.Tensor, parameters: ConvParameters) struct { zml.Tensor, ConvCache } {
         var cache = cache_;
-        const BCx = self.in_proj.forward(input);
+        const BCx = self.in_proj.forward(input.withPartitioning(.{ .d = .replicated }));
 
         const B, const C, const x = BCx.chunkExact(.d, 3);
         const Bx = B.mul(x);
@@ -473,10 +473,10 @@ pub const Attention = struct {
         const head_dim = config.hidden_size / config.num_attention_heads;
         const num_key_value_groups = config.num_attention_heads / config.num_key_value_heads;
         return .{
-            .q_proj = initLinear(store.withPrefix("q_proj"), .d),
-            .k_proj = initLinear(store.withPrefix("k_proj"), .d),
-            .v_proj = initLinear(store.withPrefix("v_proj"), .d),
-            .out_proj = initLinear(store.withPrefix("out_proj"), .d),
+            .q_proj = .init(store.withPrefix("q_proj").createTensor("weight", .{ .out, .d }, .{ .out = .model, .d = .replicated }), null, .d),
+            .k_proj = .init(store.withPrefix("k_proj").createTensor("weight", .{ .out, .d }, .{ .out = .model, .d = .replicated }), null, .d),
+            .v_proj = .init(store.withPrefix("v_proj").createTensor("weight", .{ .out, .d }, .{ .out = .model, .d = .replicated }), null, .d),
+            .out_proj = .init(store.withPrefix("out_proj").createTensor("weight", .{ .out, .d }, .{ .out = .replicated, .d = .model }), null, .d),
             .q_layernorm = RmsNorm.init(store.withPrefix("q_layernorm"), config.norm_eps, .hd),
             .k_layernorm = RmsNorm.init(store.withPrefix("k_layernorm"), config.norm_eps, .hd),
             .head_dim = head_dim,
@@ -494,9 +494,14 @@ pub const Attention = struct {
         attention_metadata: zml.attention.attention.Metadata,
         attention_parameters: zml.attention.attention.Parameters,
     ) struct { zml.Tensor, KvCache } {
-        var q = self.q_proj.forward(x).splitAxis(-1, .{ .h = .auto, .hd = self.head_dim });
-        var k = self.k_proj.forward(x).splitAxis(-1, .{ .h = .auto, .hd = self.head_dim });
-        var v = self.v_proj.forward(x).splitAxis(-1, .{ .h = .auto, .hd = self.head_dim });
+        const x_qkv = x.withPartitioning(.{ .d = .replicated });
+
+        var q = self.q_proj.forward(x_qkv).splitAxis(-1, .{ .h = .auto, .hd = self.head_dim });
+        var k = self.k_proj.forward(x_qkv).splitAxis(-1, .{ .h = .auto, .hd = self.head_dim });
+        var v = self.v_proj.forward(x_qkv).splitAxis(-1, .{ .h = .auto, .hd = self.head_dim });
+        q = q.withPartitioning(.{ .seq = .replicated, .h = .model, .hd = .replicated });
+        k = k.withPartitioning(.{ .seq = .replicated, .h = .model, .hd = .replicated });
+        v = v.withPartitioning(.{ .seq = .replicated, .h = .model, .hd = .replicated });
 
         q = self.q_layernorm.forward(q);
         k = self.k_layernorm.forward(k);
@@ -509,18 +514,35 @@ pub const Attention = struct {
         q = zml.nn.rope(q, token_positions, self.rope_opts);
         k = zml.nn.rope(k, token_positions, self.rope_opts);
 
-        q = q.rename(.{ .seq = .q });
-        k = k.rename(.{ .seq = .k });
-        v = v.rename(.{ .seq = .k });
+        q = q.rename(.{ .seq = .q }).withPartitioning(.{ .q = .replicated, .h = .model, .hd = .replicated });
+        k = k.rename(.{ .seq = .k }).withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated });
+        v = v.rename(.{ .seq = .k }).withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated });
 
         const new_kv_cache = kv_cache.update(k, v, tokens_position_offset, cache_index);
-        k = new_kv_cache.keys(cache_index);
-        v = new_kv_cache.values(cache_index);
+        k = new_kv_cache.keys(cache_index).withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated });
+        v = new_kv_cache.values(cache_index).withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated });
 
         stdx.debug.assert(q.dim(.batch) == 1, "LFM attention currently expects batch size 1 for flash attention backend, got {}", .{q.dim(.batch)});
         const attn = switch (attention_parameters) {
-            .vanilla => zml.attention.attention.attention(q, k, v, tokens_position_offset, attention_metadata, attention_parameters).merge(.{ .d = .{ .h, .hd } }),
-            else => zml.attention.attention.attention(q.squeeze(.batch), k.squeeze(.batch), v.squeeze(.batch), tokens_position_offset.squeeze(.batch), attention_metadata, attention_parameters).merge(.{ .d = .{ .h, .hd } }).rename(.{ .q = .seq }).insertAxes(.seq, .{.batch}),
+            .vanilla => zml.attention.attention.attention(
+                q,
+                k,
+                v,
+                tokens_position_offset,
+                attention_metadata,
+                attention_parameters,
+            ).withPartitioning(.{ .q = .replicated, .h = .model, .hd = .replicated }).merge(.{ .d = .{ .h, .hd } }),
+            else => zml.attention.attention.attention(
+                q.squeeze(.batch),
+                k.squeeze(.batch),
+                v.squeeze(.batch),
+                tokens_position_offset.squeeze(.batch),
+                attention_metadata,
+                attention_parameters,
+            ).withPartitioning(.{ .q = .replicated, .h = .model, .hd = .replicated })
+                .merge(.{ .d = .{ .h, .hd } })
+                .rename(.{ .q = .seq })
+                .insertAxes(.seq, .{.batch}),
         };
 
         return .{ self.out_proj.forward(attn).reuseBuffer(x), new_kv_cache.reuseBuffer(kv_cache) };
@@ -583,7 +605,8 @@ pub const KvCache = struct {
     v: zml.Tensor,
 
     pub fn init(kv_shape: zml.Shape) KvCache {
-        return .{ .k = .fromShape(kv_shape), .v = .fromShape(kv_shape) };
+        const sharded_shape = kv_shape.withPartitioning(.{ .h = .model });
+        return .{ .k = .fromShape(sharded_shape), .v = .fromShape(sharded_shape) };
     }
 
     pub fn initBuffers(self: KvCache, io: std.Io, platform: *const zml.Platform, sharding: zml.Sharding) !zml.Bufferized(KvCache) {
@@ -617,10 +640,6 @@ pub const KvCache = struct {
     }
 };
 
-fn initLinear(store: zml.io.TensorStore.View, tag: anytype) Linear {
-    return .init(store.createTensor("weight", .{ .out, tag }, .replicated), null, tag);
-}
-
 pub const Linear = struct {
     weight: zml.Tensor,
     bias: ?zml.Tensor = null,
@@ -651,7 +670,11 @@ const Mlp = struct {
     w3: Linear,
 
     pub fn init(store: zml.io.TensorStore.View) Mlp {
-        return .{ .w1 = initLinear(store.withPrefix("w1"), .d), .w2 = initLinear(store.withPrefix("w2"), .d), .w3 = initLinear(store.withPrefix("w3"), .d) };
+        return .{
+            .w1 = .init(store.withPrefix("w1").createTensor("weight", .{ .out, .d }, .{ .out = .model, .d = .replicated }), null, .d),
+            .w2 = .init(store.withPrefix("w2").createTensor("weight", .{ .out, .d }, .{ .out = .replicated, .d = .model }), null, .d),
+            .w3 = .init(store.withPrefix("w3").createTensor("weight", .{ .out, .d }, .{ .out = .model, .d = .replicated }), null, .d),
+        };
     }
 
     pub fn unloadBuffers(self: *zml.Bufferized(Mlp)) void {

--- a/examples/llm/models/lfm2/session.zig
+++ b/examples/llm/models/lfm2/session.zig
@@ -40,7 +40,7 @@ pub const Session = struct {
             .tokenizer = tokenizer,
             .config = &compiled_model.loaded_model.parsed_config.value,
             .seqlen = compiled_model.params.seqlen,
-            .cache_buffers = try compiled_model.params.cache.initBuffers(allocator, io, platform, .replicated),
+            .cache_buffers = try compiled_model.params.cache.initBuffers(allocator, io, platform, compiled_model.params.shardings.model),
             .attention_metadata_buffers = try compiled_model.params.attention_metadata.initBuffer(io, platform, compiled_model.params.shardings.model),
             .rng_buf = try zml.Tensor.Rng.initBuffer(io, platform, .replicated, seed),
             .generated_token_slice = try .alloc(allocator, zml.Shape.init(.{ .batch = 1, .seq = 1 }, .u32)),

--- a/examples/llm/models/lfm2_tests.zig
+++ b/examples/llm/models/lfm2_tests.zig
@@ -53,7 +53,13 @@ pub fn main(init: std.process.Init) !void {
     defer repo_model.unloadBuffers(&model_buffers, allocator);
 
     const backend = args.backend orelse attention.Backend.auto(platform);
-    const params = lfm2.CompilationParameters.init(repo_model.inner, repo_model.parsed_config.value, repo_model.parsed_config.value.max_position_embeddings, backend, false, shardings);
+    const params = lfm2.CompilationParameters.init(
+        repo_model.inner,
+        repo_model.parsed_config.value,
+        repo_model.parsed_config.value.max_position_embeddings,
+        backend,
+        shardings,
+    );
     progress.end();
 
     try run(allocator, io, platform, args.activations, repo_model.parsed_config.value, repo_model.inner, &model_buffers, params.attention_metadata, params.attention_parameters);

--- a/examples/llm/models/llama/inference.zig
+++ b/examples/llm/models/llama/inference.zig
@@ -7,6 +7,7 @@ const common = @import("../common.zig");
 const model = @import("model.zig");
 
 const log = std.log.scoped(.llama);
+const Phase = common.Phase;
 
 pub const CompilationParameters = struct {
     prefill_tokens: zml.Tensor,
@@ -63,10 +64,24 @@ pub const CompilationParameters = struct {
     }
 };
 
+pub const CompilationOptions = CompilationParameters;
+
+pub const Args = struct {
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    platform: *const zml.Platform,
+    model_buffers: *model.Buffers,
+    tokens_buf: *zml.Buffer,
+    token_index_buf: *zml.Buffer,
+    kv_cache_buffers: *zml.Bufferized(model.KvCache),
+    rng_buffers: *zml.Bufferized(zml.Tensor.Rng),
+    attention_metadata_buffers: *const zml.Bufferized(attention.Metadata),
+};
+
 pub const CompiledModel = struct {
     loaded_model: *const model.LoadedModel,
-    prefill_exe: zml.Exe,
-    decode_exe: zml.Exe,
+    prefill: KernelExe,
+    decode: KernelExe,
     params: CompilationParameters,
 
     pub fn init(
@@ -78,113 +93,476 @@ pub const CompiledModel = struct {
         parameters: CompilationParameters,
         progress: *std.Progress.Node,
     ) !CompiledModel {
-        const compiled = try compileModel(allocator, io, platform, llama_model, parameters, progress);
-        return .{ .loaded_model = loaded_model, .prefill_exe = compiled.prefill_exe, .decode_exe = compiled.decode_exe, .params = parameters };
+        return .{
+            .loaded_model = loaded_model,
+            .prefill = try KernelExe.init(allocator, io, platform, llama_model, parameters, @intCast(parameters.prefill_tokens.dim(.s)), parameters.prefill_attention_parameters, .prefill, progress),
+            .decode = try KernelExe.init(allocator, io, platform, llama_model, parameters, @intCast(parameters.decode_tokens.dim(.s)), parameters.decode_attention_parameters, .decode, progress),
+            .params = parameters,
+        };
     }
 
     pub fn deinit(self: *CompiledModel) void {
-        self.prefill_exe.deinit();
-        self.decode_exe.deinit();
+        self.prefill.deinit();
+        self.decode.deinit();
     }
 };
 
-const CompileModelResult = struct {
-    prefill_exe: zml.Exe,
-    decode_exe: zml.Exe,
+pub const Inference = CompiledModel;
+
+pub const KernelExe = struct {
+    composed: ComposedKernelExe,
+
+    pub const Runner = struct {
+        exe: *const ComposedKernelExe,
+        embed_args: zml.exe.Exe.Arguments,
+        embed_results: zml.exe.Exe.Results,
+        layers: Layers,
+        lm_head_args: zml.exe.Exe.Arguments,
+        lm_head_results: zml.exe.Exe.Results,
+
+        const Layers = struct {
+            args: []zml.exe.Exe.Arguments,
+            results: []zml.exe.Exe.Results,
+            kv_cache_indices: []zml.Buffer,
+
+            fn init(
+                allocator: std.mem.Allocator,
+                io: std.Io,
+                platform: *const zml.Platform,
+                exe: *const ComposedKernelExe,
+                model_buffers: *model.Buffers,
+            ) !Layers {
+                const args = try allocator.alloc(zml.exe.Exe.Arguments, model_buffers.model.layers.len);
+                errdefer allocator.free(args);
+                const results = try allocator.alloc(zml.exe.Exe.Results, model_buffers.model.layers.len);
+                errdefer allocator.free(results);
+                const kv_cache_indices = try allocator.alloc(zml.Buffer, model_buffers.model.layers.len);
+                errdefer allocator.free(kv_cache_indices);
+
+                var initialized_args: usize = 0;
+                errdefer {
+                    for (args[0..initialized_args]) |*exe_args| {
+                        exe_args.deinit(allocator);
+                    }
+                }
+
+                var initialized_results: usize = 0;
+                errdefer {
+                    for (results[0..initialized_results]) |*exe_results| {
+                        exe_results.deinit(allocator);
+                    }
+                }
+
+                var initialized_kv_cache_indices: usize = 0;
+                errdefer {
+                    for (kv_cache_indices[0..initialized_kv_cache_indices]) |*kv_cache_index| {
+                        kv_cache_index.deinit();
+                    }
+                }
+
+                for (model_buffers.model.layers, 0..) |layer_bufs, i| {
+                    args[i] = try exe.layer.args(allocator);
+                    initialized_args = i + 1;
+                    args[i].bake(layer_bufs);
+
+                    results[i] = try exe.layer.results(allocator);
+                    initialized_results = i + 1;
+
+                    kv_cache_indices[i] = try zml.Buffer.scalar(io, platform, i, .u32);
+                    initialized_kv_cache_indices = i + 1;
+                }
+
+                return .{ .args = args, .results = results, .kv_cache_indices = kv_cache_indices };
+            }
+
+            fn deinit(self: *Layers, allocator: std.mem.Allocator) void {
+                for (self.args) |*exe_args| {
+                    exe_args.deinit(allocator);
+                }
+                allocator.free(self.args);
+                for (self.results) |*exe_results| {
+                    exe_results.deinit(allocator);
+                }
+                allocator.free(self.results);
+                for (self.kv_cache_indices) |*kv_cache_index| {
+                    kv_cache_index.deinit();
+                }
+                allocator.free(self.kv_cache_indices);
+            }
+        };
+
+        pub fn init(
+            allocator: std.mem.Allocator,
+            io: std.Io,
+            platform: *const zml.Platform,
+            exe: *const ComposedKernelExe,
+            model_buffers: *model.Buffers,
+        ) !Runner {
+            var embed_args = try exe.embed_tokens.args(allocator);
+            errdefer embed_args.deinit(allocator);
+            embed_args.bake(ComposedKernelExe.embedTokensBuffers(model_buffers));
+
+            var embed_results = try exe.embed_tokens.results(allocator);
+            errdefer embed_results.deinit(allocator);
+
+            var layers = try Layers.init(allocator, io, platform, exe, model_buffers);
+            errdefer layers.deinit(allocator);
+
+            var lm_head_args = try exe.lm_head.args(allocator);
+            errdefer lm_head_args.deinit(allocator);
+            lm_head_args.bake(ComposedKernelExe.lmHeadBuffers(model_buffers));
+
+            var lm_head_results = try exe.lm_head.results(allocator);
+            errdefer lm_head_results.deinit(allocator);
+
+            return .{
+                .exe = exe,
+                .embed_args = embed_args,
+                .embed_results = embed_results,
+                .layers = layers,
+                .lm_head_args = lm_head_args,
+                .lm_head_results = lm_head_results,
+            };
+        }
+
+        pub fn deinit(self: *Runner, allocator: std.mem.Allocator) void {
+            self.embed_args.deinit(allocator);
+            self.embed_results.deinit(allocator);
+            self.layers.deinit(allocator);
+            self.lm_head_args.deinit(allocator);
+            self.lm_head_results.deinit(allocator);
+        }
+
+        pub fn run(self: *Runner, args: Args) !void {
+            var hidden_buf: zml.Buffer = b: {
+                self.embed_args.set(.{args.tokens_buf});
+                self.exe.embed_tokens.call(self.embed_args, &self.embed_results);
+                break :b self.embed_results.get(zml.Buffer);
+            };
+            defer hidden_buf.deinit();
+
+            for (self.layers.args, self.layers.results, self.layers.kv_cache_indices) |*exe_args, *results, *kv_cache_index_buf| {
+                self.exe.runLayer(exe_args, results, args, &hidden_buf, kv_cache_index_buf);
+            }
+
+            self.exe.runLmHead(&self.lm_head_args, &self.lm_head_results, args, &hidden_buf);
+        }
+    };
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *const zml.Platform,
+        llama_model: model.Model,
+        parameters: CompilationOptions,
+        seqlen: usize,
+        attention_parameters: attention.Parameters,
+        phase: Phase,
+        progress: *std.Progress.Node,
+    ) !KernelExe {
+        return .{
+            .composed = try ComposedKernelExe.init(allocator, io, platform, llama_model, parameters, seqlen, attention_parameters, phase, progress),
+        };
+    }
+
+    pub fn deinit(self: KernelExe) void {
+        self.composed.deinit();
+    }
+
+    pub fn run(self: *const KernelExe, args: Args) !void {
+        try self.composed.run(args);
+    }
+
+    pub fn initRunner(
+        self: *const KernelExe,
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *const zml.Platform,
+        model_buffers: *model.Buffers,
+    ) !Runner {
+        return Runner.init(allocator, io, platform, &self.composed, model_buffers);
+    }
 };
 
-fn compileModel(
-    allocator: std.mem.Allocator,
-    io: std.Io,
-    platform: *const zml.Platform,
-    llama_model: model.Model,
-    parameters: CompilationParameters,
-    progress: *std.Progress.Node,
-) !CompileModelResult {
-    const now: std.Io.Timestamp = .now(io, .awake);
-    defer log.info("Compiled model [{f}]", .{now.untilNow(io, .awake)});
+const ComposedKernelExe = struct {
+    embed_tokens: zml.Exe,
+    layer: zml.Exe,
+    lm_head: zml.Exe,
 
-    const all_shardings = parameters.shardings.all();
+    const EmbedTokens = struct {
+        embed_tokens: zml.nn.TokenEmbedding,
 
-    var prefill_future = try io.concurrent(struct {
-        fn call(
-            allocator_: std.mem.Allocator,
-            io_: std.Io,
-            platform_: *const zml.Platform,
-            llama_model_: model.Model,
-            parameters_: CompilationParameters,
-            shardings_: []const zml.Sharding,
-            progress_: *std.Progress.Node,
-        ) !zml.Exe {
-            progress_.increaseEstimatedTotalItems(1);
-            var node_ = progress_.start("Compiling prefill...", 1);
-            defer node_.end();
-
-            return platform_.compile(
-                allocator_,
-                io_,
-                llama_model_,
-                .forward,
-                .{
-                    parameters_.prefill_tokens,
-                    parameters_.token_index,
-                    parameters_.kv_cache,
-                    parameters_.rng,
-                    parameters_.attention_metadata,
-                    parameters_.prefill_attention_parameters,
-                },
-                .{
-                    .shardings = shardings_,
-                },
-            );
+        pub fn forward(self: EmbedTokens, tokens_: zml.Tensor) zml.Tensor {
+            const tokens = tokens_.withPartialTags(.{.s});
+            const hidden_sharded = self.embed_tokens.forward(tokens)
+                .withPartialTags(.{.d})
+                .withPartitioning(.{ .d = .model });
+            return hidden_sharded.withPartitioning(.{ .d = .replicated });
         }
-    }.call, .{ allocator, io, platform, llama_model, parameters, &all_shardings, progress });
-    var prefill_future_awaited = false;
-    errdefer if (!prefill_future_awaited) if (prefill_future.cancel(io)) |v| v.deinit() else |_| {};
-
-    var decode_future = try io.concurrent(struct {
-        fn call(
-            allocator_: std.mem.Allocator,
-            io_: std.Io,
-            platform_: *const zml.Platform,
-            llama_model_: model.Model,
-            parameters_: CompilationParameters,
-            shardings_: []const zml.Sharding,
-            progress_: *std.Progress.Node,
-        ) !zml.Exe {
-            progress_.increaseEstimatedTotalItems(1);
-            var node_ = progress_.start("Compiling decode...", 1);
-            defer node_.end();
-
-            return platform_.compile(
-                allocator_,
-                io_,
-                llama_model_,
-                .forward,
-                .{
-                    parameters_.decode_tokens,
-                    parameters_.token_index,
-                    parameters_.kv_cache,
-                    parameters_.rng,
-                    parameters_.attention_metadata,
-                    parameters_.decode_attention_parameters,
-                },
-                .{ .shardings = shardings_ },
-            );
-        }
-    }.call, .{ allocator, io, platform, llama_model, parameters, &all_shardings, progress });
-    var decode_future_awaited = false;
-    errdefer if (!decode_future_awaited) if (decode_future.cancel(io)) |v| v.deinit() else |_| {};
-
-    const prefill_exe = try prefill_future.await(io);
-    prefill_future_awaited = true;
-    errdefer prefill_exe.deinit();
-
-    const decode_exe = try decode_future.await(io);
-    decode_future_awaited = true;
-
-    return .{
-        .prefill_exe = prefill_exe,
-        .decode_exe = decode_exe,
     };
-}
+
+    fn init(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *const zml.Platform,
+        llama_model: model.Model,
+        parameters: CompilationOptions,
+        seqlen: usize,
+        attention_parameters: attention.Parameters,
+        phase: Phase,
+        progress: *std.Progress.Node,
+    ) !ComposedKernelExe {
+        const embed_tokens = try ComposedKernelExe.compileEmbedTokens(allocator, io, platform, llama_model.model.embed_tokens, parameters, seqlen, phase, progress);
+        errdefer embed_tokens.deinit();
+
+        const layer = try ComposedKernelExe.compileLayer(allocator, io, platform, llama_model, parameters, seqlen, attention_parameters, phase, progress);
+        errdefer layer.deinit();
+        const lm_head = try ComposedKernelExe.compileLmHead(allocator, io, platform, llama_model, parameters, seqlen, phase, progress);
+        errdefer lm_head.deinit();
+
+        return .{
+            .embed_tokens = embed_tokens,
+            .layer = layer,
+            .lm_head = lm_head,
+        };
+    }
+
+    fn deinit(self: ComposedKernelExe) void {
+        self.embed_tokens.deinit();
+        self.layer.deinit();
+        self.lm_head.deinit();
+    }
+
+    fn run(self: *const ComposedKernelExe, args: Args) !void {
+        var hidden_buf: zml.Buffer = b: {
+            var exe_args = try self.embed_tokens.args(args.allocator);
+            defer exe_args.deinit(args.allocator);
+            var results = try self.embed_tokens.results(args.allocator);
+            defer results.deinit(args.allocator);
+
+            exe_args.bake(ComposedKernelExe.embedTokensBuffers(args.model_buffers));
+            exe_args.set(.{args.tokens_buf});
+            self.embed_tokens.call(exe_args, &results);
+            break :b results.get(zml.Buffer);
+        };
+        defer hidden_buf.deinit();
+
+        for (args.model_buffers.model.layers, 0..) |layer_bufs, i| {
+            var exe_args = try self.layer.args(args.allocator);
+            defer exe_args.deinit(args.allocator);
+            var results = try self.layer.results(args.allocator);
+            defer results.deinit(args.allocator);
+            var kv_cache_index_buf: zml.Buffer = try .scalar(args.io, args.platform, i, .u32);
+            defer kv_cache_index_buf.deinit();
+
+            exe_args.bake(layer_bufs);
+            self.runLayer(&exe_args, &results, args, &hidden_buf, &kv_cache_index_buf);
+        }
+
+        {
+            var exe_args = try self.lm_head.args(args.allocator);
+            defer exe_args.deinit(args.allocator);
+            var results = try self.lm_head.results(args.allocator);
+            defer results.deinit(args.allocator);
+
+            exe_args.bake(ComposedKernelExe.lmHeadBuffers(args.model_buffers));
+            self.runLmHead(&exe_args, &results, args, &hidden_buf);
+        }
+    }
+
+    fn runLayer(
+        self: *const ComposedKernelExe,
+        exe_args: *zml.exe.Exe.Arguments,
+        results: *zml.exe.Exe.Results,
+        args: Args,
+        hidden_buf: *zml.Buffer,
+        kv_cache_index_buf: *zml.Buffer,
+    ) void {
+        exe_args.set(.{
+            hidden_buf,
+            args.token_index_buf,
+            args.kv_cache_buffers,
+            kv_cache_index_buf,
+            args.attention_metadata_buffers,
+        });
+        self.layer.call(exe_args.*, results);
+
+        var new_hidden, var new_kv_cache = results.get(struct {
+            zml.Buffer,
+            zml.Bufferized(model.KvCache),
+        });
+        ComposedKernelExe.replaceBuffer(hidden_buf, &new_hidden);
+        ComposedKernelExe.replaceKvCacheBuffers(args.kv_cache_buffers, &new_kv_cache);
+    }
+
+    fn runLmHead(
+        self: *const ComposedKernelExe,
+        exe_args: *zml.exe.Exe.Arguments,
+        results: *zml.exe.Exe.Results,
+        args: Args,
+        hidden_buf: *zml.Buffer,
+    ) void {
+        exe_args.set(.{ hidden_buf, args.tokens_buf, args.rng_buffers });
+        self.lm_head.call(exe_args.*, results);
+
+        var new_tokens, var new_rng = results.get(struct {
+            zml.Buffer,
+            zml.Bufferized(zml.Tensor.Rng),
+        });
+        ComposedKernelExe.replaceBuffer(args.tokens_buf, &new_tokens);
+        ComposedKernelExe.replaceBuffer(&args.rng_buffers._state, &new_rng._state);
+    }
+
+    fn embedTokensBuffers(model_buffers: *const model.Buffers) zml.Bufferized(EmbedTokens) {
+        return .{
+            .embed_tokens = model_buffers.model.embed_tokens,
+        };
+    }
+
+    fn lmHeadBuffers(model_buffers: *const model.Buffers) zml.Bufferized(model.LmHead) {
+        return .{
+            .lm_head = model_buffers.lm_head,
+            .embed_tokens = model_buffers.model.embed_tokens,
+            .norm = model_buffers.model.norm,
+        };
+    }
+
+    fn replaceKvCacheBuffers(dst: *zml.Bufferized(model.KvCache), src: *zml.Bufferized(model.KvCache)) void {
+        ComposedKernelExe.replaceBuffer(&dst.k, &src.k);
+        ComposedKernelExe.replaceBuffer(&dst.v, &src.v);
+    }
+
+    fn replaceBuffer(dst: *zml.Buffer, src: *zml.Buffer) void {
+        if (!ComposedKernelExe.sameBufferHandle(dst.*, src.*)) {
+            dst.deinit();
+        }
+        dst.* = src.*;
+    }
+
+    fn sameBufferHandle(a: zml.Buffer, b: zml.Buffer) bool {
+        if (a._shards.len != b._shards.len) return false;
+        for (a._shards.constSlice(), b._shards.constSlice()) |a_shard, b_shard| {
+            if (a_shard != b_shard) return false;
+        }
+        return true;
+    }
+
+    fn compileEmbedTokens(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *const zml.Platform,
+        embed_tokens: zml.nn.TokenEmbedding,
+        parameters: CompilationOptions,
+        seqlen: usize,
+        phase: Phase,
+        progress: *std.Progress.Node,
+    ) !zml.Exe {
+        progress.increaseEstimatedTotalItems(1);
+        var node = progress.start(phase.startMessage("embed_tokens"), 1);
+        defer node.end();
+        const from: std.Io.Timestamp = .now(io, .awake);
+        defer phase.logCompileDone(log, "embed_tokens", io, from);
+
+        const tokens: zml.Tensor = .init(.{ .s = seqlen }, .u32);
+        const all_shardings = parameters.shardings.all();
+        return platform.compile(allocator, io, EmbedTokens{ .embed_tokens = embed_tokens }, .forward, .{tokens}, .{
+            .shardings = &all_shardings,
+            .program_name = phase.programName("llama", "embed_tokens"),
+        });
+    }
+
+    fn compileLayer(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *const zml.Platform,
+        llama_model: model.Model,
+        parameters: CompilationOptions,
+        seqlen: usize,
+        attention_parameters: attention.Parameters,
+        phase: Phase,
+        progress: *std.Progress.Node,
+    ) !zml.Exe {
+        const Layer = struct {
+            layer: @TypeOf(llama_model.model.layers[0]),
+
+            pub fn forward(
+                self: @This(),
+                hidden: zml.Tensor,
+                token_index: zml.Tensor,
+                kv_cache: model.KvCache,
+                kv_cache_index: zml.Tensor,
+                attention_metadata: attention.Metadata,
+                attention_parameters_: attention.Parameters,
+            ) struct { zml.Tensor, model.KvCache } {
+                const new_hidden, const new_kv_cache, _ = self.layer.forward(
+                    hidden,
+                    token_index,
+                    kv_cache,
+                    kv_cache_index,
+                    attention_metadata,
+                    attention_parameters_,
+                );
+                return .{ new_hidden, new_kv_cache };
+            }
+        };
+
+        progress.increaseEstimatedTotalItems(1);
+        var node = progress.start(phase.startMessage("transformer layer"), 1);
+        defer node.end();
+        const from: std.Io.Timestamp = .now(io, .awake);
+        defer phase.logCompileDone(log, "transformer layer", io, from);
+
+        const hidden: zml.Tensor = .fromShape(zml.Shape.init(
+            .{ .s = seqlen, .d = llama_model.config.hidden_size },
+            llama_model.model.embed_tokens.weight.dtype(),
+        ).withPartitioning(.{ .d = .replicated }));
+        const kv_cache_index: zml.Tensor = .init(.{}, .u32);
+        const all_shardings = parameters.shardings.all();
+        return platform.compile(
+            allocator,
+            io,
+            Layer{ .layer = llama_model.model.layers[0] },
+            .forward,
+            .{
+                hidden,
+                parameters.token_index,
+                parameters.kv_cache,
+                kv_cache_index,
+                parameters.attention_metadata,
+                attention_parameters,
+            },
+            .{
+                .shardings = &all_shardings,
+                .program_name = phase.programName("llama", "layer"),
+            },
+        );
+    }
+
+    fn compileLmHead(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *const zml.Platform,
+        llama_model: model.Model,
+        parameters: CompilationOptions,
+        seqlen: usize,
+        phase: Phase,
+        progress: *std.Progress.Node,
+    ) !zml.Exe {
+        progress.increaseEstimatedTotalItems(1);
+        var node = progress.start(phase.startMessage("lm_head"), 1);
+        defer node.end();
+        const from: std.Io.Timestamp = .now(io, .awake);
+        defer phase.logCompileDone(log, "lm_head", io, from);
+
+        const hidden: zml.Tensor = .fromShape(zml.Shape.init(
+            .{ .s = seqlen, .d = llama_model.config.hidden_size },
+            llama_model.model.embed_tokens.weight.dtype(),
+        ).withPartitioning(.{ .d = .replicated }));
+        const tokens: zml.Tensor = .init(.{ .s = seqlen }, .u32);
+        const all_shardings = parameters.shardings.all();
+        return platform.compile(allocator, io, model.LmHead.init(llama_model), .forward, .{ hidden, tokens, parameters.rng }, .{
+            .shardings = &all_shardings,
+            .program_name = phase.programName("llama", "lm_head"),
+        });
+    }
+};

--- a/examples/llm/models/llama/inference.zig
+++ b/examples/llm/models/llama/inference.zig
@@ -23,6 +23,7 @@ pub const CompilationParameters = struct {
 
     pub fn init(mdl: model.Model, config: model.Config, seqlen: u32, backend: attention.Backend, shardings: common.Shardings) CompilationParameters {
         const head_dim = config.head_dim orelse @divExact(config.hidden_size, config.num_attention_heads);
+
         return .{
             .prefill_tokens = .init(.{ .s = seqlen }, .u32),
             .decode_tokens = .init(.{ .s = 1 }, .u32),
@@ -134,8 +135,10 @@ pub const KernelExe = struct {
             ) !Layers {
                 const args = try allocator.alloc(zml.exe.Exe.Arguments, model_buffers.model.layers.len);
                 errdefer allocator.free(args);
+
                 const results = try allocator.alloc(zml.exe.Exe.Results, model_buffers.model.layers.len);
                 errdefer allocator.free(results);
+
                 const kv_cache_indices = try allocator.alloc(zml.Buffer, model_buffers.model.layers.len);
                 errdefer allocator.free(kv_cache_indices);
 
@@ -180,10 +183,12 @@ pub const KernelExe = struct {
                     exe_args.deinit(allocator);
                 }
                 allocator.free(self.args);
+
                 for (self.results) |*exe_results| {
                     exe_results.deinit(allocator);
                 }
                 allocator.free(self.results);
+
                 for (self.kv_cache_indices) |*kv_cache_index| {
                     kv_cache_index.deinit();
                 }
@@ -200,6 +205,7 @@ pub const KernelExe = struct {
         ) !Runner {
             var embed_args = try exe.embed_tokens.args(allocator);
             errdefer embed_args.deinit(allocator);
+
             embed_args.bake(ComposedKernelExe.embedTokensBuffers(model_buffers));
 
             var embed_results = try exe.embed_tokens.results(allocator);
@@ -210,6 +216,7 @@ pub const KernelExe = struct {
 
             var lm_head_args = try exe.lm_head.args(allocator);
             errdefer lm_head_args.deinit(allocator);
+
             lm_head_args.bake(ComposedKernelExe.lmHeadBuffers(model_buffers));
 
             var lm_head_results = try exe.lm_head.results(allocator);
@@ -237,6 +244,7 @@ pub const KernelExe = struct {
             var hidden_buf: zml.Buffer = b: {
                 self.embed_args.set(.{args.tokens_buf});
                 self.exe.embed_tokens.call(self.embed_args, &self.embed_results);
+
                 break :b self.embed_results.get(zml.Buffer);
             };
             defer hidden_buf.deinit();
@@ -280,7 +288,7 @@ pub const KernelExe = struct {
         platform: *const zml.Platform,
         model_buffers: *model.Buffers,
     ) !Runner {
-        return Runner.init(allocator, io, platform, &self.composed, model_buffers);
+        return .init(allocator, io, platform, &self.composed, model_buffers);
     }
 };
 
@@ -294,10 +302,9 @@ const ComposedKernelExe = struct {
 
         pub fn forward(self: EmbedTokens, tokens_: zml.Tensor) zml.Tensor {
             const tokens = tokens_.withPartialTags(.{.s});
-            const hidden_sharded = self.embed_tokens.forward(tokens)
+            return self.embed_tokens.forward(tokens)
                 .withPartialTags(.{.d})
-                .withPartitioning(.{ .d = .model });
-            return hidden_sharded.withPartitioning(.{ .d = .replicated });
+                .withPartitioning(.{ .d = .replicated });
         }
     };
 
@@ -317,6 +324,7 @@ const ComposedKernelExe = struct {
 
         const layer = try ComposedKernelExe.compileLayer(allocator, io, platform, llama_model, parameters, seqlen, attention_parameters, phase, progress);
         errdefer layer.deinit();
+
         const lm_head = try ComposedKernelExe.compileLmHead(allocator, io, platform, llama_model, parameters, seqlen, phase, progress);
         errdefer lm_head.deinit();
 
@@ -337,12 +345,15 @@ const ComposedKernelExe = struct {
         var hidden_buf: zml.Buffer = b: {
             var exe_args = try self.embed_tokens.args(args.allocator);
             defer exe_args.deinit(args.allocator);
+
             var results = try self.embed_tokens.results(args.allocator);
             defer results.deinit(args.allocator);
 
             exe_args.bake(ComposedKernelExe.embedTokensBuffers(args.model_buffers));
             exe_args.set(.{args.tokens_buf});
+
             self.embed_tokens.call(exe_args, &results);
+
             break :b results.get(zml.Buffer);
         };
         defer hidden_buf.deinit();
@@ -350,22 +361,27 @@ const ComposedKernelExe = struct {
         for (args.model_buffers.model.layers, 0..) |layer_bufs, i| {
             var exe_args = try self.layer.args(args.allocator);
             defer exe_args.deinit(args.allocator);
+
             var results = try self.layer.results(args.allocator);
             defer results.deinit(args.allocator);
+
             var kv_cache_index_buf: zml.Buffer = try .scalar(args.io, args.platform, i, .u32);
             defer kv_cache_index_buf.deinit();
 
             exe_args.bake(layer_bufs);
+
             self.runLayer(&exe_args, &results, args, &hidden_buf, &kv_cache_index_buf);
         }
 
         {
             var exe_args = try self.lm_head.args(args.allocator);
             defer exe_args.deinit(args.allocator);
+
             var results = try self.lm_head.results(args.allocator);
             defer results.deinit(args.allocator);
 
             exe_args.bake(ComposedKernelExe.lmHeadBuffers(args.model_buffers));
+
             self.runLmHead(&exe_args, &results, args, &hidden_buf);
         }
     }
@@ -385,12 +401,14 @@ const ComposedKernelExe = struct {
             kv_cache_index_buf,
             args.attention_metadata_buffers,
         });
+
         self.layer.call(exe_args.*, results);
 
         var new_hidden, var new_kv_cache = results.get(struct {
             zml.Buffer,
             zml.Bufferized(model.KvCache),
         });
+
         ComposedKernelExe.replaceBuffer(hidden_buf, &new_hidden);
         ComposedKernelExe.replaceKvCacheBuffers(args.kv_cache_buffers, &new_kv_cache);
     }
@@ -409,6 +427,7 @@ const ComposedKernelExe = struct {
             zml.Buffer,
             zml.Bufferized(zml.Tensor.Rng),
         });
+
         ComposedKernelExe.replaceBuffer(args.tokens_buf, &new_tokens);
         ComposedKernelExe.replaceBuffer(&args.rng_buffers._state, &new_rng._state);
     }
@@ -436,14 +455,17 @@ const ComposedKernelExe = struct {
         if (!ComposedKernelExe.sameBufferHandle(dst.*, src.*)) {
             dst.deinit();
         }
+
         dst.* = src.*;
     }
 
     fn sameBufferHandle(a: zml.Buffer, b: zml.Buffer) bool {
         if (a._shards.len != b._shards.len) return false;
+
         for (a._shards.constSlice(), b._shards.constSlice()) |a_shard, b_shard| {
             if (a_shard != b_shard) return false;
         }
+
         return true;
     }
 
@@ -460,13 +482,14 @@ const ComposedKernelExe = struct {
         progress.increaseEstimatedTotalItems(1);
         var node = progress.start(phase.startMessage("embed_tokens"), 1);
         defer node.end();
+
         const from: std.Io.Timestamp = .now(io, .awake);
         defer phase.logCompileDone(log, "embed_tokens", io, from);
 
         const tokens: zml.Tensor = .init(.{ .s = seqlen }, .u32);
-        const all_shardings = parameters.shardings.all();
+
         return platform.compile(allocator, io, EmbedTokens{ .embed_tokens = embed_tokens }, .forward, .{tokens}, .{
-            .shardings = &all_shardings,
+            .shardings = &parameters.shardings.all(),
             .program_name = phase.programName("llama", "embed_tokens"),
         });
     }
@@ -483,7 +506,7 @@ const ComposedKernelExe = struct {
         progress: *std.Progress.Node,
     ) !zml.Exe {
         const Layer = struct {
-            layer: @TypeOf(llama_model.model.layers[0]),
+            layer: model.TransformerLayer,
 
             pub fn forward(
                 self: @This(),
@@ -502,13 +525,16 @@ const ComposedKernelExe = struct {
                     attention_metadata,
                     attention_parameters_,
                 );
+
                 return .{ new_hidden, new_kv_cache };
             }
         };
 
         progress.increaseEstimatedTotalItems(1);
+
         var node = progress.start(phase.startMessage("transformer layer"), 1);
         defer node.end();
+
         const from: std.Io.Timestamp = .now(io, .awake);
         defer phase.logCompileDone(log, "transformer layer", io, from);
 
@@ -516,8 +542,9 @@ const ComposedKernelExe = struct {
             .{ .s = seqlen, .d = llama_model.config.hidden_size },
             llama_model.model.embed_tokens.weight.dtype(),
         ).withPartitioning(.{ .d = .replicated }));
+
         const kv_cache_index: zml.Tensor = .init(.{}, .u32);
-        const all_shardings = parameters.shardings.all();
+
         return platform.compile(
             allocator,
             io,
@@ -532,7 +559,7 @@ const ComposedKernelExe = struct {
                 attention_parameters,
             },
             .{
-                .shardings = &all_shardings,
+                .shardings = &parameters.shardings.all(),
                 .program_name = phase.programName("llama", "layer"),
             },
         );
@@ -549,8 +576,10 @@ const ComposedKernelExe = struct {
         progress: *std.Progress.Node,
     ) !zml.Exe {
         progress.increaseEstimatedTotalItems(1);
+
         var node = progress.start(phase.startMessage("lm_head"), 1);
         defer node.end();
+
         const from: std.Io.Timestamp = .now(io, .awake);
         defer phase.logCompileDone(log, "lm_head", io, from);
 
@@ -558,10 +587,11 @@ const ComposedKernelExe = struct {
             .{ .s = seqlen, .d = llama_model.config.hidden_size },
             llama_model.model.embed_tokens.weight.dtype(),
         ).withPartitioning(.{ .d = .replicated }));
+
         const tokens: zml.Tensor = .init(.{ .s = seqlen }, .u32);
-        const all_shardings = parameters.shardings.all();
+
         return platform.compile(allocator, io, model.LmHead.init(llama_model), .forward, .{ hidden, tokens, parameters.rng }, .{
-            .shardings = &all_shardings,
+            .shardings = &parameters.shardings.all(),
             .program_name = phase.programName("llama", "lm_head"),
         });
     }

--- a/examples/llm/models/llama/model.zig
+++ b/examples/llm/models/llama/model.zig
@@ -81,19 +81,17 @@ pub const LoadedModel = struct {
             std.log.scoped(.llama).info("Loaded weights [{Bi:.2}, {f}, {Bi:.2}/s]", .{ total_bytes, took, bytes_per_sec });
         }
 
-        const all_shardings = shardings.all();
         return zml.io.load(Model, &self.inner, allocator, io, platform, store, .{
             .dma_chunks = 32,
             .dma_chunk_size = 128 * zml.MiB,
             .progress = progress,
-            .shardings = &all_shardings,
+            .shardings = &shardings.all(),
             .parallelism = 16,
             .total_bytes = &total_bytes,
         });
     }
 
-    pub fn unloadBuffers(self: *const LoadedModel, buffers: *Buffers, allocator: std.mem.Allocator) void {
-        _ = self;
+    pub fn unloadBuffers(_: *const LoadedModel, buffers: *Buffers, allocator: std.mem.Allocator) void {
         if (buffers.lm_head) |*lm_head| lm_head.weight.deinit();
         Llama.unloadBuffers(&buffers.model, allocator);
     }
@@ -109,6 +107,7 @@ pub const LoadedModel = struct {
         progress: *std.Progress.Node,
     ) !inference.CompiledModel {
         const params = inference.CompilationParameters.init(self.inner, self.parsed_config.value, @intCast(seqlen), backend, shardings);
+
         return inference.CompiledModel.init(allocator, io, platform, self, self.inner, params, progress);
     }
 };
@@ -327,7 +326,7 @@ pub const LmHead = struct {
     }
 };
 
-const TransformerLayer = struct {
+pub const TransformerLayer = struct {
     input_layernorm: RmsNorm,
     self_attn: SelfAttn,
     post_attention_layernorm: RmsNorm,

--- a/examples/llm/models/llama/model.zig
+++ b/examples/llm/models/llama/model.zig
@@ -25,7 +25,7 @@ pub const Config = struct {
     rope_scaling: zml.nn.RopeOpts.Scaling = .{ .default = .{} },
 };
 
-pub const Options = struct {
+const Options = struct {
     sampling_strategy: ?zml.nn.SamplingStrategy,
     max_seq_len: u32,
 };
@@ -187,6 +187,11 @@ pub const Model = struct {
         if (self.lm_head) |*lm_head| lm_head.weight.deinit();
         Llama.unloadBuffers(&self.model, allocator);
     }
+
+    fn lmHead(self: Model) LmHead {
+        return .init(self);
+    }
+
     /// Predicts the token at `token_index` position.
     /// Returns:
     ///  - updated `tokens`,
@@ -202,6 +207,7 @@ pub const Model = struct {
         attention_parameters: zml.attention.attention.Parameters,
     ) struct { zml.Tensor, KvCache, zml.Tensor.Rng } {
         const tokens = tokens_.withPartialTags(.{.s});
+
         const out, const updated_kv_cache = self.model.forward(
             tokens,
             token_index,
@@ -209,37 +215,14 @@ pub const Model = struct {
             attention_metadata,
             attention_parameters,
         );
-        const new_tokens, const new_rng = self.sampleTokens(self.lm_head, out, rng, self.gen_opts);
 
-        return .{ new_tokens.convert(tokens.dtype()).reuseBuffer(tokens), updated_kv_cache, new_rng };
-    }
+        const new_tokens, const new_rng = self.lmHead().forward(out, tokens, rng);
 
-    pub fn sampleTokens(
-        self: Model,
-        lm_head_: ?zml.nn.Linear,
-        out_: zml.Tensor,
-        rng: zml.Tensor.Rng,
-        opts: zml.nn.SamplingStrategy,
-    ) struct { zml.Tensor, zml.Tensor.Rng } {
-        const out = out_.withPartialTags(.{ .s, .d });
-
-        var logits = blk: {
-            if (lm_head_) |lm_head| {
-                break :blk lm_head.forward(out).rename(.{ .dout = .d });
-            } else {
-                break :blk self.model.embed_tokens.weight.withTags(.{ .voc, .d }).dot(out, .d);
-            }
-        };
-
-        if (logits.shape().hasTag(.voc) == null)
-            logits = logits.rename(.{ .d = .voc });
-
-        const next_tokens, const new_rng = zml.nn.sampleTokens(logits, opts, rng);
-        return .{ next_tokens, new_rng };
+        return .{ new_tokens, updated_kv_cache, new_rng };
     }
 };
 
-pub const Llama = struct {
+const Llama = struct {
     embed_tokens: zml.nn.TokenEmbedding,
     norm: RmsNorm,
     layers: []TransformerLayer,
@@ -289,26 +272,18 @@ pub const Llama = struct {
         attention_metadata: zml.attention.attention.Metadata,
         attention_parameters: zml.attention.attention.Parameters,
     ) struct { zml.Tensor, KvCache } {
-        const embeds = embed_tokensForward(self.embed_tokens, tokens);
+        const embeds = self.embed_tokens.forward(tokens).withPartialTags(.{.d});
         var hidden = embeds;
         var updated_kv_cache = kv_cache;
+        var kv_cache_index = zml.Tensor.scalar(0, .u32);
 
-        for (self.layers, 0..) |layer, i| {
-            const layer_attention_metadata: zml.attention.attention.Metadata = switch (attention_parameters) {
-                .attnd => .{ .attnd = .{
-                    .layer_id = zml.Tensor.scalar(i, .u16),
-                    .conversation_id = attention_metadata.attnd.conversation_id,
-                    .num_tokens = attention_metadata.attnd.num_tokens,
-                } },
-                .vanilla => attention_metadata,
-                .cuda_fa2 => attention_metadata,
-                .cuda_fa3 => attention_metadata,
-            };
-            hidden, updated_kv_cache = layer.forward(
+        for (self.layers) |layer| {
+            hidden, updated_kv_cache, kv_cache_index = layer.forward(
                 hidden,
                 token_index,
-                updated_kv_cache.atLayer(i),
-                layer_attention_metadata,
+                updated_kv_cache,
+                kv_cache_index,
+                attention_metadata,
                 attention_parameters,
             );
         }
@@ -317,11 +292,42 @@ pub const Llama = struct {
     }
 };
 
-fn embed_tokensForward(embed_tokens_: zml.nn.TokenEmbedding, tokens_: zml.Tensor) zml.Tensor {
-    return embed_tokens_.forward(tokens_).withPartialTags(.{.d});
-}
+pub const LmHead = struct {
+    lm_head: ?zml.nn.Linear,
+    embed_tokens: zml.nn.TokenEmbedding,
+    norm: RmsNorm,
+    gen_opts: zml.nn.SamplingStrategy,
 
-pub const TransformerLayer = struct {
+    pub fn init(mdl: Model) LmHead {
+        return .{
+            .lm_head = mdl.lm_head,
+            .embed_tokens = mdl.model.embed_tokens,
+            .norm = mdl.model.norm,
+            .gen_opts = mdl.gen_opts,
+        };
+    }
+
+    pub fn forward(self: LmHead, hidden_: zml.Tensor, tokens_: zml.Tensor, rng: zml.Tensor.Rng) struct { zml.Tensor, zml.Tensor.Rng } {
+        const tokens = tokens_.withPartialTags(.{.s});
+        const hidden = self.norm.forward(hidden_.withPartialTags(.{ .s, .d }));
+
+        var logits = blk: {
+            if (self.lm_head) |lm_head| {
+                break :blk lm_head.forward(hidden).rename(.{ .dout = .d });
+            } else {
+                break :blk self.embed_tokens.weight.withTags(.{ .voc, .d }).dot(hidden, .d);
+            }
+        };
+
+        if (logits.shape().hasTag(.voc) == null)
+            logits = logits.rename(.{ .d = .voc });
+
+        const next_tokens, const new_rng = zml.nn.sampleTokens(logits, self.gen_opts, rng);
+        return .{ next_tokens.convert(tokens.dtype()).reuseBuffer(tokens), new_rng };
+    }
+};
+
+const TransformerLayer = struct {
     input_layernorm: RmsNorm,
     self_attn: SelfAttn,
     post_attention_layernorm: RmsNorm,
@@ -348,9 +354,10 @@ pub const TransformerLayer = struct {
         x0: zml.Tensor,
         token_index: zml.Tensor,
         kv_cache: KvCache,
+        kv_cache_index: zml.Tensor,
         attention_metadata: zml.attention.attention.Metadata,
         attention_parameters: zml.attention.attention.Parameters,
-    ) struct { zml.Tensor, KvCache } {
+    ) struct { zml.Tensor, KvCache, zml.Tensor } {
         // Self Attention
         //log.debug("TransformerLayer({f}) -> {f}", .{ x0, self.input_layernorm.forward(x0) });
         stdx.debug.assert(x0.rank() >= 2 and x0.shape().hasTags(.{ .s, .d }), "TransformerLayer expected input shape: {{..., .s, .d}}, received: {f}", .{x0});
@@ -362,9 +369,11 @@ pub const TransformerLayer = struct {
             x0_normalized,
             token_index,
             kv_cache,
+            kv_cache_index,
             attention_metadata,
             attention_parameters,
         );
+        const updated_kv_cache_index = kv_cache_index.add(zml.Tensor.scalar(@as(u32, 1), .u32));
 
         // Fully Connected
         const x1 = x0_replicated.add(delta0).withPartitioning(.{ .d = .replicated });
@@ -375,7 +384,7 @@ pub const TransformerLayer = struct {
             .add(x1)
             .withPartitioning(.{ .d = .replicated });
 
-        return .{ x2.reuseBuffer(x0), updated_kv_cache };
+        return .{ x2.reuseBuffer(x0), updated_kv_cache, updated_kv_cache_index.reuseBuffer(kv_cache_index) };
     }
 };
 
@@ -432,7 +441,7 @@ const Mlp = struct {
     }
 };
 
-pub const SelfAttn = struct {
+const SelfAttn = struct {
     q_proj: zml.nn.Linear,
     k_proj: zml.nn.Linear,
     v_proj: zml.nn.Linear,
@@ -491,6 +500,7 @@ pub const SelfAttn = struct {
         x: zml.Tensor,
         token_index: zml.Tensor,
         kv_cache: KvCache,
+        kv_cache_index: zml.Tensor,
         attention_metadata: zml.attention.attention.Metadata,
         attention_parameters: zml.attention.attention.Parameters,
     ) struct { zml.Tensor, KvCache } {
@@ -522,18 +532,29 @@ pub const SelfAttn = struct {
         v = v.rename(.{ .s = .k });
 
         const dtype = q.dtype();
-        const new_kv_cache = kv_cache.update(k, v, token_index);
-        k = new_kv_cache.keys().convert(dtype);
-        v = new_kv_cache.values().convert(dtype);
+        const new_kv_cache = kv_cache.updateAt(k, v, token_index, kv_cache_index);
+        k = new_kv_cache.keysAt(kv_cache_index).convert(dtype);
+        v = new_kv_cache.valuesAt(kv_cache_index).convert(dtype);
         k = k.withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated });
         v = v.withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated });
+
+        const layer_attention_metadata: zml.attention.attention.Metadata = switch (attention_parameters) {
+            .attnd => .{ .attnd = .{
+                .layer_id = kv_cache_index.convert(.u16),
+                .conversation_id = attention_metadata.attnd.conversation_id,
+                .num_tokens = attention_metadata.attnd.num_tokens,
+            } },
+            .vanilla => attention_metadata,
+            .cuda_fa2 => attention_metadata,
+            .cuda_fa3 => attention_metadata,
+        };
 
         const attn_output = zml.attention.attention.attention(
             q,
             k,
             v,
             token_index,
-            attention_metadata,
+            layer_attention_metadata,
             attention_parameters,
         ).withPartitioning(.{ .q = .replicated, .h = .model, .hd = .replicated });
 
@@ -548,7 +569,6 @@ pub const SelfAttn = struct {
 pub const KvCache = struct {
     k: zml.Tensor,
     v: zml.Tensor,
-    layer_index: ?u32,
 
     pub const Buffer = zml.Bufferized(KvCache);
 
@@ -558,7 +578,6 @@ pub const KvCache = struct {
         return .{
             .k = .fromShape(sharded_shape),
             .v = .fromShape(sharded_shape),
-            .layer_index = null,
         };
     }
 
@@ -574,37 +593,19 @@ pub const KvCache = struct {
         kv.v.deinit();
     }
 
-    pub fn keys(kv: KvCache) zml.Tensor {
-        return kv.k.slice1d(.layer, .single(kv.layer_index orelse @panic("forgot to call atLayer")));
+    pub fn keysAt(kv: KvCache, layer_index: zml.Tensor) zml.Tensor {
+        return kv.k.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = layer_index, .len = 1 } }).squeeze(.layer);
     }
 
-    pub fn values(kv: KvCache) zml.Tensor {
-        return kv.v.slice1d(.layer, .single(kv.layer_index orelse @panic("forgot to call atLayer")));
+    pub fn valuesAt(kv: KvCache, layer_index: zml.Tensor) zml.Tensor {
+        return kv.v.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = layer_index, .len = 1 } }).squeeze(.layer);
     }
 
-    pub fn update(kv: KvCache, new_k: zml.Tensor, new_v: zml.Tensor, token_index: ?zml.Tensor) KvCache {
+    pub fn updateAt(kv: KvCache, new_k: zml.Tensor, new_v: zml.Tensor, token_index: zml.Tensor, layer_index: zml.Tensor) KvCache {
         const k_shape = kv.k.shape().drop(.layer);
-        const layer: zml.Tensor = .scalar(kv.layer_index orelse @panic("forgot to call atLayer"), .u32);
-
-        return if (token_index) |idx|
-            .{
-                .k = kv.k.scatterSlices(.{ .layer = layer, .k = idx }, new_k.convert(kv.k.dtype()).transpose(k_shape), .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override }).reuseBuffer(kv.k),
-                .v = kv.v.scatterSlices(.{ .layer = layer, .k = idx }, new_v.convert(kv.v.dtype()).transpose(k_shape), .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override }).reuseBuffer(kv.v),
-                .layer_index = kv.layer_index,
-            }
-        else
-            .{
-                .k = kv.k.scatterSlices(.{ .layer = layer }, new_k.convert(kv.k.dtype()).transpose(k_shape), .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override }).reuseBuffer(kv.k),
-                .v = kv.v.scatterSlices(.{ .layer = layer }, new_v.convert(kv.v.dtype()).transpose(k_shape), .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override }).reuseBuffer(kv.v),
-                .layer_index = kv.layer_index,
-            };
-    }
-
-    pub fn atLayer(kv: KvCache, layer_index: usize) KvCache {
         return .{
-            .k = kv.k,
-            .v = kv.v,
-            .layer_index = @intCast(layer_index),
+            .k = kv.k.scatterSlices(.{ .layer = layer_index, .k = token_index }, new_k.convert(kv.k.dtype()).transpose(k_shape), .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override }).reuseBuffer(kv.k),
+            .v = kv.v.scatterSlices(.{ .layer = layer_index, .k = token_index }, new_v.convert(kv.v.dtype()).transpose(kv.v.shape().drop(.layer)), .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override }).reuseBuffer(kv.v),
         };
     }
 
@@ -612,7 +613,6 @@ pub const KvCache = struct {
         return .{
             .k = kv.k.reuseBuffer(other.k),
             .v = kv.v.reuseBuffer(other.v),
-            .layer_index = null,
         };
     }
 };

--- a/examples/llm/models/llama/session.zig
+++ b/examples/llm/models/llama/session.zig
@@ -11,8 +11,11 @@ pub const Session = struct {
     platform: *const zml.Platform,
     model_buffers: *model.Buffers,
     compiled_model: *const inference.CompiledModel,
+    decode_runner: inference.KernelExe.Runner,
     kv_cache_buffers: zml.Bufferized(model.KvCache),
+    token_index_buffers: []zml.Buffer,
     attention_metadata_buffers: zml.Bufferized(zml.attention.attention.Metadata),
+    decode_attention_metadata_buffers: ?zml.Bufferized(zml.attention.attention.Metadata),
     rng_buffers: zml.Bufferized(zml.Tensor.Rng),
     tokenizer: zml.tokenizer.Tokenizer,
     config: *const model.Config,
@@ -32,12 +35,43 @@ pub const Session = struct {
         var kv_cache_buffers = try compiled_model.params.kv_cache.initBuffer(io, platform, shardings.model);
         errdefer model.KvCache.deinitBuffer(&kv_cache_buffers);
 
+        const token_index_buffers = try allocator.alloc(zml.Buffer, compiled_model.params.seqlen);
+        errdefer allocator.free(token_index_buffers);
+        var initialized_token_index_buffers: usize = 0;
+        errdefer {
+            for (token_index_buffers[0..initialized_token_index_buffers]) |*token_index_buffer| {
+                token_index_buffer.deinit();
+            }
+        }
+        for (token_index_buffers, 0..) |*token_index_buffer, i| {
+            token_index_buffer.* = try zml.Buffer.scalar(io, platform, i, .u32);
+            initialized_token_index_buffers = i + 1;
+        }
+
         var attention_metadata_buffers = try compiled_model.params.attention_metadata.initBuffer(io, platform, shardings.model);
         errdefer zml.attention.attention.Metadata.deinitBuffer(&attention_metadata_buffers);
+
+        const conversation_id: u64 = @bitCast(std.Io.Clock.now(.real, io).toMicroseconds());
+
+        var decode_attention_metadata_buffers: ?zml.Bufferized(zml.attention.attention.Metadata) = switch (compiled_model.params.decode_attention_parameters) {
+            .attnd => b: {
+                const buffers: zml.Bufferized(zml.attention.attention.Metadata) = .{ .attnd = .{
+                    .conversation_id = try zml.Buffer.scalar(io, platform, conversation_id, .u64),
+                    .layer_id = try zml.Buffer.scalar(io, platform, 0, .u16),
+                    .num_tokens = try zml.Buffer.scalar(io, platform, 1, .u32),
+                } };
+                break :b buffers;
+            },
+            .vanilla, .cuda_fa2, .cuda_fa3 => null,
+        };
+        errdefer if (decode_attention_metadata_buffers) |*buffers| zml.attention.attention.Metadata.deinitBuffer(buffers);
 
         const seed: u128 = @intCast(std.Io.Clock.now(.real, io).toNanoseconds());
         var rng_buffers = try zml.Tensor.Rng.initBuffer(io, platform, .replicated, seed);
         errdefer zml.Tensor.Rng.deinitBuffer(&rng_buffers);
+
+        var decode_runner = try compiled_model.decode.initRunner(allocator, io, platform, model_buffers);
+        errdefer decode_runner.deinit(allocator);
 
         return .{
             .allocator = allocator,
@@ -45,19 +79,28 @@ pub const Session = struct {
             .platform = platform,
             .model_buffers = model_buffers,
             .compiled_model = compiled_model,
+            .decode_runner = decode_runner,
             .kv_cache_buffers = kv_cache_buffers,
+            .token_index_buffers = token_index_buffers,
             .attention_metadata_buffers = attention_metadata_buffers,
+            .decode_attention_metadata_buffers = decode_attention_metadata_buffers,
             .rng_buffers = rng_buffers,
             .tokenizer = tokenizer,
             .config = &compiled_model.loaded_model.parsed_config.value,
             .seqlen = @intCast(compiled_model.params.seqlen),
-            .conversation_id = @bitCast(std.Io.Clock.now(.real, io).toMicroseconds()),
+            .conversation_id = conversation_id,
         };
     }
 
     pub fn deinit(self: *Session) void {
+        self.decode_runner.deinit(self.allocator);
         model.KvCache.deinitBuffer(&self.kv_cache_buffers);
+        for (self.token_index_buffers) |*token_index_buffer| {
+            token_index_buffer.deinit();
+        }
+        self.allocator.free(self.token_index_buffers);
         zml.attention.attention.Metadata.deinitBuffer(&self.attention_metadata_buffers);
+        if (self.decode_attention_metadata_buffers) |*buffers| zml.attention.attention.Metadata.deinitBuffer(buffers);
         zml.Tensor.Rng.deinitBuffer(&self.rng_buffers);
     }
 
@@ -110,21 +153,13 @@ pub const Session = struct {
     }
 
     pub fn runPrefill(self: *Session, all_tokens: []const u32) !void {
-        var prefill_args = try self.compiled_model.prefill_exe.args(self.allocator);
-        defer prefill_args.deinit(self.allocator);
-
-        var prefill_results = try self.compiled_model.prefill_exe.results(self.allocator);
-        defer prefill_results.deinit(self.allocator);
-
         const prefill_tokens_slice: zml.Slice = try .alloc(self.allocator, .init(.{self.seqlen}, .u32));
         defer prefill_tokens_slice.free(self.allocator);
+        @memset(prefill_tokens_slice.items(u32), 0);
         @memcpy(prefill_tokens_slice.items(u32)[0..all_tokens.len], all_tokens);
 
         var prefill_tokens_buffer: zml.Buffer = try .fromSlice(self.io, self.platform, prefill_tokens_slice, .replicated);
         defer prefill_tokens_buffer.deinit();
-
-        var prefill_token_pos_buffer = try zml.Buffer.scalar(self.io, self.platform, 0, .u32);
-        defer prefill_token_pos_buffer.deinit();
 
         const attention_metadata_buffers: zml.Bufferized(zml.attention.attention.Metadata) = switch (self.compiled_model.params.prefill_attention_parameters) {
             .attnd => .{ .attnd = .{
@@ -135,17 +170,17 @@ pub const Session = struct {
             .vanilla, .cuda_fa2, .cuda_fa3 => self.attention_metadata_buffers,
         };
 
-        prefill_args.set(.{
-            self.model_buffers,
-            prefill_tokens_buffer,
-            prefill_token_pos_buffer,
-            &self.kv_cache_buffers,
-            &self.rng_buffers,
-            &attention_metadata_buffers,
+        try self.compiled_model.prefill.run(.{
+            .allocator = self.allocator,
+            .io = self.io,
+            .platform = self.platform,
+            .model_buffers = self.model_buffers,
+            .tokens_buf = &prefill_tokens_buffer,
+            .token_index_buf = &self.token_index_buffers[0],
+            .kv_cache_buffers = &self.kv_cache_buffers,
+            .rng_buffers = &self.rng_buffers,
+            .attention_metadata_buffers = &attention_metadata_buffers,
         });
-        self.compiled_model.prefill_exe.call(prefill_args, &prefill_results);
-
-        prefill_results.fill(.{ &prefill_tokens_buffer, &self.kv_cache_buffers, &self.rng_buffers });
         try prefill_tokens_buffer.toSlice(self.io, prefill_tokens_slice);
 
         self.last_generated_token = prefill_tokens_slice.items(u32)[all_tokens.len - 1];
@@ -157,14 +192,6 @@ pub const Session = struct {
 
         const decoder_out_buffer: []u8 = try self.allocator.alloc(u8, 256);
         defer self.allocator.free(decoder_out_buffer);
-
-        var decode_args = try self.compiled_model.decode_exe.args(self.allocator);
-        defer decode_args.deinit(self.allocator);
-        // Fix model buffers, since they are stable for the full gen.
-        decode_args.bake(self.model_buffers.*);
-
-        var decode_results = try self.compiled_model.decode_exe.results(self.allocator);
-        defer decode_results.deinit(self.allocator);
 
         var last_token_id: u32 = self.last_generated_token;
         var current_token_buffer: zml.Buffer = try .fromBytes(self.io, self.platform, .init(.{ .s = 1 }, .u32), .replicated, @ptrCast(&last_token_id));
@@ -179,28 +206,20 @@ pub const Session = struct {
             try all_tokens.append(self.allocator, last_token_id);
             if (all_tokens.items.len >= self.seqlen) break :generation;
 
-            var token_pos_buffer: zml.Buffer = try .scalar(self.io, self.platform, all_tokens.items.len, .u32);
-            defer token_pos_buffer.deinit();
+            const attention_metadata_buffers: zml.Bufferized(zml.attention.attention.Metadata) =
+                self.decode_attention_metadata_buffers orelse self.attention_metadata_buffers;
 
-            const attention_metadata_buffers: zml.Bufferized(zml.attention.attention.Metadata) = switch (self.compiled_model.params.decode_attention_parameters) {
-                .attnd => .{ .attnd = .{
-                    .conversation_id = try zml.Buffer.scalar(self.io, self.platform, self.conversation_id, .u64),
-                    .layer_id = try zml.Buffer.scalar(self.io, self.platform, 0, .u16),
-                    .num_tokens = try zml.Buffer.scalar(self.io, self.platform, 1, .u32),
-                } },
-                .vanilla, .cuda_fa2, .cuda_fa3 => self.attention_metadata_buffers,
-            };
-
-            decode_args.set(.{
-                current_token_buffer,
-                token_pos_buffer,
-                &self.kv_cache_buffers,
-                &self.rng_buffers,
-                &attention_metadata_buffers,
+            try self.decode_runner.run(.{
+                .allocator = self.allocator,
+                .io = self.io,
+                .platform = self.platform,
+                .model_buffers = self.model_buffers,
+                .tokens_buf = &current_token_buffer,
+                .token_index_buf = &self.token_index_buffers[all_tokens.items.len],
+                .kv_cache_buffers = &self.kv_cache_buffers,
+                .rng_buffers = &self.rng_buffers,
+                .attention_metadata_buffers = &attention_metadata_buffers,
             });
-            self.compiled_model.decode_exe.call(decode_args, &decode_results);
-
-            decode_results.fill(.{ &current_token_buffer, &self.kv_cache_buffers, &self.rng_buffers });
             last_token_id = try current_token_buffer.getValue(u32, self.io);
         }
 

--- a/examples/llm/models/qwen3_5/inference.zig
+++ b/examples/llm/models/qwen3_5/inference.zig
@@ -6,11 +6,7 @@ const common = @import("../common.zig");
 const model = @import("model.zig");
 
 const log = std.log.scoped(.qwen3_5);
-
-const CompileModelResult = struct {
-    prefill_exe: ?zml.Exe = null,
-    decode_exe: ?zml.Exe = null,
-};
+const Phase = common.Phase;
 
 pub const CompilationParameters = struct {
     prefill_tokens: zml.Tensor,
@@ -38,10 +34,21 @@ pub const CompilationParameters = struct {
 
 pub const CompilationOptions = CompilationParameters;
 
+pub const Args = struct {
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    platform: *const zml.Platform,
+    model_buffers: *model.Buffers,
+    tokens_buf: *zml.Buffer,
+    token_index_buf: *zml.Buffer,
+    kv_cache_buffers: *zml.Bufferized(model.KvCache),
+    rng_buffers: *zml.Bufferized(zml.Tensor.Rng),
+};
+
 pub const CompiledModel = struct {
     loaded_model: *const model.LoadedModel,
-    prefill_exe: zml.Exe,
-    decode_exe: zml.Exe,
+    prefill: KernelExe,
+    decode: KernelExe,
     params: CompilationParameters,
 
     pub fn init(
@@ -53,104 +60,662 @@ pub const CompiledModel = struct {
         parameters: CompilationParameters,
         progress: *std.Progress.Node,
     ) !CompiledModel {
-        const compile_result = try compileModel(allocator, io, platform, qwen_model, parameters, progress);
-        return .{ .loaded_model = loaded_model, .prefill_exe = compile_result.prefill_exe.?, .decode_exe = compile_result.decode_exe.?, .params = parameters };
+        return .{
+            .loaded_model = loaded_model,
+            .prefill = try .init(
+                allocator,
+                io,
+                platform,
+                qwen_model,
+                parameters,
+                @intCast(parameters.prefill_tokens.dim(.s)),
+                .prefill,
+                progress,
+            ),
+            .decode = try .init(
+                allocator,
+                io,
+                platform,
+                qwen_model,
+                parameters,
+                @intCast(parameters.decode_tokens.dim(.s)),
+                .decode,
+                progress,
+            ),
+            .params = parameters,
+        };
     }
 
     pub fn deinit(self: *CompiledModel) void {
-        self.prefill_exe.deinit();
-        self.decode_exe.deinit();
+        self.prefill.deinit();
+        self.decode.deinit();
     }
 };
 
 pub const Inference = CompiledModel;
 
-fn compileModel(
-    allocator: std.mem.Allocator,
-    io: std.Io,
-    platform: *const zml.Platform,
-    qwen_model: model.Model,
-    parameters: CompilationParameters,
-    progress: *std.Progress.Node,
-) !CompileModelResult {
-    const now: std.Io.Timestamp = .now(io, .awake);
-    defer log.info("Compiled model [{f}]", .{now.untilNow(io, .awake)});
+pub const KernelExe = struct {
+    composed: ComposedKernelExe,
 
-    const all_shardings = parameters.shardings.all();
+    pub const Runner = struct {
+        exe: *const ComposedKernelExe,
+        embed_args: zml.exe.Exe.Arguments,
+        embed_results: zml.exe.Exe.Results,
+        layers: Layers,
+        sampler_args: zml.exe.Exe.Arguments,
+        sampler_results: zml.exe.Exe.Results,
 
-    var prefill_future = try io.concurrent(struct {
-        fn call(
-            allocator_: std.mem.Allocator,
-            io_: std.Io,
-            platform_: *const zml.Platform,
-            qwen_model_: model.Model,
-            parameters_: CompilationParameters,
-            shardings_: []const zml.Sharding,
-            progress_: *std.Progress.Node,
-        ) !zml.Exe {
-            progress_.increaseEstimatedTotalItems(1);
-            var node_ = progress_.start("Compiling prefill...", 1);
-            defer node_.end();
+        const Layers = struct {
+            args: []zml.exe.Exe.Arguments,
+            results: []zml.exe.Exe.Results,
+            layer_indices: []zml.Buffer,
+            layer_types: []const model.LayerType,
 
-            const now_: std.Io.Timestamp = .now(io_, .awake);
-            defer log.info("Compiled prefill [{f}]", .{now_.untilNow(io_, .awake)});
+            fn init(
+                allocator: std.mem.Allocator,
+                io: std.Io,
+                platform: *const zml.Platform,
+                exe: *const ComposedKernelExe,
+                model_buffers: *model.Buffers,
+            ) !Layers {
+                const args = try allocator.alloc(zml.exe.Exe.Arguments, model_buffers.text_model.layers.len);
+                errdefer allocator.free(args);
 
-            return platform_.compile(
-                allocator_,
-                io_,
-                qwen_model_,
-                .forward,
-                .{
-                    parameters_.prefill_tokens,
-                    parameters_.token_index,
-                    parameters_.kv_cache,
-                    parameters_.rng,
-                },
-                .{ .shardings = shardings_ },
-            );
+                const results = try allocator.alloc(zml.exe.Exe.Results, model_buffers.text_model.layers.len);
+                errdefer allocator.free(results);
+
+                const layer_indices = try allocator.alloc(zml.Buffer, model_buffers.text_model.layers.len);
+                errdefer allocator.free(layer_indices);
+
+                var initialized_args: usize = 0;
+                errdefer {
+                    for (args[0..initialized_args]) |*exe_args| {
+                        exe_args.deinit(allocator);
+                    }
+                }
+
+                var initialized_results: usize = 0;
+                errdefer {
+                    for (results[0..initialized_results]) |*exe_results| {
+                        exe_results.deinit(allocator);
+                    }
+                }
+
+                var initialized_layer_indices: usize = 0;
+                errdefer {
+                    for (layer_indices[0..initialized_layer_indices]) |*layer_index| {
+                        layer_index.deinit();
+                    }
+                }
+
+                var self_attn_layer_index: usize = 0;
+                var linear_attn_layer_index: usize = 0;
+                for (model_buffers.text_model.layers, exe.layer_types, 0..) |layer_bufs, layer_type, i| {
+                    args[i] = try switch (layer_type) {
+                        .full_attention => (exe.full_attention_layer orelse unreachable).args(allocator),
+                        .linear_attention => (exe.linear_attention_layer orelse unreachable).args(allocator),
+                    };
+                    initialized_args = i + 1;
+                    args[i].bake(layer_bufs);
+
+                    results[i] = try switch (layer_type) {
+                        .full_attention => (exe.full_attention_layer orelse unreachable).results(allocator),
+                        .linear_attention => (exe.linear_attention_layer orelse unreachable).results(allocator),
+                    };
+                    initialized_results = i + 1;
+
+                    layer_indices[i] = try switch (layer_type) {
+                        .full_attention => b: {
+                            defer self_attn_layer_index += 1;
+                            break :b zml.Buffer.scalar(io, platform, @as(u32, @intCast(self_attn_layer_index)), .u32);
+                        },
+                        .linear_attention => b: {
+                            defer linear_attn_layer_index += 1;
+                            break :b zml.Buffer.scalar(io, platform, @as(u32, @intCast(linear_attn_layer_index)), .u32);
+                        },
+                    };
+                    initialized_layer_indices = i + 1;
+                }
+
+                return .{
+                    .args = args,
+                    .results = results,
+                    .layer_indices = layer_indices,
+                    .layer_types = exe.layer_types,
+                };
+            }
+
+            fn deinit(self: *Layers, allocator: std.mem.Allocator) void {
+                for (self.args) |*exe_args| {
+                    exe_args.deinit(allocator);
+                }
+                allocator.free(self.args);
+
+                for (self.results) |*exe_results| {
+                    exe_results.deinit(allocator);
+                }
+                allocator.free(self.results);
+
+                for (self.layer_indices) |*layer_index| {
+                    layer_index.deinit();
+                }
+                allocator.free(self.layer_indices);
+            }
+        };
+
+        pub fn init(
+            allocator: std.mem.Allocator,
+            io: std.Io,
+            platform: *const zml.Platform,
+            exe: *const ComposedKernelExe,
+            model_buffers: *model.Buffers,
+        ) !Runner {
+            var embed_args = try exe.embed_tokens.args(allocator);
+            errdefer embed_args.deinit(allocator);
+            embed_args.bake(ComposedKernelExe.embedTokensBuffers(model_buffers));
+
+            var embed_results = try exe.embed_tokens.results(allocator);
+            errdefer embed_results.deinit(allocator);
+
+            var layers = try Layers.init(allocator, io, platform, exe, model_buffers);
+            errdefer layers.deinit(allocator);
+
+            var sampler_args = try exe.sampler.args(allocator);
+            errdefer sampler_args.deinit(allocator);
+            sampler_args.bake(ComposedKernelExe.samplerBuffers(model_buffers));
+
+            var sampler_results = try exe.sampler.results(allocator);
+            errdefer sampler_results.deinit(allocator);
+
+            return .{
+                .exe = exe,
+                .embed_args = embed_args,
+                .embed_results = embed_results,
+                .layers = layers,
+                .sampler_args = sampler_args,
+                .sampler_results = sampler_results,
+            };
         }
-    }.call, .{ allocator, io, platform, qwen_model, parameters, &all_shardings, progress });
-    errdefer if (prefill_future.cancel(io)) |v| v.deinit() else |_| {};
 
-    var decode_future = try io.concurrent(struct {
-        fn call(
-            allocator_: std.mem.Allocator,
-            io_: std.Io,
-            platform_: *const zml.Platform,
-            qwen_model_: model.Model,
-            parameters_: CompilationParameters,
-            shardings_: []const zml.Sharding,
-            progress_: *std.Progress.Node,
-        ) !zml.Exe {
-            progress_.increaseEstimatedTotalItems(1);
-            var node_ = progress_.start("Compiling decode...", 1);
-            defer node_.end();
-
-            const now_: std.Io.Timestamp = .now(io_, .awake);
-            defer log.info("Compiled decode [{f}]", .{now_.untilNow(io_, .awake)});
-
-            return platform_.compile(
-                allocator_,
-                io_,
-                qwen_model_,
-                .forward,
-                .{
-                    parameters_.decode_tokens,
-                    parameters_.token_index,
-                    parameters_.kv_cache,
-                    parameters_.rng,
-                },
-                .{ .shardings = shardings_ },
-            );
+        pub fn deinit(self: *Runner, allocator: std.mem.Allocator) void {
+            self.embed_args.deinit(allocator);
+            self.embed_results.deinit(allocator);
+            self.layers.deinit(allocator);
+            self.sampler_args.deinit(allocator);
+            self.sampler_results.deinit(allocator);
         }
-    }.call, .{ allocator, io, platform, qwen_model, parameters, &all_shardings, progress });
-    errdefer if (decode_future.cancel(io)) |v| v.deinit() else |_| {};
 
-    const prefill_exe = try prefill_future.await(io);
-    const decode_exe = try decode_future.await(io);
+        pub fn run(self: *Runner, args: Args) !void {
+            var hidden_buf: zml.Buffer = b: {
+                self.embed_args.set(.{args.tokens_buf});
+                self.exe.embed_tokens.call(self.embed_args, &self.embed_results);
 
-    return .{
-        .prefill_exe = prefill_exe,
-        .decode_exe = decode_exe,
+                break :b self.embed_results.get(zml.Buffer);
+            };
+            defer hidden_buf.deinit();
+
+            for (
+                self.layers.args,
+                self.layers.results,
+                self.layers.layer_indices,
+                self.layers.layer_types,
+            ) |*exe_args, *results, *layer_index_buf, layer_type| {
+                self.exe.runLayer(exe_args, results, layer_type, args, &hidden_buf, layer_index_buf);
+            }
+
+            self.exe.runSampler(&self.sampler_args, &self.sampler_results, args, &hidden_buf);
+        }
     };
-}
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *const zml.Platform,
+        qwen_model: model.Model,
+        parameters: CompilationOptions,
+        seqlen: usize,
+        phase: Phase,
+        progress: *std.Progress.Node,
+    ) !KernelExe {
+        return .{
+            .composed = try .init(allocator, io, platform, qwen_model, parameters, seqlen, phase, progress),
+        };
+    }
+
+    pub fn deinit(self: KernelExe) void {
+        self.composed.deinit();
+    }
+
+    pub fn run(self: *const KernelExe, args: Args) !void {
+        try self.composed.run(args);
+    }
+
+    pub fn initRunner(
+        self: *const KernelExe,
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *const zml.Platform,
+        model_buffers: *model.Buffers,
+    ) !Runner {
+        return .init(allocator, io, platform, &self.composed, model_buffers);
+    }
+};
+
+const ComposedKernelExe = struct {
+    embed_tokens: zml.Exe,
+    full_attention_layer: ?zml.Exe,
+    linear_attention_layer: ?zml.Exe,
+    sampler: zml.Exe,
+    layer_types: []const model.LayerType,
+    phase: Phase,
+
+    const EmbedTokens = struct {
+        embed_tokens: zml.nn.TokenEmbedding,
+
+        pub fn forward(self: EmbedTokens, tokens_: zml.Tensor) zml.Tensor {
+            const tokens = tokens_.withPartialTags(.{.s});
+            return self.embed_tokens.forward(tokens)
+                .withPartialTags(.{.d})
+                .withPartitioning(.{ .d = .replicated });
+        }
+    };
+
+    fn init(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *const zml.Platform,
+        qwen_model: model.Model,
+        parameters: CompilationOptions,
+        seqlen: usize,
+        phase: Phase,
+        progress: *std.Progress.Node,
+    ) !ComposedKernelExe {
+        const embed_tokens = try ComposedKernelExe.compileEmbedTokens(allocator, io, platform, qwen_model.text_model.embed_tokens, parameters, seqlen, phase, progress);
+        errdefer embed_tokens.deinit();
+
+        const full_attention_layer: ?zml.Exe = b: {
+            const index = ComposedKernelExe.findFirstLayerIndex(qwen_model.config.text_config.layer_types, .full_attention) orelse break :b null;
+            break :b try ComposedKernelExe.compileFullAttentionLayer(allocator, io, platform, qwen_model, parameters, seqlen, index, phase, progress);
+        };
+        errdefer if (full_attention_layer) |exe| exe.deinit();
+
+        const linear_attention_layer: ?zml.Exe = b: {
+            const index = ComposedKernelExe.findFirstLayerIndex(qwen_model.config.text_config.layer_types, .linear_attention) orelse break :b null;
+            break :b try ComposedKernelExe.compileLinearAttentionLayer(allocator, io, platform, qwen_model, parameters, seqlen, index, phase, progress);
+        };
+        errdefer if (linear_attention_layer) |exe| exe.deinit();
+
+        const sampler = try ComposedKernelExe.compileSampler(allocator, io, platform, qwen_model, parameters, seqlen, phase, progress);
+        errdefer sampler.deinit();
+
+        return .{
+            .embed_tokens = embed_tokens,
+            .full_attention_layer = full_attention_layer,
+            .linear_attention_layer = linear_attention_layer,
+            .sampler = sampler,
+            .layer_types = qwen_model.config.text_config.layer_types,
+            .phase = phase,
+        };
+    }
+
+    fn deinit(self: ComposedKernelExe) void {
+        self.embed_tokens.deinit();
+        if (self.full_attention_layer) |exe| exe.deinit();
+        if (self.linear_attention_layer) |exe| exe.deinit();
+        self.sampler.deinit();
+    }
+
+    fn run(self: *const ComposedKernelExe, args: Args) !void {
+        var hidden_buf: zml.Buffer = b: {
+            var exe_args = try self.embed_tokens.args(args.allocator);
+            defer exe_args.deinit(args.allocator);
+
+            var results = try self.embed_tokens.results(args.allocator);
+            defer results.deinit(args.allocator);
+
+            exe_args.bake(ComposedKernelExe.embedTokensBuffers(args.model_buffers));
+            exe_args.set(.{args.tokens_buf});
+
+            self.embed_tokens.call(exe_args, &results);
+
+            break :b results.get(zml.Buffer);
+        };
+        defer hidden_buf.deinit();
+
+        var self_attn_layer_index: usize = 0;
+        var linear_attn_layer_index: usize = 0;
+        for (args.model_buffers.text_model.layers, self.layer_types) |layer_bufs, layer_type| {
+            var exe_args = try switch (layer_type) {
+                .full_attention => (self.full_attention_layer orelse unreachable).args(args.allocator),
+                .linear_attention => (self.linear_attention_layer orelse unreachable).args(args.allocator),
+            };
+            defer exe_args.deinit(args.allocator);
+            exe_args.bake(layer_bufs);
+
+            var results = try switch (layer_type) {
+                .full_attention => (self.full_attention_layer orelse unreachable).results(args.allocator),
+                .linear_attention => (self.linear_attention_layer orelse unreachable).results(args.allocator),
+            };
+            defer results.deinit(args.allocator);
+
+            var layer_index_buf: zml.Buffer = try switch (layer_type) {
+                .full_attention => b: {
+                    defer self_attn_layer_index += 1;
+                    break :b zml.Buffer.scalar(args.io, args.platform, @as(u32, @intCast(self_attn_layer_index)), .u32);
+                },
+                .linear_attention => b: {
+                    defer linear_attn_layer_index += 1;
+                    break :b zml.Buffer.scalar(args.io, args.platform, @as(u32, @intCast(linear_attn_layer_index)), .u32);
+                },
+            };
+            defer layer_index_buf.deinit();
+
+            self.runLayer(&exe_args, &results, layer_type, args, &hidden_buf, &layer_index_buf);
+        }
+
+        {
+            var exe_args = try self.sampler.args(args.allocator);
+            defer exe_args.deinit(args.allocator);
+
+            var results = try self.sampler.results(args.allocator);
+            defer results.deinit(args.allocator);
+
+            exe_args.bake(ComposedKernelExe.samplerBuffers(args.model_buffers));
+
+            self.runSampler(&exe_args, &results, args, &hidden_buf);
+        }
+    }
+
+    fn runLayer(
+        self: *const ComposedKernelExe,
+        exe_args: *zml.exe.Exe.Arguments,
+        results: *zml.exe.Exe.Results,
+        layer_type: model.LayerType,
+        args: Args,
+        hidden_buf: *zml.Buffer,
+        layer_index_buf: *zml.Buffer,
+    ) void {
+        switch (layer_type) {
+            .full_attention => {
+                const layer_cache: zml.Bufferized(model.KvCache.SelfAttnCache) = .{
+                    .k = args.kv_cache_buffers.self_attn.k,
+                    .v = args.kv_cache_buffers.self_attn.v,
+                    .layer_index = layer_index_buf.*,
+                };
+                exe_args.set(.{ hidden_buf, args.token_index_buf, layer_cache });
+                (self.full_attention_layer orelse unreachable).call(exe_args.*, results);
+
+                var new_hidden, var new_cache = results.get(struct {
+                    zml.Buffer,
+                    zml.Bufferized(model.KvCache.SelfAttnCache),
+                });
+                ComposedKernelExe.replaceBuffer(hidden_buf, &new_hidden);
+                ComposedKernelExe.replaceBuffer(&args.kv_cache_buffers.self_attn.k, &new_cache.k);
+                ComposedKernelExe.replaceBuffer(&args.kv_cache_buffers.self_attn.v, &new_cache.v);
+                ComposedKernelExe.releaseBuffer(layer_index_buf.*, &new_cache.layer_index);
+            },
+            .linear_attention => {
+                const layer_cache: zml.Bufferized(model.KvCache.GatedDeltaNetCache) = .{
+                    .conv_state = args.kv_cache_buffers.gated_delta_net.conv_state,
+                    .recurrent_state = args.kv_cache_buffers.gated_delta_net.recurrent_state,
+                    .layer_index = layer_index_buf.*,
+                };
+                exe_args.set(.{ hidden_buf, args.token_index_buf, layer_cache });
+                (self.linear_attention_layer orelse unreachable).call(exe_args.*, results);
+
+                var new_hidden, var new_cache = results.get(struct {
+                    zml.Buffer,
+                    zml.Bufferized(model.KvCache.GatedDeltaNetCache),
+                });
+                ComposedKernelExe.replaceBuffer(hidden_buf, &new_hidden);
+                ComposedKernelExe.replaceBuffer(&args.kv_cache_buffers.gated_delta_net.conv_state, &new_cache.conv_state);
+                ComposedKernelExe.replaceBuffer(&args.kv_cache_buffers.gated_delta_net.recurrent_state, &new_cache.recurrent_state);
+                ComposedKernelExe.releaseBuffer(layer_index_buf.*, &new_cache.layer_index);
+            },
+        }
+    }
+
+    fn runSampler(
+        self: *const ComposedKernelExe,
+        exe_args: *zml.exe.Exe.Arguments,
+        results: *zml.exe.Exe.Results,
+        args: Args,
+        hidden_buf: *zml.Buffer,
+    ) void {
+        switch (self.phase) {
+            .prefill => self.runPrefillSampler(exe_args, results, args, hidden_buf),
+            .decode => self.runDecodeSampler(exe_args, results, args, hidden_buf),
+        }
+    }
+
+    fn runPrefillSampler(
+        self: *const ComposedKernelExe,
+        exe_args: *zml.exe.Exe.Arguments,
+        results: *zml.exe.Exe.Results,
+        args: Args,
+        hidden_buf: *zml.Buffer,
+    ) void {
+        exe_args.set(.{ hidden_buf, args.rng_buffers });
+        self.sampler.call(exe_args.*, results);
+
+        var new_tokens, var new_rng = results.get(struct {
+            zml.Buffer,
+            zml.Bufferized(zml.Tensor.Rng),
+        });
+
+        ComposedKernelExe.replaceBuffer(args.tokens_buf, &new_tokens);
+        ComposedKernelExe.replaceBuffer(&args.rng_buffers._state, &new_rng._state);
+    }
+
+    fn runDecodeSampler(
+        self: *const ComposedKernelExe,
+        exe_args: *zml.exe.Exe.Arguments,
+        results: *zml.exe.Exe.Results,
+        args: Args,
+        hidden_buf: *zml.Buffer,
+    ) void {
+        exe_args.set(.{ hidden_buf, args.rng_buffers, args.token_index_buf });
+        self.sampler.call(exe_args.*, results);
+
+        var new_tokens, var new_rng, var new_token_index = results.get(struct {
+            zml.Buffer,
+            zml.Bufferized(zml.Tensor.Rng),
+            zml.Buffer,
+        });
+
+        ComposedKernelExe.replaceBuffer(args.tokens_buf, &new_tokens);
+        ComposedKernelExe.replaceBuffer(&args.rng_buffers._state, &new_rng._state);
+        ComposedKernelExe.replaceBuffer(args.token_index_buf, &new_token_index);
+    }
+
+    fn embedTokensBuffers(model_buffers: *const model.Buffers) zml.Bufferized(EmbedTokens) {
+        return .{
+            .embed_tokens = model_buffers.text_model.embed_tokens,
+        };
+    }
+
+    fn samplerBuffers(model_buffers: *const model.Buffers) zml.Bufferized(model.Sampler) {
+        return .{
+            .norm = model_buffers.text_model.norm,
+            .lm_head = model_buffers.lm_head,
+        };
+    }
+
+    fn replaceBuffer(dst: *zml.Buffer, src: *zml.Buffer) void {
+        if (!ComposedKernelExe.sameBufferHandle(dst.*, src.*)) {
+            dst.deinit();
+        }
+
+        dst.* = src.*;
+    }
+
+    fn releaseBuffer(expected: zml.Buffer, actual: *zml.Buffer) void {
+        if (!ComposedKernelExe.sameBufferHandle(expected, actual.*)) {
+            actual.deinit();
+        }
+    }
+
+    fn sameBufferHandle(a: zml.Buffer, b: zml.Buffer) bool {
+        if (a._shards.len != b._shards.len) return false;
+
+        for (a._shards.constSlice(), b._shards.constSlice()) |a_shard, b_shard| {
+            if (a_shard != b_shard) return false;
+        }
+
+        return true;
+    }
+
+    fn compileEmbedTokens(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *const zml.Platform,
+        embed_tokens: zml.nn.TokenEmbedding,
+        parameters: CompilationOptions,
+        seqlen: usize,
+        phase: Phase,
+        progress: *std.Progress.Node,
+    ) !zml.Exe {
+        progress.increaseEstimatedTotalItems(1);
+        var node = progress.start(phase.startMessage("embed tokens"), 1);
+        defer node.end();
+
+        const from: std.Io.Timestamp = .now(io, .awake);
+        defer phase.logCompileDone(log, "embed tokens", io, from);
+
+        const tokens: zml.Tensor = .init(.{ .b = 1, .s = seqlen }, .u32);
+
+        return platform.compile(allocator, io, EmbedTokens{ .embed_tokens = embed_tokens }, .forward, .{tokens}, .{
+            .shardings = &parameters.shardings.all(),
+            .program_name = phase.programName("qwen3_5", "embed_tokens"),
+        });
+    }
+
+    fn compileFullAttentionLayer(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *const zml.Platform,
+        qwen_model: model.Model,
+        parameters: CompilationOptions,
+        seqlen: usize,
+        layer_index: usize,
+        phase: Phase,
+        progress: *std.Progress.Node,
+    ) !zml.Exe {
+        progress.increaseEstimatedTotalItems(1);
+        var node = progress.start(phase.startMessage("full attention layer"), 1);
+        defer node.end();
+
+        const from: std.Io.Timestamp = .now(io, .awake);
+        defer phase.logCompileDone(log, "full attention layer", io, from);
+
+        const hidden_tensor = ComposedKernelExe.hidden(qwen_model, seqlen);
+        const self_attn_cache: model.KvCache.SelfAttnCache = .{
+            .k = parameters.kv_cache.self_attn.k,
+            .v = parameters.kv_cache.self_attn.v,
+            .layer_index = zml.Tensor.init(.{}, .u32),
+        };
+
+        return platform.compile(
+            allocator,
+            io,
+            qwen_model.text_model.layers[layer_index],
+            .forwardSelfAttn,
+            .{ hidden_tensor, parameters.token_index, self_attn_cache },
+            .{
+                .shardings = &parameters.shardings.all(),
+                .program_name = phase.programName("qwen3_5", "full_attention_layer"),
+            },
+        );
+    }
+
+    fn compileLinearAttentionLayer(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *const zml.Platform,
+        qwen_model: model.Model,
+        parameters: CompilationOptions,
+        seqlen: usize,
+        layer_index: usize,
+        phase: Phase,
+        progress: *std.Progress.Node,
+    ) !zml.Exe {
+        progress.increaseEstimatedTotalItems(1);
+        var node = progress.start(phase.startMessage("linear attention layer"), 1);
+        defer node.end();
+
+        const from: std.Io.Timestamp = .now(io, .awake);
+        defer phase.logCompileDone(log, "linear attention layer", io, from);
+
+        const hidden_tensor = ComposedKernelExe.hidden(qwen_model, seqlen);
+        const linear_attn_cache: model.KvCache.GatedDeltaNetCache = .{
+            .conv_state = parameters.kv_cache.gated_delta_net.conv_state,
+            .recurrent_state = parameters.kv_cache.gated_delta_net.recurrent_state,
+            .layer_index = zml.Tensor.init(.{}, .u32),
+        };
+
+        return platform.compile(
+            allocator,
+            io,
+            qwen_model.text_model.layers[layer_index],
+            .forwardLinearAttn,
+            .{ hidden_tensor, parameters.token_index, linear_attn_cache },
+            .{
+                .shardings = &parameters.shardings.all(),
+                .program_name = phase.programName("qwen3_5", "linear_attention_layer"),
+            },
+        );
+    }
+
+    fn compileSampler(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        platform: *const zml.Platform,
+        qwen_model: model.Model,
+        parameters: CompilationOptions,
+        seqlen: usize,
+        phase: Phase,
+        progress: *std.Progress.Node,
+    ) !zml.Exe {
+        progress.increaseEstimatedTotalItems(1);
+        var node = progress.start(phase.startMessage("sampler"), 1);
+        defer node.end();
+
+        const from: std.Io.Timestamp = .now(io, .awake);
+        defer phase.logCompileDone(log, "sampler", io, from);
+
+        const token_index: ?zml.Tensor = switch (phase) {
+            .prefill => null,
+            .decode => parameters.token_index,
+        };
+
+        return platform.compile(
+            allocator,
+            io,
+            qwen_model.sampler(),
+            .sampleTokens,
+            .{ ComposedKernelExe.hidden(qwen_model, seqlen), parameters.rng, token_index },
+            .{
+                .shardings = &parameters.shardings.all(),
+                .program_name = phase.programName("qwen3_5", "sampler"),
+            },
+        );
+    }
+
+    fn hidden(qwen_model: model.Model, seqlen: usize) zml.Tensor {
+        return .fromShape(zml.Shape.init(
+            .{ .b = 1, .s = seqlen, .d = qwen_model.config.text_config.hidden_size },
+            qwen_model.text_model.embed_tokens.weight.dtype(),
+        ).withPartitioning(.{
+            .b = .replicated,
+            .s = .replicated,
+            .d = .replicated,
+        }));
+    }
+
+    fn findFirstLayerIndex(layer_types: []const model.LayerType, target: model.LayerType) ?usize {
+        for (layer_types, 0..) |layer_type, index| {
+            if (layer_type == target) return index;
+        }
+        return null;
+    }
+};

--- a/examples/llm/models/qwen3_5/model.zig
+++ b/examples/llm/models/qwen3_5/model.zig
@@ -49,10 +49,11 @@ fn kvHeadsAreReplicated(axis_size: i64, model_partitions: i64) bool {
 }
 
 fn partitionKvCacheShape(kv_shape: zml.Shape, kv_heads: i64, model_partitions: i64) zml.Shape {
-    return if (kvHeadsAreReplicated(kv_heads, model_partitions))
-        kv_shape.withPartitioning(.{ .h = .replicated })
-    else
-        kv_shape.withPartitioning(.{ .h = .model });
+    if (kvHeadsAreReplicated(kv_heads, model_partitions)) {
+        return kv_shape.withPartitioning(.{ .h = .replicated });
+    }
+
+    return kv_shape.withPartitioning(.{ .h = .model });
 }
 
 pub const LoadedModel = struct {
@@ -163,7 +164,10 @@ pub const Model = struct {
 
     pub fn init(allocator: std.mem.Allocator, store: zml.io.TensorStore.View, config: Config, gen_options: GenOptions) !Model {
         // For some Qwen3.5 versions, the output projection lm_head has a standalone weight tensor, while for others it's the same as the input embedding layer
-        const lm_head_prefix = if (store.hasKey("lm_head.weight")) "lm_head" else "model.language_model.embed_tokens";
+        const lm_head_prefix = b: {
+            if (store.hasKey("lm_head.weight")) break :b "lm_head";
+            break :b "model.language_model.embed_tokens";
+        };
         return .{
             .text_model = try .init(allocator, store.withPrefix("model.language_model"), config),
             .lm_head = .init(
@@ -220,22 +224,39 @@ pub const Model = struct {
     ) struct { zml.Tensor, KvCache, zml.Tensor.Rng } {
         const tokens = tokens_.withPartialTags(.{.s});
         const text_model_output, const updated_kv_cache = self.text_model.forward(tokens, token_index, kv_cache);
-        const new_tokens, const new_rng = self.sampleTokens(text_model_output, rng);
+        const new_tokens, const new_rng, _ = self.sampler().sampleTokens(text_model_output, rng, null);
         return .{ new_tokens.convert(tokens.dtype()).reuseBuffer(tokens), updated_kv_cache, new_rng };
     }
 
-    pub fn sampleTokens(
-        self: Model,
-        out: zml.Tensor,
-        rng: zml.Tensor.Rng,
-    ) struct { zml.Tensor, zml.Tensor.Rng } {
-        const logits = self.lm_head.forward(out.withPartialTags(.{.d})).rename(.{ .dout = .voc });
-        const next_tokens, const new_rng = zml.nn.sampleTokens(logits, self.gen_options.sampling_strategy, rng);
-        return .{ next_tokens, new_rng };
+    pub fn sampler(self: Model) Sampler {
+        return .{
+            .norm = self.text_model.norm,
+            .lm_head = self.lm_head,
+            .gen_options = self.gen_options,
+        };
     }
 };
 
-//========================Text model========================
+pub const Sampler = struct {
+    norm: RmsNorm,
+    lm_head: zml.nn.Linear,
+    gen_options: Model.GenOptions,
+
+    pub fn sampleTokens(
+        self: Sampler,
+        out: zml.Tensor,
+        rng: zml.Tensor.Rng,
+        token_index: ?zml.Tensor,
+    ) struct { zml.Tensor, zml.Tensor.Rng, ?zml.Tensor } {
+        const x = self.norm.forward(out);
+        const logits = self.lm_head.forward(x.withPartialTags(.{.d})).rename(.{ .dout = .voc });
+        const next_tokens, const new_rng = zml.nn.sampleTokens(logits, self.gen_options.sampling_strategy, rng);
+        if (token_index) |token_idx| {
+            return .{ next_tokens.convert(.u32), new_rng, token_idx.addConstant(1) };
+        }
+        return .{ next_tokens.convert(.u32), new_rng, null };
+    }
+};
 
 pub const TextModel = struct {
     embed_tokens: zml.nn.TokenEmbedding,
@@ -284,10 +305,9 @@ pub const TextModel = struct {
 
         var updated_kv_cache = kv_cache;
         for (self.layers, 0..) |layer, i| {
-            hidden_states, updated_kv_cache = layer.forward(hidden_states, token_index, updated_kv_cache, @intCast(i));
+            hidden_states, updated_kv_cache = layer.forward(hidden_states, token_index, updated_kv_cache.atLayer(i));
         }
 
-        hidden_states = self.norm.forward(hidden_states);
         return .{ hidden_states, updated_kv_cache.reuseBuffer(kv_cache) };
     }
 };
@@ -305,12 +325,13 @@ pub const TransformerLayer = struct {
 
     pub fn init(store: zml.io.TensorStore.View, config: Config, layer_index: usize) !TransformerLayer {
         const is_full_attention = config.text_config.layer_types[layer_index] == .full_attention;
+        const attn: Attn = switch (is_full_attention) {
+            true => .{ .full_attention = try .init(store.withPrefix("self_attn"), config) },
+            false => .{ .linear_attention = .init(store.withPrefix("linear_attn"), config) },
+        };
         return .{
             .input_layernorm = RmsNorm.init(store.withPrefix("input_layernorm"), config.text_config.rms_norm_eps),
-            .attn = if (is_full_attention)
-                .{ .full_attention = try .init(store.withPrefix("self_attn"), config) }
-            else
-                .{ .linear_attention = .init(store.withPrefix("linear_attn"), config) },
+            .attn = attn,
             .mlp = .init(store.withPrefix("mlp")),
             .post_attention_layernorm = RmsNorm.init(store.withPrefix("post_attention_layernorm"), config.text_config.rms_norm_eps),
         };
@@ -330,32 +351,82 @@ pub const TransformerLayer = struct {
         self: TransformerLayer,
         x0: zml.Tensor,
         token_index: zml.Tensor,
-        kv_cache: KvCache,
-        layer_id: u32,
+        kv_cache: KvCache.LayerView,
     ) struct { zml.Tensor, KvCache } {
         const x0_replicated = x0.withPartitioning(.{ .d = .replicated });
         const normalized_x0 = self.input_layernorm.forward(x0_replicated);
 
         var attention_output: zml.Tensor = undefined;
-        var updated_kv_cache: KvCache = kv_cache;
-        const layer_type, const dense_id = kv_cache.getDenseIndex(layer_id);
-        std.debug.assert(self.attn == layer_type);
+        var updated_kv_cache: KvCache = kv_cache.parent;
         switch (self.attn) {
             .full_attention => |*self_attn| {
-                const result = self_attn.forward(normalized_x0, token_index, kv_cache.self_attn.atLayer(dense_id));
+                const cache = switch (kv_cache.cache) {
+                    .self_attn => |cache| cache,
+                    .linear_attn => unreachable,
+                };
+                const result = self_attn.forward(normalized_x0, token_index, cache);
                 attention_output = result[0];
-                updated_kv_cache.self_attn = result[1];
+                updated_kv_cache.self_attn = result[1].reuseBuffer(updated_kv_cache.self_attn);
             },
             .linear_attention => |*linear_attn| {
-                const result = linear_attn.forward(normalized_x0, kv_cache.gated_delta_net.atLayer(dense_id));
+                const cache = switch (kv_cache.cache) {
+                    .linear_attn => |cache| cache,
+                    .self_attn => unreachable,
+                };
+                const result = linear_attn.forward(normalized_x0, cache);
                 attention_output = result[0];
-                updated_kv_cache.gated_delta_net = result[1];
+                updated_kv_cache.gated_delta_net = result[1].reuseBuffer(updated_kv_cache.gated_delta_net);
             },
         }
 
         const x1 = attention_output.add(x0_replicated).withPartitioning(.{ .d = .replicated });
         const normalized_hidden = self.post_attention_layernorm.forward(x1);
 
+        const mlp_output = self.mlp.forward(normalized_hidden).withPartitioning(.{ .d = .replicated });
+
+        return .{ mlp_output.add(x1).withPartitioning(.{ .d = .replicated }).reuseBuffer(x0), updated_kv_cache };
+    }
+
+    pub fn forwardSelfAttn(
+        self: TransformerLayer,
+        x0: zml.Tensor,
+        token_index: zml.Tensor,
+        kv_cache: KvCache.SelfAttnCache,
+    ) struct { zml.Tensor, KvCache.SelfAttnCache } {
+        const x0_replicated = x0.withPartitioning(.{ .d = .replicated });
+        const normalized_x0 = self.input_layernorm.forward(x0_replicated);
+
+        const self_attn = switch (self.attn) {
+            .full_attention => |self_attn| self_attn,
+            .linear_attention => unreachable,
+        };
+        const attention_output, const updated_kv_cache = self_attn.forward(normalized_x0, token_index, kv_cache);
+
+        const x1 = attention_output.add(x0_replicated).withPartitioning(.{ .d = .replicated });
+        const normalized_hidden = self.post_attention_layernorm.forward(x1);
+        const mlp_output = self.mlp.forward(normalized_hidden).withPartitioning(.{ .d = .replicated });
+
+        return .{ mlp_output.add(x1).withPartitioning(.{ .d = .replicated }).reuseBuffer(x0), updated_kv_cache };
+    }
+
+    pub fn forwardLinearAttn(
+        self: TransformerLayer,
+        x0: zml.Tensor,
+        token_index: zml.Tensor,
+        kv_cache: KvCache.GatedDeltaNetCache,
+    ) struct { zml.Tensor, KvCache.GatedDeltaNetCache } {
+        _ = token_index;
+        const x0_replicated = x0.withPartitioning(.{ .d = .replicated });
+        const normalized_x0 = self.input_layernorm.forward(x0_replicated);
+
+        const linear_attn = switch (self.attn) {
+            .linear_attention => |linear_attn| linear_attn,
+            .full_attention => unreachable,
+        };
+        const attention_output, const updated_kv_cache = linear_attn.forward(normalized_x0, kv_cache);
+
+        const x1 = attention_output.add(x0_replicated).withPartitioning(.{ .d = .replicated });
+        const normalized_hidden = self.post_attention_layernorm.forward(x1);
         const mlp_output = self.mlp.forward(normalized_hidden).withPartitioning(.{ .d = .replicated });
 
         return .{ mlp_output.add(x1).withPartitioning(.{ .d = .replicated }).reuseBuffer(x0), updated_kv_cache };
@@ -468,24 +539,30 @@ pub const SelfAttn = struct {
     }
 
     fn projectKV(self: SelfAttn, x: zml.Tensor) struct { zml.Tensor, zml.Tensor } {
-        const num_kv_heads = if (self.num_kv_heads > 0) self.num_kv_heads else self.num_heads;
+        const num_kv_heads = b: {
+            if (self.num_kv_heads > 0) break :b self.num_kv_heads;
+            break :b self.num_heads;
+        };
         const k = self.k_proj.forward(x).splitAxis(.dout, .{ .h = num_kv_heads, .hd = self.head_dim });
         const v = self.v_proj.forward(x).splitAxis(.dout, .{ .h = num_kv_heads, .hd = self.head_dim });
         return .{ k, v };
     }
 
     fn partitionProjectedKv(tensor: zml.Tensor, replicate_kv_heads: bool) zml.Tensor {
-        return if (replicate_kv_heads)
-            tensor.withPartitioning(.{ .s = .replicated, .h = .replicated, .hd = .replicated })
-        else
-            tensor.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
+        if (replicate_kv_heads) {
+            return tensor.withPartitioning(.{ .s = .replicated, .h = .replicated, .hd = .replicated });
+        }
+
+        return tensor.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
     }
 
     fn partitionCachedKv(tensor: zml.Tensor, replicate_kv_heads: bool) zml.Tensor {
-        return if (replicate_kv_heads)
-            tensor.rename(.{ .s = .k }).withPartitioning(.{ .k = .replicated, .h = .replicated, .hd = .replicated })
-        else
-            tensor.rename(.{ .s = .k }).withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated });
+        const cache_tensor = tensor.rename(.{ .s = .k });
+        if (replicate_kv_heads) {
+            return cache_tensor.withPartitioning(.{ .k = .replicated, .h = .replicated, .hd = .replicated });
+        }
+
+        return cache_tensor.withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated });
     }
 
     pub fn forward(
@@ -570,7 +647,12 @@ pub const TextRotaryEmbedding = struct {
         return .{ cos, sin };
     }
 
-    pub fn getCosAndSinInterleaved(self: TextRotaryEmbedding, position_ids: zml.Tensor, dtype: zml.DataType) struct { zml.Tensor, zml.Tensor } { // To be used later in image extension
+    pub fn getCosAndSinInterleaved(
+        self: TextRotaryEmbedding,
+        position_ids: zml.Tensor,
+        dtype: zml.DataType,
+    ) struct { zml.Tensor, zml.Tensor } {
+        // To be used later in image extension.
         const stacked_position_ids = zml.Tensor.stack(&.{ position_ids, position_ids, position_ids }, 0, .g).convert(.f32);
         const inv_freq = zml.nn.InvFreq(self.rotary_dim, self.rope_opts).withTags(.{.hd});
 
@@ -671,7 +753,14 @@ pub const GatedDeltaNet = struct {
         RmsNormGated.unloadBuffers(&self.norm);
     }
 
-    fn recurrentGatedDeltaRule(query: zml.Tensor, key: zml.Tensor, value: zml.Tensor, g: zml.Tensor, beta: zml.Tensor, initial_state: ?zml.Tensor) struct { zml.Tensor, zml.Tensor } {
+    fn recurrentGatedDeltaRule(
+        query: zml.Tensor,
+        key: zml.Tensor,
+        value: zml.Tensor,
+        g: zml.Tensor,
+        beta: zml.Tensor,
+        initial_state: ?zml.Tensor,
+    ) struct { zml.Tensor, zml.Tensor } {
         const scale: f32 = 1.0 / @sqrt(@as(f32, @floatFromInt(query.dim(.khd))));
         const query_norm = zml.nn.normalizeL2(query.rename(.{ .kh = .vh }), 1e-6);
         const key_norm = zml.nn.normalizeL2(key.rename(.{ .kh = .vh }), 1e-6);
@@ -684,15 +773,18 @@ pub const GatedDeltaNet = struct {
             beta.convert(.f32).rename(.{ .vh = .h }),
         };
 
-        const initial_recurrent_state = if (initial_state) |state|
-            state.convert(.f32).transpose(.{ .b, .vh, .vhd, .khd }).rename(.{ .vh = .h, .vhd = .v, .khd = .k })
-        else
-            zml.Tensor.constant(zml.DataType.zero(.f32)).broad(zml.Shape.init(.{
+        const initial_recurrent_state = b: {
+            if (initial_state) |state| {
+                break :b state.convert(.f32).transpose(.{ .b, .vh, .vhd, .khd }).rename(.{ .vh = .h, .vhd = .v, .khd = .k });
+            }
+
+            break :b zml.Tensor.constant(zml.DataType.zero(.f32)).broad(zml.Shape.init(.{
                 .b = value.dim(.b),
                 .h = value.dim(.vh),
                 .v = value.dim(.vhd),
                 .k = query.dim(.khd),
             }, .f32));
+        };
 
         const result = zml.nn.GatedDeltaNet.forward(
             query_f32,
@@ -728,10 +820,10 @@ pub const GatedDeltaNet = struct {
         const x_in = x.withPartitioning(.{ .d = .replicated });
         const projected_qkv = self.in_proj_qkv.forward(x_in).rename(.{ .dout = .mix }).withPartitioning(.{ .s = .replicated, .mix = .model });
         const use_cached_state = x.dim(.s) == 1 and left_pad > 0;
-        const conv_input = if (use_cached_state)
-            zml.Tensor.concatenate(&.{ cache.convState(), projected_qkv }, .s)
-        else
-            projected_qkv;
+        const conv_input = b: {
+            if (use_cached_state) break :b zml.Tensor.concatenate(&.{ cache.convState(), projected_qkv }, .s);
+            break :b projected_qkv;
+        };
 
         const kernel = self.conv1d_weight;
         var mixed_qkv = zml.Tensor.conv1d(
@@ -758,7 +850,9 @@ pub const GatedDeltaNet = struct {
         }
         mixed_qkv = mixed_qkv.withPartitioning(.{ .s = .replicated, .mix = .model });
 
-        const z = self.in_proj_z.forward(x_in).splitAxis(.dout, .{ .vh = self.num_v_heads, .vhd = self.head_v_dim }).withPartitioning(.{ .s = .replicated, .vh = .model, .vhd = .replicated });
+        const z = self.in_proj_z.forward(x_in)
+            .splitAxis(.dout, .{ .vh = self.num_v_heads, .vhd = self.head_v_dim })
+            .withPartitioning(.{ .s = .replicated, .vh = .model, .vhd = .replicated });
         const b = self.in_proj_b.forward(x_in).rename(.{ .dout = .vh }).withPartitioning(.{ .s = .replicated, .vh = .model });
         const a = self.in_proj_a.forward(x_in).rename(.{ .dout = .vh }).withPartitioning(.{ .s = .replicated, .vh = .model });
 
@@ -779,8 +873,14 @@ pub const GatedDeltaNet = struct {
         const aLog_type = self.aLog.dtype();
         const g = self.aLog.broad(a.shape()).exp().mul(softplus(a.convert(aLog_type).add(self.dt_bias.convert(aLog_type).broad(a.shape())))).negate();
 
-        const query_for_rule = if (self.qk_head_repetition == 1) query else query.stutter1d(@intCast(query.axis(.kh)), @intCast(self.qk_head_repetition));
-        const key_for_rule = if (self.qk_head_repetition == 1) key else key.stutter1d(@intCast(key.axis(.kh)), @intCast(self.qk_head_repetition));
+        const query_for_rule = b: {
+            if (self.qk_head_repetition == 1) break :b query;
+            break :b query.stutter1d(@intCast(query.axis(.kh)), @intCast(self.qk_head_repetition));
+        };
+        const key_for_rule = b: {
+            if (self.qk_head_repetition == 1) break :b key;
+            break :b key.stutter1d(@intCast(key.axis(.kh)), @intCast(self.qk_head_repetition));
+        };
 
         const core_attn_out, const last_recurrent_state = recurrentGatedDeltaRule(
             query_for_rule,
@@ -788,7 +888,10 @@ pub const GatedDeltaNet = struct {
             value,
             g,
             beta,
-            if (use_cached_state) cache.recurrentState() else null,
+            b: {
+                if (use_cached_state) break :b cache.recurrentState();
+                break :b null;
+            },
         );
 
         const core_attn_out_normed = self.norm
@@ -861,7 +964,7 @@ pub const KvCache = struct {
     pub const SelfAttnCache = struct {
         k: zml.Tensor,
         v: zml.Tensor,
-        layer_index: ?u32,
+        layer_index: zml.Tensor,
 
         pub const Buffers = zml.Bufferized(SelfAttnCache);
 
@@ -878,7 +981,7 @@ pub const KvCache = struct {
             return .{
                 .k = .fromShape(sharded_kv_shape),
                 .v = .fromShape(sharded_kv_shape),
-                .layer_index = null,
+                .layer_index = .init(.{}, .u32),
             };
         }
 
@@ -886,44 +989,63 @@ pub const KvCache = struct {
             return .{
                 .k = try zml.Buffer.uninitialized(io, platform, kv.k.shape(), sharding, .{}),
                 .v = try zml.Buffer.uninitialized(io, platform, kv.v.shape(), sharding, .{}),
+                .layer_index = try zml.Buffer.scalar(io, platform, 0, .u32),
             };
         }
 
         pub fn deinitBuffer(kv: *SelfAttnCache.Buffers) void {
             kv.k.deinit();
             kv.v.deinit();
+            kv.layer_index.deinit();
         }
 
         pub fn keys(kv: SelfAttnCache) zml.Tensor {
-            return kv.k.slice1d(.layer, .single(kv.layer_index orelse @panic("forgot to call atLayer")));
+            return kv.k.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = kv.layer_index, .len = 1 } }).squeeze(.layer);
         }
 
         pub fn values(kv: SelfAttnCache) zml.Tensor {
-            return kv.v.slice1d(.layer, .single(kv.layer_index orelse @panic("forgot to call atLayer")));
+            return kv.v.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = kv.layer_index, .len = 1 } }).squeeze(.layer);
         }
 
         pub fn update(kv: SelfAttnCache, new_k: zml.Tensor, new_v: zml.Tensor, token_index: ?zml.Tensor) SelfAttnCache {
             const k_shape = kv.k.shape().drop(.layer);
-            const layer: zml.Tensor = .scalar(kv.layer_index orelse @panic("forgot to call atLayer"), .u32);
-
-            return if (token_index) |idx|
-                .{
-                    .k = kv.k.scatterSlices(.{ .layer = layer, .k = idx }, new_k.convert(kv.k.dtype()).transpose(k_shape), .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override }).reuseBuffer(kv.k),
-                    .v = kv.v.scatterSlices(.{ .layer = layer, .k = idx }, new_v.convert(kv.v.dtype()).transpose(k_shape), .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override }).reuseBuffer(kv.v),
-                    .layer_index = kv.layer_index,
-                }
-            else
-                .{
-                    .k = kv.k.scatterSlices(.{ .layer = layer }, new_k.convert(kv.k.dtype()).transpose(k_shape), .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override }).reuseBuffer(kv.k),
-                    .v = kv.v.scatterSlices(.{ .layer = layer }, new_v.convert(kv.v.dtype()).transpose(k_shape), .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override }).reuseBuffer(kv.v),
+            var layer = kv.layer_index;
+            if (token_index) |idx| {
+                layer = layer.broad(idx.shape());
+                return .{
+                    .k = kv.k.scatterSlices(
+                        .{ .layer = layer, .s = idx },
+                        new_k.convert(kv.k.dtype()).transpose(k_shape),
+                        .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override },
+                    ).reuseBuffer(kv.k),
+                    .v = kv.v.scatterSlices(
+                        .{ .layer = layer, .s = idx },
+                        new_v.convert(kv.v.dtype()).transpose(k_shape),
+                        .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override },
+                    ).reuseBuffer(kv.v),
                     .layer_index = kv.layer_index,
                 };
+            }
+
+            return .{
+                .k = kv.k.scatterSlices(
+                    .{ .layer = layer },
+                    new_k.convert(kv.k.dtype()).transpose(k_shape),
+                    .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override },
+                ).reuseBuffer(kv.k),
+                .v = kv.v.scatterSlices(
+                    .{ .layer = layer },
+                    new_v.convert(kv.v.dtype()).transpose(k_shape),
+                    .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override },
+                ).reuseBuffer(kv.v),
+                .layer_index = kv.layer_index,
+            };
         }
         pub fn atLayer(kv: SelfAttnCache, layer_index: usize) SelfAttnCache {
             return .{
                 .k = kv.k,
                 .v = kv.v,
-                .layer_index = @intCast(layer_index),
+                .layer_index = zml.Tensor.scalar(layer_index, .u32),
             };
         }
 
@@ -931,7 +1053,7 @@ pub const KvCache = struct {
             return .{
                 .k = kv.k.reuseBuffer(other.k),
                 .v = kv.v.reuseBuffer(other.v),
-                .layer_index = kv.layer_index,
+                .layer_index = kv.layer_index.reuseBuffer(other.layer_index),
             };
         }
     };
@@ -939,13 +1061,15 @@ pub const KvCache = struct {
     pub const GatedDeltaNetCache = struct {
         conv_state: zml.Tensor,
         recurrent_state: zml.Tensor,
-        layer_index: ?u32,
+        layer_index: zml.Tensor,
 
         pub const Buffers = zml.Bufferized(GatedDeltaNetCache);
 
         pub fn init(config: Config, batch_dim: i64, conv_dtype: zml.DataType, recurrent_dtype: zml.DataType) GatedDeltaNetCache {
             const num_linear_attn_layers = countLayers(config.text_config.layer_types, .linear_attention);
-            const conv_dim = 2 * config.text_config.linear_num_key_heads * config.text_config.linear_key_head_dim + config.text_config.linear_num_value_heads * config.text_config.linear_value_head_dim;
+            const conv_dim =
+                2 * config.text_config.linear_num_key_heads * config.text_config.linear_key_head_dim +
+                config.text_config.linear_num_value_heads * config.text_config.linear_value_head_dim;
             const conv_state_shape = zml.Shape.init(.{
                 .b = batch_dim,
                 .layer = num_linear_attn_layers,
@@ -964,7 +1088,7 @@ pub const KvCache = struct {
             return .{
                 .conv_state = .fromShape(sharded_conv_state_shape),
                 .recurrent_state = .fromShape(sharded_recurrent_state_shape),
-                .layer_index = null,
+                .layer_index = .init(.{}, .u32),
             };
         }
 
@@ -972,41 +1096,48 @@ pub const KvCache = struct {
             return .{
                 .conv_state = try zml.Buffer.uninitialized(io, platform, self.conv_state.shape(), sharding, .{}),
                 .recurrent_state = try zml.Buffer.uninitialized(io, platform, self.recurrent_state.shape(), sharding, .{}),
+                .layer_index = try zml.Buffer.scalar(io, platform, 0, .u32),
             };
         }
 
         pub fn deinitBuffer(self: *GatedDeltaNetCache.Buffers) void {
             self.conv_state.deinit();
             self.recurrent_state.deinit();
+            self.layer_index.deinit();
         }
 
         pub fn convState(self: GatedDeltaNetCache) zml.Tensor {
-            return self.conv_state.slice1d(.layer, .single(self.layer_index orelse @panic("forgot to call atLayer")));
+            return self.conv_state.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = self.layer_index, .len = 1 } }).squeeze(.layer);
         }
 
         pub fn recurrentState(self: GatedDeltaNetCache) zml.Tensor {
-            return self.recurrent_state.slice1d(.layer, .single(self.layer_index orelse @panic("forgot to call atLayer")));
+            return self.recurrent_state.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = self.layer_index, .len = 1 } }).squeeze(.layer);
         }
 
         pub fn update(self: GatedDeltaNetCache, new_conv_state: ?zml.Tensor, new_recurrent_state: ?zml.Tensor) GatedDeltaNetCache {
-            const layer: zml.Tensor = .scalar(self.layer_index orelse @panic("forgot to call atLayer"), .u32);
-            const conv_state = if (new_conv_state) |state|
-                self.conv_state.scatterSlices(
-                    .{ .layer = layer },
-                    state.convert(self.conv_state.dtype()).transpose(self.conv_state.shape().drop(.layer)),
-                    .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override },
-                ).reuseBuffer(self.conv_state)
-            else
-                self.conv_state;
+            const conv_state = b: {
+                if (new_conv_state) |state| {
+                    break :b self.conv_state.scatterSlices(
+                        .{ .layer = self.layer_index },
+                        state.convert(self.conv_state.dtype()).transpose(self.conv_state.shape().drop(.layer)),
+                        .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override },
+                    ).reuseBuffer(self.conv_state);
+                }
 
-            const recurrent_state = if (new_recurrent_state) |state|
-                self.recurrent_state.scatterSlices(
-                    .{ .layer = layer },
-                    state.convert(self.recurrent_state.dtype()).transpose(self.recurrent_state.shape().drop(.layer)),
-                    .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override },
-                ).reuseBuffer(self.recurrent_state)
-            else
-                self.recurrent_state;
+                break :b self.conv_state;
+            };
+
+            const recurrent_state = b: {
+                if (new_recurrent_state) |state| {
+                    break :b self.recurrent_state.scatterSlices(
+                        .{ .layer = self.layer_index },
+                        state.convert(self.recurrent_state.dtype()).transpose(self.recurrent_state.shape().drop(.layer)),
+                        .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override },
+                    ).reuseBuffer(self.recurrent_state);
+                }
+
+                break :b self.recurrent_state;
+            };
 
             return .{
                 .conv_state = conv_state,
@@ -1019,7 +1150,7 @@ pub const KvCache = struct {
             return .{
                 .conv_state = self.conv_state,
                 .recurrent_state = self.recurrent_state,
-                .layer_index = @intCast(layer_index),
+                .layer_index = zml.Tensor.scalar(layer_index, .u32),
             };
         }
 
@@ -1027,7 +1158,7 @@ pub const KvCache = struct {
             return .{
                 .conv_state = self.conv_state.reuseBuffer(other.conv_state),
                 .recurrent_state = self.recurrent_state.reuseBuffer(other.recurrent_state),
-                .layer_index = null,
+                .layer_index = self.layer_index.reuseBuffer(other.layer_index),
             };
         }
     };
@@ -1067,27 +1198,49 @@ pub const KvCache = struct {
         };
     }
 
+    pub const LayerView = struct {
+        parent: KvCache,
+        cache: union(enum) {
+            self_attn: SelfAttnCache,
+            linear_attn: GatedDeltaNetCache,
+        },
+    };
+
+    pub fn atLayer(self: KvCache, layer_index: usize) LayerView {
+        return switch (denseIndex(self.layer_types, layer_index)) {
+            .full_attention => |dense_index| .{
+                .parent = self,
+                .cache = .{ .self_attn = self.self_attn.atLayer(dense_index.layer_dense_index) },
+            },
+            .linear_attention => |dense_index| .{
+                .parent = self,
+                .cache = .{ .linear_attn = self.gated_delta_net.atLayer(dense_index.layer_dense_index) },
+            },
+        };
+    }
+
     fn countLayers(layer_types: []const LayerType, layer_type: LayerType) i64 {
         return @intCast(std.mem.countScalar(LayerType, layer_types, layer_type));
     }
 
-    pub fn getDenseIndex(cache: KvCache, layer_index: usize) struct { LayerType, u32 } {
-        var self_attn_layer_index: u32 = 0;
-        var linear_attn_layer_index: u32 = 0;
-        for (cache.layer_types[0..layer_index]) |layer_type| {
+    fn denseIndex(layer_types: []const LayerType, layer_index: usize) union(enum) {
+        full_attention: struct { layer_dense_index: usize },
+        linear_attention: struct { layer_dense_index: usize },
+    } {
+        var self_attn_layer_index: usize = 0;
+        var linear_attn_layer_index: usize = 0;
+        for (layer_types[0..layer_index]) |layer_type| {
             switch (layer_type) {
                 .full_attention => self_attn_layer_index += 1,
                 .linear_attention => linear_attn_layer_index += 1,
             }
         }
-        return switch (cache.layer_types[layer_index]) {
-            .full_attention => .{ .full_attention, self_attn_layer_index },
-            .linear_attention => .{ .linear_attention, linear_attn_layer_index },
+        return switch (layer_types[layer_index]) {
+            .full_attention => .{ .full_attention = .{ .layer_dense_index = self_attn_layer_index } },
+            .linear_attention => .{ .linear_attention = .{ .layer_dense_index = linear_attn_layer_index } },
         };
     }
 };
-
-//========================Utils========================
 
 fn softplus(x: zml.Tensor) zml.Tensor {
     return x.exp().addConstant(1).log();

--- a/examples/llm/models/qwen3_5/model.zig
+++ b/examples/llm/models/qwen3_5/model.zig
@@ -989,7 +989,7 @@ pub const KvCache = struct {
         }
 
         pub fn update(self: GatedDeltaNetCache, new_conv_state: ?zml.Tensor, new_recurrent_state: ?zml.Tensor) GatedDeltaNetCache {
-            const layer: zml.Tensor = .scalar(self.layer_index, .u32);
+            const layer: zml.Tensor = .scalar(self.layer_index orelse @panic("forgot to call atLayer"), .u32);
             const conv_state = if (new_conv_state) |state|
                 self.conv_state.scatterSlices(
                     .{ .layer = layer },

--- a/examples/llm/models/qwen3_5/session.zig
+++ b/examples/llm/models/qwen3_5/session.zig
@@ -11,10 +11,10 @@ pub const Session = struct {
     platform: *const zml.Platform,
     model_buffers: *model.Buffers,
     compiled_model: *const inference.CompiledModel,
+    decode_runner: inference.KernelExe.Runner,
     kv_cache_buffers: zml.Bufferized(model.KvCache),
     rng_buffers: zml.Bufferized(zml.Tensor.Rng),
     tokenizer: zml.tokenizer.Tokenizer,
-    step_token_slice: zml.Slice,
     generated_token_slice: zml.Slice,
     seqlen: u32,
     eos_token_id: u32,
@@ -37,16 +37,24 @@ pub const Session = struct {
         var rng_buffers = try zml.Tensor.Rng.initBuffer(io, platform, .replicated, seed);
         errdefer zml.Tensor.Rng.deinitBuffer(&rng_buffers);
 
+        var decode_runner = try compiled_model.decode.initRunner(
+            allocator,
+            io,
+            platform,
+            model_buffers,
+        );
+        errdefer decode_runner.deinit(allocator);
+
         return .{
             .allocator = allocator,
             .io = io,
             .platform = platform,
             .model_buffers = model_buffers,
             .compiled_model = compiled_model,
+            .decode_runner = decode_runner,
             .kv_cache_buffers = kv_cache_buffers,
             .rng_buffers = rng_buffers,
             .tokenizer = tokenizer,
-            .step_token_slice = try .alloc(allocator, zml.Shape.init(.{ .b = 1, .s = 1 }, .u32)),
             .generated_token_slice = try .alloc(allocator, zml.Shape.init(.{ .b = 1, .s = 1 }, .u32)),
             .seqlen = compiled_model.params.seqlen,
             .eos_token_id = compiled_model.loaded_model.inner.special_tokens.end_of_text_token_id,
@@ -57,9 +65,9 @@ pub const Session = struct {
     }
 
     pub fn deinit(self: *Session) void {
+        self.decode_runner.deinit(self.allocator);
         model.KvCache.deinitBuffer(&self.kv_cache_buffers);
         zml.Tensor.Rng.deinitBuffer(&self.rng_buffers);
-        self.step_token_slice.free(self.allocator);
         self.generated_token_slice.free(self.allocator);
     }
 
@@ -78,30 +86,26 @@ pub const Session = struct {
         @memset(prefill_tokens_slice.items(u32), 0);
         @memcpy(prefill_tokens_slice.items(u32)[0..all_tokens.len], all_tokens);
 
-        var prefill_tokens_buffer = try zml.Buffer.fromSlice(self.io, self.platform, prefill_tokens_slice, .replicated);
+        const replicated_sharding: zml.Sharding = .replicated;
+
+        var prefill_tokens_buffer = try zml.Buffer.fromSlice(self.io, self.platform, prefill_tokens_slice, replicated_sharding);
         defer prefill_tokens_buffer.deinit();
 
-        var prefill_token_index_buffer = try zml.Buffer.scalar(self.io, self.platform, 0, .u32);
+        var prefill_token_index_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, 0), .u32);
         defer prefill_token_index_buffer.deinit();
 
-        var args = try self.compiled_model.prefill_exe.args(self.allocator);
-        defer args.deinit(self.allocator);
-
-        var results = try self.compiled_model.prefill_exe.results(self.allocator);
-        defer results.deinit(self.allocator);
-
-        args.set(.{
-            self.model_buffers,
-            prefill_tokens_buffer,
-            prefill_token_index_buffer,
-            &self.kv_cache_buffers,
-            &self.rng_buffers,
+        try self.compiled_model.prefill.run(.{
+            .allocator = self.allocator,
+            .io = self.io,
+            .platform = self.platform,
+            .model_buffers = self.model_buffers,
+            .tokens_buf = &prefill_tokens_buffer,
+            .token_index_buf = &prefill_token_index_buffer,
+            .kv_cache_buffers = &self.kv_cache_buffers,
+            .rng_buffers = &self.rng_buffers,
         });
-        self.compiled_model.prefill_exe.call(args, &results);
 
-        results.fill(.{ &prefill_tokens_buffer, &self.kv_cache_buffers, &self.rng_buffers });
         try prefill_tokens_buffer.toSlice(self.io, prefill_tokens_slice);
-
         const generated_token = prefill_tokens_slice.items(u32)[all_tokens.len - 1];
         self.generated_token_slice.items(u32)[0] = generated_token;
     }
@@ -112,6 +116,14 @@ pub const Session = struct {
 
         const out_tokens_buffer: []u8 = try self.allocator.alloc(u8, 1024);
         defer self.allocator.free(out_tokens_buffer);
+        const replicated_sharding: zml.Sharding = .replicated;
+
+        var current_token_buffer = try zml.Buffer.fromSlice(self.io, self.platform, self.generated_token_slice, replicated_sharding);
+        defer current_token_buffer.deinit();
+
+        var token_index_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, @intCast(all_tokens.items.len)), .u32);
+        defer token_index_buffer.deinit();
+
         generation: while (true) {
             const token_id = self.generated_token_slice.items(u32)[0];
             if (token_id == self.eos_token_id) break :generation;
@@ -129,43 +141,32 @@ pub const Session = struct {
             try all_tokens.append(self.allocator, token_id);
             if (all_tokens.items.len >= self.seqlen) break :generation;
 
-            try self.runDecodeStep(token_id, @intCast(all_tokens.items.len));
+            try self.decode_runner.run(.{
+                .allocator = self.allocator,
+                .io = self.io,
+                .platform = self.platform,
+                .model_buffers = self.model_buffers,
+                .tokens_buf = &current_token_buffer,
+                .token_index_buf = &token_index_buffer,
+                .kv_cache_buffers = &self.kv_cache_buffers,
+                .rng_buffers = &self.rng_buffers,
+            });
+
+            try current_token_buffer.toSlice(self.io, self.generated_token_slice);
         }
 
         try stdout.writeAll(try decoder.finalize(out_tokens_buffer));
         try stdout.flush();
     }
-
-    fn runDecodeStep(self: *Session, token_id: u32, token_index: u32) !void {
-        self.step_token_slice.items(u32)[0] = token_id;
-
-        var token_buffer = try zml.Buffer.fromSlice(self.io, self.platform, self.step_token_slice, .replicated);
-        defer token_buffer.deinit();
-
-        var token_index_buffer = try zml.Buffer.scalar(self.io, self.platform, token_index, .u32);
-        defer token_index_buffer.deinit();
-
-        var args = try self.compiled_model.decode_exe.args(self.allocator);
-        defer args.deinit(self.allocator);
-
-        var results = try self.compiled_model.decode_exe.results(self.allocator);
-        defer results.deinit(self.allocator);
-
-        args.set(.{
-            self.model_buffers,
-            token_buffer,
-            token_index_buffer,
-            &self.kv_cache_buffers,
-            &self.rng_buffers,
-        });
-        self.compiled_model.decode_exe.call(args, &results);
-
-        results.fill(.{ &token_buffer, &self.kv_cache_buffers, &self.rng_buffers });
-        try token_buffer.toSlice(self.io, self.generated_token_slice);
-    }
 };
 
-fn tokenizeChatPrompt(allocator: std.mem.Allocator, tokenizer: zml.tokenizer.Tokenizer, prompt: []const u8, special_tokens: model.Model.SpecialTokens, is_first_turn: bool) ![]const u32 {
+fn tokenizeChatPrompt(
+    allocator: std.mem.Allocator,
+    tokenizer: zml.tokenizer.Tokenizer,
+    prompt: []const u8,
+    special_tokens: model.Model.SpecialTokens,
+    is_first_turn: bool,
+) ![]const u32 {
     var encoder = try tokenizer.encoder();
     defer encoder.deinit();
 

--- a/zml/safetensors.zig
+++ b/zml/safetensors.zig
@@ -320,7 +320,7 @@ pub const TensorRegistry = struct {
             if (gop.found_existing) {
                 gop.value_ptr.*.deinit(allocator);
                 gop.value_ptr.* = value;
-                log.info("Overwrote existing metadata key={s} with value={f}", .{ key, value });
+                log.debug("Overwrote existing metadata key={s} with value={f}", .{ key, value });
             } else {
                 gop.value_ptr.* = value;
                 log.debug("Added new metadata key={s} with value={f}", .{ key, value });


### PR DESCRIPTION
This PR splits Llama in `examples/llm` into separate `embed_tokens`, `layer`, and `lm_head` kernels for both prefill and decode, and brings LFM2 onto the same composed execution path. And done same work for Qwen 3.5 .

It removes the old LFM2 `--single` mode, reworks Llama KV-cache access to use explicit layer indices, and reuses more decode-time state through a persistent runner and prebuilt token index buffers. 

It also tightens sharding/partitioning in LFM2 for multi-device runs, adds clearer per-phase compile logging/program names, removes the unused `--single` CLI flag.

**Llama 3.1 8B on 2x5090**

```
$ CUDA_VISIBLE_DEVICES=0,1 bazel run --config=release --//platforms:cuda=true --//platforms:cpu=false //examples/llm -- --model=file:///var/models/meta-llama/Llama-3.1-8B-Instruct/ --prompt="Tell me a story so I sleep well. I love fantasy settings and weird machines." --seqlen=1024

INFO: Running command line: bazel-bin/examples/llm/llm <args omitted>
warning(zml/io/vfs/hf): No Hugging Face authentication token found in environment or home config; proceeding without authentication.
warning(zml/io/vfs/s3): S3 initialized without full credentials (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY). Access will be unauthenticated. Using default endpoint: https://s3.amazonaws.com (set AWS_ENDPOINT_URL or AWS_ENDPOINT_URL_S3). Using default region: us-east-1 (set AWS_REGION or AWS_DEFAULT_REGION).
warning(zml/platforms/cuda): Detected NVIDIA GPU that requires CUDA compatibility libraries.
info(zml/platforms/cuda): Loaded CUDA compatibility libraries.
info(pjrt): Loading: libpjrt_cuda.so...
info(pjrt): Loaded: libpjrt_cuda.so
info(llm): Selected backend: .cuda_fa2
info(llm): Resolving model repository..
info(llm): Initializing model..
info(llm): Detected model type: .llama
info(llm): Loaded tokenizer [184.022ms]
info(llama): Compiled prefill embed_tokens [326.51ms]
info(llama): Compiled prefill transformer layer [2.212s]
info(llama): Compiled prefill lm_head [2.219s]
info(llama): Compiled decode embed_tokens [39.536ms]
info(llama): Compiled decode transformer layer [726.752ms]
info(llama): Compiled decode lm_head [895.093ms]
info(llama): Loaded weights [14.96GiB, 1.704s, 8.78GiB/s]

....


decode 5.593s · 145.7tok/s
```


**LFM2.5-1.2B-Thinking on 2x5090**

```
$ CUDA_VISIBLE_DEVICES=0 bazel run --//platforms:cuda=true --//platforms:cpu=false //examples/llm -- --model=file:///var/models/liquidai/LFM2.5-1.2B-Thinking/ --prompt="Tell me a story so I sleep well. I love fantasy settings and weird machines." --seqlen=1024

INFO: Running command line: bazel-bin/examples/llm/llm <args omitted>
warning(zml/io/vfs/hf): No Hugging Face authentication token found in environment or home config; proceeding without authentication.
warning(zml/io/vfs/s3): S3 initialized without full credentials (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY). Access will be unauthenticated. Using default endpoint: https://s3.amazonaws.com (set AWS_ENDPOINT_URL or AWS_ENDPOINT_URL_S3). Using default region: us-east-1 (set AWS_REGION or AWS_DEFAULT_REGION).
warning(zml/platforms/cuda): Detected NVIDIA GPU that requires CUDA compatibility libraries.
info(zml/platforms/cuda): Loaded CUDA compatibility libraries.
info(pjrt): Loading: libpjrt_cuda.so...
info(pjrt): Loaded: libpjrt_cuda.so
info(llm): Selected backend: .cuda_fa2
info(llm): Resolving model repository..
info(llm): Initializing model..
info(llm): Detected model type: .lfm2
info(llm): Loaded tokenizer [247.717ms]
info(lfm): Compiled prefill embed_tokens [73.931ms]
info(lfm): Compiled prefill conv layer [2.107s]
info(lfm): Compiled prefill attn layer [1.351s]
info(lfm): Compiled prefill lm_head [1.5s]
info(lfm): Compiled decode embed_tokens [51.92ms]
info(lfm): Compiled decode conv layer [714.508ms]
info(lfm): Compiled decode attn layer [368.091ms]
info(lfm): Compiled decode lm_head [617.405ms]
info(lfm): Loaded weights [2.18GiB, 732.992ms, 2.97GiB/s]

...

decode 2.357s · 423.4tok/s
```

```
$ CUDA_VISIBLE_DEVICES=0,1 bazel run --//platforms:cuda=true --//platforms:cpu=false //examples/llm -- --model=file:///var/models/liquidai/LFM2.5-1.2B-Thinking/ --prompt="Tell me a story so I sleep well. I love fantasy settings and weird machines." --seqlen=1024

INFO: Running command line: bazel-bin/examples/llm/llm <args omitted>
warning(zml/io/vfs/hf): No Hugging Face authentication token found in environment or home config; proceeding without authentication.
warning(zml/io/vfs/s3): S3 initialized without full credentials (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY). Access will be unauthenticated. Using default endpoint: https://s3.amazonaws.com (set AWS_ENDPOINT_URL or AWS_ENDPOINT_URL_S3). Using default region: us-east-1 (set AWS_REGION or AWS_DEFAULT_REGION).
warning(zml/platforms/cuda): Detected NVIDIA GPU that requires CUDA compatibility libraries.
info(zml/platforms/cuda): Loaded CUDA compatibility libraries.
info(pjrt): Loading: libpjrt_cuda.so...
info(pjrt): Loaded: libpjrt_cuda.so
info(llm): Selected backend: .cuda_fa2
info(llm): Resolving model repository..
info(llm): Initializing model..
info(llm): Detected model type: .lfm2
info(llm): Loaded tokenizer [246.123ms]
info(lfm): Compiled prefill embed_tokens [322.102ms]
info(lfm): Compiled prefill conv layer [2.007s]
info(lfm): Compiled prefill attn layer [1.318s]
info(lfm): Compiled prefill lm_head [1.015s]
info(lfm): Compiled decode embed_tokens [45.969ms]
info(lfm): Compiled decode conv layer [667.924ms]
info(lfm): Compiled decode attn layer [338.054ms]
info(lfm): Compiled decode lm_head [571.43ms]
info(lfm): Loaded weights [2.18GiB, 1.269s, 1.72GiB/s]

....

decode 3.295s · 302.9tok/s
```


**Qwen 3.5 9B on 2x5090**

```
$ CUDA_VISIBLE_DEVICES=0,1 bazel run --config=release --//platforms:cuda=true --//platforms:cpu=false //examples/llm -- --model=file:///var/models/Qwen/Qwen3.5-9B/ --prompt="Tell me a story so I sleep well. I love fantasy settings and weird machines." --seqlen=1024

INFO: Running command line: bazel-bin/examples/llm/llm <args omitted>
warning(zml/io/vfs/hf): No Hugging Face authentication token found in environment or home config; proceeding without authentication.
warning(zml/io/vfs/s3): S3 initialized without full credentials (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY). Access will be unauthenticated. Using default endpoint: https://s3.amazonaws.com (set AWS_ENDPOINT_URL or AWS_ENDPOINT_URL_S3). Using default region: us-east-1 (set AWS_REGION or AWS_DEFAULT_REGION).
warning(zml/platforms/cuda): Detected NVIDIA GPU that requires CUDA compatibility libraries.
info(zml/platforms/cuda): Loaded CUDA compatibility libraries.
info(pjrt): Loading: libpjrt_cuda.so...
info(pjrt): Loaded: libpjrt_cuda.so
info(llm): Selected backend: .cuda_fa2
info(llm): Resolving model repository..
info(llm): Initializing model..
info(llm): Detected model type: .qwen3_5
info(llm): Loaded tokenizer [347.125ms]
info(qwen3_5): Compiled prefill embed tokens [310.31ms]
info(qwen3_5): Compiled prefill full attention layer [2.882s]
info(qwen3_5): Compiled prefill linear attention layer [1.056s]
info(qwen3_5): Compiled prefill sampler [1.742s]
info(qwen3_5): Compiled decode embed tokens [39.163ms]
info(qwen3_5): Compiled decode full attention layer [961.298ms]
info(qwen3_5): Compiled decode linear attention layer [364.989ms]
info(qwen3_5): Compiled decode sampler [952.984ms]
info(qwen3_5): Loaded weights [16.68GiB, 1.887s, 8.84GiB/s]

...

decode 5.062s · 133.0tok/s
```

_With 1 device_

```
decode 8.623s · 88.3tok/s
```