### PR TITLE
zml: make Buffer.from faster

### DIFF
--- a/stdx/bounded_array.zig
+++ b/stdx/bounded_array.zig
@@ -49,6 +49,12 @@ pub fn BoundedArrayAligned(
 
         pub const empty: Self = .{ .buffer = undefined, .len = 0 };
 
+        pub fn init(m: []const T) Self {
+            var buf: Self = .{ .buffer = undefined, .len = m.len };
+            @memcpy(buf.buffer[0..m.len], m);
+            return buf;
+        }
+
         /// View the internal array as a slice whose size was previously set.
         pub fn slice(self: anytype) switch (@TypeOf(&self.buffer)) {
             *align(alignment.toByteUnits()) [buffer_capacity]T => []align(alignment.toByteUnits()) T,
@@ -78,10 +84,7 @@ pub fn BoundedArrayAligned(
         /// Copy the content of an existing slice.
         pub fn fromSlice(m: []const T) error{Overflow}!Self {
             if (m.len > buffer_capacity) return error.Overflow;
-
-            var list: Self = .{ .buffer = undefined, .len = m.len };
-            @memcpy(list.buffer[0..m.len], m);
-            return list;
+            return .init(m);
         }
 
         /// Return the element at index `i` of the slice.

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -1,7 +1,6 @@
 //! Explain how to split a buffer across different devices.
 const std = @import("std");
 
-const c = @import("c");
 const dialects = @import("mlir/dialects");
 const mlir = @import("mlir");
 const pjrt = @import("pjrt");
@@ -217,17 +216,20 @@ pub const Device = struct {
     id: usize,
 
     /// Coordinates in the physical mesh
-    coords: stdx.BoundedArray(u8, MAX_MESH_RANK) = .empty,
+    coords: Coords,
 
-    pub fn coordsSlice(self: *const Device) ?[]const u8 {
-        if (self.coords.len == 0) return null;
-        return self.coords.constSlice();
+    const Coords = [MAX_MESH_RANK]u8;
+    // Placeholder coords, that would most likely trigger panic if used like that.
+    const undefined_coords: Coords = @splat(0xff);
+
+    fn isFullInitialized(device: Device) bool {
+        return @as(u32, @bitCast(device.coords)) != @as(u32, @bitCast(undefined_coords));
     }
 
-    pub fn format(self: Device, writer: *std.Io.Writer) !void {
+    pub fn format(device: Device, writer: *std.Io.Writer) !void {
         try writer.print(
             "Device(id={d} coords={any})",
-            .{ self.id, self.coords.constSlice() },
+            .{ device.id, device.coords },
         );
     }
 };
@@ -297,7 +299,7 @@ pub const PhysicalNode = union(enum) {
         return .{
             .leaf = .{
                 .id = @intCast(device_.id()),
-                .coords = .empty,
+                .coords = Device.undefined_coords,
             },
         };
     }
@@ -436,7 +438,7 @@ pub const PhysicalMesh = struct {
         try validateGeometry(root);
 
         var owned_root = root;
-        var path: [MAX_MESH_RANK]u8 = @splat(0);
+        var path: Device.Coords = @splat(0);
         assignCoords(&owned_root, &path, 0);
 
         var mesh: PhysicalMesh = .{
@@ -446,6 +448,10 @@ pub const PhysicalMesh = struct {
             .devices_in_canonical_order = undefined,
         };
         try mesh.populateDevicesInCanonicalOrder(allocator);
+        for (0.., mesh.devices_in_canonical_order) |i, device| {
+            std.debug.assert(device.id == i);
+            std.debug.assert(device.isFullInitialized());
+        }
         return mesh;
     }
 
@@ -458,10 +464,8 @@ pub const PhysicalMesh = struct {
         const Order = struct {
             mesh: *const PhysicalMesh,
             fn lessThan(ctx: @This(), a: Device, b: Device) bool {
-                const ca = a.coordsSlice() orelse unreachable;
-                const cb = b.coordsSlice() orelse unreachable;
-                const ia = ctx.mesh.linearIndexFromCoords(ca);
-                const ib = ctx.mesh.linearIndexFromCoords(cb);
+                const ia = ctx.mesh.linearIndexFromCoords(a.coords);
+                const ib = ctx.mesh.linearIndexFromCoords(b.coords);
                 return ia < ib;
             }
         };
@@ -558,13 +562,13 @@ pub const PhysicalMesh = struct {
     /// coords:
     ///   (0,0) (0,1)
     ///   (1,0) (1,1)
-    fn assignCoords(node: *PhysicalNode, path: *[MAX_MESH_RANK]u8, depth: usize) void {
+    fn assignCoords(node: *PhysicalNode, path: *Device.Coords, depth: usize) void {
         switch (node.*) {
             .leaf => |*d| {
                 // Coords can already been set by caller
-                if (d.coords.len > 0) return;
+                if (d.isFullInitialized()) return;
 
-                d.coords = .init(path[0..depth]);
+                d.coords = path.*;
             },
             .branch => |*b| {
                 for (b.children, 0..) |*child, i| {
@@ -594,7 +598,7 @@ pub const PhysicalMesh = struct {
     ///
     /// sizes: S0..Sk, coords: C0..Ck
     /// linear = (((C0 * S1) + C1) * S2 + C2) ...
-    pub fn linearIndexFromCoords(self: PhysicalMesh, coords: []const u8) usize {
+    pub fn linearIndexFromCoords(self: PhysicalMesh, coords: Device.Coords) usize {
         const order = self.axisOrder();
         var idx: usize = 0;
         for (order.constSlice()) |tag| {
@@ -706,7 +710,7 @@ pub const PhysicalMesh = struct {
     const CoordsTopology = struct {
         const CoordPlacement = struct {
             device_id: usize,
-            coords: stdx.BoundedArray(u8, MAX_MESH_RANK),
+            coords: Device.Coords,
         };
 
         const CoordLayout = struct {
@@ -722,22 +726,20 @@ pub const PhysicalMesh = struct {
         fn parseDevice(device: PlatformDevice) !CoordPlacement {
             const api = device.platform.pjrt_api;
             const coords_attr = device.pjrt_desc.attribute(api, "coords") orelse return error.MissingDeviceCoords;
-            var coords: stdx.BoundedArray(u8, MAX_MESH_RANK) = .empty;
-            switch (coords_attr) {
+            const coords: Device.Coords = coords: switch (coords_attr) {
                 .int64list => |values| {
+                    var coords: Device.Coords = @splat(0);
                     if (values.len == 0 or values.len > MAX_MESH_RANK) return error.InvalidDeviceCoords;
-                    for (values) |value| {
+                    for (coords[0..values.len], values) |*coord, value| {
                         if (value < 0) return error.InvalidDeviceCoords;
-                        coords.appendAssumeCapacity(@intCast(value));
+                        coord.* = @intCast(value);
                     }
+                    break :coords coords;
                 },
                 else => return error.InvalidDeviceCoords,
-            }
-
-            return .{
-                .device_id = device.id(),
-                .coords = coords,
             };
+
+            return .{ .device_id = device.id(), .coords = coords };
         }
 
         pub fn collect(allocator: std.mem.Allocator, platform_devices: []const PlatformDevice) ![]CoordPlacement {
@@ -763,7 +765,7 @@ pub const PhysicalMesh = struct {
             for (0..rank) |ax_i| {
                 var max_coord: usize = 0;
                 for (placements) |coord_placement| {
-                    max_coord = @max(max_coord, coord_placement.coords.constSlice()[ax_i]);
+                    max_coord = @max(max_coord, coord_placement.coords[ax_i]);
                 }
                 axis_sizes[ax_i] = max_coord + 1;
             }
@@ -774,7 +776,7 @@ pub const PhysicalMesh = struct {
             };
         }
 
-        fn linearIndex(coords: []const u8, rank: usize, axis_sizes: []const usize) usize {
+        fn linearIndex(coords: Device.Coords, rank: usize, axis_sizes: []const usize) usize {
             var linear: usize = 0;
             var stride: usize = 1;
             var ax = rank;
@@ -791,7 +793,7 @@ pub const PhysicalMesh = struct {
             for (placements, indexed) |coord_placement, *out| {
                 out.* = .{
                     .placement = coord_placement,
-                    .linear = linearIndex(coord_placement.coords.constSlice(), rank, axis_sizes),
+                    .linear = linearIndex(coord_placement.coords, rank, axis_sizes),
                 };
             }
 
@@ -809,13 +811,8 @@ pub const PhysicalMesh = struct {
             return indexed;
         }
 
-        pub fn leaf(coord_placement: *const CoordPlacement, coords_slice: []const u8) !PhysicalNode {
-            return .{
-                .leaf = .{
-                    .id = coord_placement.device_id,
-                    .coords = try .fromSlice(coords_slice),
-                },
-            };
+        pub fn leaf(coord_placement: *const CoordPlacement, coords: Device.Coords) !PhysicalNode {
+            return .{ .leaf = .{ .id = coord_placement.device_id, .coords = coords } };
         }
 
         pub fn axisStrides(axis_sizes: []const usize) ![MAX_MESH_RANK]usize {
@@ -843,7 +840,7 @@ pub const PhysicalMesh = struct {
         ) !PhysicalNode {
             if (depth == axis_sizes.len) {
                 const coord_placement = &indexed[base_offset].placement;
-                return leaf(coord_placement, coord_placement.coords.constSlice()[0..axis_sizes.len]);
+                return leaf(coord_placement, coord_placement.coords);
             }
 
             const children = try allocator.alloc(PhysicalNode, axis_sizes[depth]);
@@ -913,8 +910,8 @@ pub const PhysicalMesh = struct {
 
         const nodes = try allocator.alloc(PhysicalNode, platform_devices.len);
         for (nodes, indexed, 0..) |*n, entry, i| {
-            const linear_coord: [1]u8 = .{@intCast(i)};
-            n.* = try CoordsTopology.leaf(&entry.placement, linear_coord[0..]);
+            const linear_coord: Device.Coords = .{ @intCast(i), 0, 0, 0 };
+            n.* = try CoordsTopology.leaf(&entry.placement, linear_coord);
         }
 
         return .{
@@ -1543,7 +1540,7 @@ pub const Data = struct {
         @memset(ids, std.math.maxInt(usize));
 
         for (self.physical.devices_in_canonical_order) |d| {
-            const coords = d.coordsSlice() orelse return error.MissingDeviceCoords;
+            const coords = d.coords;
             const idx = self.physical.linearIndexFromCoords(coords);
             ids[idx] = d.id;
         }
@@ -1773,11 +1770,10 @@ pub const Placement = struct {
         return pl;
     }
 
-    pub fn slices(pl: *const Placement, device_id: usize) Slices {
-        const coords = pl.deviceCoords(device_id);
+    pub fn slices(pl: *const Placement, device: Device.Coords) Slices {
         var res: Slices = .{ .buffer = undefined, .len = pl.shape.rank() };
         for (0.., res.slice(), pl.shape.dims(), pl.axis_plans.constSlice()) |a, *r, size, plan| {
-            const start = plan.linearIndex(coords) * size;
+            const start = plan.linearIndex(device) * size;
             r.* = .{
                 .axis = @intCast(a),
                 .start = start,
@@ -1787,16 +1783,15 @@ pub const Placement = struct {
         return res;
     }
 
-    pub fn shardPtr(pl: *const Placement, device_id: usize, slice: Slice) [*]const u8 {
+    pub fn shardPtr(pl: *const Placement, device: Device.Coords, slice: Slice) [*]const u8 {
         if (builtin.mode == .Debug) {
             // there is a bug in caller code that used a placement for a different shape
             std.debug.assert(pl.global_shape.eql(slice.shape));
         }
-        const coords = pl.deviceCoords(device_id);
 
         var ptr: [*]const u8 = slice.constData().ptr;
         for (pl.shape.dims(), pl.axis_plans.constSlice(), slice.byte_strides.constSlice()) |size, plan, stride| {
-            const start = plan.linearIndex(coords) * size;
+            const start = plan.linearIndex(device) * size;
             ptr = ptr[@intCast(start * stride)..];
         }
         return ptr;
@@ -1804,8 +1799,8 @@ pub const Placement = struct {
 
     /// Given a Slice, returns the subslice corresponding to a specific device.
     /// Depending on the layout, the sub-slice may or may not be contiguous.
-    pub fn shardSlice(pl: *const Placement, device_id: usize, slice: Slice) Slice {
-        const shard_ptr = pl.shardPtr(device_id, slice);
+    pub fn shardSlice(pl: *const Placement, device: Device.Coords, slice: Slice) Slice {
+        const shard_ptr = pl.shardPtr(device, slice);
         const offset_bytes = @intFromPtr(shard_ptr) - @intFromPtr(slice.bytes.ptr);
         return .{
             .bytes = slice.bytes,
@@ -1816,23 +1811,14 @@ pub const Placement = struct {
         };
     }
 
-    fn deviceCoords(pl: Placement, device_id: usize) [MAX_MESH_RANK]u8 {
-        var coords: [MAX_MESH_RANK]u8 = @splat(0);
-        for (pl.sharding.devicesInCanonicalOrder()[device_id].coords.constSlice(), 0..) |coord, i| {
-            coords[i] = coord;
-        }
-        return coords;
-    }
-
     pub fn format(pl: Placement, writer: *std.Io.Writer) std.Io.Writer.Error!void {
         const ordered_devices = pl.sharding.devicesInCanonicalOrder();
 
         try pl.formatPlacementSummary(pl.shape, ordered_devices.len, writer);
         try writer.writeAll("Per-shard placement:\n");
         for (ordered_devices, 0..) |device, shard_index| {
-            const device_id: u8 = @intCast(device.id);
-            try writer.print("└─ Shard[{d}] device_id={d} coords={any}, slices=[", .{ shard_index, device_id, device.coords.constSlice() });
-            for (pl.slices(device_id).constSlice(), 0..) |s, i| {
+            try writer.print("└─ Shard[{d}] device={d} coords={any}, slices=[", .{ shard_index, device.id, device.coords });
+            for (pl.slices(device.coords).constSlice(), 0..) |s, i| {
                 if (i > 0) try writer.writeAll(", ");
                 const axis_label = pl.shape.debugTag(s.axis);
                 try writer.print("{s}:[{d}:{d}]", .{ axis_label, s.start, s.start + s.size });
@@ -1849,7 +1835,7 @@ pub const Placement = struct {
         try writer.print("Placement(shape={f} shards={d})\n", .{ shape, shard_count });
 
         try writer.writeAll("Axis partitioning summary:\n");
-        for (0.., pl.slices(0).constSlice()) |ax, slice| {
+        for (0.., pl.slices(@splat(0)).constSlice()) |ax, slice| {
             const dim = shape.dim(ax);
             const spec = shape.partition(ax);
             const axis_label = shape.debugTag(ax);
@@ -1871,8 +1857,8 @@ pub const Placement = struct {
 const AxisSplit = struct {
     /// For each physical coordinate depth, the contribution of that coordinate
     /// to the linear shard index. Unused depths have stride 0.
-    coord_strides: [MAX_MESH_RANK]u8,
-    counts: [MAX_MESH_RANK]u8,
+    coord_strides: Device.Coords,
+    counts: Device.Coords,
     product_count: u32,
 
     pub const empty: AxisSplit = .{
@@ -1888,7 +1874,7 @@ const AxisSplit = struct {
         split.product_count *= size;
     }
 
-    pub fn linearIndex(split: AxisSplit, device_coords: [MAX_MESH_RANK]u8) u32 {
+    pub fn linearIndex(split: AxisSplit, device_coords: Device.Coords) u32 {
         @setRuntimeSafety(false);
         const coords_u8: @Vector(MAX_MESH_RANK, u8) = device_coords;
         const strides: @Vector(MAX_MESH_RANK, u8) = split.coord_strides;
@@ -2013,7 +1999,7 @@ const ShardingTest = struct {
         if (depth == tags.len) {
             const id = next_id.*;
             next_id.* += 1;
-            return .{ .leaf = .{ .id = id } };
+            return .{ .leaf = .{ .id = id, .coords = Device.undefined_coords } };
         }
         const count = sizes[depth];
         const children = try self.allocator.alloc(PhysicalNode, count);
@@ -2061,10 +2047,12 @@ const ShardingTest = struct {
             const pl = try sharding_ref.placement(s.shape);
             errdefer std.log.warn("Expected shards failed. Got {f}", .{pl});
             try std.testing.expectEqual(s.expected_shards.len, ordered_devices.len);
-            for (s.expected_shards) |expected| {
+            for (s.expected_shards, ordered_devices) |expected, device| {
                 {
-                    // Check pl.slices(device.id)
-                    const actual_slices = pl.slices(expected.device_id);
+                    try std.testing.expectEqual(expected.device_id, device.id);
+
+                    // Check pl.slices(device)
+                    const actual_slices = pl.slices(device.coords);
 
                     // Consider rewriting test cases to use Slice1D. This requires passing the axis
                     const actual_start_len = try self.allocator.alloc([2]i64, actual_slices.len);

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -223,7 +223,7 @@ pub const Device = struct {
     // Private so it's kept as implementation detail
     const undefined_coords: Coords = @splat(0xff);
 
-    fn asValidCoords(device: Device) bool {
+    fn hasValidCoords(device: Device) bool {
         return @as(u32, @bitCast(device.coords)) != @as(u32, @bitCast(undefined_coords));
     }
 
@@ -451,7 +451,7 @@ pub const PhysicalMesh = struct {
         try mesh.populateDevicesInCanonicalOrder(allocator);
         for (0.., mesh.devices_in_canonical_order) |i, device| {
             std.debug.assert(device.id == i);
-            std.debug.assert(device.asValidCoords());
+            std.debug.assert(device.hasValidCoords());
         }
         return mesh;
     }
@@ -567,7 +567,7 @@ pub const PhysicalMesh = struct {
         switch (node.*) {
             .leaf => |*d| {
                 // Coords can already been set by caller
-                if (d.asValidCoords()) return;
+                if (d.hasValidCoords()) return;
 
                 d.coords = path.*;
             },

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -217,9 +217,6 @@ pub const Device = struct {
     /// Coordinates in the physical mesh
     coords: stdx.BoundedArray(usize, Shape.MAX_RANK) = .empty,
 
-    /// Placeholder
-    pjrt_device: ?*const pjrt.Device = null,
-
     pub fn coordsSlice(self: *const Device) ?[]const usize {
         if (self.coords.len == 0) return null;
         return self.coords.constSlice();
@@ -299,7 +296,6 @@ pub const PhysicalNode = union(enum) {
             .leaf = .{
                 .id = @intCast(device_.id()),
                 .coords = .empty,
-                .pjrt_device = device_.pjrt_device,
             },
         };
     }
@@ -477,7 +473,6 @@ pub const PhysicalMesh = struct {
                 .leaf = .{
                     .id = d.id,
                     .coords = d.coords,
-                    .pjrt_device = d.pjrt_device,
                 },
             },
             .branch => |b| blk: {
@@ -709,7 +704,6 @@ pub const PhysicalMesh = struct {
     const CoordsTopology = struct {
         const CoordPlacement = struct {
             device_id: usize,
-            pjrt_device: ?*const pjrt.Device,
             coords: stdx.BoundedArray(usize, Shape.MAX_RANK),
         };
 
@@ -740,7 +734,6 @@ pub const PhysicalMesh = struct {
 
             return .{
                 .device_id = device.id(),
-                .pjrt_device = device.pjrt_device,
                 .coords = coords,
             };
         }
@@ -819,7 +812,6 @@ pub const PhysicalMesh = struct {
                 .leaf = .{
                     .id = coord_placement.device_id,
                     .coords = try .fromSlice(coords_slice),
-                    .pjrt_device = coord_placement.pjrt_device,
                 },
             };
         }
@@ -1223,9 +1215,8 @@ pub const Data = struct {
     folds_consumed: std.EnumSet(PhysicalAxisTag),
 
     pub fn binding(self: *const Data, tag: Shape.Tag) ?[]const PhysicalAxisTag {
-        const target = std.mem.span(tag);
         for (self.bindings.constSlice()) |*b| {
-            if (std.mem.eql(u8, std.mem.span(b.logical), target)) return b.physical.constSlice();
+            if (b.logical == tag) return b.physical.constSlice();
         }
         return null;
     }
@@ -1714,7 +1705,18 @@ pub const Strategy = struct {
     }
 };
 
+/// For a given shape, compute the size of the slice each shard will receive.
+pub fn shardedDims(sharding: Sharding, shape: Shape) Shape.DimsArray {
+	// TODO: simplify me
+	// placement is doing too much work because Sharding creation doesn't enough.
+	const pl = sharding.placement(shape, sharding.data.physical.devices_in_canonical_order[0]) catch @panic("MissingDeviceCoords");
+	return pl.shape._dims;
+}
+
 pub fn placement(sharding: Sharding, shape: Shape, device: Device) !Placement {
+	// TODO: placement should be device agnostic
+	// For a given shape compute how it should be sharded across all devices,
+	// then getting the offset for a specific device should be easy peasy.
     if (device.coords.len == 0) return error.MissingDeviceCoords;
 
     var placement_: Placement = .{

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -704,7 +704,7 @@ pub const PhysicalMesh = struct {
     const CoordsTopology = struct {
         const CoordPlacement = struct {
             device_id: usize,
-            coords: stdx.BoundedArray(usize, Shape.MAX_RANK),
+            coords: stdx.BoundedArray(u8, Shape.MAX_RANK),
         };
 
         const CoordLayout = struct {
@@ -720,7 +720,7 @@ pub const PhysicalMesh = struct {
         fn parseDevice(device: PlatformDevice) !CoordPlacement {
             const api = device.platform.pjrt_api;
             const coords_attr = device.pjrt_desc.attribute(api, "coords") orelse return error.MissingDeviceCoords;
-            var coords: stdx.BoundedArray(usize, Shape.MAX_RANK) = .empty;
+            var coords: stdx.BoundedArray(u8, Shape.MAX_RANK) = .empty;
             switch (coords_attr) {
                 .int64list => |values| {
                     if (values.len == 0 or values.len > Shape.MAX_RANK) return error.InvalidDeviceCoords;
@@ -772,7 +772,7 @@ pub const PhysicalMesh = struct {
             };
         }
 
-        fn linearIndex(coords: []const usize, rank: usize, axis_sizes: []const usize) usize {
+        fn linearIndex(coords: []const u8, rank: usize, axis_sizes: []const usize) usize {
             var linear: usize = 0;
             var stride: usize = 1;
             var ax = rank;
@@ -807,7 +807,7 @@ pub const PhysicalMesh = struct {
             return indexed;
         }
 
-        pub fn leaf(coord_placement: *const CoordPlacement, coords_slice: []const usize) !PhysicalNode {
+        pub fn leaf(coord_placement: *const CoordPlacement, coords_slice: []const u8) !PhysicalNode {
             return .{
                 .leaf = .{
                     .id = coord_placement.device_id,
@@ -911,7 +911,7 @@ pub const PhysicalMesh = struct {
 
         const nodes = try allocator.alloc(PhysicalNode, platform_devices.len);
         for (nodes, indexed, 0..) |*n, entry, i| {
-            const linear_coord: [1]usize = .{i};
+            const linear_coord: [1]u8 = .{@intCast(i)};
             n.* = try CoordsTopology.leaf(&entry.placement, linear_coord[0..]);
         }
 
@@ -1009,7 +1009,7 @@ pub const PhysicalMesh = struct {
                     const device = platform_devices_[placement_.input_index];
                     next_device_.* += 1;
 
-                    var coords: stdx.BoundedArray(usize, Shape.MAX_RANK) = .empty;
+                    var coords: stdx.BoundedArray(u8, Shape.MAX_RANK) = .empty;
                     for (coords_buf_[0..axis_tags_.len]) |coord| coords.appendAssumeCapacity(coord);
 
                     return .{
@@ -1300,7 +1300,7 @@ pub const Data = struct {
         return view;
     }
 
-    pub fn logicalIndexFromCoords(self: *const Data, coords: []const usize) usize {
+    pub fn logicalIndexFromCoords(self: *const Data, coords: []const u8) usize {
         return self.physical.linearIndexFromCoords(coords);
     }
 
@@ -1625,6 +1625,24 @@ pub const Strategy = struct {
         .bindings = .empty,
         .folding = .empty,
     };
+
+    pub fn parse(strategy: anytype) Strategy {
+        const err_msg = "Strategy.parse excepts fields to be PhysicalAxisTag or tuple of PhysicalAxisTag";
+        var res: Strategy = .init;
+        inline for (@typeInfo(@TypeOf(strategy)).@"struct".fields) |field_info| {
+            switch (@typeInfo(field_info.type)) {
+                .@"enum" => res.addBinding(field_info, @field(strategy, field_info.name)),
+                .@"struct" => |struct_info| {
+                    stdx.debug.assertComptime(struct_info.is_tuple, err_msg, .{});
+                    inline for (@field(strategy, field_info.name)) |axis_tag| {
+                        res.addBinding(field_info, axis_tag);
+                    }
+                },
+                else => @compileError(err_msg),
+            }
+        }
+        return res;
+    }
 
     pub fn addBinding(self: *Strategy, logical: anytype, physical: PhysicalAxisTag) void {
         const raw_tag = Shape.toTag(logical);
@@ -2018,7 +2036,7 @@ const ShardingTest = struct {
         // Verify Shard Slices (Math)
         if (s.expected_shards.len > 0) {
             const pl = try sharding_ref.placement(s.shape);
-
+            std.log.warn("Sharding {f} -> \nPlacement {f}", .{ s, pl });
             errdefer std.log.warn("Expected shards failed. Got {f}", .{pl});
             try std.testing.expectEqual(s.expected_shards.len, ordered_devices.len);
             for (s.expected_shards) |expected| {
@@ -2062,12 +2080,8 @@ test "sharding: unknown partitioning implies replication" {
     strategy.addBinding(.batch, .link_x);
 
     const scenario: ShardingTest.Scenario = .{
-        .sharding = try .init(
-            "folded_mesh",
-            &physical,
-            logical,
-            strategy,
-        ),
+        .sharding = try .init("folded_mesh", &physical, logical, strategy),
+        // No partitioning on shape
         .shape = Shape.init(.{ .batch = 8 }, .f32),
         .expected_sdy = "#sdy.sharding<@folded_mesh, [{}], replicated={\"link_x\", \"link_y\"}>",
         .expected_shards = &.{
@@ -2150,22 +2164,37 @@ test "sharding: multiple physical axes on one logical dimension (folding)" {
     const physical: PhysicalMesh = try runner.physical(.{ 2, 2 }, .{ .mesh = .torus });
     const logical: LogicalMesh = .mesh(.{ .model = .high_bandwidth });
 
-    var strategy: Strategy = .init;
-    strategy.addBinding(.model, .link_x);
-    strategy.addBinding(.model, .link_y);
+    {
+        const strategy: Strategy = .parse(.{ .model = .{ .link_x, .link_y } });
+        try runner.run(.{
+            .sharding = try .init("folded_mesh", &physical, logical, strategy),
+            .shape = Shape.init(.{ .model = 16 }, .f32).withPartitioning(.{ .model = .model }),
+            .expected_sdy = "#sdy.sharding<@folded_mesh, [{\"link_x\", \"link_y\"}]>",
+            .expected_shards = &.{
+                .{ .device_id = 0, .slices = &.{.{ 0, 4 }} },
+                .{ .device_id = 1, .slices = &.{.{ 4, 4 }} },
+                .{ .device_id = 2, .slices = &.{.{ 8, 4 }} },
+                .{ .device_id = 3, .slices = &.{.{ 12, 4 }} },
+            },
+        });
+    }
 
-    const scenario: ShardingTest.Scenario = .{
-        .sharding = try .init("folded_mesh", &physical, logical, strategy),
-        .shape = Shape.init(.{ .model = 16 }, .f32).withPartitioning(.{ .model = .model }),
-        .expected_sdy = "#sdy.sharding<@folded_mesh, [{\"link_x\", \"link_y\"}]>",
-        .expected_shards = &.{
-            .{ .device_id = 0, .slices = &.{.{ 0, 4 }} },
-            .{ .device_id = 1, .slices = &.{.{ 4, 4 }} },
-            .{ .device_id = 2, .slices = &.{.{ 8, 4 }} },
-            .{ .device_id = 3, .slices = &.{.{ 12, 4 }} },
-        },
-    };
-    try runner.run(scenario);
+    {
+        // Swap link_x and link_y order:
+        // -> the roles of devices 1 (0,1) and 2 (1,0) are swapped
+        const strategy: Strategy = .parse(.{ .model = .{ .link_y, .link_x } });
+        try runner.run(.{
+            .sharding = try .init("folded_mesh", &physical, logical, strategy),
+            .shape = Shape.init(.{ .model = 16 }, .f32).withPartitioning(.{ .model = .model }),
+            .expected_sdy = "#sdy.sharding<@folded_mesh, [{\"link_y\", \"link_x\"}]>",
+            .expected_shards = &.{
+                .{ .device_id = 0, .slices = &.{.{ 0, 4 }} },
+                .{ .device_id = 1, .slices = &.{.{ 8, 4 }} },
+                .{ .device_id = 2, .slices = &.{.{ 4, 4 }} },
+                .{ .device_id = 3, .slices = &.{.{ 12, 4 }} },
+            },
+        });
+    }
 }
 
 test "sharding: explicit strategy folding" {
@@ -2239,17 +2268,18 @@ test "sharding: full 3D cluster sharding" {
 
     const scenario: ShardingTest.Scenario = .{
         .sharding = try .init("3d_mesh", &physical, logical, strategy),
-        .shape = Shape.init(.{ .batch = 4, .model = 4, .context = 4 }, .f32)
+        // Note: .context and .model are swapped compared to .link_x and .link_z
+        .shape = Shape.init(.{ .batch = 4, .context = 4, .model = 4 }, .f32)
             .withPartitioning(.{ .batch = .batch, .model = .model, .context = .context }),
-        .expected_sdy = "#sdy.sharding<@\"3d_mesh\", [{\"link_x\"}, {\"link_y\"}, {\"link_z\"}]>",
+        .expected_sdy = "#sdy.sharding<@\"3d_mesh\", [{\"link_x\"}, {\"link_z\"}, {\"link_y\"}]>",
         .expected_shards = &.{
             .{ .device_id = 0, .slices = &.{ .{ 0, 2 }, .{ 0, 2 }, .{ 0, 2 } } },
-            .{ .device_id = 1, .slices = &.{ .{ 0, 2 }, .{ 0, 2 }, .{ 2, 2 } } },
-            .{ .device_id = 2, .slices = &.{ .{ 0, 2 }, .{ 2, 2 }, .{ 0, 2 } } },
+            .{ .device_id = 1, .slices = &.{ .{ 0, 2 }, .{ 2, 2 }, .{ 0, 2 } } },
+            .{ .device_id = 2, .slices = &.{ .{ 0, 2 }, .{ 0, 2 }, .{ 2, 2 } } },
             .{ .device_id = 3, .slices = &.{ .{ 0, 2 }, .{ 2, 2 }, .{ 2, 2 } } },
             .{ .device_id = 4, .slices = &.{ .{ 2, 2 }, .{ 0, 2 }, .{ 0, 2 } } },
-            .{ .device_id = 5, .slices = &.{ .{ 2, 2 }, .{ 0, 2 }, .{ 2, 2 } } },
-            .{ .device_id = 6, .slices = &.{ .{ 2, 2 }, .{ 2, 2 }, .{ 0, 2 } } },
+            .{ .device_id = 5, .slices = &.{ .{ 2, 2 }, .{ 2, 2 }, .{ 0, 2 } } },
+            .{ .device_id = 6, .slices = &.{ .{ 2, 2 }, .{ 0, 2 }, .{ 2, 2 } } },
             .{ .device_id = 7, .slices = &.{ .{ 2, 2 }, .{ 2, 2 }, .{ 2, 2 } } },
         },
     };

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -449,8 +449,7 @@ pub const PhysicalMesh = struct {
             .devices_in_canonical_order = undefined,
         };
         try mesh.populateDevicesInCanonicalOrder(allocator);
-        for (0.., mesh.devices_in_canonical_order) |i, device| {
-            std.debug.assert(device.id == i);
+        for (mesh.devices_in_canonical_order) |device| {
             std.debug.assert(device.hasValidCoords());
         }
         return mesh;
@@ -870,12 +869,23 @@ pub const PhysicalMesh = struct {
             .cpu => cpu(allocator, platform_devices),
             .cuda, .rocm => gpu(allocator, platform_devices),
             .tpu => tpu(allocator, platform_devices),
-            .neuron => neuron(allocator, platform_devices),
+            .neuron => return neuron(allocator, platform_devices),
             .oneapi => cpu(allocator, platform_devices),
         };
         errdefer freeNode(allocator, root);
 
-        return try fromOwnedTree(allocator, target, root);
+        // We check a posteriori that the device id is a valid offset into platform.devices.
+        // This is generally true because platform.devices is sorted by id and ids are 0-N.
+        // For platforms where this isn't true like Neuron,
+        // the platform specific builder need to correctly update the ids so that it's true.
+        const mesh = try fromOwnedTree(allocator, target, root);
+        for (mesh.devices_in_canonical_order) |pl| {
+            const device = platform_devices[pl.id];
+            std.debug.assert(pl.hasValidCoords());
+            std.debug.assert(device.id() == pl.id);
+        }
+
+        return mesh;
     }
 
     pub fn cpu(allocator: std.mem.Allocator, platform_devices: []const PlatformDevice) !Tree {
@@ -944,7 +954,7 @@ pub const PhysicalMesh = struct {
         return CoordsTopology.buildMeshNode(allocator, indexed, axis_sizes[0..rank], axis_tags[0..rank], axis_strides[0..rank], 0, 0);
     }
 
-    pub fn neuron(allocator: std.mem.Allocator, platform_devices: []const PlatformDevice) !Tree {
+    pub fn neuron(allocator: std.mem.Allocator, platform_devices: []const PlatformDevice) !PhysicalMesh {
         if (comptime !platforms.isEnabled(.neuron)) {
             return error.UnsupportedPlatform;
         }
@@ -997,19 +1007,12 @@ pub const PhysicalMesh = struct {
             ) !PhysicalNode {
                 if (depth == axis_tags_.len) {
                     const placement_ = placements[next_device_.*];
-                    const device = platform_devices_[placement_.input_index];
                     next_device_.* += 1;
 
                     var coords: stdx.BoundedArray(u8, MAX_MESH_RANK) = .empty;
-                    for (coords_buf_[0..axis_tags_.len]) |coord| coords.appendAssumeCapacity(coord);
+                    for (coords_buf_[0..axis_tags_.len]) |coord| coords.appendAssumeCapacity(@intCast(coord));
 
-                    return .{
-                        .leaf = .{
-                            .id = placement_.nc_id,
-                            .coords = coords,
-                            .pjrt_device = device.pjrt_device,
-                        },
-                    };
+                    return .{ .leaf = .{ .id = placement_.nc_id, .coords = coords } };
                 }
 
                 const children = try allocator_.alloc(PhysicalNode, axis_sizes_[depth]);
@@ -1045,7 +1048,7 @@ pub const PhysicalMesh = struct {
             }
         };
 
-        return Node.build(
+        const root = try Node.build(
             allocator,
             platform_devices,
             topology.placements,
@@ -1056,6 +1059,22 @@ pub const PhysicalMesh = struct {
             &coords_buf,
             &next_device,
         );
+        const mesh: PhysicalMesh = try fromOwnedTree(allocator, .neuron, root);
+        std.log.warn("Devices in devices_in_canonical_order with nc_ids: {any}", .{mesh.devices_in_canonical_order});
+        for (mesh.devices_in_canonical_order) |*dev| {
+            // In Node.build we use nc_id as the Device id.
+            // But now we want to use the id to get the offset into platform.devices.
+            const dev_nc_id = dev.id;
+            for (0.., topology.placements) |order, placement_| {
+                if (placement_.nc_id == dev_nc_id) {
+                    dev.id = @intCast(order);
+                    std.debug.assert(platform_devices[order].localHardwareId() == dev_nc_id);
+                    break;
+                }
+            }
+        }
+        std.log.warn("Devices in devices_in_canonical_order with final ids: {any}", .{mesh.devices_in_canonical_order});
+        return mesh;
     }
 };
 

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -1231,6 +1231,7 @@ pub const Data = struct {
     ) !Data {
         const axis_order = physical.axisOrder().constSlice();
         if (axis_order.len == 0) return error.InvalidPhysicalMesh;
+        if (strategy.bindings.len == 0) return error.InvalidStrategy;
 
         var bindings: Bindings = .empty;
         for (strategy.bindings.constSlice()) |bind| {
@@ -1628,19 +1629,19 @@ pub const Strategy = struct {
         .folding = .empty,
     };
 
-    pub fn parse(strategy: anytype) Strategy {
-        const err_msg = "Strategy.parse excepts fields to be PhysicalAxisTag or tuple of PhysicalAxisTag";
+    pub fn parseBindings(bindings: anytype) Strategy {
+        const err_msg = "Strategy.parseBindings excepts fields to be PhysicalAxisTag or tuple of PhysicalAxisTag, got {}";
         var res: Strategy = .init;
-        inline for (@typeInfo(@TypeOf(strategy)).@"struct".fields) |field_info| {
+        inline for (@typeInfo(@TypeOf(bindings)).@"struct".fields) |field_info| {
             switch (@typeInfo(field_info.type)) {
-                .@"enum" => res.addBinding(field_info, @field(strategy, field_info.name)),
+                .enum_literal, .@"enum" => res.addBinding(field_info, @field(bindings, field_info.name)),
                 .@"struct" => |struct_info| {
-                    stdx.debug.assertComptime(struct_info.is_tuple, err_msg, .{});
-                    inline for (@field(strategy, field_info.name)) |axis_tag| {
+                    stdx.debug.assertComptime(struct_info.is_tuple, err_msg, .{@TypeOf(bindings)});
+                    inline for (@field(bindings, field_info.name)) |axis_tag| {
                         res.addBinding(field_info, axis_tag);
                     }
                 },
-                else => @compileError(err_msg),
+                else => stdx.debug.compileError(err_msg, .{@TypeOf(bindings)}),
             }
         }
         return res;
@@ -1772,10 +1773,10 @@ pub const Placement = struct {
         return pl;
     }
 
-    pub fn slices(self: *const Placement, device_id: usize) Slices {
-        const coords = self.deviceCoords(device_id);
-        var res: Slices = .{ .buffer = undefined, .len = self.shape.rank() };
-        for (0.., res.slice(), self.shape.dims(), self.axis_plans.constSlice()) |a, *r, size, plan| {
+    pub fn slices(pl: *const Placement, device_id: usize) Slices {
+        const coords = pl.deviceCoords(device_id);
+        var res: Slices = .{ .buffer = undefined, .len = pl.shape.rank() };
+        for (0.., res.slice(), pl.shape.dims(), pl.axis_plans.constSlice()) |a, *r, size, plan| {
             const start = plan.linearIndex(coords) * size;
             r.* = .{
                 .axis = @intCast(a),
@@ -1786,52 +1787,56 @@ pub const Placement = struct {
         return res;
     }
 
-    pub fn shardSlice(self: *const Placement, device_id: usize, slice: Slice) Slice {
+    pub fn shardSlice(pl: *const Placement, device_id: usize, slice: Slice) Slice {
         if (builtin.mode == .Debug) {
             // there is a bug in caller code that used a placement for a different shape
-            std.debug.assert(self.global_shape.eql(slice.shape));
+            std.debug.assert(pl.global_shape.eql(slice.shape));
         }
 
         var offset_i64: i64 = @intCast(slice.offset_bytes);
 
-        const coords = self.deviceCoords(device_id);
-        for (self.shape.dims(), self.axis_plans.constSlice(), slice.byte_strides.constSlice()) |size, plan, stride| {
+        const coords = pl.deviceCoords(device_id);
+        for (pl.shape.dims(), pl.axis_plans.constSlice(), slice.byte_strides.constSlice()) |size, plan, stride| {
             const start = plan.linearIndex(coords) * size;
             offset_i64 += start * stride;
         }
-        return .{ .inner_data = slice.inner_data, .shape = self.shape, .offset_bytes = @intCast(offset_i64), .byte_strides = slice.byte_strides };
+        return .{ .inner_data = slice.inner_data, .shape = pl.shape, .offset_bytes = @intCast(offset_i64), .byte_strides = slice.byte_strides };
     }
 
-    fn deviceCoords(self: Placement, device_id: usize) []const u8 {
-        return self.sharding.devicesInCanonicalOrder()[device_id].coords.constSlice();
+    fn deviceCoords(pl: Placement, device_id: usize) [MAX_MESH_RANK]u8 {
+        var coords: [MAX_MESH_RANK]u8 = @splat(0);
+        for (pl.sharding.devicesInCanonicalOrder()[device_id].coords.constSlice(), 0..) |coord, i| {
+            coords[i] = coord;
+        }
+        return coords;
     }
 
-    pub fn format(self: Placement, writer: *std.Io.Writer) std.Io.Writer.Error!void {
-        const ordered_devices = self.sharding.devicesInCanonicalOrder();
+    pub fn format(pl: Placement, writer: *std.Io.Writer) std.Io.Writer.Error!void {
+        const ordered_devices = pl.sharding.devicesInCanonicalOrder();
 
-        try self.formatPlacementSummary(self.shape, ordered_devices.len, writer);
+        try pl.formatPlacementSummary(pl.shape, ordered_devices.len, writer);
         try writer.writeAll("Per-shard placement:\n");
         for (ordered_devices, 0..) |device, shard_index| {
             const device_id: u8 = @intCast(device.id);
             try writer.print("└─ Shard[{d}] device_id={d} coords={any}, slices=[", .{ shard_index, device_id, device.coords.constSlice() });
-            for (self.slices(device_id).constSlice(), 0..) |s, i| {
+            for (pl.slices(device_id).constSlice(), 0..) |s, i| {
                 if (i > 0) try writer.writeAll(", ");
-                const axis_label = self.shape.debugTag(s.axis);
+                const axis_label = pl.shape.debugTag(s.axis);
                 try writer.print("{s}:[{d}:{d}]", .{ axis_label, s.start, s.start + s.size });
             }
             try writer.writeAll("]\n");
         }
 
-        for (0.., self.axis_plans.slice()) |ax, plan| {
+        for (0.., pl.axis_plans.slice()) |ax, plan| {
             try writer.print("- axis{d} -> plan {f}\n", .{ ax, plan });
         }
     }
 
-    fn formatPlacementSummary(self: Placement, shape: Shape, shard_count: usize, writer: *std.Io.Writer) std.Io.Writer.Error!void {
+    fn formatPlacementSummary(pl: Placement, shape: Shape, shard_count: usize, writer: *std.Io.Writer) std.Io.Writer.Error!void {
         try writer.print("Placement(shape={f} shards={d})\n", .{ shape, shard_count });
 
         try writer.writeAll("Axis partitioning summary:\n");
-        for (0.., self.slices(0).constSlice()) |ax, slice| {
+        for (0.., pl.slices(0).constSlice()) |ax, slice| {
             const dim = shape.dim(ax);
             const spec = shape.partition(ax);
             const axis_label = shape.debugTag(ax);
@@ -1851,35 +1856,38 @@ pub const Placement = struct {
 };
 
 const AxisSplit = struct {
-    counts: stdx.BoundedArray(u8, MAX_MESH_RANK),
-    depths: stdx.BoundedArray(u8, MAX_MESH_RANK),
+    /// For each physical coordinate depth, the contribution of that coordinate
+    /// to the linear shard index. Unused depths have stride 0.
+    coord_strides: [MAX_MESH_RANK]u8,
+    counts: [MAX_MESH_RANK]u8,
+    product_count: u32,
 
     pub const empty: AxisSplit = .{
-        .counts = .empty,
-        .depths = .empty,
+        .coord_strides = @splat(0),
+        .counts = @splat(0),
+        .product_count = 1,
     };
 
     pub fn add(split: *AxisSplit, size: u8, depth: u8) void {
-        split.counts.appendAssumeCapacity(size);
-        split.depths.appendAssumeCapacity(depth);
+        for (&split.coord_strides) |*stride| stride.* *= size;
+        split.coord_strides[depth] = 1;
+        split.counts[depth] = size;
+        split.product_count *= size;
     }
 
-    pub fn linearIndex(self: AxisSplit, device_coords: []const u8) u32 {
-        var linear: u32 = 0;
-        for (self.counts.constSlice(), self.depths.constSlice()) |count, depth| {
-            linear = linear * count + @as(u32, device_coords[depth]);
-        }
-        return linear;
+    pub fn linearIndex(split: AxisSplit, device_coords: [MAX_MESH_RANK]u8) u32 {
+        @setRuntimeSafety(false);
+        const coords_u8: @Vector(MAX_MESH_RANK, u8) = device_coords;
+        const strides: @Vector(MAX_MESH_RANK, u8) = split.coord_strides;
+        return @reduce(.Add, coords_u8 * strides);
     }
 
     pub fn product(split: AxisSplit) u32 {
-        var p: u32 = 1;
-        for (split.counts.constSlice()) |count| p *= count;
-        return p;
+        return split.product_count;
     }
 
-    pub fn format(self: AxisSplit, writer: *std.Io.Writer) std.Io.Writer.Error!void {
-        try writer.print("Plan(counts={any},depths={any})", .{ self.counts.slice(), self.depths.slice() });
+    pub fn format(split: AxisSplit, writer: *std.Io.Writer) std.Io.Writer.Error!void {
+        try writer.print("Plan(counts={any},strides={any})", .{ split.counts, split.coord_strides });
     }
 };
 
@@ -2038,7 +2046,6 @@ const ShardingTest = struct {
         // Verify Shard Slices (Math)
         if (s.expected_shards.len > 0) {
             const pl = try sharding_ref.placement(s.shape);
-            std.log.warn("Sharding {f} -> \nPlacement {f}", .{ s, pl });
             errdefer std.log.warn("Expected shards failed. Got {f}", .{pl});
             try std.testing.expectEqual(s.expected_shards.len, ordered_devices.len);
             for (s.expected_shards) |expected| {
@@ -2078,10 +2085,9 @@ test "sharding: unknown partitioning implies replication" {
     const physical: PhysicalMesh = try runner.physical(.{ 2, 2 }, .{ .mesh = .torus });
     const logical: LogicalMesh = .mesh(.{ .batch = .low_bandwidth });
 
-    var strategy: Strategy = .init;
-    strategy.addBinding(.batch, .link_x);
+    const strategy: Strategy = .parseBindings(.{ .batch = .link_x });
 
-    const scenario: ShardingTest.Scenario = .{
+    try runner.run(.{
         .sharding = try .init("folded_mesh", &physical, logical, strategy),
         // No partitioning on shape
         .shape = Shape.init(.{ .batch = 8 }, .f32),
@@ -2092,8 +2098,7 @@ test "sharding: unknown partitioning implies replication" {
             .{ .device_id = 2, .slices = &.{.{ 0, 8 }} },
             .{ .device_id = 3, .slices = &.{.{ 0, 8 }} },
         },
-    };
-    try runner.run(scenario);
+    });
 }
 
 test "sharding: suggest strategy realization" {
@@ -2110,7 +2115,7 @@ test "sharding: suggest strategy realization" {
 
     const strategy: Strategy = .suggest(logical, &physical);
 
-    const scenario: ShardingTest.Scenario = .{
+    try runner.run(.{
         .sharding = try .init("suggested_mesh", &physical, logical, strategy),
         .shape = Shape.init(.{ .batch = 4, .model = 4 }, .f32)
             .withPartitioning(.{ .batch = .batch, .model = .model }),
@@ -2125,8 +2130,7 @@ test "sharding: suggest strategy realization" {
             .{ .device_id = 6, .slices = &.{ .{ 0, 2 }, .{ 2, 2 } } },
             .{ .device_id = 7, .slices = &.{ .{ 2, 2 }, .{ 2, 2 } } },
         },
-    };
-    try runner.run(scenario);
+    });
 }
 
 test "sharding: suggest folds logical axes with same intent" {
@@ -2143,7 +2147,7 @@ test "sharding: suggest folds logical axes with same intent" {
 
     const strategy: Strategy = .suggest(logical, &physical);
 
-    const scenario: ShardingTest.Scenario = .{
+    try runner.run(.{
         .sharding = try .init("fold_mesh", &physical, logical, strategy),
         .shape = Shape.init(.{ .model = 4, .experts = 4 }, .f32)
             .withPartitioning(.{ .model = .model, .experts = .experts }),
@@ -2154,8 +2158,7 @@ test "sharding: suggest folds logical axes with same intent" {
             .{ .device_id = 2, .slices = &.{ .{ 2, 1 }, .{ 0, 4 } } },
             .{ .device_id = 3, .slices = &.{ .{ 3, 1 }, .{ 0, 4 } } },
         },
-    };
-    try runner.run(scenario);
+    });
 }
 
 test "sharding: multiple physical axes on one logical dimension (folding)" {
@@ -2167,7 +2170,7 @@ test "sharding: multiple physical axes on one logical dimension (folding)" {
     const logical: LogicalMesh = .mesh(.{ .model = .high_bandwidth });
 
     {
-        const strategy: Strategy = .parse(.{ .model = .{ .link_x, .link_y } });
+        const strategy: Strategy = .parseBindings(.{ .model = .{ .link_x, .link_y } });
         try runner.run(.{
             .sharding = try .init("folded_mesh", &physical, logical, strategy),
             .shape = Shape.init(.{ .model = 16 }, .f32).withPartitioning(.{ .model = .model }),
@@ -2184,7 +2187,7 @@ test "sharding: multiple physical axes on one logical dimension (folding)" {
     {
         // Swap link_x and link_y order:
         // -> the roles of devices 1 (0,1) and 2 (1,0) are swapped
-        const strategy: Strategy = .parse(.{ .model = .{ .link_y, .link_x } });
+        const strategy: Strategy = .parseBindings(.{ .model = .{ .link_y, .link_x } });
         try runner.run(.{
             .sharding = try .init("folded_mesh", &physical, logical, strategy),
             .shape = Shape.init(.{ .model = 16 }, .f32).withPartitioning(.{ .model = .model }),
@@ -2207,11 +2210,10 @@ test "sharding: explicit strategy folding" {
     const physical: PhysicalMesh = try runner.physical(.{ 2, 2, 2 }, .{ .mesh = .torus });
     const logical: LogicalMesh = .mesh(.{ .model = .high_bandwidth });
 
-    var strategy: Strategy = .init;
-    strategy.addBinding(.model, .link_x);
+    var strategy: Strategy = .parseBindings(.{ .model = .link_x });
     strategy.addFold(.link_x, &.{ .link_x, .link_z });
 
-    const scenario: ShardingTest.Scenario = .{
+    try runner.run(.{
         .sharding = try .init("strategy_fold", &physical, logical, strategy),
         .shape = Shape.init(.{ .model = 16 }, .f32).withPartitioning(.{ .model = .model }),
         .expected_sdy = "#sdy.sharding<@strategy_fold, [{\"link_x\"}], replicated={\"link_y\"}>",
@@ -2225,8 +2227,7 @@ test "sharding: explicit strategy folding" {
             .{ .device_id = 6, .slices = &.{.{ 8, 4 }} },
             .{ .device_id = 7, .slices = &.{.{ 12, 4 }} },
         },
-    };
-    try runner.run(scenario);
+    });
 }
 
 test "sharding: open and replicated dimension mix" {
@@ -2237,11 +2238,9 @@ test "sharding: open and replicated dimension mix" {
     const physical: PhysicalMesh = try runner.physical(.{ 2, 2 }, .{ .mesh = .torus });
     const logical: LogicalMesh = .mesh(.{ .batch = .low_bandwidth, .model = .high_bandwidth });
 
-    var strategy: Strategy = .init;
-    strategy.addBinding(.batch, .link_x);
-    strategy.addBinding(.model, .link_y);
+    const strategy: Strategy = .parseBindings(.{ .batch = .link_x, .model = .link_y });
 
-    const scenario: ShardingTest.Scenario = .{
+    try runner.run(.{
         .sharding = try .init("mix_mesh", &physical, logical, strategy),
         .shape = Shape.init(.{ .batch = 8, .model = 8 }, .f32).withPartitioning(.{ .batch = .open, .model = .replicated }),
         .expected_sdy = "#sdy.sharding<@mix_mesh, [{?}, {}], replicated={\"link_x\", \"link_y\"}>",
@@ -2251,8 +2250,7 @@ test "sharding: open and replicated dimension mix" {
             .{ .device_id = 2, .slices = &.{ .{ 0, 8 }, .{ 0, 8 } } },
             .{ .device_id = 3, .slices = &.{ .{ 0, 8 }, .{ 0, 8 } } },
         },
-    };
-    try runner.run(scenario);
+    });
 }
 
 test "sharding: full 3D cluster sharding" {
@@ -2263,12 +2261,13 @@ test "sharding: full 3D cluster sharding" {
     const physical: PhysicalMesh = try runner.physical(.{ 2, 2, 2 }, .{ .mesh = .torus });
     const logical: LogicalMesh = .mesh(.{ .batch = .low_bandwidth, .model = .high_bandwidth, .context = .balanced });
 
-    var strategy: Strategy = .init;
-    strategy.addBinding(.batch, .link_x);
-    strategy.addBinding(.model, .link_y);
-    strategy.addBinding(.context, .link_z);
+    const strategy: Strategy = .parseBindings(.{
+        .batch = .link_x,
+        .model = .link_y,
+        .context = .link_z,
+    });
 
-    const scenario: ShardingTest.Scenario = .{
+    try runner.run(.{
         .sharding = try .init("3d_mesh", &physical, logical, strategy),
         // Note: .context and .model are swapped compared to .link_x and .link_z
         .shape = Shape.init(.{ .batch = 4, .context = 4, .model = 4 }, .f32)
@@ -2284,8 +2283,7 @@ test "sharding: full 3D cluster sharding" {
             .{ .device_id = 6, .slices = &.{ .{ 2, 2 }, .{ 0, 2 }, .{ 2, 2 } } },
             .{ .device_id = 7, .slices = &.{ .{ 2, 2 }, .{ 2, 2 }, .{ 2, 2 } } },
         },
-    };
-    try runner.run(scenario);
+    });
 }
 
 test "sharding: num partitions for logical axis" {
@@ -2299,8 +2297,7 @@ test "sharding: num partitions for logical axis" {
         .batch = .low_bandwidth,
     });
 
-    var strategy: Strategy = .init;
-    strategy.addBinding(.model, .link_x);
+    var strategy: Strategy = .parseBindings(.{ .model = .link_x });
     strategy.addFold(.link_x, &.{ .link_x, .link_z });
 
     const sharding: Sharding.Data = try .init("axis_parts_mesh", &physical, logical, strategy);

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -1707,16 +1707,16 @@ pub const Strategy = struct {
 
 /// For a given shape, compute the size of the slice each shard will receive.
 pub fn shardedDims(sharding: Sharding, shape: Shape) Shape.DimsArray {
-	// TODO: simplify me
-	// placement is doing too much work because Sharding creation doesn't enough.
-	const pl = sharding.placement(shape, sharding.data.physical.devices_in_canonical_order[0]) catch @panic("MissingDeviceCoords");
-	return pl.shape._dims;
+    // TODO: simplify me
+    // placement is doing too much work because Sharding creation doesn't enough.
+    const pl = sharding.placement(shape, sharding.data.physical.devices_in_canonical_order[0]) catch @panic("MissingDeviceCoords");
+    return pl.shape._dims;
 }
 
 pub fn placement(sharding: Sharding, shape: Shape, device: Device) !Placement {
-	// TODO: placement should be device agnostic
-	// For a given shape compute how it should be sharded across all devices,
-	// then getting the offset for a specific device should be easy peasy.
+    // TODO: placement should be device agnostic
+    // For a given shape compute how it should be sharded across all devices,
+    // then getting the offset for a specific device should be easy peasy.
     if (device.coords.len == 0) return error.MissingDeviceCoords;
 
     var placement_: Placement = .{

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -1615,10 +1615,7 @@ pub const Strategy = struct {
 
     // TODO: remove .init, promote .parseBindings to .init
     // It's currently an error to call .init and never calling `addBinding`
-    pub const init: Strategy = .{
-        .bindings = .empty,
-        .folding = .empty,
-    };
+    pub const init: Strategy = .{ .bindings = .empty, .folding = .empty };
 
     pub fn parseBindings(bindings: anytype) Strategy {
         const err_msg = "Strategy.parseBindings excepts fields to be PhysicalAxisTag or tuple of PhysicalAxisTag, got {}";
@@ -1684,7 +1681,7 @@ pub const Strategy = struct {
 
     /// suggest builds a Strategy from logical intents.
     pub fn suggest(logical: LogicalMesh, physical: *const PhysicalMesh) Strategy {
-        var strategy: Strategy = .init;
+        var strategy: Strategy = .{ .bindings = .empty, .folding = .empty };
 
         const base_order = physical.shardableAxes();
         var available: stdx.BoundedArray(PhysicalAxisTag, MAX_MESH_RANK) = .empty;
@@ -1738,6 +1735,8 @@ pub const Placement = struct {
     };
 
     sharding: Sharding,
+    // Note this shape is mainly use to indicate the dims of the sharded buffer.
+    // We may want to only store that.
     shape: Shape,
     global_shape: if (builtin.mode == .Debug) Shape else void,
 
@@ -1757,8 +1756,8 @@ pub const Placement = struct {
             pl.axis_plans.appendAssumeCapacity(try axisSplit(sharding, shape, &used_axes, axis_index));
         }
 
-        for (0.., shape.dims(), pl.axis_plans.slice()) |a, dim, plan| {
-            pl.shape._dims.buffer[a] = @divExact(dim, plan.product());
+        for (pl.shape._dims.slice(), shape.dims(), pl.axis_plans.slice()) |*shard_dim, dim, plan| {
+            shard_dim.* = @divExact(dim, plan.num_devices);
         }
         return pl;
     }
@@ -1851,19 +1850,19 @@ const AxisSplit = struct {
     /// to the linear shard index. Unused depths have stride 0.
     coord_strides: Device.Coords,
     counts: Device.Coords,
-    product_count: u32,
+    num_devices: u32,
 
     pub const empty: AxisSplit = .{
         .coord_strides = @splat(0),
         .counts = @splat(0),
-        .product_count = 1,
+        .num_devices = 1,
     };
 
     pub fn add(split: *AxisSplit, size: u8, depth: u8) void {
         for (&split.coord_strides) |*stride| stride.* *= size;
         split.coord_strides[depth] = 1;
         split.counts[depth] = size;
-        split.product_count *= size;
+        split.num_devices *= size;
     }
 
     pub fn linearIndex(split: AxisSplit, device_coords: Device.Coords) u32 {
@@ -1871,10 +1870,6 @@ const AxisSplit = struct {
         const coords_u8: @Vector(MAX_MESH_RANK, u8) = device_coords;
         const strides: @Vector(MAX_MESH_RANK, u8) = split.coord_strides;
         return @reduce(.Add, coords_u8 * strides);
-    }
-
-    pub fn product(split: AxisSplit) u32 {
-        return split.product_count;
     }
 
     pub fn format(split: AxisSplit, writer: *std.Io.Writer) std.Io.Writer.Error!void {
@@ -1926,7 +1921,7 @@ fn calculateSplit(
         }
     }
 
-    if (plan.product() > 0 and @rem(dim, plan.product()) != 0) {
+    if (plan.num_devices > 0 and @rem(dim, plan.num_devices) != 0) {
         return error.IncompatibleSharding;
     }
     return plan;

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -8,7 +8,6 @@ const pjrt = @import("pjrt");
 const platforms = @import("platforms");
 const stdx = @import("stdx");
 
-const Memory = @import("platform.zig").Memory;
 const Platform = @import("platform.zig").Platform;
 const PlatformDevice = @import("platform.zig").Device;
 const Shape = @import("shape.zig").Shape;
@@ -1758,24 +1757,8 @@ pub const Placement = struct {
     slices: stdx.BoundedArray(Slice1d, Shape.MAX_RANK),
 
     pub fn platformDeviceIndex(self: *const Placement, platform: *const Platform) ?usize {
-        for (platform.devices, 0..) |d, device_index| {
-            const device_id = switch (platform.target) {
-                .neuron => @as(usize, @intCast(d.localHardwareId())),
-                .cuda, .rocm, .tpu, .cpu, .oneapi => d.id(),
-            };
-            if (device_id == self.device_id) return device_index;
-        }
-
-        return null;
-    }
-
-    pub fn device(self: *const Placement, platform: *const Platform) PlatformDevice {
-        const device_index = self.platformDeviceIndex(platform) orelse unreachable;
-        return platform.devices[device_index];
-    }
-
-    pub fn memory(self: *const Placement, platform: *const Platform, kind: Memory.Kind) *const Memory {
-        return self.device(platform).memory(kind);
+        if (self.device_id >= platform.devices.len) return null;
+        return self.device_id;
     }
 
     pub fn shardSlice(self: *const Placement, slice: Slice) Slice {

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -13,6 +13,7 @@ const PlatformDevice = @import("platform.zig").Device;
 const Shape = @import("shape.zig").Shape;
 const Slice = @import("slice.zig").Slice;
 const Target = @import("platform.zig").Target;
+const builtin = @import("builtin");
 
 const Sharding = @This();
 
@@ -1706,20 +1707,15 @@ pub const Strategy = struct {
 
 /// For a given shape, compute the shape of the slice each shard will receive.
 pub fn shardedShape(sharding: Sharding, shape: Shape) !Shape {
-    // TODO: simplify me
-    // placement is doing too much work because Sharding creation doesn't enough.
     const pl = try sharding.placement(shape);
     return pl.shape;
-}
-
-pub fn shardedDims(sharding: Sharding, shape: Shape) !Shape.DimsArray {
-    return (try sharding.shardedShape(shape))._dims;
 }
 
 pub fn placement(sharding: Sharding, shape: Shape) !Placement {
     return .init(sharding, shape);
 }
 
+/// Precompute sharding information common to all devices for a given shape.
 pub const Placement = struct {
     pub const Slices = stdx.BoundedArray(Slice1d, Shape.MAX_RANK);
     pub const Slice1d = struct {
@@ -1730,36 +1726,36 @@ pub const Placement = struct {
 
     sharding: Sharding,
     shape: Shape,
-    global_shape: Shape,
+    global_shape: if (builtin.mode == .Debug) Shape else void,
+
     // This is a big field, reconsider how AxisSplit store information
-    axis_splits: stdx.BoundedArray(AxisSplit, Shape.MAX_RANK),
+    axis_plans: stdx.BoundedArray(AxisSplit, Shape.MAX_RANK),
 
     pub fn init(sharding: Sharding, shape: Shape) !Placement {
         // TODO: placement should be device agnostic
         var pl: Placement = .{
             .sharding = sharding,
             .shape = shape, // modified below
-            .global_shape = shape,
-            .axis_splits = .empty, // set below
+            .global_shape = if (builtin.mode == .Debug) shape else {},
+            .axis_plans = .empty, // set below
         };
         var used_axes: std.EnumSet(PhysicalAxisTag) = .empty;
 
         for (0..shape.rank()) |ax| {
             const axis_index: u8 = @intCast(ax);
-            pl.axis_splits.appendAssumeCapacity(try axisSplit(sharding, shape, &used_axes, axis_index));
+            pl.axis_plans.appendAssumeCapacity(try axisSplit(sharding, shape, &used_axes, axis_index));
         }
 
-        for (0.., pl.axis_splits.constSlice()) |a, split| {
-            pl.shape._dims.buffer[a] = split.product;
+        for (0.., shape.dims(), pl.axis_plans.constSlice()) |a, dim, plan| {
+            pl.shape._dims.buffer[a] = @divExact(dim, plan.product);
         }
         return pl;
     }
 
     pub fn slices(self: *const Placement, device_id: usize) Slices {
-        const coords = self.sharding.devicesInCanonicalOrder()[device_id].coords.constSlice();
+        const coords = self.deviceCoords(device_id);
         var res: Slices = .{ .buffer = undefined, .len = self.shape.rank() };
-        for (0.., res.slice(), self.shape.dims(), self.axis_splits.constSlice()) |a, *r, dim, plan| {
-            const size = @divExact(dim, plan.product);
+        for (0.., res.slice(), self.shape.dims(), self.axis_plans.constSlice()) |a, *r, size, plan| {
             const start = plan.linearIndex(coords) * size;
             r.* = .{
                 .axis = @intCast(a),
@@ -1771,20 +1767,23 @@ pub const Placement = struct {
     }
 
     pub fn shardSlice(self: *const Placement, device_id: usize, slice: Slice) Slice {
-        _ = device_id; // TODO
-        stdx.debug.assert(
-            self.global_shape.eql(slice.shape),
-            "Placement global shape {f} doesn't match slice shape {f}",
-            .{ self.global_shape, slice.shape },
-        );
+        if (builtin.mode == .Debug) {
+            // there is a bug in caller code that used a placement for a different shape
+            std.debug.assert(self.global_shape.eql(slice.shape));
+        }
 
         var offset_i64: i64 = @intCast(slice.offset_bytes);
-        for (self.axis_splits.constSlice()) |split| {
-            // const dim = slice.shape.dim(s.axis);
-            const stride_bytes = slice.byte_strides.get(split.axis);
-            offset_i64 += split.start * stride_bytes;
+
+        const coords = self.deviceCoords(device_id);
+        for (self.shape.dims(), self.axis_plans.constSlice(), slice.byte_strides.constSlice()) |size, plan, stride| {
+            const start = plan.linearIndex(coords) * size;
+            offset_i64 += start * stride;
         }
         return .{ .inner_data = slice.inner_data, .shape = self.shape, .offset_bytes = @intCast(offset_i64), .byte_strides = slice.byte_strides };
+    }
+
+    fn deviceCoords(self: Placement, device_id: usize) []const usize {
+        return self.sharding.devicesInCanonicalOrder()[device_id].coords.constSlice();
     }
 
     pub fn format(self: Placement, writer: *std.Io.Writer) std.Io.Writer.Error!void {
@@ -1794,13 +1793,13 @@ pub const Placement = struct {
         try writer.writeAll("Per-shard placement:\n");
         for (ordered_devices, 0..) |device, shard_index| {
             const device_id: u8 = @intCast(device.id);
-            try writer.print("└─ Shard[{d}] device_id={d} coords={any}, slices=[", .{ shard_index, device_id, device.coords });
+            try writer.print("└─ Shard[{d}] device_id={d} coords={any}, slices=[", .{ shard_index, device_id, device.coords.constSlice() });
             for (self.slices(device_id).constSlice(), 0..) |s, i| {
                 if (i > 0) try writer.writeAll(", ");
-                const axis_label = self.global_shape.debugTag(s.axis);
+                const axis_label = self.shape.debugTag(s.axis);
                 try writer.print("{s}:[{d}:{d}]", .{ axis_label, s.start, s.start + s.size });
             }
-            try writer.writeAll("]");
+            try writer.writeAll("]\n");
         }
     }
 
@@ -1808,19 +1807,12 @@ pub const Placement = struct {
         try writer.print("Placement(shape={f} shards={d})\n", .{ shape, shard_count });
 
         try writer.writeAll("Axis partitioning summary:\n");
-        for (0..shape.rank()) |ax| {
+        for (0.., self.slices(0).constSlice()) |ax, slice| {
             const dim = shape.dim(ax);
             const spec = shape.partition(ax);
             const axis_label = shape.debugTag(ax);
 
-            var shard_size: i64 = dim;
-            for (self._slices.constSlice()) |s| {
-                if (s.axis == ax) {
-                    shard_size = s.size;
-                    break;
-                }
-            }
-
+            const shard_size: i64 = slice.size;
             const shards_count: i64 = if (shard_size > 0 and @rem(dim, shard_size) == 0)
                 @divExact(dim, shard_size)
             else
@@ -1854,7 +1846,7 @@ const AxisSplit = struct {
     pub fn linearIndex(self: AxisSplit, device_coords: []const usize) i64 {
         var linear: i64 = 0;
         for (self.counts.constSlice(), self.depths.constSlice()) |c_, depth| {
-            linear = linear * c_ + device_coords[depth];
+            linear = linear * c_ + @as(i64, @intCast(device_coords[depth]));
         }
         return linear;
     }
@@ -1920,6 +1912,7 @@ fn addPhysicalToSplit(sharding: Sharding, plan: *AxisSplit, tag: PhysicalAxisTag
 
 const ShardingTest = struct {
     pub const ExpectedShard = struct {
+        // TODO: remove device_id from here, we always have ids from 0 to N
         device_id: usize,
         slices: []const [2]i64,
     };
@@ -1928,10 +1921,19 @@ const ShardingTest = struct {
         sharding: Sharding.Data,
         shape: Shape,
 
+        expect_error: ?anyerror = null,
         expected_sdy: ?[]const u8 = null,
         expected_shards: []const ExpectedShard = &.{},
 
-        expect_error: ?anyerror = null,
+        pub fn format(scenario: Scenario, writer: *std.Io.Writer) std.Io.Writer.Error!void {
+            try writer.print("Scenario:\n", .{});
+            if (scenario.expect_error) |err| try writer.print("- error {}\n", .{err});
+            if (scenario.expected_sdy) |sdy| try writer.print("- shardy: {s}\n", .{sdy});
+            if (scenario.expected_shards.len > 0) try writer.print("- shards:\n", .{});
+            for (scenario.expected_shards) |shard| {
+                try writer.print("\t- device {d}: slices={any}\n", .{ shard.device_id, shard.slices });
+            }
+        }
     };
 
     allocator: std.mem.Allocator,
@@ -1971,9 +1973,11 @@ const ShardingTest = struct {
 
     pub fn run(self: ShardingTest, s: Scenario) !void {
         const sharding = s.sharding;
+        errdefer std.log.warn("Failed sharding {f}", .{s});
 
         // Verify MLIR String
         if (s.expected_sdy) |expected_attr| {
+            errdefer std.log.warn("Expected shardy annotation failed", .{});
             const registry: *mlir.DialectRegistry = try .init();
             defer registry.deinit();
             registry.registerDialect("sdy");
@@ -1994,6 +1998,7 @@ const ShardingTest = struct {
         const sharding_ref: Sharding = .{ .data = &sharding };
         const ordered_devices = sharding_ref.devicesInCanonicalOrder();
         if (s.expect_error) |err| {
+            errdefer std.log.warn("Expected error failed", .{});
             try std.testing.expect(ordered_devices.len > 0);
             try std.testing.expectError(err, sharding_ref.placement(s.shape));
             return;
@@ -2002,12 +2007,31 @@ const ShardingTest = struct {
         const pl = try sharding_ref.placement(s.shape);
         // Verify Shard Slices (Math)
         if (s.expected_shards.len > 0) {
+            errdefer std.log.warn("Expected shards failed. Got {f}", .{pl});
             try std.testing.expectEqual(s.expected_shards.len, ordered_devices.len);
-            for (s.expected_shards, ordered_devices) |expected, device| {
-                const actual = pl.slices(@intCast(device.id));
-                for (expected.slices, actual.constSlice()) |exp_slice, actual_slice| {
-                    try std.testing.expectEqual(exp_slice[0], actual_slice.start);
-                    try std.testing.expectEqual(exp_slice[1], actual_slice.size);
+            for (s.expected_shards) |expected| {
+                {
+                    // Check pl.slices(device.id)
+                    const actual_slices = pl.slices(expected.device_id);
+
+                    // Consider rewriting test cases to use Slice1D. This requires passing the axis
+                    const actual_start_len = try self.allocator.alloc([2]i64, actual_slices.len);
+                    defer self.allocator.free(actual_start_len);
+                    for (actual_start_len, actual_slices.constSlice()) |*s_l, slice| {
+                        s_l.* = .{ slice.start, slice.size };
+                    }
+
+                    try std.testing.expectEqualSlices([2]i64, expected.slices, actual_start_len);
+                }
+                {
+                    // Check pl.shape
+                    const expected_sizes = try self.allocator.alloc(i64, expected.slices.len);
+                    defer self.allocator.free(expected_sizes);
+                    for (expected_sizes, expected.slices) |*expected_size, slice| {
+                        expected_size.* = slice[1];
+                    }
+
+                    try std.testing.expectEqualSlices(i64, expected_sizes, pl.shape.dims());
                 }
             }
         }

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -19,6 +19,8 @@ const Sharding = @This();
 
 data: *const Data,
 
+pub const MAX_MESH_RANK = 4;
+
 var _replicated: [11]u8 align(@alignOf(Data)) = "_replicated".*;
 
 // special value to make public apis more fluent.
@@ -215,7 +217,7 @@ pub const Device = struct {
     id: usize,
 
     /// Coordinates in the physical mesh
-    coords: stdx.BoundedArray(u8, Shape.MAX_RANK) = .empty,
+    coords: stdx.BoundedArray(u8, MAX_MESH_RANK) = .empty,
 
     pub fn coordsSlice(self: *const Device) ?[]const u8 {
         if (self.coords.len == 0) return null;
@@ -330,7 +332,7 @@ pub const PhysicalMesh = struct {
 
     /// AxisTraversal captures canonical axis order and depth mapping.
     pub const AxisTraversal = struct {
-        pub const Order = stdx.BoundedArray(PhysicalAxisTag, Shape.MAX_RANK);
+        pub const Order = stdx.BoundedArray(PhysicalAxisTag, MAX_MESH_RANK);
         pub const DepthByTag = std.EnumArray(PhysicalAxisTag, ?u8);
 
         /// Order of axes (DFS, first-child descent).
@@ -434,7 +436,7 @@ pub const PhysicalMesh = struct {
         try validateGeometry(root);
 
         var owned_root = root;
-        var path: [Shape.MAX_RANK]u8 = @splat(0);
+        var path: [MAX_MESH_RANK]u8 = @splat(0);
         assignCoords(&owned_root, &path, 0);
 
         var mesh: PhysicalMesh = .{
@@ -556,7 +558,7 @@ pub const PhysicalMesh = struct {
     /// coords:
     ///   (0,0) (0,1)
     ///   (1,0) (1,1)
-    fn assignCoords(node: *PhysicalNode, path: *[Shape.MAX_RANK]u8, depth: usize) void {
+    fn assignCoords(node: *PhysicalNode, path: *[MAX_MESH_RANK]u8, depth: usize) void {
         switch (node.*) {
             .leaf => |*d| {
                 // Coords can already been set by caller
@@ -704,12 +706,12 @@ pub const PhysicalMesh = struct {
     const CoordsTopology = struct {
         const CoordPlacement = struct {
             device_id: usize,
-            coords: stdx.BoundedArray(u8, Shape.MAX_RANK),
+            coords: stdx.BoundedArray(u8, MAX_MESH_RANK),
         };
 
         const CoordLayout = struct {
             rank: usize,
-            axis_sizes: [Shape.MAX_RANK]usize,
+            axis_sizes: [MAX_MESH_RANK]usize,
         };
 
         const IndexedCoord = struct {
@@ -720,10 +722,10 @@ pub const PhysicalMesh = struct {
         fn parseDevice(device: PlatformDevice) !CoordPlacement {
             const api = device.platform.pjrt_api;
             const coords_attr = device.pjrt_desc.attribute(api, "coords") orelse return error.MissingDeviceCoords;
-            var coords: stdx.BoundedArray(u8, Shape.MAX_RANK) = .empty;
+            var coords: stdx.BoundedArray(u8, MAX_MESH_RANK) = .empty;
             switch (coords_attr) {
                 .int64list => |values| {
-                    if (values.len == 0 or values.len > Shape.MAX_RANK) return error.InvalidDeviceCoords;
+                    if (values.len == 0 or values.len > MAX_MESH_RANK) return error.InvalidDeviceCoords;
                     for (values) |value| {
                         if (value < 0) return error.InvalidDeviceCoords;
                         coords.appendAssumeCapacity(@intCast(value));
@@ -757,7 +759,7 @@ pub const PhysicalMesh = struct {
                 if (coord_placement.coords.len != rank) return error.InvalidDeviceCoordsRank;
             }
 
-            var axis_sizes = [_]usize{1} ** Shape.MAX_RANK;
+            var axis_sizes = [_]usize{1} ** MAX_MESH_RANK;
             for (0..rank) |ax_i| {
                 var max_coord: usize = 0;
                 for (placements) |coord_placement| {
@@ -816,8 +818,8 @@ pub const PhysicalMesh = struct {
             };
         }
 
-        pub fn axisStrides(axis_sizes: []const usize) ![Shape.MAX_RANK]usize {
-            var strides: [Shape.MAX_RANK]usize = @splat(0);
+        pub fn axisStrides(axis_sizes: []const usize) ![MAX_MESH_RANK]usize {
+            var strides: [MAX_MESH_RANK]usize = @splat(0);
             var stride: usize = 1;
 
             var i = axis_sizes.len;
@@ -905,7 +907,7 @@ pub const PhysicalMesh = struct {
         const placements = try CoordsTopology.collect(allocator, platform_devices);
         defer allocator.free(placements);
 
-        const layout = try CoordsTopology.layout(placements, Shape.MAX_RANK);
+        const layout = try CoordsTopology.layout(placements, MAX_MESH_RANK);
         const indexed = try CoordsTopology.sorted(allocator, placements, layout.rank, layout.axis_sizes[0..layout.rank]);
         defer allocator.free(indexed);
 
@@ -969,9 +971,9 @@ pub const PhysicalMesh = struct {
         var topology = try neuron_topology.visibleMeshFromNcIds(allocator, nc_ids);
         defer topology.deinit(allocator);
 
-        var axis_tags: stdx.BoundedArray(PhysicalAxisTag, Shape.MAX_RANK) = .empty;
-        var axis_sizes: stdx.BoundedArray(usize, Shape.MAX_RANK) = .empty;
-        var axis_geometries: stdx.BoundedArray(AxisGeometry, Shape.MAX_RANK) = .empty;
+        var axis_tags: stdx.BoundedArray(PhysicalAxisTag, MAX_MESH_RANK) = .empty;
+        var axis_sizes: stdx.BoundedArray(usize, MAX_MESH_RANK) = .empty;
+        var axis_geometries: stdx.BoundedArray(AxisGeometry, MAX_MESH_RANK) = .empty;
 
         for (topology.axes()) |mesh_axis| {
             axis_tags.appendAssumeCapacity(switch (mesh_axis.fabric) {
@@ -989,7 +991,7 @@ pub const PhysicalMesh = struct {
             });
         }
 
-        var coords_buf: [Shape.MAX_RANK]usize = [_]usize{0} ** Shape.MAX_RANK;
+        var coords_buf: [MAX_MESH_RANK]usize = [_]usize{0} ** MAX_MESH_RANK;
         var next_device: usize = 0;
 
         const Node = struct {
@@ -1001,7 +1003,7 @@ pub const PhysicalMesh = struct {
                 axis_sizes_: []const usize,
                 axis_geometries_: []const AxisGeometry,
                 depth: usize,
-                coords_buf_: *[Shape.MAX_RANK]usize,
+                coords_buf_: *[MAX_MESH_RANK]usize,
                 next_device_: *usize,
             ) !PhysicalNode {
                 if (depth == axis_tags_.len) {
@@ -1009,7 +1011,7 @@ pub const PhysicalMesh = struct {
                     const device = platform_devices_[placement_.input_index];
                     next_device_.* += 1;
 
-                    var coords: stdx.BoundedArray(u8, Shape.MAX_RANK) = .empty;
+                    var coords: stdx.BoundedArray(u8, MAX_MESH_RANK) = .empty;
                     for (coords_buf_[0..axis_tags_.len]) |coord| coords.appendAssumeCapacity(coord);
 
                     return .{
@@ -1099,8 +1101,8 @@ pub const LogicalAxisIntent = enum {
 /// Limitations:
 /// - No sizes here; no divisibility checks here.
 pub const LogicalMesh = struct {
-    pub const Axes = stdx.BoundedArray(Shape.Tag, Shape.MAX_RANK);
-    pub const Intents = stdx.BoundedArray(LogicalAxisIntent, Shape.MAX_RANK);
+    pub const Axes = stdx.BoundedArray(Shape.Tag, MAX_MESH_RANK);
+    pub const Intents = stdx.BoundedArray(LogicalAxisIntent, MAX_MESH_RANK);
 
     axes: Axes,
     intents: Intents,
@@ -1156,24 +1158,24 @@ pub const LogicalMesh = struct {
     }
 };
 
-pub const AxisList = stdx.BoundedArray(PhysicalAxisTag, Shape.MAX_RANK);
+pub const AxisList = stdx.BoundedArray(PhysicalAxisTag, MAX_MESH_RANK);
 pub const Binding = struct {
     logical: Shape.Tag,
     physical: AxisList,
 };
-pub const Bindings = stdx.BoundedArray(Binding, Shape.MAX_RANK);
+pub const Bindings = stdx.BoundedArray(Binding, MAX_MESH_RANK);
 
 pub const Fold = struct {
     target: PhysicalAxisTag,
     sources: AxisList,
 };
-pub const Folds = stdx.BoundedArray(Fold, Shape.MAX_RANK);
+pub const Folds = stdx.BoundedArray(Fold, MAX_MESH_RANK);
 
 pub const Axis = struct {
     tag: PhysicalAxisTag,
     size: i64,
     geometry: ?AxisGeometry,
-    folded: stdx.BoundedArray(PhysicalAxisTag, Shape.MAX_RANK),
+    folded: stdx.BoundedArray(PhysicalAxisTag, MAX_MESH_RANK),
 
     pub fn contains(self: *const Axis, tag: PhysicalAxisTag) bool {
         if (self.tag == tag) return true;
@@ -1183,7 +1185,7 @@ pub const Axis = struct {
 };
 
 pub const PhysicalView = struct {
-    axes: stdx.BoundedArray(Axis, Shape.MAX_RANK),
+    axes: stdx.BoundedArray(Axis, MAX_MESH_RANK),
     total_devices: i64,
 
     pub fn axisCoordFromLinearShard(self: *const PhysicalView, axis_index: usize, linear_idx: usize) usize {
@@ -1275,7 +1277,7 @@ pub const Data = struct {
             if (!physical.hasAxis(tag)) continue;
             if (self.folds_consumed.contains(tag) and self.foldSources(tag) == null) continue;
 
-            var folded: stdx.BoundedArray(PhysicalAxisTag, Shape.MAX_RANK) = .empty;
+            var folded: stdx.BoundedArray(PhysicalAxisTag, MAX_MESH_RANK) = .empty;
             var size: i64 = 1;
 
             if (self.foldSources(tag)) |sources| {
@@ -1606,17 +1608,17 @@ pub const Data = struct {
 };
 
 pub const Strategy = struct {
-    pub const PhysicalList = stdx.BoundedArray(PhysicalAxisTag, Shape.MAX_RANK);
+    pub const PhysicalList = stdx.BoundedArray(PhysicalAxisTag, MAX_MESH_RANK);
     pub const Binding = struct {
         logical: Shape.Tag,
         physical: PhysicalList,
     };
-    pub const Bindings = stdx.BoundedArray(Strategy.Binding, Shape.MAX_RANK);
+    pub const Bindings = stdx.BoundedArray(Strategy.Binding, MAX_MESH_RANK);
     pub const Fold = struct {
         target: PhysicalAxisTag,
         sources: PhysicalList,
     };
-    pub const Folding = stdx.BoundedArray(Strategy.Fold, Shape.MAX_RANK);
+    pub const Folding = stdx.BoundedArray(Strategy.Fold, MAX_MESH_RANK);
 
     bindings: Strategy.Bindings,
     folding: Folding,
@@ -1691,7 +1693,7 @@ pub const Strategy = struct {
         var strategy: Strategy = .init;
 
         const base_order = physical.shardableAxes();
-        var available: stdx.BoundedArray(PhysicalAxisTag, Shape.MAX_RANK) = .empty;
+        var available: stdx.BoundedArray(PhysicalAxisTag, MAX_MESH_RANK) = .empty;
         for (base_order) |tag| {
             if (physical.hasAxis(tag)) available.appendAssumeCapacity(tag);
         }
@@ -1849,8 +1851,8 @@ pub const Placement = struct {
 };
 
 const AxisSplit = struct {
-    counts: stdx.BoundedArray(u8, Shape.MAX_RANK),
-    depths: stdx.BoundedArray(u8, Shape.MAX_RANK),
+    counts: stdx.BoundedArray(u8, MAX_MESH_RANK),
+    depths: stdx.BoundedArray(u8, MAX_MESH_RANK),
 
     pub const empty: AxisSplit = .{
         .counts = .empty,

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -215,9 +215,9 @@ pub const Device = struct {
     id: usize,
 
     /// Coordinates in the physical mesh
-    coords: stdx.BoundedArray(usize, Shape.MAX_RANK) = .empty,
+    coords: stdx.BoundedArray(u8, Shape.MAX_RANK) = .empty,
 
-    pub fn coordsSlice(self: *const Device) ?[]const usize {
+    pub fn coordsSlice(self: *const Device) ?[]const u8 {
         if (self.coords.len == 0) return null;
         return self.coords.constSlice();
     }
@@ -434,7 +434,7 @@ pub const PhysicalMesh = struct {
         try validateGeometry(root);
 
         var owned_root = root;
-        var path: [Shape.MAX_RANK]usize = @splat(0);
+        var path: [Shape.MAX_RANK]u8 = @splat(0);
         assignCoords(&owned_root, &path, 0);
 
         var mesh: PhysicalMesh = .{
@@ -556,17 +556,17 @@ pub const PhysicalMesh = struct {
     /// coords:
     ///   (0,0) (0,1)
     ///   (1,0) (1,1)
-    fn assignCoords(node: *PhysicalNode, path: *[Shape.MAX_RANK]usize, depth: usize) void {
+    fn assignCoords(node: *PhysicalNode, path: *[Shape.MAX_RANK]u8, depth: usize) void {
         switch (node.*) {
             .leaf => |*d| {
                 // Coords can already been set by caller
                 if (d.coords.len > 0) return;
 
-                d.coords = stdx.BoundedArray(usize, Shape.MAX_RANK).fromSlice(path[0..depth]) catch unreachable;
+                d.coords = .init(path[0..depth]);
             },
             .branch => |*b| {
                 for (b.children, 0..) |*child, i| {
-                    path[depth] = i;
+                    path[depth] = @intCast(i);
                     assignCoords(child, path, depth + 1);
                 }
             },
@@ -592,7 +592,7 @@ pub const PhysicalMesh = struct {
     ///
     /// sizes: S0..Sk, coords: C0..Ck
     /// linear = (((C0 * S1) + C1) * S2 + C2) ...
-    pub fn linearIndexFromCoords(self: PhysicalMesh, coords: []const usize) usize {
+    pub fn linearIndexFromCoords(self: PhysicalMesh, coords: []const u8) usize {
         const order = self.axisOrder();
         var idx: usize = 0;
         for (order.constSlice()) |tag| {
@@ -1747,7 +1747,7 @@ pub const Placement = struct {
         }
 
         for (0.., shape.dims(), pl.axis_plans.constSlice()) |a, dim, plan| {
-            pl.shape._dims.buffer[a] = @divExact(dim, plan.product);
+            pl.shape._dims.buffer[a] = @divExact(dim, plan.product());
         }
         return pl;
     }
@@ -1782,7 +1782,7 @@ pub const Placement = struct {
         return .{ .inner_data = slice.inner_data, .shape = self.shape, .offset_bytes = @intCast(offset_i64), .byte_strides = slice.byte_strides };
     }
 
-    fn deviceCoords(self: Placement, device_id: usize) []const usize {
+    fn deviceCoords(self: Placement, device_id: usize) []const u8 {
         return self.sharding.devicesInCanonicalOrder()[device_id].coords.constSlice();
     }
 
@@ -1800,6 +1800,10 @@ pub const Placement = struct {
                 try writer.print("{s}:[{d}:{d}]", .{ axis_label, s.start, s.start + s.size });
             }
             try writer.writeAll("]\n");
+        }
+
+        for (0.., self.axis_plans.slice()) |ax, plan| {
+            try writer.print("- axis{d} -> plan {f}\n", .{ ax, plan });
         }
     }
 
@@ -1827,28 +1831,35 @@ pub const Placement = struct {
 };
 
 const AxisSplit = struct {
-    product: i64,
-    counts: stdx.BoundedArray(i64, Shape.MAX_RANK),
+    counts: stdx.BoundedArray(u8, Shape.MAX_RANK),
     depths: stdx.BoundedArray(u8, Shape.MAX_RANK),
 
     pub const empty: AxisSplit = .{
-        .product = 1,
         .counts = .empty,
         .depths = .empty,
     };
 
-    pub fn add(split: *AxisSplit, size: i64, depth: u8) void {
+    pub fn add(split: *AxisSplit, size: u8, depth: u8) void {
         split.counts.appendAssumeCapacity(size);
         split.depths.appendAssumeCapacity(depth);
-        split.product *= size;
     }
 
-    pub fn linearIndex(self: AxisSplit, device_coords: []const usize) i64 {
-        var linear: i64 = 0;
-        for (self.counts.constSlice(), self.depths.constSlice()) |c_, depth| {
-            linear = linear * c_ + @as(i64, @intCast(device_coords[depth]));
+    pub fn linearIndex(self: AxisSplit, device_coords: []const u8) u32 {
+        var linear: u32 = 0;
+        for (self.counts.constSlice(), self.depths.constSlice()) |count, depth| {
+            linear = linear * count + @as(u32, device_coords[depth]);
         }
         return linear;
+    }
+
+    pub fn product(split: AxisSplit) u32 {
+        var p: u32 = 1;
+        for (split.counts.constSlice()) |count| p *= count;
+        return p;
+    }
+
+    pub fn format(self: AxisSplit, writer: *std.Io.Writer) std.Io.Writer.Error!void {
+        try writer.print("Plan(counts={any},depths={any})", .{ self.counts.slice(), self.depths.slice() });
     }
 };
 
@@ -1896,7 +1907,7 @@ fn calculateSplit(
         }
     }
 
-    if (plan.product > 0 and @rem(dim, plan.product) != 0) {
+    if (plan.product() > 0 and @rem(dim, plan.product()) != 0) {
         return error.IncompatibleSharding;
     }
     return plan;
@@ -1907,7 +1918,7 @@ fn addPhysicalToSplit(sharding: Sharding, plan: *AxisSplit, tag: PhysicalAxisTag
     const physical = sharding.data.physical;
     const info = physical.axisInfo(tag) orelse return;
     const depth = physical.axis_traversal.depth(tag) orelse return;
-    plan.add(info.size, depth);
+    plan.add(@intCast(info.size), depth);
 }
 
 const ShardingTest = struct {
@@ -2004,9 +2015,10 @@ const ShardingTest = struct {
             return;
         }
 
-        const pl = try sharding_ref.placement(s.shape);
         // Verify Shard Slices (Math)
         if (s.expected_shards.len > 0) {
+            const pl = try sharding_ref.placement(s.shape);
+
             errdefer std.log.warn("Expected shards failed. Got {f}", .{pl});
             try std.testing.expectEqual(s.expected_shards.len, ordered_devices.len);
             for (s.expected_shards) |expected| {

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -209,20 +209,21 @@ fn shapeHasAxisPartition(shape: Shape) bool {
     return false;
 }
 
-/// Device is the leaf representation in a PhysicalMesh.
-/// It carries identity, optional coordinates, and PJRT handle.
+/// Device as part of a PhysicalMesh.
 pub const Device = struct {
     /// Unique device identifier in the mesh
-    id: usize,
+    id: u32,
 
     /// Coordinates in the physical mesh
     coords: Coords,
 
     const Coords = [MAX_MESH_RANK]u8;
     // Placeholder coords, that would most likely trigger panic if used like that.
+    // Those are used when creating a mesh, before calling assignCoords
+    // Private so it's kept as implementation detail
     const undefined_coords: Coords = @splat(0xff);
 
-    fn isFullInitialized(device: Device) bool {
+    fn asValidCoords(device: Device) bool {
         return @as(u32, @bitCast(device.coords)) != @as(u32, @bitCast(undefined_coords));
     }
 
@@ -348,7 +349,7 @@ pub const PhysicalMesh = struct {
             axisOrderNode(root, &order);
 
             var depth_by_tag: DepthByTag = .initFill(null);
-            for (order.constSlice(), 0..) |t, i| {
+            for (order.slice(), 0..) |t, i| {
                 depth_by_tag.set(t, @intCast(i));
             }
 
@@ -365,7 +366,7 @@ pub const PhysicalMesh = struct {
         pub fn format(self: AxisTraversal, writer: *std.Io.Writer) !void {
             try writer.writeAll("AxisTraversal(order=[");
 
-            for (self.order.constSlice(), 0..) |tag, i| {
+            for (self.order.slice(), 0..) |tag, i| {
                 if (i > 0) try writer.writeAll(", ");
                 try writer.writeAll(@tagName(tag));
             }
@@ -450,7 +451,7 @@ pub const PhysicalMesh = struct {
         try mesh.populateDevicesInCanonicalOrder(allocator);
         for (0.., mesh.devices_in_canonical_order) |i, device| {
             std.debug.assert(device.id == i);
-            std.debug.assert(device.isFullInitialized());
+            std.debug.assert(device.asValidCoords());
         }
         return mesh;
     }
@@ -566,7 +567,7 @@ pub const PhysicalMesh = struct {
         switch (node.*) {
             .leaf => |*d| {
                 // Coords can already been set by caller
-                if (d.isFullInitialized()) return;
+                if (d.asValidCoords()) return;
 
                 d.coords = path.*;
             },
@@ -601,7 +602,7 @@ pub const PhysicalMesh = struct {
     pub fn linearIndexFromCoords(self: PhysicalMesh, coords: Device.Coords) usize {
         const order = self.axisOrder();
         var idx: usize = 0;
-        for (order.constSlice()) |tag| {
+        for (order.slice()) |tag| {
             const depth = self.axis_traversal.depth(tag);
             if (depth) |d| {
                 const coord = coords[@intCast(d)];
@@ -708,22 +709,17 @@ pub const PhysicalMesh = struct {
 
     /// CoordsTopology builds a mesh from PJRT `coords` attributes.
     const CoordsTopology = struct {
-        const CoordPlacement = struct {
-            device_id: usize,
-            coords: Device.Coords,
-        };
-
         const CoordLayout = struct {
             rank: usize,
             axis_sizes: [MAX_MESH_RANK]usize,
         };
 
         const IndexedCoord = struct {
-            placement: CoordPlacement,
+            placement: Device,
             linear: usize,
         };
 
-        fn parseDevice(device: PlatformDevice) !CoordPlacement {
+        fn parseDevice(device: PlatformDevice) !Device {
             const api = device.platform.pjrt_api;
             const coords_attr = device.pjrt_desc.attribute(api, "coords") orelse return error.MissingDeviceCoords;
             const coords: Device.Coords = coords: switch (coords_attr) {
@@ -739,18 +735,18 @@ pub const PhysicalMesh = struct {
                 else => return error.InvalidDeviceCoords,
             };
 
-            return .{ .device_id = device.id(), .coords = coords };
+            return .{ .id = device.id(), .coords = coords };
         }
 
-        pub fn collect(allocator: std.mem.Allocator, platform_devices: []const PlatformDevice) ![]CoordPlacement {
-            const placements = try allocator.alloc(CoordPlacement, platform_devices.len);
+        pub fn collect(allocator: std.mem.Allocator, platform_devices: []const PlatformDevice) ![]Device {
+            const placements = try allocator.alloc(Device, platform_devices.len);
             for (platform_devices, 0..) |device, i| {
                 placements[i] = try parseDevice(device);
             }
             return placements;
         }
 
-        pub fn layout(placements: []const CoordPlacement, max_rank: usize) !CoordLayout {
+        pub fn layout(placements: []const Device, max_rank: usize) !CoordLayout {
             if (placements.len == 0) return error.InvalidPhysicalMesh;
 
             const rank = placements[0].coords.len;
@@ -788,7 +784,7 @@ pub const PhysicalMesh = struct {
             return linear;
         }
 
-        pub fn sorted(allocator: std.mem.Allocator, placements: []const CoordPlacement, rank: usize, axis_sizes: []const usize) ![]IndexedCoord {
+        pub fn sorted(allocator: std.mem.Allocator, placements: []const Device, rank: usize, axis_sizes: []const usize) ![]IndexedCoord {
             const indexed = try allocator.alloc(IndexedCoord, placements.len);
             for (placements, indexed) |coord_placement, *out| {
                 out.* = .{
@@ -809,10 +805,6 @@ pub const PhysicalMesh = struct {
             }
 
             return indexed;
-        }
-
-        pub fn leaf(coord_placement: *const CoordPlacement, coords: Device.Coords) !PhysicalNode {
-            return .{ .leaf = .{ .id = coord_placement.device_id, .coords = coords } };
         }
 
         pub fn axisStrides(axis_sizes: []const usize) ![MAX_MESH_RANK]usize {
@@ -839,8 +831,8 @@ pub const PhysicalMesh = struct {
             base_offset: usize,
         ) !PhysicalNode {
             if (depth == axis_sizes.len) {
-                const coord_placement = &indexed[base_offset].placement;
-                return leaf(coord_placement, coord_placement.coords);
+                const device = &indexed[base_offset].placement;
+                return .{ .leaf = device.* };
             }
 
             const children = try allocator.alloc(PhysicalNode, axis_sizes[depth]);
@@ -911,7 +903,7 @@ pub const PhysicalMesh = struct {
         const nodes = try allocator.alloc(PhysicalNode, platform_devices.len);
         for (nodes, indexed, 0..) |*n, entry, i| {
             const linear_coord: Device.Coords = .{ @intCast(i), 0, 0, 0 };
-            n.* = try CoordsTopology.leaf(&entry.placement, linear_coord);
+            n.* = .{ .leaf = .{ .id = entry.placement.id, .coords = linear_coord } };
         }
 
         return .{
@@ -1057,9 +1049,9 @@ pub const PhysicalMesh = struct {
             allocator,
             platform_devices,
             topology.placements,
-            axis_tags.constSlice(),
-            axis_sizes.constSlice(),
-            axis_geometries.constSlice(),
+            axis_tags.slice(),
+            axis_sizes.slice(),
+            axis_geometries.slice(),
             0,
             &coords_buf,
             &next_device,
@@ -1128,7 +1120,7 @@ pub const LogicalMesh = struct {
 
     pub fn intent(self: LogicalMesh, tag: Shape.Tag) ?LogicalAxisIntent {
         const target = std.mem.span(tag);
-        for (self.axes.constSlice(), self.intents.constSlice()) |t, i| {
+        for (self.axes.slice(), self.intents.slice()) |t, i| {
             if (std.mem.eql(u8, std.mem.span(t), target)) return i;
         }
 
@@ -1148,7 +1140,7 @@ pub const LogicalMesh = struct {
 
     pub fn format(self: LogicalMesh, writer: *std.Io.Writer) !void {
         try writer.writeAll("LogicalMesh(");
-        for (self.axes.constSlice(), self.intents.constSlice()) |axis, int| {
+        for (self.axes.slice(), self.intents.slice()) |axis, int| {
             try writer.print(" {s}={s}", .{ axis, @tagName(int) });
         }
         try writer.writeAll(")");
@@ -1176,7 +1168,7 @@ pub const Axis = struct {
 
     pub fn contains(self: *const Axis, tag: PhysicalAxisTag) bool {
         if (self.tag == tag) return true;
-        for (self.folded.constSlice()) |t| if (t == tag) return true;
+        for (self.folded.slice()) |t| if (t == tag) return true;
         return false;
     }
 };
@@ -1187,7 +1179,7 @@ pub const PhysicalView = struct {
 
     pub fn axisCoordFromLinearShard(self: *const PhysicalView, axis_index: usize, linear_idx: usize) usize {
         const stride = self.axisStrideForLinear(axis_index);
-        const axis_size: usize = @intCast(self.axes.constSlice()[axis_index].size);
+        const axis_size: usize = @intCast(self.axes.slice()[axis_index].size);
         return (linear_idx / stride) % axis_size;
     }
 
@@ -1195,7 +1187,7 @@ pub const PhysicalView = struct {
         var stride: usize = 1;
         var j = axis_index + 1;
         while (j < self.axes.len) : (j += 1) {
-            stride *= @intCast(self.axes.constSlice()[j].size);
+            stride *= @intCast(self.axes.slice()[j].size);
         }
         return stride;
     }
@@ -1214,8 +1206,8 @@ pub const Data = struct {
     folds_consumed: std.EnumSet(PhysicalAxisTag),
 
     pub fn binding(self: *const Data, tag: Shape.Tag) ?[]const PhysicalAxisTag {
-        for (self.bindings.constSlice()) |*b| {
-            if (b.logical == tag) return b.physical.constSlice();
+        for (self.bindings.slice()) |*b| {
+            if (b.logical == tag) return b.physical.slice();
         }
         return null;
     }
@@ -1226,19 +1218,19 @@ pub const Data = struct {
         logical: LogicalMesh,
         strategy: Strategy,
     ) !Data {
-        const axis_order = physical.axisOrder().constSlice();
+        const axis_order = physical.axisOrder().slice();
         if (axis_order.len == 0) return error.InvalidPhysicalMesh;
         if (strategy.bindings.len == 0) return error.InvalidStrategy;
 
         var bindings: Bindings = .empty;
-        for (strategy.bindings.constSlice()) |bind| {
+        for (strategy.bindings.slice()) |bind| {
             bindings.appendAssumeCapacity(.{ .logical = bind.logical, .physical = bind.physical });
         }
 
         var folds: Folds = .empty;
         var folds_consumed: std.EnumSet(PhysicalAxisTag) = .empty;
-        for (strategy.folding.constSlice()) |entry| {
-            for (entry.sources.constSlice()) |src| {
+        for (strategy.folding.slice()) |entry| {
+            for (entry.sources.slice()) |src| {
                 if (!physical.hasAxis(src)) return error.InvalidPhysicalAxis;
                 folds_consumed.insert(src);
             }
@@ -1256,8 +1248,8 @@ pub const Data = struct {
     }
 
     fn foldSources(self: *const Data, tag: PhysicalAxisTag) ?[]const PhysicalAxisTag {
-        for (self.folds.constSlice()) |*f| {
-            if (f.target == tag) return f.sources.constSlice();
+        for (self.folds.slice()) |*f| {
+            if (f.target == tag) return f.sources.slice();
         }
         return null;
     }
@@ -1269,7 +1261,7 @@ pub const Data = struct {
             .total_devices = 1,
         };
 
-        const axis_order = physical.axisOrder().constSlice();
+        const axis_order = physical.axisOrder().slice();
 
         for (axis_order) |tag| {
             if (!physical.hasAxis(tag)) continue;
@@ -1339,7 +1331,7 @@ pub const Data = struct {
     }
 
     pub fn covers(sharding: *const Data, shape: Shape) bool {
-        for (shape._partitioning.constSlice()) |partitioning| {
+        for (shape._partitioning.slice()) |partitioning| {
             switch (partitioning) {
                 .axis => |tag| if (sharding.binding(tag) == null) return false,
                 else => {},
@@ -1354,7 +1346,7 @@ pub const Data = struct {
 
         const view = self.physicalView();
         try out.writer.writeAll("#sdy.mesh<[");
-        for (view.axes.constSlice(), 0..) |p, i| {
+        for (view.axes.slice(), 0..) |p, i| {
             if (i > 0) try out.writer.writeAll(", ");
             try out.writer.print("\"{s}\"={d}", .{ @tagName(p.tag), p.size });
         }
@@ -1385,7 +1377,7 @@ pub const Data = struct {
             if (spec == .axis) {
                 if (self.binding(spec.axis)) |binding_| {
                     for (binding_) |p_tag| {
-                        for (view.axes.constSlice(), 0..) |v_ax, i| {
+                        for (view.axes.slice(), 0..) |v_ax, i| {
                             // Only use the axis if it's bound and hasn't been consumed by a previous dimension
                             if (v_ax.contains(p_tag) and !globally_used.contains(v_ax.tag)) {
                                 dim_axes.appendAssumeCapacity(i);
@@ -1442,7 +1434,7 @@ pub const Data = struct {
                             break :d .replicated(ctx);
                         } else {
                             const axes = try allocator.alloc(*const dialects.shardy.AxisRefAttribute, dim_phys_indices.len);
-                            for (dim_phys_indices.constSlice(), 0..) |p_idx, i| {
+                            for (dim_phys_indices.slice(), 0..) |p_idx, i| {
                                 axes[i] = .named(ctx, @tagName(mapping.view.axes.get(p_idx).tag));
                             }
                             break :d .closed(ctx, axes);
@@ -1457,7 +1449,7 @@ pub const Data = struct {
         }
 
         const replicated_axes = try allocator.alloc(*const dialects.shardy.AxisRefAttribute, mapping.replicated_axes.len);
-        for (replicated_axes, mapping.replicated_axes.constSlice()) |*r, p_idx| {
+        for (replicated_axes, mapping.replicated_axes.slice()) |*r, p_idx| {
             r.* = .named(ctx, @tagName(mapping.view.axes.get(p_idx).tag));
         }
 
@@ -1482,9 +1474,9 @@ pub const Data = struct {
         var tile_shape: stdx.BoundedArray(i64, Shape.MAX_RANK + 1) = .empty;
 
         //  Calculate tile sizes per tensor dimension
-        for (mapping.axes_per_dim.constSlice()) |dim_axes| {
+        for (mapping.axes_per_dim.slice()) |dim_axes| {
             var combined: i64 = 1;
-            for (dim_axes.constSlice()) |idx| {
+            for (dim_axes.slice()) |idx| {
                 combined *= mapping.view.axes.get(idx).size;
             }
             tile_shape.appendAssumeCapacity(combined);
@@ -1494,7 +1486,7 @@ pub const Data = struct {
         const has_replication = mapping.replicated_axes.len > 0;
         if (has_replication) {
             var repl_size: i64 = 1;
-            for (mapping.replicated_axes.constSlice()) |idx| {
+            for (mapping.replicated_axes.slice()) |idx| {
                 repl_size *= mapping.view.axes.get(idx).size;
             }
             tile_shape.appendAssumeCapacity(repl_size);
@@ -1509,7 +1501,7 @@ pub const Data = struct {
         defer allocator.free(ids);
 
         try out.writer.writeAll("{devices=[");
-        for (tile_shape.constSlice(), 0..) |s, i| {
+        for (tile_shape.slice(), 0..) |s, i| {
             if (i > 0) try out.writer.writeAll(",");
             try out.writer.print("{d}", .{s});
         }
@@ -1556,7 +1548,7 @@ pub const Data = struct {
         try writer.print("Sharding(name={s})\n", .{self.name});
 
         try writer.writeAll("Bindings:\n");
-        for (self.logical.axes.constSlice(), self.logical.intents.constSlice()) |l_tag, l_intent| {
+        for (self.logical.axes.slice(), self.logical.intents.slice()) |l_tag, l_intent| {
             try writer.print("  - {s} ({s}) -> ", .{ l_tag, @tagName(l_intent) });
 
             if (self.binding(l_tag)) |axes| {
@@ -1582,7 +1574,7 @@ pub const Data = struct {
         if (view.axes.len == 0) {
             try writer.writeAll("(none)\n");
         } else {
-            for (view.axes.constSlice(), 0..) |axis, i| {
+            for (view.axes.slice(), 0..) |axis, i| {
                 if (i > 0) try writer.writeAll(" × ");
                 try writer.print("{s}[{d}]", .{ @tagName(axis.tag), axis.size });
             }
@@ -1593,7 +1585,7 @@ pub const Data = struct {
         if (view.axes.len == 0) {
             try writer.writeAll("(none)\n");
         } else {
-            for (view.axes.constSlice(), 0..) |axis, i| {
+            for (view.axes.slice(), 0..) |axis, i| {
                 if (i > 0) try writer.writeAll(", ");
                 try writer.print("{s}={s}", .{
                     @tagName(axis.tag),
@@ -1621,6 +1613,8 @@ pub const Strategy = struct {
     bindings: Strategy.Bindings,
     folding: Folding,
 
+    // TODO: remove .init, promote .parseBindings to .init
+    // It's currently an error to call .init and never calling `addBinding`
     pub const init: Strategy = .{
         .bindings = .empty,
         .folding = .empty,
@@ -1628,8 +1622,10 @@ pub const Strategy = struct {
 
     pub fn parseBindings(bindings: anytype) Strategy {
         const err_msg = "Strategy.parseBindings excepts fields to be PhysicalAxisTag or tuple of PhysicalAxisTag, got {}";
-        var res: Strategy = .init;
-        inline for (@typeInfo(@TypeOf(bindings)).@"struct".fields) |field_info| {
+        var res: Strategy = .{ .bindings = .empty, .folding = .empty };
+        const fields = @typeInfo(@TypeOf(bindings)).@"struct".fields;
+        if (fields.len == 0) @compileError("Strategy.parseBindings requires at least one binding");
+        inline for (fields) |field_info| {
             switch (@typeInfo(field_info.type)) {
                 .enum_literal, .@"enum" => res.addBinding(field_info, @field(bindings, field_info.name)),
                 .@"struct" => |struct_info| {
@@ -1697,14 +1693,14 @@ pub const Strategy = struct {
         }
 
         if (available.len == 0) {
-            for (physical.axisOrder().constSlice()) |tag| available.appendAssumeCapacity(tag);
+            for (physical.axisOrder().slice()) |tag| available.appendAssumeCapacity(tag);
         }
 
-        const avail = available.constSlice();
+        const avail = available.slice();
         var counters = std.EnumArray(LogicalAxisIntent, usize).initFill(0);
 
         inline for (std.meta.tags(LogicalAxisIntent)) |target_intent| {
-            for (logical.axes.constSlice(), logical.intents.constSlice()) |l_tag, l_intent| {
+            for (logical.axes.slice(), logical.intents.slice()) |l_tag, l_intent| {
                 if (l_intent != target_intent) continue;
 
                 const i = counters.get(target_intent);
@@ -1737,7 +1733,6 @@ pub fn placement(sharding: Sharding, shape: Shape) !Placement {
 pub const Placement = struct {
     pub const Slices = stdx.BoundedArray(Slice1d, Shape.MAX_RANK);
     pub const Slice1d = struct {
-        axis: u8,
         start: i64,
         size: i64,
     };
@@ -1746,11 +1741,9 @@ pub const Placement = struct {
     shape: Shape,
     global_shape: if (builtin.mode == .Debug) Shape else void,
 
-    // This is a big field, reconsider how AxisSplit store information
     axis_plans: stdx.BoundedArray(AxisSplit, Shape.MAX_RANK),
 
     pub fn init(sharding: Sharding, shape: Shape) !Placement {
-        // TODO: placement should be device agnostic
         var pl: Placement = .{
             .sharding = sharding,
             .shape = shape, // modified below
@@ -1764,7 +1757,7 @@ pub const Placement = struct {
             pl.axis_plans.appendAssumeCapacity(try axisSplit(sharding, shape, &used_axes, axis_index));
         }
 
-        for (0.., shape.dims(), pl.axis_plans.constSlice()) |a, dim, plan| {
+        for (0.., shape.dims(), pl.axis_plans.slice()) |a, dim, plan| {
             pl.shape._dims.buffer[a] = @divExact(dim, plan.product());
         }
         return pl;
@@ -1772,10 +1765,9 @@ pub const Placement = struct {
 
     pub fn slices(pl: *const Placement, device: Device.Coords) Slices {
         var res: Slices = .{ .buffer = undefined, .len = pl.shape.rank() };
-        for (0.., res.slice(), pl.shape.dims(), pl.axis_plans.constSlice()) |a, *r, size, plan| {
+        for (res.slice(), pl.shape.dims(), pl.axis_plans.slice()) |*r, size, plan| {
             const start = plan.linearIndex(device) * size;
             r.* = .{
-                .axis = @intCast(a),
                 .start = start,
                 .size = size,
             };
@@ -1790,7 +1782,7 @@ pub const Placement = struct {
         }
 
         var ptr: [*]const u8 = slice.constData().ptr;
-        for (pl.shape.dims(), pl.axis_plans.constSlice(), slice.byte_strides.constSlice()) |size, plan, stride| {
+        for (pl.shape.dims(), pl.axis_plans.slice(), slice.byte_strides.slice()) |size, plan, stride| {
             const start = plan.linearIndex(device) * size;
             ptr = ptr[@intCast(start * stride)..];
         }
@@ -1818,9 +1810,9 @@ pub const Placement = struct {
         try writer.writeAll("Per-shard placement:\n");
         for (ordered_devices, 0..) |device, shard_index| {
             try writer.print("└─ Shard[{d}] device={d} coords={any}, slices=[", .{ shard_index, device.id, device.coords });
-            for (pl.slices(device.coords).constSlice(), 0..) |s, i| {
-                if (i > 0) try writer.writeAll(", ");
-                const axis_label = pl.shape.debugTag(s.axis);
+            for (0.., pl.slices(device.coords).slice()) |ax, s| {
+                if (ax > 0) try writer.writeAll(", ");
+                const axis_label = pl.shape.debugTag(ax);
                 try writer.print("{s}:[{d}:{d}]", .{ axis_label, s.start, s.start + s.size });
             }
             try writer.writeAll("]\n");
@@ -1835,7 +1827,7 @@ pub const Placement = struct {
         try writer.print("Placement(shape={f} shards={d})\n", .{ shape, shard_count });
 
         try writer.writeAll("Axis partitioning summary:\n");
-        for (0.., pl.slices(@splat(0)).constSlice()) |ax, slice| {
+        for (0.., pl.slices(@splat(0)).slice()) |ax, slice| {
             const dim = shape.dim(ax);
             const spec = shape.partition(ax);
             const axis_label = shape.debugTag(ax);
@@ -1990,12 +1982,12 @@ const ShardingTest = struct {
         }
 
         const tags: [3]PhysicalAxisTag = .{ .link_x, .link_y, .link_z };
-        var next_id: usize = 0;
+        var next_id: u32 = 0;
         const root = try self.buildNode(tags[0..N], sizes[0..N], 0, &next_id, geometry);
         return try .fromTree(self.allocator, .tpu, root);
     }
 
-    fn buildNode(self: ShardingTest, tags: []const PhysicalAxisTag, sizes: []const usize, depth: usize, next_id: *usize, geometry: AxisGeometry) !PhysicalNode {
+    fn buildNode(self: ShardingTest, tags: []const PhysicalAxisTag, sizes: []const usize, depth: usize, next_id: *u32, geometry: AxisGeometry) !PhysicalNode {
         if (depth == tags.len) {
             const id = next_id.*;
             next_id.* += 1;
@@ -2057,7 +2049,7 @@ const ShardingTest = struct {
                     // Consider rewriting test cases to use Slice1D. This requires passing the axis
                     const actual_start_len = try self.allocator.alloc([2]i64, actual_slices.len);
                     defer self.allocator.free(actual_start_len);
-                    for (actual_start_len, actual_slices.constSlice()) |*s_l, slice| {
+                    for (actual_start_len, actual_slices.slice()) |*s_l, slice| {
                         s_l.* = .{ slice.start, slice.size };
                     }
 

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -1787,20 +1787,33 @@ pub const Placement = struct {
         return res;
     }
 
-    pub fn shardSlice(pl: *const Placement, device_id: usize, slice: Slice) Slice {
+    pub fn shardPtr(pl: *const Placement, device_id: usize, slice: Slice) [*]const u8 {
         if (builtin.mode == .Debug) {
             // there is a bug in caller code that used a placement for a different shape
             std.debug.assert(pl.global_shape.eql(slice.shape));
         }
-
-        var offset_i64: i64 = @intCast(slice.offset_bytes);
-
         const coords = pl.deviceCoords(device_id);
+
+        var ptr: [*]const u8 = slice.constData().ptr;
         for (pl.shape.dims(), pl.axis_plans.constSlice(), slice.byte_strides.constSlice()) |size, plan, stride| {
             const start = plan.linearIndex(coords) * size;
-            offset_i64 += start * stride;
+            ptr = ptr[@intCast(start * stride)..];
         }
-        return .{ .inner_data = slice.inner_data, .shape = pl.shape, .offset_bytes = @intCast(offset_i64), .byte_strides = slice.byte_strides };
+        return ptr;
+    }
+
+    /// Given a Slice, returns the subslice corresponding to a specific device.
+    /// Depending on the layout, the sub-slice may or may not be contiguous.
+    pub fn shardSlice(pl: *const Placement, device_id: usize, slice: Slice) Slice {
+        const shard_ptr = pl.shardPtr(device_id, slice);
+        const offset_bytes = @intFromPtr(shard_ptr) - @intFromPtr(slice.bytes.ptr);
+        return .{
+            .bytes = slice.bytes,
+            .mutable = slice.mutable,
+            .shape = pl.shape,
+            .offset_bytes = offset_bytes,
+            .byte_strides = slice.byte_strides,
+        };
     }
 
     fn deviceCoords(pl: Placement, device_id: usize) [MAX_MESH_RANK]u8 {

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -108,8 +108,7 @@ pub const Partitioning = struct {
         const sharding = try self.selectSharding(shape);
         const ordered_devices = sharding.devicesInCanonicalOrder();
         if (ordered_devices.len == 0) return error.InvalidPhysicalMesh;
-        const placement_ = try sharding.placement(shape, ordered_devices[0]);
-        return placement_.shape.withDefaultPartitioning();
+        return sharding.shardedShape(shape);
     }
 
     pub fn numPartitionsForLogicalAxis(self: Partitioning, shape: Shape, logical_axis: anytype) !i64 {
@@ -1705,124 +1704,168 @@ pub const Strategy = struct {
     }
 };
 
-/// For a given shape, compute the size of the slice each shard will receive.
-pub fn shardedDims(sharding: Sharding, shape: Shape) Shape.DimsArray {
+/// For a given shape, compute the shape of the slice each shard will receive.
+pub fn shardedShape(sharding: Sharding, shape: Shape) !Shape {
     // TODO: simplify me
     // placement is doing too much work because Sharding creation doesn't enough.
-    const pl = sharding.placement(shape, sharding.data.physical.devices_in_canonical_order[0]) catch @panic("MissingDeviceCoords");
-    return pl.shape._dims;
+    const pl = try sharding.placement(shape);
+    return pl.shape;
 }
 
-pub fn placement(sharding: Sharding, shape: Shape, device: Device) !Placement {
-    // TODO: placement should be device agnostic
-    // For a given shape compute how it should be sharded across all devices,
-    // then getting the offset for a specific device should be easy peasy.
-    if (device.coords.len == 0) return error.MissingDeviceCoords;
+pub fn shardedDims(sharding: Sharding, shape: Shape) !Shape.DimsArray {
+    return (try sharding.shardedShape(shape))._dims;
+}
 
-    var placement_: Placement = .{
-        .device_id = device.id,
-        .device_coords = device.coords,
-        .shape = undefined,
-        .global_shape = shape,
-        .slices = .empty,
-    };
-    var used_axes: std.EnumSet(PhysicalAxisTag) = .empty;
-
-    for (0..shape.rank()) |ax| {
-        const axis_index: u8 = @intCast(ax);
-        const slice = try sliceForDevice(sharding, shape, placement_.device_coords.constSlice(), &used_axes, axis_index);
-        placement_.slices.appendAssumeCapacity(slice);
-    }
-
-    placement_.shape = blk: {
-        var sh = shape;
-        for (placement_.slices.constSlice()) |slice| {
-            sh = sh.set(slice.axis, slice.size);
-        }
-        break :blk sh;
-    };
-
-    return placement_;
+pub fn placement(sharding: Sharding, shape: Shape) !Placement {
+    return .init(sharding, shape);
 }
 
 pub const Placement = struct {
+    pub const Slices = stdx.BoundedArray(Slice1d, Shape.MAX_RANK);
     pub const Slice1d = struct {
         axis: u8,
         start: i64,
         size: i64,
     };
 
-    device_id: usize,
-    device_coords: stdx.BoundedArray(usize, Shape.MAX_RANK),
+    sharding: Sharding,
     shape: Shape,
     global_shape: Shape,
-    slices: stdx.BoundedArray(Slice1d, Shape.MAX_RANK),
+    // This is a big field, reconsider how AxisSplit store information
+    axis_splits: stdx.BoundedArray(AxisSplit, Shape.MAX_RANK),
 
-    pub fn platformDeviceIndex(self: *const Placement, platform: *const Platform) ?usize {
-        if (self.device_id >= platform.devices.len) return null;
-        return self.device_id;
+    pub fn init(sharding: Sharding, shape: Shape) !Placement {
+        // TODO: placement should be device agnostic
+        var pl: Placement = .{
+            .sharding = sharding,
+            .shape = shape, // modified below
+            .global_shape = shape,
+            .axis_splits = .empty, // set below
+        };
+        var used_axes: std.EnumSet(PhysicalAxisTag) = .empty;
+
+        for (0..shape.rank()) |ax| {
+            const axis_index: u8 = @intCast(ax);
+            pl.axis_splits.appendAssumeCapacity(try axisSplit(sharding, shape, &used_axes, axis_index));
+        }
+
+        for (0.., pl.axis_splits.constSlice()) |a, split| {
+            pl.shape._dims.buffer[a] = split.product;
+        }
+        return pl;
     }
 
-    pub fn shardSlice(self: *const Placement, slice: Slice) Slice {
+    pub fn slices(self: *const Placement, device_id: usize) Slices {
+        const coords = self.sharding.devicesInCanonicalOrder()[device_id].coords.constSlice();
+        var res: Slices = .{ .buffer = undefined, .len = self.shape.rank() };
+        for (0.., res.slice(), self.shape.dims(), self.axis_splits.constSlice()) |a, *r, dim, plan| {
+            const size = @divExact(dim, plan.product);
+            const start = plan.linearIndex(coords) * size;
+            r.* = .{
+                .axis = @intCast(a),
+                .start = start,
+                .size = size,
+            };
+        }
+        return res;
+    }
+
+    pub fn shardSlice(self: *const Placement, device_id: usize, slice: Slice) Slice {
+        _ = device_id; // TODO
         stdx.debug.assert(
             self.global_shape.eql(slice.shape),
             "Placement global shape {f} doesn't match slice shape {f}",
             .{ self.global_shape, slice.shape },
         );
 
-        var res = slice;
-        for (self.slices.constSlice()) |s| {
-            res = res.subSlice(s.axis, s.start, s.size);
+        var offset_i64: i64 = @intCast(slice.offset_bytes);
+        for (self.axis_splits.constSlice()) |split| {
+            // const dim = slice.shape.dim(s.axis);
+            const stride_bytes = slice.byte_strides.get(split.axis);
+            offset_i64 += split.start * stride_bytes;
         }
-        return res;
+        return .{ .inner_data = slice.inner_data, .shape = self.shape, .offset_bytes = @intCast(offset_i64), .byte_strides = slice.byte_strides };
     }
 
-    pub fn format(self: Placement, writer: *std.Io.Writer) !void {
-        try writer.print("device_id={d} coords={any}", .{ self.device_id, self.device_coords.constSlice() });
+    pub fn format(self: Placement, writer: *std.Io.Writer) std.Io.Writer.Error!void {
+        const ordered_devices = self.sharding.devicesInCanonicalOrder();
 
-        try writer.writeAll(" slices=[");
-        for (self.slices.constSlice(), 0..) |s, i| {
-            if (i > 0) try writer.writeAll(", ");
-            const axis_label = self.global_shape.debugTag(s.axis);
-            try writer.print("{s}:[{d}:{d}]", .{ axis_label, s.start, s.start + s.size });
+        try self.formatPlacementSummary(self.shape, ordered_devices.len, writer);
+        try writer.writeAll("Per-shard placement:\n");
+        for (ordered_devices, 0..) |device, shard_index| {
+            const device_id: u8 = @intCast(device.id);
+            try writer.print("└─ Shard[{d}] device_id={d} coords={any}, slices=[", .{ shard_index, device_id, device.coords });
+            for (self.slices(device_id).constSlice(), 0..) |s, i| {
+                if (i > 0) try writer.writeAll(", ");
+                const axis_label = self.global_shape.debugTag(s.axis);
+                try writer.print("{s}:[{d}:{d}]", .{ axis_label, s.start, s.start + s.size });
+            }
+            try writer.writeAll("]");
         }
-        try writer.writeAll("]");
+    }
+
+    fn formatPlacementSummary(self: Placement, shape: Shape, shard_count: usize, writer: *std.Io.Writer) std.Io.Writer.Error!void {
+        try writer.print("Placement(shape={f} shards={d})\n", .{ shape, shard_count });
+
+        try writer.writeAll("Axis partitioning summary:\n");
+        for (0..shape.rank()) |ax| {
+            const dim = shape.dim(ax);
+            const spec = shape.partition(ax);
+            const axis_label = shape.debugTag(ax);
+
+            var shard_size: i64 = dim;
+            for (self._slices.constSlice()) |s| {
+                if (s.axis == ax) {
+                    shard_size = s.size;
+                    break;
+                }
+            }
+
+            const shards_count: i64 = if (shard_size > 0 and @rem(dim, shard_size) == 0)
+                @divExact(dim, shard_size)
+            else
+                0;
+
+            try writer.print(
+                "└─ {s}: dim={d}, spec={s}, shard_size={d}, shards={d}\n",
+                .{ axis_label, dim, @tagName(spec), shard_size, shards_count },
+            );
+        }
     }
 };
 
 const AxisSplit = struct {
     product: i64,
     counts: stdx.BoundedArray(i64, Shape.MAX_RANK),
-    indices: stdx.BoundedArray(i64, Shape.MAX_RANK),
+    depths: stdx.BoundedArray(u8, Shape.MAX_RANK),
 
     pub const empty: AxisSplit = .{
         .product = 1,
         .counts = .empty,
-        .indices = .empty,
+        .depths = .empty,
     };
 
-    pub fn add(split: *AxisSplit, size: i64, coord: usize) void {
+    pub fn add(split: *AxisSplit, size: i64, depth: u8) void {
         split.counts.appendAssumeCapacity(size);
-        split.indices.appendAssumeCapacity(@intCast(coord));
+        split.depths.appendAssumeCapacity(depth);
         split.product *= size;
     }
 
-    pub fn linearIndex(self: AxisSplit) i64 {
+    pub fn linearIndex(self: AxisSplit, device_coords: []const usize) i64 {
         var linear: i64 = 0;
-        for (self.counts.constSlice(), self.indices.constSlice()) |c_, iidx| {
-            linear = linear * c_ + iidx;
+        for (self.counts.constSlice(), self.depths.constSlice()) |c_, depth| {
+            linear = linear * c_ + device_coords[depth];
         }
         return linear;
     }
 };
 
-fn sliceForDevice(
+fn axisSplit(
     sharding: Sharding,
     shape: Shape,
-    device_coords: []const usize,
     used_axes: *std.EnumSet(PhysicalAxisTag),
     axis_index: u8,
-) !Placement.Slice1d {
+) !AxisSplit {
     const dim = shape.dim(axis_index);
     const spec = shape.partition(axis_index);
 
@@ -1831,18 +1874,9 @@ fn sliceForDevice(
             const binding = sharding.data.binding(logical_tag) orelse return error.MissingLogicalBinding;
 
             // Calculate the split based on the physical coordinates of the current device.
-            const plan = try calculateSplit(sharding, dim, binding, device_coords, used_axes);
-
-            const size = @divExact(dim, plan.product);
-            const start = plan.linearIndex() * size;
-
-            return .{
-                .axis = axis_index,
-                .start = start,
-                .size = size,
-            };
+            return try calculateSplit(sharding, dim, binding, used_axes);
         },
-        else => return .{ .axis = axis_index, .start = 0, .size = dim },
+        else => return .empty,
     }
 }
 
@@ -1850,7 +1884,6 @@ fn calculateSplit(
     sharding: Sharding,
     dim: i64,
     binding: []const PhysicalAxisTag,
-    device_coords: []const usize,
     used_axes: *std.EnumSet(PhysicalAxisTag),
 ) !AxisSplit {
     var plan: AxisSplit = .empty;
@@ -1860,13 +1893,13 @@ fn calculateSplit(
         if (sharding.data.foldSources(p_tag)) |sources| {
             for (sources) |src| {
                 if (used_axes.contains(src)) continue;
-                addPhysicalToSplit(sharding, &plan, src, device_coords);
+                addPhysicalToSplit(sharding, &plan, src);
                 used_axes.insert(src);
             }
         } else {
             // Standard case: directly bound, not part of an explicit fold.
             if (used_axes.contains(p_tag)) continue;
-            addPhysicalToSplit(sharding, &plan, p_tag, device_coords);
+            addPhysicalToSplit(sharding, &plan, p_tag);
             used_axes.insert(p_tag);
         }
     }
@@ -1878,81 +1911,11 @@ fn calculateSplit(
 }
 
 /// Extract coordinate data from the physical mesh for a specific axis.
-fn addPhysicalToSplit(sharding: Sharding, plan: *AxisSplit, tag: PhysicalAxisTag, device_coords: []const usize) void {
+fn addPhysicalToSplit(sharding: Sharding, plan: *AxisSplit, tag: PhysicalAxisTag) void {
     const physical = sharding.data.physical;
     const info = physical.axisInfo(tag) orelse return;
     const depth = physical.axis_traversal.depth(tag) orelse return;
-    const coord = device_coords[depth];
-
-    plan.add(info.size, coord);
-}
-
-pub fn fmtPlacements(sharding: Sharding, shape: Shape) PlacementsFormatter {
-    return .{ .sharding = sharding, .shape = shape };
-}
-
-pub const PlacementsFormatter = struct {
-    sharding: Sharding,
-    shape: Shape,
-
-    pub fn format(self: PlacementsFormatter, writer: *std.Io.Writer) std.Io.Writer.Error!void {
-        const ordered_devices = self.sharding.devicesInCanonicalOrder();
-        const first_shard: ?Placement = if (ordered_devices.len > 0)
-            self.sharding.placement(self.shape, ordered_devices[0]) catch |err| return formatPlacementError(self.shape, ordered_devices.len, err, writer)
-        else
-            null;
-
-        try formatPlacementSummary(self.shape, ordered_devices.len, first_shard, writer);
-        try writer.writeAll("Per-shard placement:\n");
-        for (ordered_devices, 0..) |device, shard_index| {
-            const placement_ = self.sharding.placement(self.shape, device) catch |err| {
-                try writer.print("└─ Shard[{d}] error={s}\n", .{ shard_index, @errorName(err) });
-                return;
-            };
-            try writer.print("└─ Shard[{d}] {f}\n", .{ shard_index, placement_ });
-        }
-    }
-};
-
-fn formatPlacementSummary(shape: Shape, shard_count: usize, first_shard: ?Placement, writer: *std.Io.Writer) std.Io.Writer.Error!void {
-    try writer.print("Placement(shape={f} shards={d})\n", .{ shape, shard_count });
-
-    try writer.writeAll("Axis partitioning summary:\n");
-    for (0..shape.rank()) |ax| {
-        const dim = shape.dim(ax);
-        const spec = shape.partition(ax);
-        const axis_label = shape.debugTag(ax);
-
-        var shard_size: i64 = dim;
-        if (first_shard) |shard| {
-            for (shard.slices.constSlice()) |s| {
-                if (s.axis == ax) {
-                    shard_size = s.size;
-                    break;
-                }
-            }
-        }
-
-        const shards_count: i64 = if (shard_size > 0 and @rem(dim, shard_size) == 0)
-            @divExact(dim, shard_size)
-        else
-            0;
-
-        try writer.print(
-            "└─ {s}: dim={d}, spec={s}, shard_size={d}, shards={d}\n",
-            .{ axis_label, dim, @tagName(spec), shard_size, shards_count },
-        );
-    }
-}
-
-fn formatPlacementError(
-    shape: Shape,
-    shard_count: usize,
-    err: anyerror,
-    writer: *std.Io.Writer,
-) std.Io.Writer.Error!void {
-    try writer.print("Placement(shape={f} shards={d})\n", .{ shape, shard_count });
-    try writer.print("Shard placement error: {s}\n", .{@errorName(err)});
+    plan.add(info.size, depth);
 }
 
 const ShardingTest = struct {
@@ -2032,17 +1995,17 @@ const ShardingTest = struct {
         const ordered_devices = sharding_ref.devicesInCanonicalOrder();
         if (s.expect_error) |err| {
             try std.testing.expect(ordered_devices.len > 0);
-            try std.testing.expectError(err, sharding_ref.placement(s.shape, ordered_devices[0]));
+            try std.testing.expectError(err, sharding_ref.placement(s.shape));
             return;
         }
 
+        const pl = try sharding_ref.placement(s.shape);
         // Verify Shard Slices (Math)
         if (s.expected_shards.len > 0) {
             try std.testing.expectEqual(s.expected_shards.len, ordered_devices.len);
             for (s.expected_shards, ordered_devices) |expected, device| {
-                const actual = try sharding_ref.placement(s.shape, device);
-                try std.testing.expectEqual(expected.device_id, actual.device_id);
-                for (expected.slices, actual.slices.constSlice()) |exp_slice, actual_slice| {
+                const actual = pl.slices(@intCast(device.id));
+                for (expected.slices, actual.constSlice()) |exp_slice, actual_slice| {
                     try std.testing.expectEqual(exp_slice[0], actual_slice.start);
                     try std.testing.expectEqual(exp_slice[1], actual_slice.size);
                 }

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -1009,10 +1009,10 @@ pub const PhysicalMesh = struct {
                     const placement_ = placements[next_device_.*];
                     next_device_.* += 1;
 
-                    var coords: stdx.BoundedArray(u8, MAX_MESH_RANK) = .empty;
-                    for (coords_buf_[0..axis_tags_.len]) |coord| coords.appendAssumeCapacity(@intCast(coord));
+                    var coords: Device.Coords = @splat(0);
+                    for (coords_buf_[0..axis_tags_.len], 0..) |coord, i| coords[i] = @intCast(coord);
 
-                    return .{ .leaf = .{ .id = placement_.nc_id, .coords = coords } };
+                    return .{ .leaf = .{ .id = @intCast(placement_.nc_id), .coords = coords } };
                 }
 
                 const children = try allocator_.alloc(PhysicalNode, axis_sizes_[depth]);
@@ -1060,7 +1060,6 @@ pub const PhysicalMesh = struct {
             &next_device,
         );
         const mesh: PhysicalMesh = try fromOwnedTree(allocator, .neuron, root);
-        std.log.warn("Devices in devices_in_canonical_order with nc_ids: {any}", .{mesh.devices_in_canonical_order});
         for (mesh.devices_in_canonical_order) |*dev| {
             // In Node.build we use nc_id as the Device id.
             // But now we want to use the id to get the offset into platform.devices.
@@ -1073,7 +1072,6 @@ pub const PhysicalMesh = struct {
                 }
             }
         }
-        std.log.warn("Devices in devices_in_canonical_order with final ids: {any}", .{mesh.devices_in_canonical_order});
         return mesh;
     }
 };

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -113,20 +113,9 @@ pub const Buffer = struct {
         const slice = Slice.init(sh, data_);
         const buffer_type = pjrtx.bufferTypeFromDtype(sh.dtype());
 
-        const placement = try res._sharding.placement(res._shape);
+        const placement = try res._sharding.placement(sh);
         const shard_dims: []const i64 = placement.shape.dims();
-        const layout: pjrt.MemoryLayout = switch (platform.target) {
-            .tpu => tpu: {
-                if (comptime !platforms.isEnabled(.tpu)) unreachable;
-                const default = try platform.pjrt_client.defaultMemoryLayout(platform.pjrt_api, buffer_type, shard_dims);
-                break :tpu default.toMemoryLayout();
-            },
-            else => .{ .tiled = .{
-                .minor_to_major = constants.minorToMajor(sh.rank()),
-                .tile_dims = &.{},
-                .tile_dims_sizes = &.{},
-            } },
-        };
+        const layout = platform.defaultMemoryLayout(sh);
 
         for (platform.physical_mesh.devices_in_canonical_order) |device| {
             const args: pjrt.Client.BufferFromHostBufferArgs = .{

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 
 const pjrt = @import("pjrt");
+const platforms = @import("platforms");
 const stdx = @import("stdx");
 
 const constants = @import("constants.zig");
@@ -106,39 +107,47 @@ pub const Buffer = struct {
             shard.deinit(platform.pjrt_api);
         };
 
-        const buffer_type = pjrtx.bufferTypeFromDtype(sh.dtype());
         const slice = Slice.init(sh, data_);
+        const buffer_type = pjrtx.bufferTypeFromDtype(sh.dtype());
 
-        for (res._sharding.devicesInCanonicalOrder()) |device| {
+        var layout: pjrt.MemoryLayout = undefined;
+        var shard_dims: Shape.DimsArray = .{ .buffer = undefined, .len = sh.rank() };
+
+        for (0.., platform.physical_mesh.devices_in_canonical_order) |device_id, device| {
             const placement = try res._sharding.placement(res._shape, device);
             const sub_slice = placement.shardSlice(slice);
-            var default_layout: ?pjrt.DefaultMemoryLayout = null;
-            const layout: pjrt.MemoryLayout = switch (platform.target) {
-                .tpu => blk: {
-                    default_layout = try platform.pjrt_client.defaultMemoryLayout(
-                        platform.pjrt_api,
-                        pjrtx.bufferTypeFromDtype(placement.shape.dtype()),
-                        placement.shape.dims(),
-                    );
-                    break :blk default_layout.?.toMemoryLayout();
-                },
-                else => .{
-                    .tiled = .{
-                        .minor_to_major = constants.minorToMajor(placement.shape.rank()),
-                        .tile_dims = &.{},
-                        .tile_dims_sizes = &.{},
-                    },
-                },
-            };
+            if (device_id == 0) {
+	            shard_dims.buffer = placement.shape._dims.buffer;
+	            layout = switch (platform.target) {
+	                .tpu => tpu: {
+	                	if (comptime !platforms.isEnabled(.tpu)) unreachable;
+	                    const default = try platform.pjrt_client.defaultMemoryLayout(
+	                        platform.pjrt_api,
+	                        buffer_type,
+	                        shard_dims.slice()
+	                    );
+	                    break :tpu default.toMemoryLayout();
+	                },
+	                else => .{
+	                    .tiled = .{
+	                        .minor_to_major = constants.minorToMajor(sh.rank()),
+	                        .tile_dims = &.{},
+	                        .tile_dims_sizes = &.{},
+	                    }
+	                },
+	            };
+            }
+
             const args: pjrt.Client.BufferFromHostBufferArgs = .{
-                .data = sub_slice.constData().ptr,
-                .buffer_type = buffer_type,
-                .dims = placement.shape.dims(),
-                .byte_strides = sub_slice.byte_strides.constSlice(),
-                .layout = layout,
-                .host_buffer_semantics = .ImmutableUntilTransferCompletes,
-                .dst = .{ .memory = placement.memory(platform, opts.memory).pjrt_memory },
-            };
+	            .data = sub_slice.constData().ptr,
+	            .dst = .{ .memory = platform.devices[device_id].memory(opts.memory).pjrt_memory },
+	            .layout = layout, // set on first iter
+	            .dims = shard_dims.slice(), // filled on first iter
+	            .buffer_type = buffer_type,
+	            .byte_strides = slice.byte_strides.constSlice(),
+	            .host_buffer_semantics = .ImmutableUntilTransferCompletes,
+	        };
+
 
             const pjrt_buffer, const event = try platform.pjrt_client.bufferFromHostBuffer(platform.pjrt_api, args);
             if (event) |ev| ev.deinit(platform.pjrt_api);
@@ -222,6 +231,8 @@ pub const Buffer = struct {
         const element_type = pjrtx.bufferTypeFromDtype(res._shape.dtype()); // dtype doesn't change with sharding.
         for (res._sharding.devicesInCanonicalOrder()) |device| {
             const placement = try res._sharding.placement(res._shape, device);
+            const device_index = placement.platformDeviceIndex(platform) orelse unreachable;
+            const dst_memory = platform.devices[device_index].memory(opts.memory);
             var default_layout: ?pjrt.DefaultMemoryLayout = null;
             const layout: pjrt.MemoryLayout = switch (platform.target) {
                 .tpu => blk: {
@@ -244,7 +255,7 @@ pub const Buffer = struct {
                 .dims = placement.shape.dims(),
                 .element_type = element_type,
                 .layout = layout,
-                .dst = .{ .memory = placement.memory(platform, opts.memory).pjrt_memory },
+                .dst = .{ .memory = dst_memory.pjrt_memory },
             };
 
             const shard_buffer = try platform.pjrt_client.createUninitializedBuffer(platform.pjrt_api, args);

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -129,11 +129,9 @@ pub const Buffer = struct {
         };
 
         for (platform.physical_mesh.devices_in_canonical_order) |device| {
-            const sub_slice = placement.shardSlice(device.id, slice);
-
             const args: pjrt.Client.BufferFromHostBufferArgs = .{
                 // Change for each device
-                .data = sub_slice.constData().ptr,
+                .data = placement.shardPtr(device.id, slice),
                 .dst = .{ .memory = platform.devices[device.id].memory(opts.memory).pjrt_memory },
                 // Constant across devices
                 .layout = layout,
@@ -272,15 +270,12 @@ pub const Buffer = struct {
 
         const placement = try self._sharding.placement(self._shape);
         for (self._sharding.devicesInCanonicalOrder(), 0..) |device, shard_index| {
+            // TODO: handle replicated information, we shouldn't iterate over all the devices unless needed
             const sub_slice = placement.shardSlice(device.id, slice);
             if (!sub_slice.isContiguous()) return error.NonContiguousShardRead;
 
             const size_bytes = placement.shape.byteSize();
-            const start = sub_slice.offset_bytes;
-            const end = start + size_bytes;
-            stdx.debug.assert(end <= slice.constData().len, "Shard sub_slice exceeds destination slice", .{});
-
-            const destination = slice.data()[start..end];
+            const destination = sub_slice.data()[0..size_bytes];
             const maybe_event = try self._shards.get(shard_index).toHostBuffer(self._platform.pjrt_api, destination);
 
             if (maybe_event) |event| {

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -120,7 +120,7 @@ pub const Buffer = struct {
 
         const placement = try res._sharding.placement(sh);
         const shard_dims: []const i64 = placement.shape.dims();
-        const layout = platform.defaultMemoryLayout(sh);
+        const layout = platform.defaultMemoryLayout(shard_dims, sh.dtype());
 
         for (platform.physical_mesh.devices_in_canonical_order) |device| {
             const memory = platform.devices[device.id].memory(opts.memory).?;
@@ -216,10 +216,10 @@ pub const Buffer = struct {
         };
 
         stdx.debug.assert(platform.devices[0].memory(opts.memory) != null, "Device doesn't have {} memory", .{opts.memory});
-        const element_type = pjrtx.bufferTypeFromDtype(res._shape.dtype());
-        const placement = try res._sharding.placement(res._shape);
+        const element_type = pjrtx.bufferTypeFromDtype(sh.dtype());
+        const placement = try res._sharding.placement(sh);
         const shard_dims: []const i64 = placement.shape.dims();
-        const layout = platform.defaultMemoryLayout(res._shape);
+        const layout = platform.defaultMemoryLayout(shard_dims, sh.dtype());
 
         for (platform.physical_mesh.devices_in_canonical_order) |device| {
             const memory = platform.devices[device.id].memory(opts.memory).?;

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -221,35 +221,19 @@ pub const Buffer = struct {
             shard.deinit(platform.pjrt_api);
         };
 
-        const minor_to_major = constants.minorToMajor(res._shape.rank()); // Rank doesn't change with sharding.
-        const element_type = pjrtx.bufferTypeFromDtype(res._shape.dtype()); // dtype doesn't change with sharding.
-        for (res._sharding.devicesInCanonicalOrder()) |device| {
-            const placement = try res._sharding.placement(res._shape, device);
-            const device_index = placement.platformDeviceIndex(platform) orelse unreachable;
-            const dst_memory = platform.devices[device_index].memory(opts.memory);
-            var default_layout: ?pjrt.DefaultMemoryLayout = null;
-            const layout: pjrt.MemoryLayout = switch (platform.target) {
-                .tpu => blk: {
-                    default_layout = try platform.pjrt_client.defaultMemoryLayout(
-                        platform.pjrt_api,
-                        pjrtx.bufferTypeFromDtype(placement.shape.dtype()),
-                        placement.shape.dims(),
-                    );
-                    break :blk default_layout.?.toMemoryLayout();
-                },
-                else => .{
-                    .tiled = .{
-                        .minor_to_major = minor_to_major,
-                        .tile_dims = &.{},
-                        .tile_dims_sizes = &.{},
-                    },
-                },
-            };
+        const element_type = pjrtx.bufferTypeFromDtype(res._shape.dtype());
+        const placement = try res._sharding.placement(res._shape);
+        const shard_dims: []const i64 = placement.shape.dims();
+        const layout = platform.defaultMemoryLayout(res._shape);
+
+        for (platform.physical_mesh.devices_in_canonical_order) |device| {
             const args: pjrt.Client.CreateUninitializedBufferArgs = .{
-                .dims = placement.shape.dims(),
-                .element_type = element_type,
+                // Change for each device
+                .dst = .{ .memory = platform.devices[device.id].memory(opts.memory).pjrt_memory },
+                // Constant across devices
                 .layout = layout,
-                .dst = .{ .memory = dst_memory.pjrt_memory },
+                .dims = shard_dims,
+                .element_type = element_type,
             };
 
             const shard_buffer = try platform.pjrt_client.createUninitializedBuffer(platform.pjrt_api, args);

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -77,7 +77,7 @@ pub const Buffer = struct {
         return self._shape;
     }
 
-    pub fn numDevices(self: Buffer) u32 {
+    pub fn numShards(self: Buffer) u32 {
         return @intCast(self._shards.len);
     }
 

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -121,7 +121,7 @@ pub const Buffer = struct {
             const args: pjrt.Client.BufferFromHostBufferArgs = .{
                 // Change for each device
                 .data = placement.shardPtr(device.coords, slice),
-                .dst = .{ .memory = platform.devices[device.id].memory(opts.memory).pjrt_memory },
+                .dst = .{ .memory = if (platform.devices[device.id].memory(opts.memory)) |m| m.pjrt_memory else @panic("Device doesn't have this memory") },
                 // Constant across devices
                 .layout = layout,
                 .dims = shard_dims,

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -131,7 +131,7 @@ pub const Buffer = struct {
         for (platform.physical_mesh.devices_in_canonical_order) |device| {
             const args: pjrt.Client.BufferFromHostBufferArgs = .{
                 // Change for each device
-                .data = placement.shardPtr(device.id, slice),
+                .data = placement.shardPtr(device.coords, slice),
                 .dst = .{ .memory = platform.devices[device.id].memory(opts.memory).pjrt_memory },
                 // Constant across devices
                 .layout = layout,
@@ -271,7 +271,7 @@ pub const Buffer = struct {
         const placement = try self._sharding.placement(self._shape);
         for (self._sharding.devicesInCanonicalOrder(), 0..) |device, shard_index| {
             // TODO: handle replicated information, we shouldn't iterate over all the devices unless needed
-            const sub_slice = placement.shardSlice(device.id, slice);
+            const sub_slice = placement.shardSlice(device.coords, slice);
             if (!sub_slice.isContiguous()) return error.NonContiguousShardRead;
 
             const size_bytes = placement.shape.byteSize();
@@ -292,7 +292,7 @@ pub const Buffer = struct {
 
         const placement = try self._sharding.placement(self._shape);
         for (self._sharding.devicesInCanonicalOrder(), 0..) |device, shard_index| {
-            const sub_slice = placement.shardSlice(device.id, slice);
+            const sub_slice = placement.shardSlice(device.coords, slice);
 
             var shard_slice = try Slice.alloc(allocator, sub_slice.shape);
             defer shard_slice.free(allocator);

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -110,44 +110,41 @@ pub const Buffer = struct {
         const slice = Slice.init(sh, data_);
         const buffer_type = pjrtx.bufferTypeFromDtype(sh.dtype());
 
-        var layout: pjrt.MemoryLayout = undefined;
-        var shard_dims: Shape.DimsArray = .{ .buffer = undefined, .len = sh.rank() };
+        var shard_dims: Shape.DimsArray = res._sharding.shardedDims(sh);
+        const layout: pjrt.MemoryLayout = switch (platform.target) {
+            .tpu => tpu: {
+            	if (comptime !platforms.isEnabled(.tpu)) unreachable;
+                const default = try platform.pjrt_client.defaultMemoryLayout(
+                    platform.pjrt_api,
+                    buffer_type,
+                    shard_dims.slice()
+                );
+                break :tpu default.toMemoryLayout();
+            },
+            else => .{
+                .tiled = .{
+                    .minor_to_major = constants.minorToMajor(sh.rank()),
+                    .tile_dims = &.{},
+                    .tile_dims_sizes = &.{},
+                }
+            },
+        };
 
         for (0.., platform.physical_mesh.devices_in_canonical_order) |device_id, device| {
             const placement = try res._sharding.placement(res._shape, device);
             const sub_slice = placement.shardSlice(slice);
-            if (device_id == 0) {
-	            shard_dims.buffer = placement.shape._dims.buffer;
-	            layout = switch (platform.target) {
-	                .tpu => tpu: {
-	                	if (comptime !platforms.isEnabled(.tpu)) unreachable;
-	                    const default = try platform.pjrt_client.defaultMemoryLayout(
-	                        platform.pjrt_api,
-	                        buffer_type,
-	                        shard_dims.slice()
-	                    );
-	                    break :tpu default.toMemoryLayout();
-	                },
-	                else => .{
-	                    .tiled = .{
-	                        .minor_to_major = constants.minorToMajor(sh.rank()),
-	                        .tile_dims = &.{},
-	                        .tile_dims_sizes = &.{},
-	                    }
-	                },
-	            };
-            }
 
             const args: pjrt.Client.BufferFromHostBufferArgs = .{
+            	// Change for each device
 	            .data = sub_slice.constData().ptr,
 	            .dst = .{ .memory = platform.devices[device_id].memory(opts.memory).pjrt_memory },
-	            .layout = layout, // set on first iter
-	            .dims = shard_dims.slice(), // filled on first iter
+	            // Constant across devices
+	            .layout = layout,
+	            .dims = shard_dims.slice(),
 	            .buffer_type = buffer_type,
 	            .byte_strides = slice.byte_strides.constSlice(),
 	            .host_buffer_semantics = .ImmutableUntilTransferCompletes,
 	        };
-
 
             const pjrt_buffer, const event = try platform.pjrt_client.bufferFromHostBuffer(platform.pjrt_api, args);
             if (event) |ev| ev.deinit(platform.pjrt_api);

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -85,7 +85,10 @@ pub const Buffer = struct {
     }
 
     pub fn format(self: Buffer, writer: *std.Io.Writer) !void {
-        try writer.print("{f}", .{self._sharding.fmtPlacements(self._shape)});
+        const placement = self._sharding.placement(self._shape) catch {
+            return try writer.print("sharding error {} vs {}", .{ self._sharding, self._shape });
+        };
+        try writer.print("{f}", .{placement});
     }
 
     /// Copies the content of the given buffer from host memory to the accelerator memory.
@@ -110,11 +113,12 @@ pub const Buffer = struct {
         const slice = Slice.init(sh, data_);
         const buffer_type = pjrtx.bufferTypeFromDtype(sh.dtype());
 
-        var shard_dims: Shape.DimsArray = res._sharding.shardedDims(sh);
+        const placement = try res._sharding.placement(res._shape);
+        const shard_dims: []const i64 = placement.shape.dims();
         const layout: pjrt.MemoryLayout = switch (platform.target) {
             .tpu => tpu: {
                 if (comptime !platforms.isEnabled(.tpu)) unreachable;
-                const default = try platform.pjrt_client.defaultMemoryLayout(platform.pjrt_api, buffer_type, shard_dims.slice());
+                const default = try platform.pjrt_client.defaultMemoryLayout(platform.pjrt_api, buffer_type, shard_dims);
                 break :tpu default.toMemoryLayout();
             },
             else => .{ .tiled = .{
@@ -124,17 +128,16 @@ pub const Buffer = struct {
             } },
         };
 
-        for (0.., platform.physical_mesh.devices_in_canonical_order) |device_id, device| {
-            const placement = try res._sharding.placement(res._shape, device);
-            const sub_slice = placement.shardSlice(slice);
+        for (platform.physical_mesh.devices_in_canonical_order) |device| {
+            const sub_slice = placement.shardSlice(device.id, slice);
 
             const args: pjrt.Client.BufferFromHostBufferArgs = .{
                 // Change for each device
                 .data = sub_slice.constData().ptr,
-                .dst = .{ .memory = platform.devices[device_id].memory(opts.memory).pjrt_memory },
+                .dst = .{ .memory = platform.devices[device.id].memory(opts.memory).pjrt_memory },
                 // Constant across devices
                 .layout = layout,
-                .dims = shard_dims.slice(),
+                .dims = shard_dims,
                 .buffer_type = buffer_type,
                 .byte_strides = slice.byte_strides.constSlice(),
                 .host_buffer_semantics = .ImmutableUntilTransferCompletes,
@@ -283,9 +286,9 @@ pub const Buffer = struct {
     pub fn toSlice(self: Buffer, io: std.Io, slice: Slice) !void {
         stdx.debug.assert(self._shape.eql(slice.shape), "Buffer shape {f} doesn't match destination slice {f}", .{ self._shape, slice.shape });
 
+        const placement = try self._sharding.placement(self._shape);
         for (self._sharding.devicesInCanonicalOrder(), 0..) |device, shard_index| {
-            const placement = try self._sharding.placement(self._shape, device);
-            const sub_slice = placement.shardSlice(slice);
+            const sub_slice = placement.shardSlice(device.id, slice);
             if (!sub_slice.isContiguous()) return error.NonContiguousShardRead;
 
             const size_bytes = placement.shape.byteSize();
@@ -308,9 +311,9 @@ pub const Buffer = struct {
         const slice = try Slice.alloc(allocator, self.shape());
         errdefer slice.free(allocator);
 
+        const placement = try self._sharding.placement(self._shape);
         for (self._sharding.devicesInCanonicalOrder(), 0..) |device, shard_index| {
-            const placement = try self._sharding.placement(self._shape, device);
-            const sub_slice = placement.shardSlice(slice);
+            const sub_slice = placement.shardSlice(device.id, slice);
 
             var shard_slice = try Slice.alloc(allocator, sub_slice.shape);
             defer shard_slice.free(allocator);

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -114,6 +114,7 @@ pub const Buffer = struct {
             shard.deinit(platform.pjrt_api);
         };
 
+        stdx.debug.assert(platform.devices[0].memory(opts.memory) != null, "Device doesn't have {} memory", .{opts.memory});
         const slice = Slice.init(sh, data_);
         const buffer_type = pjrtx.bufferTypeFromDtype(sh.dtype());
 
@@ -122,8 +123,7 @@ pub const Buffer = struct {
         const layout = platform.defaultMemoryLayout(sh);
 
         for (platform.physical_mesh.devices_in_canonical_order) |device| {
-            // TODO: detect this failure earlier and out of the for loop.
-            const memory = platform.devices[device.id].memory(opts.memory) orelse @panic("Device doesn't have this memory");
+            const memory = platform.devices[device.id].memory(opts.memory).?;
             const args: pjrt.Client.BufferFromHostBufferArgs = .{
                 // Change for each device
                 .data = placement.shardPtr(device.coords, slice),
@@ -196,6 +196,7 @@ pub const Buffer = struct {
             .neuron => {
                 const allocator = std.heap.smp_allocator;
 
+                // TODO: use the strides trick to avoid allocating so much memory
                 const host = try allocator.alloc(u8, sh.byteSize());
                 defer allocator.free(host);
 
@@ -214,13 +215,14 @@ pub const Buffer = struct {
             shard.deinit(platform.pjrt_api);
         };
 
+        stdx.debug.assert(platform.devices[0].memory(opts.memory) != null, "Device doesn't have {} memory", .{opts.memory});
         const element_type = pjrtx.bufferTypeFromDtype(res._shape.dtype());
         const placement = try res._sharding.placement(res._shape);
         const shard_dims: []const i64 = placement.shape.dims();
         const layout = platform.defaultMemoryLayout(res._shape);
 
         for (platform.physical_mesh.devices_in_canonical_order) |device| {
-            const memory = platform.devices[device.id].memory(opts.memory) orelse @panic("Device doesn't have this memory");
+            const memory = platform.devices[device.id].memory(opts.memory).?;
             const args: pjrt.Client.CreateUninitializedBufferArgs = .{
                 // Change for each device
                 .dst = .{ .memory = memory.pjrt_memory },

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -113,21 +113,15 @@ pub const Buffer = struct {
         var shard_dims: Shape.DimsArray = res._sharding.shardedDims(sh);
         const layout: pjrt.MemoryLayout = switch (platform.target) {
             .tpu => tpu: {
-            	if (comptime !platforms.isEnabled(.tpu)) unreachable;
-                const default = try platform.pjrt_client.defaultMemoryLayout(
-                    platform.pjrt_api,
-                    buffer_type,
-                    shard_dims.slice()
-                );
+                if (comptime !platforms.isEnabled(.tpu)) unreachable;
+                const default = try platform.pjrt_client.defaultMemoryLayout(platform.pjrt_api, buffer_type, shard_dims.slice());
                 break :tpu default.toMemoryLayout();
             },
-            else => .{
-                .tiled = .{
-                    .minor_to_major = constants.minorToMajor(sh.rank()),
-                    .tile_dims = &.{},
-                    .tile_dims_sizes = &.{},
-                }
-            },
+            else => .{ .tiled = .{
+                .minor_to_major = constants.minorToMajor(sh.rank()),
+                .tile_dims = &.{},
+                .tile_dims_sizes = &.{},
+            } },
         };
 
         for (0.., platform.physical_mesh.devices_in_canonical_order) |device_id, device| {
@@ -135,16 +129,16 @@ pub const Buffer = struct {
             const sub_slice = placement.shardSlice(slice);
 
             const args: pjrt.Client.BufferFromHostBufferArgs = .{
-            	// Change for each device
-	            .data = sub_slice.constData().ptr,
-	            .dst = .{ .memory = platform.devices[device_id].memory(opts.memory).pjrt_memory },
-	            // Constant across devices
-	            .layout = layout,
-	            .dims = shard_dims.slice(),
-	            .buffer_type = buffer_type,
-	            .byte_strides = slice.byte_strides.constSlice(),
-	            .host_buffer_semantics = .ImmutableUntilTransferCompletes,
-	        };
+                // Change for each device
+                .data = sub_slice.constData().ptr,
+                .dst = .{ .memory = platform.devices[device_id].memory(opts.memory).pjrt_memory },
+                // Constant across devices
+                .layout = layout,
+                .dims = shard_dims.slice(),
+                .buffer_type = buffer_type,
+                .byte_strides = slice.byte_strides.constSlice(),
+                .host_buffer_semantics = .ImmutableUntilTransferCompletes,
+            };
 
             const pjrt_buffer, const event = try platform.pjrt_client.bufferFromHostBuffer(platform.pjrt_api, args);
             if (event) |ev| ev.deinit(platform.pjrt_api);

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -77,6 +77,10 @@ pub const Buffer = struct {
         return self._shape;
     }
 
+    pub fn numDevices(self: Buffer) u32 {
+        return @intCast(self._shards.len);
+    }
+
     pub fn shards(self: *const Buffer) ShardIterator {
         return .{
             ._platform = self._platform,
@@ -118,10 +122,12 @@ pub const Buffer = struct {
         const layout = platform.defaultMemoryLayout(sh);
 
         for (platform.physical_mesh.devices_in_canonical_order) |device| {
+            // TODO: detect this failure earlier and out of the for loop.
+            const memory = platform.devices[device.id].memory(opts.memory) orelse @panic("Device doesn't have this memory");
             const args: pjrt.Client.BufferFromHostBufferArgs = .{
                 // Change for each device
                 .data = placement.shardPtr(device.coords, slice),
-                .dst = .{ .memory = if (platform.devices[device.id].memory(opts.memory)) |m| m.pjrt_memory else @panic("Device doesn't have this memory") },
+                .dst = .{ .memory = memory.pjrt_memory },
                 // Constant across devices
                 .layout = layout,
                 .dims = shard_dims,
@@ -214,9 +220,10 @@ pub const Buffer = struct {
         const layout = platform.defaultMemoryLayout(res._shape);
 
         for (platform.physical_mesh.devices_in_canonical_order) |device| {
+            const memory = platform.devices[device.id].memory(opts.memory) orelse @panic("Device doesn't have this memory");
             const args: pjrt.Client.CreateUninitializedBufferArgs = .{
                 // Change for each device
-                .dst = .{ .memory = platform.devices[device.id].memory(opts.memory).pjrt_memory },
+                .dst = .{ .memory = memory.pjrt_memory },
                 // Constant across devices
                 .layout = layout,
                 .dims = shard_dims,
@@ -306,5 +313,9 @@ pub const Buffer = struct {
         }
 
         return byte_size;
+    }
+
+    pub fn opaqueDevicePtr(self: Buffer, device_id: usize) *anyopaque {
+        return self._shards.get(device_id).opaqueDeviceMemoryDataPointer(self._platform.pjrt_api) catch unreachable;
     }
 };

--- a/zml/io.zig
+++ b/zml/io.zig
@@ -806,8 +806,9 @@ pub const DirectMemoryWriter = struct {
             const device_index = placement.platformDeviceIndex(platform) orelse return error.UnknownShardDevice;
             const pool = &pools[device_index];
             const shard_dma_allocator = dma_allocators[device_index].allocator();
+            const dst_memory = platform.devices[device_index].memory(.default);
 
-            shard_writers[i] = try DirectShardWriter.init(shard_dma_allocator, io, placement.memory(platform, .default), pool, placement.shape);
+            shard_writers[i] = try DirectShardWriter.init(shard_dma_allocator, io, dst_memory, pool, placement.shape);
 
             pjrt_buffers.appendAssumeCapacity(shard_writers[i].pjrt_buffer);
         }

--- a/zml/io.zig
+++ b/zml/io.zig
@@ -789,7 +789,7 @@ pub const DirectMemoryWriter = struct {
 
             const pool = &pools[device.id];
             const shard_dma_allocator = dma_allocators[device.id].allocator();
-            const dst_memory = platform.devices[device.id].memory(.default);
+            const dst_memory = platform.devices[device.id].memory(.default).?;
 
             shard_writers[i] = try DirectShardWriter.init(shard_dma_allocator, io, dst_memory, pool, placement.shape);
 

--- a/zml/io.zig
+++ b/zml/io.zig
@@ -630,7 +630,7 @@ pub const DirectMemoryWriter = struct {
         fn collectRawSegments(self: *StreamPlanner) !void {
             const placement = try self.sharding.placement(self.shape);
             for (self.sharding.devicesInCanonicalOrder(), 0..) |device, writer_index| {
-                try self.appendShardSegments(placement.slices(device.id).constSlice(), writer_index);
+                try self.appendShardSegments(placement.slices(device.coords).constSlice(), writer_index);
             }
         }
 

--- a/zml/io.zig
+++ b/zml/io.zig
@@ -691,22 +691,6 @@ pub const DirectMemoryWriter = struct {
             });
         }
 
-        fn axisRange(self: *const StreamPlanner, slices: []const Placement.Slice1d, axis: usize) AxisRange {
-            for (slices) |slice| {
-                if (slice.axis == axis) {
-                    return .{
-                        .start = slice.start,
-                        .size = slice.size,
-                    };
-                }
-            }
-
-            return .{
-                .start = 0,
-                .size = self.shape.dim(axis),
-            };
-        }
-
         fn appendShardSegmentsAtAxis(
             self: *StreamPlanner,
             slices: []const Placement.Slice1d,
@@ -716,7 +700,7 @@ pub const DirectMemoryWriter = struct {
             base_start: i64,
             strides: []const i64,
         ) !void {
-            const range = self.axisRange(slices, axis);
+            const range: AxisRange = .{ .start = slices[axis].start, .size = slices[axis].size };
             if (range.size == 0) return;
 
             if (axis + 1 == rank) {

--- a/zml/io.zig
+++ b/zml/io.zig
@@ -1361,12 +1361,7 @@ test "DirectMemoryWriter: replicated with auto topology" {
         .shape = Shape.init(.{ .rows = 8, .cols = 128 }, .f32)
             .withPartitioning(.{ .rows = .replicated, .cols = .replicated }),
         .logical_mesh = .mesh(.{ .x = .high_bandwidth }),
-        .strategy = blk: {
-            var strategy: Sharding.Strategy = .init;
-            strategy.addBinding(.x, .link_x);
-
-            break :blk strategy;
-        },
+        .strategy = .parseBindings(.{ .x = .link_x }),
     });
 }
 
@@ -1385,12 +1380,7 @@ test "DirectMemoryWriter: 1D model split with 2x2 physical mesh" {
         .shape = Shape.init(.{ .rows = 8, .cols = 1024 }, .f32)
             .withPartitioning(.{ .rows = .replicated, .cols = .model }),
         .logical_mesh = .mesh(.{ .model = .high_bandwidth }),
-        .strategy = blk: {
-            var strategy: Sharding.Strategy = .init;
-            strategy.addBinding(.model, .link_x);
-
-            break :blk strategy;
-        },
+        .strategy = .parseBindings(.{ .model = .link_x }),
     });
 }
 
@@ -1412,13 +1402,7 @@ test "DirectMemoryWriter: 2D batch/model split with 2x2 physical mesh" {
             .batch = .low_bandwidth,
             .model = .high_bandwidth,
         }),
-        .strategy = blk: {
-            var strategy: Sharding.Strategy = .init;
-            strategy.addBinding(.batch, .link_x);
-            strategy.addBinding(.model, .link_y);
-
-            break :blk strategy;
-        },
+        .strategy = .parseBindings(.{ .batch = .link_x, .model = .link_y }),
     });
 }
 
@@ -1437,10 +1421,8 @@ test "DirectMemoryWriter: folded model sharding with 2x2 physical mesh" {
         .shape = Shape.init(.{ .model = 4096 }, .f32).withPartitioning(.{ .model = .model }),
         .logical_mesh = .mesh(.{ .model = .high_bandwidth }),
         .strategy = blk: {
-            var strategy: Sharding.Strategy = .init;
-            strategy.addBinding(.model, .link_x);
+            var strategy: Sharding.Strategy = .parseBindings(.{ .model = .link_x });
             strategy.addFold(.link_x, &.{ .link_x, .link_y });
-
             break :blk strategy;
         },
     });
@@ -1461,12 +1443,7 @@ test "DirectMemoryWriter: writableSliceGreedy with mirrored shards" {
         .shape = Shape.init(.{ .rows = 8, .cols = 1024 }, .f32)
             .withPartitioning(.{ .rows = .replicated, .cols = .model }),
         .logical_mesh = .mesh(.{ .model = .high_bandwidth }),
-        .strategy = blk: {
-            var strategy: Sharding.Strategy = .init;
-            strategy.addBinding(.model, .link_x);
-
-            break :blk strategy;
-        },
+        .strategy = .parseBindings(.{ .model = .link_x }),
         .write_mode = .writable_slice_greedy,
         .writable_slice_min_len = 64,
         .pool_chunk_size = 1024,
@@ -1492,10 +1469,8 @@ test "DirectMemoryWriter: 3D topology folded model + replicated batch" {
             .model = .high_bandwidth,
         }),
         .strategy = blk: {
-            var strategy: Sharding.Strategy = .init;
-            strategy.addBinding(.model, .link_x);
+            var strategy: Sharding.Strategy = .parseBindings(.{ .model = .link_x });
             strategy.addFold(.link_x, &.{ .link_x, .link_z });
-
             break :blk strategy;
         },
     });

--- a/zml/io.zig
+++ b/zml/io.zig
@@ -628,9 +628,9 @@ pub const DirectMemoryWriter = struct {
         }
 
         fn collectRawSegments(self: *StreamPlanner) !void {
+            const placement = try self.sharding.placement(self.shape);
             for (self.sharding.devicesInCanonicalOrder(), 0..) |device, writer_index| {
-                const placement = try self.sharding.placement(self.shape, device);
-                try self.appendShardSegments(placement, writer_index);
+                try self.appendShardSegments(placement.slices(device.id).constSlice(), writer_index);
             }
         }
 
@@ -691,8 +691,8 @@ pub const DirectMemoryWriter = struct {
             });
         }
 
-        fn axisRange(self: *const StreamPlanner, placement: Placement, axis: usize) AxisRange {
-            for (placement.slices.constSlice()) |slice| {
+        fn axisRange(self: *const StreamPlanner, slices: []const Placement.Slice1d, axis: usize) AxisRange {
+            for (slices) |slice| {
                 if (slice.axis == axis) {
                     return .{
                         .start = slice.start,
@@ -709,14 +709,14 @@ pub const DirectMemoryWriter = struct {
 
         fn appendShardSegmentsAtAxis(
             self: *StreamPlanner,
-            placement: Placement,
+            slices: []const Placement.Slice1d,
             writer_index: usize,
             rank: usize,
             axis: usize,
             base_start: i64,
             strides: []const i64,
         ) !void {
-            const range = self.axisRange(placement, axis);
+            const range = self.axisRange(slices, axis);
             if (range.size == 0) return;
 
             if (axis + 1 == rank) {
@@ -729,11 +729,11 @@ pub const DirectMemoryWriter = struct {
             var i: i64 = 0;
             while (i < range.size) : (i += 1) {
                 const child_start = base_start + (range.start + i) * strides[axis];
-                try self.appendShardSegmentsAtAxis(placement, writer_index, rank, axis + 1, child_start, strides);
+                try self.appendShardSegmentsAtAxis(slices, writer_index, rank, axis + 1, child_start, strides);
             }
         }
 
-        fn appendShardSegments(self: *StreamPlanner, placement: Placement, writer_index: usize) !void {
+        fn appendShardSegments(self: *StreamPlanner, slices: []const Placement.Slice1d, writer_index: usize) !void {
             const rank = self.shape.rank();
             if (rank == 0) {
                 try self.appendRawSegment(writer_index, 0, self.shape.byteSize());
@@ -741,7 +741,7 @@ pub const DirectMemoryWriter = struct {
             }
 
             const strides = self.shape.computeByteStrides();
-            try self.appendShardSegmentsAtAxis(placement, writer_index, rank, 0, 0, strides.constSlice());
+            try self.appendShardSegmentsAtAxis(slices, writer_index, rank, 0, 0, strides.constSlice());
         }
     };
 
@@ -799,14 +799,13 @@ pub const DirectMemoryWriter = struct {
         };
 
         var pjrt_buffers: Buffer.Shards = .empty;
+        const placement = try sharding.placement(shape);
         for (ordered_devices, 0..) |device, i| {
             defer initialized += 1;
 
-            const placement = try sharding.placement(shape, device);
-            const device_index = placement.platformDeviceIndex(platform) orelse return error.UnknownShardDevice;
-            const pool = &pools[device_index];
-            const shard_dma_allocator = dma_allocators[device_index].allocator();
-            const dst_memory = platform.devices[device_index].memory(.default);
+            const pool = &pools[device.id];
+            const shard_dma_allocator = dma_allocators[device.id].allocator();
+            const dst_memory = platform.devices[device.id].memory(.default);
 
             shard_writers[i] = try DirectShardWriter.init(shard_dma_allocator, io, dst_memory, pool, placement.shape);
 

--- a/zml/mem.zig
+++ b/zml/mem.zig
@@ -22,7 +22,7 @@ pub const DmaAllocator = union(enum) {
     pub fn init(parent: std.mem.Allocator, device: *const Device) DmaAllocator {
         return switch (device.platform.target) {
             .cuda => .{ .dmam = .init(parent, device.platform) },
-            .oneapi, .tpu => .{ .uib = .init(device.memory(.host_pinned)) },
+            .oneapi, .tpu => .{ .uib = .init(device.memory(.host_pinned).?) },
             .rocm, .cpu, .neuron => .{ .passthrough = parent },
         };
     }

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -602,7 +602,10 @@ pub const Platform = struct {
         unreachable;
     }
 
-    pub fn defaultMemoryLayout(platform: *const Platform, dims: []const i64, dtype: zml.DataType) pjrt.MemoryLayout {
+    pub inline fn defaultMemoryLayout(platform: *const Platform, dims: []const i64, dtype: zml.DataType) pjrt.MemoryLayout {
+        // inline cause `default` is a huge ass struct allocated on the stack,
+        // and toMemoryLayout returns slices into it.
+        // There is probably a better way of doing this.
         return switch (platform.target) {
             .cuda, .rocm, .tpu, .neuron, .oneapi => {
                 const element_type = pjrtx.bufferTypeFromDtype(dtype);

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -130,7 +130,7 @@ pub const Device = struct {
     pjrt_device: *const pjrt.Device,
     pjrt_desc: *const pjrt.DeviceDescription,
     addressable_memories: []*const Memory,
-    memory_by_kind: std.EnumArray(Memory.Kind, *const Memory),
+    memory_by_kind: std.EnumArray(Memory.Kind, ?*const Memory),
 
     fn init(allocator: std.mem.Allocator, pjrt_device_: *const pjrt.Device, platform: *const Platform) !Device {
         const pjrt_addressable_memories = pjrt_device_.addressableMemories(platform.pjrt_api);
@@ -139,10 +139,14 @@ pub const Device = struct {
             addressable_memory.* = platform.memoryFromPjrt(pjrt_memory);
         }
 
-        var memory_by_kind: std.EnumArray(Memory.Kind, *const Memory) = undefined;
-        inline for (std.meta.tags(Memory.Kind)) |memory_kind| {
-            memory_by_kind.set(memory_kind, resolveMemory(pjrt_device_, platform, addressable_memories, memory_kind));
-        }
+        // Cache memory lookups since they are expensive
+        const default_memory: *const Memory = resolveDefaultMemory(pjrt_device_, platform, addressable_memories);
+        const memory_by_kind: std.EnumArray(Memory.Kind, ?*const Memory) = .init(.{
+            .default = default_memory,
+            .device = resolveMemory(addressable_memories, .device),
+            .host_pinned = resolveMemory(addressable_memories, .host_pinned),
+            .host_unpinned = resolveMemory(addressable_memories, .host_unpinned),
+        });
 
         return .{
             .platform = platform,
@@ -157,21 +161,23 @@ pub const Device = struct {
         allocator.free(self.addressable_memories);
     }
 
-    fn resolveMemory(pjrt_device_: *const pjrt.Device, platform: *const Platform, addressable_memories: []*const Memory, memory_kind: Memory.Kind) *const Memory {
-        if (memory_kind == .default) {
-            const pjrt_memory = pjrt_device_.defaultMemory(platform.pjrt_api);
-            for (addressable_memories) |mem| {
-                if (mem.pjrt_memory == pjrt_memory) return mem;
-            }
-            return platform.memoryFromPjrt(pjrt_memory);
+    fn resolveDefaultMemory(pjrt_device_: *const pjrt.Device, platform: *const Platform, addressable_memories: []*const Memory) *const Memory {
+        const pjrt_memory = pjrt_device_.defaultMemory(platform.pjrt_api);
+        for (addressable_memories) |mem| {
+            if (mem.pjrt_memory == pjrt_memory) return mem;
         }
+        return platform.memoryFromPjrt(pjrt_memory);
+    }
+
+    fn resolveMemory(addressable_memories: []*const Memory, memory_kind: Memory.Kind) ?*const Memory {
+        std.debug.assert(memory_kind != .default);
 
         for (addressable_memories) |mem| {
             if (mem.isOfKind(memory_kind)) {
                 return mem;
             }
         }
-        unreachable;
+        return null;
     }
 
     pub fn id(self: Device) u32 {
@@ -209,7 +215,7 @@ pub const Device = struct {
         });
     }
 
-    pub fn memory(self: *const Device, memory_kind: Memory.Kind) *const Memory {
+    pub fn memory(self: *const Device, memory_kind: Memory.Kind) ?*const Memory {
         return self.memory_by_kind.values[@intFromEnum(memory_kind)];
     }
 };

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -13,6 +13,7 @@ const pjrtx = @import("pjrtx.zig");
 const profiler_ = @import("profiling/profiler.zig");
 const Sharding = @import("Sharding.zig");
 const zml = @import("zml.zig");
+const constants = @import("constants.zig");
 
 const log = std.log.scoped(.zml);
 
@@ -604,6 +605,24 @@ pub const Platform = struct {
             if (device.pjrt_device == pjrt_device) return device;
         }
         unreachable;
+    }
+
+    pub fn defaultMemoryLayout(noalias platform: *const Platform, shape: zml.Shape) pjrt.MemoryLayout {
+        return switch (platform.target) {
+            .tpu => {
+                if (comptime !platforms.isEnabled(.tpu)) unreachable;
+                const element_type = pjrtx.bufferTypeFromDtype(shape._dtype);
+                const default = try platform.pjrt_client.defaultMemoryLayout(platform.pjrt_api, element_type, shape.dims());
+                return default.toMemoryLayout();
+            },
+            else => .{
+                .tiled = .{
+                    .minor_to_major = constants.minorToMajor(shape.rank()),
+                    .tile_dims = &.{},
+                    .tile_dims_sizes = &.{},
+                },
+            },
+        };
     }
 };
 

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -605,15 +605,17 @@ pub const Platform = struct {
     pub inline fn defaultMemoryLayout(platform: *const Platform, dims: []const i64, dtype: zml.DataType) pjrt.MemoryLayout {
         // inline cause `default` is a huge ass struct allocated on the stack,
         // and toMemoryLayout returns slices into it.
-        // There is probably a better way of doing this.
+        // There is probably a better way of doing this,
+        // but given it's compiled out (except for TPU), I'm not gonna care for now.
         return switch (platform.target) {
-            .cuda, .rocm, .tpu, .neuron, .oneapi => {
+            .tpu => {
+                if (comptime !platforms.isEnabled(.tpu)) unreachable;
                 const element_type = pjrtx.bufferTypeFromDtype(dtype);
                 const default = platform.pjrt_client.defaultMemoryLayout(platform.pjrt_api, element_type, dims) catch @panic("Failed to get default memory layout");
                 return default.toMemoryLayout();
             },
-            // CPU always return this layout so avoid complicated logic from .defaultMemoryLayout
-            .cpu => .{
+            .cuda, .rocm, .neuron, .oneapi, .cpu => .{
+                // If this is the default layout on the platform, there is no point calling PJRT
                 .tiled = .{
                     .minor_to_major = constants.minorToMajor(@intCast(dims.len)),
                     .tile_dims = &.{},
@@ -820,4 +822,30 @@ fn printCallbackInner(call_frame: *pjrt.ffi.CallFrame) !?*pjrt.ffi.Error {
     log.info("{s} {f} [device={d}]: {d}", .{ name, slice.shape, device_ordinal, slice });
 
     return null;
+}
+
+test "platform defaultMemoryLayout is boring" {
+    const platform = zml.testing.env();
+
+    const shapes = [_][]const i64{
+        &.{4096},
+        &.{ 4096, 4096 },
+        &.{ 4096, 4096, 4096 },
+    };
+    for (shapes) |dims| {
+        // Checks that the PJRT client always return the same thing than `platform.defaultMemoryLayout`
+        // This allows to bypass the PJRT calls and the string of pjrt_client.defaultMemoryLayout.
+        const default_layout = try platform.pjrt_client.defaultMemoryLayout(platform.pjrt_api, pjrtx.bufferTypeFromDtype(.f32), dims);
+        const mem_layout = default_layout.toMemoryLayout();
+
+        // Note: I'm not just calling platform.defaultMemoryLayout because I'm investigating
+        // wether TPU requires its special branch.
+        try std.testing.expectEqualDeep(mem_layout, pjrt.MemoryLayout{
+            .tiled = .{
+                .minor_to_major = constants.minorToMajor(@intCast(dims.len)),
+                .tile_dims = &.{},
+                .tile_dims_sizes = &.{},
+            },
+        });
+    }
 }

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 const c = @import("c");
 const pjrt = @import("pjrt");
@@ -128,6 +129,7 @@ pub const Device = struct {
     pjrt_device: *const pjrt.Device,
     pjrt_desc: *const pjrt.DeviceDescription,
     addressable_memories: []*const Memory,
+    memory_by_kind: std.EnumArray(Memory.Kind, *const Memory),
 
     fn init(allocator: std.mem.Allocator, pjrt_device_: *const pjrt.Device, platform: *const Platform) !Device {
         const pjrt_addressable_memories = pjrt_device_.addressableMemories(platform.pjrt_api);
@@ -136,16 +138,39 @@ pub const Device = struct {
             addressable_memory.* = platform.memoryFromPjrt(pjrt_memory);
         }
 
+        var memory_by_kind: std.EnumArray(Memory.Kind, *const Memory) = undefined;
+        inline for (std.meta.tags(Memory.Kind)) |memory_kind| {
+            memory_by_kind.set(memory_kind, resolveMemory(pjrt_device_, platform, addressable_memories, memory_kind));
+        }
+
         return .{
             .platform = platform,
             .pjrt_device = pjrt_device_,
             .pjrt_desc = pjrt_device_.getDescription(platform.pjrt_api),
             .addressable_memories = addressable_memories,
+            .memory_by_kind = memory_by_kind,
         };
     }
 
     fn deinit(self: *Device, allocator: std.mem.Allocator) void {
         allocator.free(self.addressable_memories);
+    }
+
+    fn resolveMemory(pjrt_device_: *const pjrt.Device, platform: *const Platform, addressable_memories: []*const Memory, memory_kind: Memory.Kind) *const Memory {
+        if (memory_kind == .default) {
+            const pjrt_memory = pjrt_device_.defaultMemory(platform.pjrt_api);
+            for (addressable_memories) |mem| {
+                if (mem.pjrt_memory == pjrt_memory) return mem;
+            }
+            return platform.memoryFromPjrt(pjrt_memory);
+        }
+
+        for (addressable_memories) |mem| {
+            if (mem.isOfKind(memory_kind)) {
+                return mem;
+            }
+        }
+        unreachable;
     }
 
     pub fn id(self: Device) usize {
@@ -183,23 +208,35 @@ pub const Device = struct {
         });
     }
 
-    pub fn memory(self: Device, memory_kind: Memory.Kind) *const Memory {
-        if (memory_kind == .default) {
-            const pjrt_memory = self.pjrt_device.defaultMemory(self.platform.pjrt_api);
-            for (self.addressable_memories) |mem| {
-                if (mem.pjrt_memory == pjrt_memory) return mem;
-            }
-            return self.platform.memoryFromPjrt(pjrt_memory);
-        }
-
-        for (self.addressable_memories) |mem| {
-            if (mem.isOfKind(memory_kind)) {
-                return mem;
-            }
-        }
-        unreachable;
+    pub fn memory(self: *const Device, memory_kind: Memory.Kind) *const Memory {
+        return self.memory_by_kind.values[@intFromEnum(memory_kind)];
     }
 };
+
+fn platformDeviceSortId(target: Target, device: Device) usize {
+    return switch (target) {
+        .neuron => @intCast(device.localHardwareId()),
+        .cuda, .rocm, .tpu, .cpu, .oneapi => device.id(),
+    };
+}
+
+fn sortDevicesById(target: Target, devices: []Device) void {
+    const Context = struct {
+        target: Target,
+
+        fn lessThan(ctx: @This(), lhs: Device, rhs: Device) bool {
+            return platformDeviceSortId(ctx.target, lhs) < platformDeviceSortId(ctx.target, rhs);
+        }
+    };
+
+    std.mem.sort(Device, devices, Context{ .target = target }, Context.lessThan);
+
+    if (builtin.mode == .Debug) {
+        for (devices, 0..) |device, expected_id| {
+            std.debug.assert(platformDeviceSortId(target, device) == expected_id);
+        }
+    }
+}
 
 pub const Platform = struct {
     arena: std.heap.ArenaAllocator,
@@ -271,6 +308,7 @@ pub const Platform = struct {
             for (pjrt_devices, devices) |pjrt_device, *platform_device| {
                 platform_device.* = try .init(arena, pjrt_device, platform);
             }
+            sortDevicesById(target, devices);
             for (memories) |*platform_memory| {
                 platform_memory.populateAddressableByDevices();
             }

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -174,8 +174,8 @@ pub const Device = struct {
         unreachable;
     }
 
-    pub fn id(self: Device) usize {
-        return self.pjrt_desc.id(self.platform.pjrt_api);
+    pub fn id(self: Device) u32 {
+        return @intCast(self.pjrt_desc.id(self.platform.pjrt_api));
     }
 
     pub fn processIndex(self: Device) i32 {

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -17,18 +17,7 @@ const constants = @import("constants.zig");
 
 const log = std.log.scoped(.zml);
 
-fn StaticPlatformMap(comptime E: type, comptime T: type) type {
-    const tag_count = @typeInfo(E).@"enum".fields.len;
-    var struct_field_names: [tag_count][]const u8 = undefined;
-    var struct_field_types: [tag_count]type = @splat(T);
-    const is_optional = @typeInfo(T) == .optional;
-    const default_value_ptr: ?*const anyopaque = if (is_optional) @ptrCast(&@as(T, null)) else null;
-    var struct_field_attrs: [tag_count]std.builtin.Type.StructField.Attributes = @splat(.{ .default_value_ptr = default_value_ptr });
-    inline for (@typeInfo(E).@"enum".fields, 0..) |f, i| struct_field_names[i] = f.name;
-    return @Struct(.auto, null, &struct_field_names, &struct_field_types, &struct_field_attrs);
-}
-
-var api_map: StaticPlatformMap(Target, ?*const pjrt.Api) = .{};
+var api_map: std.enums.EnumArray(Target, ?*const pjrt.Api) = .initFill(null);
 
 fn disableXlaLogs() void {
     // https://deepreg.readthedocs.io/en/latest/docs/logging.html#tensorflow-logging
@@ -62,10 +51,10 @@ fn validateDeviceCount(target: Target, num_devices: usize) !void {
 
 fn loadOrGetApi(allocator: std.mem.Allocator, io: std.Io, target: Target) !*const pjrt.Api {
     return switch (target) {
-        inline else => |tag| @field(api_map, @tagName(tag)) orelse b: {
+        inline else => |tag| api_map.get(tag) orelse b: {
             disableXlaLogs();
             const api = try platforms.load(allocator, io, tag);
-            @field(api_map, @tagName(tag)) = api;
+            api_map.set(tag, api);
             break :b api;
         },
     };

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -602,17 +602,17 @@ pub const Platform = struct {
         unreachable;
     }
 
-    pub fn defaultMemoryLayout(noalias platform: *const Platform, shape: zml.Shape) pjrt.MemoryLayout {
+    pub fn defaultMemoryLayout(platform: *const Platform, dims: []const i64, dtype: zml.DataType) pjrt.MemoryLayout {
         return switch (platform.target) {
-            .tpu => {
-                if (comptime !platforms.isEnabled(.tpu)) unreachable;
-                const element_type = pjrtx.bufferTypeFromDtype(shape._dtype);
-                const default = try platform.pjrt_client.defaultMemoryLayout(platform.pjrt_api, element_type, shape.dims());
+            .cuda, .rocm, .tpu, .neuron, .oneapi => {
+                const element_type = pjrtx.bufferTypeFromDtype(dtype);
+                const default = platform.pjrt_client.defaultMemoryLayout(platform.pjrt_api, element_type, dims) catch @panic("Failed to get default memory layout");
                 return default.toMemoryLayout();
             },
-            else => .{
+            // CPU always return this layout so avoid complicated logic from .defaultMemoryLayout
+            .cpu => .{
                 .tiled = .{
-                    .minor_to_major = constants.minorToMajor(shape.rank()),
+                    .minor_to_major = constants.minorToMajor(@intCast(dims.len)),
                     .tile_dims = &.{},
                     .tile_dims_sizes = &.{},
                 },

--- a/zml/shape.zig
+++ b/zml/shape.zig
@@ -302,9 +302,7 @@ pub const Shape = struct {
 
     fn isTagConvertible(comptime T: type) bool {
         return switch (T) {
-            @EnumLiteral() => true,
-            std.builtin.Type.StructField => true,
-            Tag => true,
+            @EnumLiteral(), std.builtin.Type.StructField, Tag => true,
             else => false,
         };
     }
@@ -319,8 +317,10 @@ pub const Shape = struct {
         };
     }
 
-    inline fn ensureAttributesAreSync(self: Shape) void {
-        stdx.debug.assert(self._dims.len == self._tags.len and self._dims.len == self._partitioning.len, "Tags, dims and partitioning have diverged! dims={d} tags={d} partitioning={d}", .{ self._dims.len, self._tags.len, self._partitioning.len });
+    fn ensureAttributesAreSync(self: Shape) void {
+        if (builtin.mode == .Debug) {
+            stdx.debug.assert(self._dims.len == self._tags.len and self._dims.len == self._partitioning.len, "Tags, dims and partitioning have diverged! dims={d} tags={d} partitioning={d}", .{ self._dims.len, self._tags.len, self._partitioning.len });
+        }
     }
 
     pub fn tag(self: Shape, ax: anytype) Tag {
@@ -387,15 +387,21 @@ pub const Shape = struct {
         self.ensureAttributesAreSync();
 
         const T = @TypeOf(axis_);
-        if (comptime stdx.meta.isInteger(T)) {
-            return self.axisFromInt(@intCast(axis_));
-        }
-
-        if (comptime isTagConvertible(T)) {
-            return self.axisFromTag(toTag(axis_));
-        }
-
-        stdx.debug.compileError("Wrong axis type, expected .literal, or an integer, got: {any}", .{T});
+        // Special handling of unsigned int, to remove runtime computations and favor inlining
+        return switch (@typeInfo(T)) {
+            .int => |info| if (info.signedness == .signed)
+                self.axisFromInt(axis_)
+            else
+                @intCast(axis_),
+            .comptime_int => if (axis_ < 0)
+                self.axisFromInt(axis_)
+            else
+                axis_,
+            else => if (comptime isTagConvertible(T))
+                self.axisFromTag(toTag(axis_))
+            else
+                stdx.debug.compileError("Wrong axis type, expected .literal, or an integer, got: {any}", .{T}),
+        };
     }
 
     pub fn axes(self: Shape, axes_: anytype) AxesArray {

--- a/zml/slice.zig
+++ b/zml/slice.zig
@@ -18,10 +18,8 @@ pub fn isBytes(comptime T: type) bool {
 }
 
 pub const Slice = struct {
-    inner_data: union(enum) {
-        mutable: []u8,
-        immutable: []const u8,
-    },
+    bytes: []const u8,
+    mutable: bool,
     shape: Shape,
     offset_bytes: usize = 0,
     byte_strides: stdx.BoundedArray(i64, constants.MAX_RANK),
@@ -31,10 +29,13 @@ pub const Slice = struct {
         stdx.debug.assert(bytes.len == shape.byteSize(), "Expected \"bytes\" to have the same length as shape.byteSize() ({}), got {}", .{ shape.byteSize(), bytes.len });
         const type_info = @typeInfo(@TypeOf(bytes));
         const byte_strides = shape.computeByteStrides();
-        return if (type_info.pointer.is_const)
-            .{ .inner_data = .{ .immutable = bytes }, .shape = shape, .offset_bytes = 0, .byte_strides = byte_strides }
-        else
-            .{ .inner_data = .{ .mutable = bytes }, .shape = shape, .offset_bytes = 0, .byte_strides = byte_strides };
+        return .{
+            .bytes = bytes,
+            .mutable = !type_info.pointer.is_const,
+            .shape = shape,
+            .offset_bytes = 0,
+            .byte_strides = byte_strides,
+        };
     }
 
     pub fn alloc(allocator: std.mem.Allocator, shape_: Shape) !Slice {
@@ -51,7 +52,8 @@ pub const Slice = struct {
         };
 
         return .{
-            .inner_data = .{ .mutable = bytes },
+            .bytes = bytes,
+            .mutable = true,
             .shape = shape_,
             .offset_bytes = 0,
             .byte_strides = shape_.computeByteStrides(),
@@ -59,8 +61,8 @@ pub const Slice = struct {
     }
 
     pub fn free(slice: Slice, allocator: std.mem.Allocator) void {
-        const d = slice.constData_();
-
+        const d = slice.bytes;
+        // TODO: It would be better to store the aligment, this can be error prone in the presence of type casting
         switch (slice.shape.dtype().alignOf()) {
             1 => allocator.free(@as([]align(1) const u8, @alignCast(d))),
             2 => allocator.free(@as([]align(2) const u8, @alignCast(d))),
@@ -79,9 +81,8 @@ pub const Slice = struct {
 
     pub fn isContiguous(slice: Slice) bool {
         const expected = slice.shape.computeByteStrides();
-        const rank = slice.shape.rank();
-        for (0..rank) |ax| {
-            if (slice.byte_strides.get(ax) != expected.get(ax)) return false;
+        for (expected.slice(), slice.byte_strides.slice()) |exp, actual| {
+            if (exp != actual) return false;
         }
         return true;
     }
@@ -122,36 +123,20 @@ pub const Slice = struct {
     }
 
     pub fn data(slice: Slice) []u8 {
-        const base = slice.data_();
-        stdx.debug.assert(slice.offset_bytes <= base.len, "Slice offset exceeds data length", .{});
-        return base[slice.offset_bytes..];
-    }
-
-    fn data_(slice: Slice) []u8 {
-        return switch (slice.inner_data) {
-            .mutable => |d| d,
-            else => stdx.debug.panic("Expected slice to be mutable but it's immutable", .{}),
-        };
+        std.debug.assert(slice.mutable);
+        return @constCast(slice.bytes[slice.offset_bytes..]);
     }
 
     pub fn constData(slice: Slice) []const u8 {
-        const base = slice.constData_();
-        stdx.debug.assert(slice.offset_bytes <= base.len, "Slice offset exceeds data length", .{});
-        return base[slice.offset_bytes..];
-    }
-
-    fn constData_(slice: Slice) []const u8 {
-        return switch (slice.inner_data) {
-            inline else => |d| d,
-        };
+        return slice.bytes[slice.offset_bytes..];
     }
 
     pub fn items(slice: Slice, comptime T: type) []T {
-        return @alignCast(std.mem.bytesAsSlice(T, slice.data()));
+        return @ptrCast(@alignCast(slice.data()));
     }
 
     pub fn constItems(slice: Slice, comptime T: type) []const T {
-        return @alignCast(std.mem.bytesAsSlice(T, slice.constData()));
+        return @ptrCast(@alignCast(slice.constData()));
     }
 
     pub fn format(

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -281,6 +281,46 @@ pub const Tensor = struct {
         return self;
     }
 
+    test reuseBuffer {
+        const zml = @import("zml.zig");
+        const platform = zml.testing.env();
+        const io = std.testing.io;
+
+        const inputs: [2][6]f32 = .{ .{ -3.0, -2, -1, 1, 2, 3 }, .{ 1, 2, 3, 4, 5, -5 } };
+        const left = Tensor.init(.{ 2, 6 }, .f32);
+        const right = Tensor.init(.{ 2, 6 }, .f32);
+
+        const Local = struct {
+            pub fn memcopy(x: Tensor, y: Tensor) Tensor {
+                return x.addConstant(1).reuseBuffer(y);
+            }
+        };
+
+        const exe = try zml.module.compile(std.testing.allocator, std.testing.io, Local.memcopy, .{ left, right }, platform, .{});
+        defer exe.deinit();
+
+        var left_d = try zml.Buffer.fromBytes(io, platform, left.shape(), .replicated, @ptrCast(&inputs));
+        defer left_d.deinit();
+
+        var right_d = try zml.Buffer.uninitialized(io, platform, left.shape(), .replicated, .{});
+        defer right_d.deinit();
+
+        var right_memory: [Platform.MAX_NUM_DEVICES]*anyopaque = undefined;
+        for (0..right_d.numDevices()) |dev| {
+            right_memory[dev] = right_d.opaqueDevicePtr(dev);
+        }
+
+        const output_d = try zml.testing.autoCall(std.testing.allocator, io, &exe, Local.memcopy, .{ left_d, right_d });
+
+        var output_memory: [Platform.MAX_NUM_DEVICES]*anyopaque = undefined;
+        for (0..output_d.numDevices()) |dev| {
+            output_memory[dev] = output_d.opaqueDevicePtr(dev);
+        }
+
+        // Check that right_d and output_d point to the same addresses on the devices.
+        try std.testing.expectEqualSlices(*anyopaque, right_memory[0..right_d.numDevices()], output_memory[0..output_d.numDevices()]);
+    }
+
     /// Returns a Tensor containing the absolute value of each element of the input Tensor.
     pub fn abs(self: Tensor) Tensor {
         const op = dialects.stablehlo.abs(mlirCtx(), self.value(), .unknown(mlirCtx())).appendTo(currentBlock());

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -313,7 +313,7 @@ pub const Tensor = struct {
         const output_d = try zml.testing.autoCall(std.testing.allocator, io, &exe, Local.memcopy, .{ left_d, right_d });
 
         var output_memory: [Platform.MAX_NUM_DEVICES]*anyopaque = undefined;
-        for (0..output_d.numDevices()) |dev| {
+        for (0..output_d.numShards()) |dev| {
             output_memory[dev] = output_d.opaqueDevicePtr(dev);
         }
 

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -306,7 +306,7 @@ pub const Tensor = struct {
         defer right_d.deinit();
 
         var right_memory: [Platform.MAX_NUM_DEVICES]*anyopaque = undefined;
-        for (0..right_d.numDevices()) |dev| {
+        for (0..right_d.numShards()) |dev| {
             right_memory[dev] = right_d.opaqueDevicePtr(dev);
         }
 
@@ -318,7 +318,7 @@ pub const Tensor = struct {
         }
 
         // Check that right_d and output_d point to the same addresses on the devices.
-        try std.testing.expectEqualSlices(*anyopaque, right_memory[0..right_d.numDevices()], output_memory[0..output_d.numDevices()]);
+        try std.testing.expectEqualSlices(*anyopaque, right_memory[0..right_d.numShards()], output_memory[0..output_d.numShards()]);
     }
 
     /// Returns a Tensor containing the absolute value of each element of the input Tensor.

--- a/zml/zml.zig
+++ b/zml/zml.zig
@@ -50,7 +50,7 @@ pub const Tensor = tensor.Tensor;
 pub const testing = @import("testing.zig");
 
 test "zml" {
-    std.testing.refAllDecls(@This());
+    std.testing.refAllDecls(Sharding);
 }
 
 pub const KiB = 1024;

--- a/zml/zml.zig
+++ b/zml/zml.zig
@@ -50,7 +50,7 @@ pub const Tensor = tensor.Tensor;
 pub const testing = @import("testing.zig");
 
 test "zml" {
-    std.testing.refAllDecls(Sharding);
+    std.testing.refAllDecls(@This());
 }
 
 pub const KiB = 1024;


### PR DESCRIPTION
`Buffer.from` is in the hot path everytime we want to send smth to the GPU.
Sometimes we can overlap it with GPU compute but not always, and sometimes it's quite complicated to do so.

I've rewrote Sharding.Placement to be device agnostic instead of device specific.
This allow to reuse most of the logic for multiple devices.

According to LLVM MCA (with script included here), we got from:

```
Iterations:        100
Instructions:      324200
Total Cycles:      175191
Total uOps:        369700
```

to 

```
    Iterations:        100
    Instructions:      162900
    Total Cycles:      85585
    Total uOps:        182600
```

So about twice as fast for this part of the code. I would need some help to confirm the numbers on TPU.


(Once the PR is approved, I'll remove the mca script as well as the build.zig)