### PR TITLE
zml/buffer: use default pjrt memory layout

### DIFF
--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -112,17 +112,25 @@ pub const Buffer = struct {
         for (res._sharding.devicesInCanonicalOrder()) |device| {
             const placement = try res._sharding.placement(res._shape, device);
             const sub_slice = placement.shardSlice(slice);
-            const default_layout = try platform.pjrt_client.defaultMemoryLayout(
-                platform.pjrt_api,
-                pjrtx.bufferTypeFromDtype(placement.shape.dtype()),
-                placement.shape.dims(),
-            );
+
+            const layout = switch (platform.target) {
+                .cpu, .cuda, .rocm, .tpu, .neuron, .oneapi => blk: {
+                    // For neuron we observed that using the default layout causes a slowdown, so we use the same layout as the host buffer.
+                    const default_layout = try platform.pjrt_client.defaultMemoryLayout(
+                        platform.pjrt_api,
+                        pjrtx.bufferTypeFromDtype(placement.shape.dtype()),
+                        placement.shape.dims(),
+                    );
+                    break :blk default_layout.toMemoryLayout();
+                },
+            };
+
             const args: pjrt.Client.BufferFromHostBufferArgs = .{
                 .data = sub_slice.constData().ptr,
                 .buffer_type = buffer_type,
                 .dims = placement.shape.dims(),
                 .byte_strides = sub_slice.byte_strides.constSlice(),
-                .layout = default_layout.toMemoryLayout(),
+                .layout = layout,
                 .host_buffer_semantics = .ImmutableUntilTransferCompletes,
                 .dst = .{ .memory = placement.memory(platform, opts.memory).pjrt_memory },
             };
@@ -208,15 +216,21 @@ pub const Buffer = struct {
         const element_type = pjrtx.bufferTypeFromDtype(res._shape.dtype()); // dtype doesn't change with sharding.
         for (res._sharding.devicesInCanonicalOrder()) |device| {
             const placement = try res._sharding.placement(res._shape, device);
-            const default_layout = try platform.pjrt_client.defaultMemoryLayout(
-                platform.pjrt_api,
-                pjrtx.bufferTypeFromDtype(placement.shape.dtype()),
-                placement.shape.dims(),
-            );
+            const layout = switch (platform.target) {
+                .cpu, .cuda, .rocm, .tpu, .neuron, .oneapi => blk: {
+                    // For neuron we observed that using the default layout causes a slowdown, so we use the same layout as the host buffer.
+                    const default_layout = try platform.pjrt_client.defaultMemoryLayout(
+                        platform.pjrt_api,
+                        pjrtx.bufferTypeFromDtype(placement.shape.dtype()),
+                        placement.shape.dims(),
+                    );
+                    break :blk default_layout.toMemoryLayout();
+                },
+            };
             const args: pjrt.Client.CreateUninitializedBufferArgs = .{
                 .dims = placement.shape.dims(),
                 .element_type = element_type,
-                .layout = default_layout.toMemoryLayout(),
+                .layout = layout,
                 .dst = .{ .memory = placement.memory(platform, opts.memory).pjrt_memory },
             };
 

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -112,7 +112,7 @@ pub const Buffer = struct {
         for (res._sharding.devicesInCanonicalOrder()) |device| {
             const placement = try res._sharding.placement(res._shape, device);
             const sub_slice = placement.shardSlice(slice);
-            var default_layout = try platform.pjrt_client.defaultMemoryLayout(
+            const default_layout = try platform.pjrt_client.defaultMemoryLayout(
                 platform.pjrt_api,
                 pjrtx.bufferTypeFromDtype(placement.shape.dtype()),
                 placement.shape.dims(),

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -205,32 +205,18 @@ pub const Buffer = struct {
             shard.deinit(platform.pjrt_api);
         };
 
-        const minor_to_major = constants.minorToMajor(res._shape.rank()); // Rank doesn't change with sharding.
         const element_type = pjrtx.bufferTypeFromDtype(res._shape.dtype()); // dtype doesn't change with sharding.
         for (res._sharding.devicesInCanonicalOrder()) |device| {
             const placement = try res._sharding.placement(res._shape, device);
-            var default_layout: ?pjrt.DefaultMemoryLayout = null;
-            const layout: pjrt.MemoryLayout = switch (platform.target) {
-                .tpu => blk: {
-                    default_layout = try platform.pjrt_client.defaultMemoryLayout(
-                        platform.pjrt_api,
-                        pjrtx.bufferTypeFromDtype(placement.shape.dtype()),
-                        placement.shape.dims(),
-                    );
-                    break :blk default_layout.?.toMemoryLayout();
-                },
-                else => .{
-                    .tiled = .{
-                        .minor_to_major = minor_to_major,
-                        .tile_dims = &.{},
-                        .tile_dims_sizes = &.{},
-                    },
-                },
-            };
+            const default_layout = try platform.pjrt_client.defaultMemoryLayout(
+                platform.pjrt_api,
+                pjrtx.bufferTypeFromDtype(placement.shape.dtype()),
+                placement.shape.dims(),
+            );
             const args: pjrt.Client.CreateUninitializedBufferArgs = .{
                 .dims = placement.shape.dims(),
                 .element_type = element_type,
-                .layout = layout,
+                .layout = default_layout.toMemoryLayout(),
                 .dst = .{ .memory = placement.memory(platform, opts.memory).pjrt_memory },
             };
 

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -112,30 +112,17 @@ pub const Buffer = struct {
         for (res._sharding.devicesInCanonicalOrder()) |device| {
             const placement = try res._sharding.placement(res._shape, device);
             const sub_slice = placement.shardSlice(slice);
-            var default_layout: ?pjrt.DefaultMemoryLayout = null;
-            const layout: pjrt.MemoryLayout = switch (platform.target) {
-                .tpu => blk: {
-                    default_layout = try platform.pjrt_client.defaultMemoryLayout(
-                        platform.pjrt_api,
-                        pjrtx.bufferTypeFromDtype(placement.shape.dtype()),
-                        placement.shape.dims(),
-                    );
-                    break :blk default_layout.?.toMemoryLayout();
-                },
-                else => .{
-                    .tiled = .{
-                        .minor_to_major = constants.minorToMajor(placement.shape.rank()),
-                        .tile_dims = &.{},
-                        .tile_dims_sizes = &.{},
-                    },
-                },
-            };
+            var default_layout = try platform.pjrt_client.defaultMemoryLayout(
+                platform.pjrt_api,
+                pjrtx.bufferTypeFromDtype(placement.shape.dtype()),
+                placement.shape.dims(),
+            );
             const args: pjrt.Client.BufferFromHostBufferArgs = .{
                 .data = sub_slice.constData().ptr,
                 .buffer_type = buffer_type,
                 .dims = placement.shape.dims(),
                 .byte_strides = sub_slice.byte_strides.constSlice(),
-                .layout = layout,
+                .layout = default_layout.toMemoryLayout(),
                 .host_buffer_semantics = .ImmutableUntilTransferCompletes,
                 .dst = .{ .memory = placement.memory(platform, opts.memory).pjrt_memory },
             };

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -110,7 +110,6 @@ pub const Buffer = struct {
         const slice = Slice.init(sh, data_);
 
         const devices = res._sharding.devicesInCanonicalOrder();
-        // Sharding requires uniform local shapes, so one default layout can be reused for every shard.
         const first_placement = try res._sharding.placement(res._shape, devices[0]);
         const default_layout = switch (platform.target) {
             .cpu, .cuda, .rocm, .tpu, .neuron, .oneapi => try platform.pjrt_client.defaultMemoryLayout(
@@ -213,9 +212,8 @@ pub const Buffer = struct {
             shard.deinit(platform.pjrt_api);
         };
 
-        const element_type = pjrtx.bufferTypeFromDtype(res._shape.dtype()); // dtype doesn't change with sharding.
+        const element_type = pjrtx.bufferTypeFromDtype(res._shape.dtype());
         const devices = res._sharding.devicesInCanonicalOrder();
-        // Sharding requires uniform local shapes, so one default layout can be reused for every shard.
         const first_placement = try res._sharding.placement(res._shape, devices[0]);
         const default_layout = switch (platform.target) {
             .cpu, .cuda, .rocm, .tpu, .neuron, .oneapi => try platform.pjrt_client.defaultMemoryLayout(

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -109,21 +109,21 @@ pub const Buffer = struct {
         const buffer_type = pjrtx.bufferTypeFromDtype(sh.dtype());
         const slice = Slice.init(sh, data_);
 
-        for (res._sharding.devicesInCanonicalOrder()) |device| {
+        const devices = res._sharding.devicesInCanonicalOrder();
+        // Sharding requires uniform local shapes, so one default layout can be reused for every shard.
+        const first_placement = try res._sharding.placement(res._shape, devices[0]);
+        const default_layout = switch (platform.target) {
+            .cpu, .cuda, .rocm, .tpu, .neuron, .oneapi => try platform.pjrt_client.defaultMemoryLayout(
+                platform.pjrt_api,
+                buffer_type,
+                first_placement.shape.dims(),
+            ),
+        };
+        const layout = default_layout.toMemoryLayout();
+
+        for (devices) |device| {
             const placement = try res._sharding.placement(res._shape, device);
             const sub_slice = placement.shardSlice(slice);
-
-            const layout = switch (platform.target) {
-                .cpu, .cuda, .rocm, .tpu, .neuron, .oneapi => blk: {
-                    // For neuron we observed that using the default layout causes a slowdown, so we use the same layout as the host buffer.
-                    const default_layout = try platform.pjrt_client.defaultMemoryLayout(
-                        platform.pjrt_api,
-                        pjrtx.bufferTypeFromDtype(placement.shape.dtype()),
-                        placement.shape.dims(),
-                    );
-                    break :blk default_layout.toMemoryLayout();
-                },
-            };
 
             const args: pjrt.Client.BufferFromHostBufferArgs = .{
                 .data = sub_slice.constData().ptr,
@@ -214,19 +214,20 @@ pub const Buffer = struct {
         };
 
         const element_type = pjrtx.bufferTypeFromDtype(res._shape.dtype()); // dtype doesn't change with sharding.
-        for (res._sharding.devicesInCanonicalOrder()) |device| {
+        const devices = res._sharding.devicesInCanonicalOrder();
+        // Sharding requires uniform local shapes, so one default layout can be reused for every shard.
+        const first_placement = try res._sharding.placement(res._shape, devices[0]);
+        const default_layout = switch (platform.target) {
+            .cpu, .cuda, .rocm, .tpu, .neuron, .oneapi => try platform.pjrt_client.defaultMemoryLayout(
+                platform.pjrt_api,
+                element_type,
+                first_placement.shape.dims(),
+            ),
+        };
+        const layout = default_layout.toMemoryLayout();
+
+        for (devices) |device| {
             const placement = try res._sharding.placement(res._shape, device);
-            const layout = switch (platform.target) {
-                .cpu, .cuda, .rocm, .tpu, .neuron, .oneapi => blk: {
-                    // For neuron we observed that using the default layout causes a slowdown, so we use the same layout as the host buffer.
-                    const default_layout = try platform.pjrt_client.defaultMemoryLayout(
-                        platform.pjrt_api,
-                        pjrtx.bufferTypeFromDtype(placement.shape.dtype()),
-                        placement.shape.dims(),
-                    );
-                    break :blk default_layout.toMemoryLayout();
-                },
-            };
             const args: pjrt.Client.CreateUninitializedBufferArgs = .{
                 .dims = placement.shape.dims(),
                 .element_type = element_type,


### PR DESCRIPTION
Alway use default memory layout given by the pjrt plugin.

remove platform switch case evaluation (improve performances in some cases).

Work on: nvidia, intel, rocm, tpu, neuron.