### PR TITLE
bin/zml-smi: keyboard nav and process kill

### DIFF
--- a/bin/zml-smi/tui/BUILD.bazel
+++ b/bin/zml-smi/tui/BUILD.bazel
@@ -18,6 +18,7 @@ zig_library(
         "pages/detail/tpu_detail.zig",
         "pages/overview.zig",
         "print.zig",
+        "selection.zig",
         "theme.zig",
         "top.zig",
         "widgets/braille_chart.zig",

--- a/bin/zml-smi/tui/pages/overview.zig
+++ b/bin/zml-smi/tui/pages/overview.zig
@@ -11,6 +11,7 @@ const DeviceCard = @import("../widgets/device_card.zig");
 const Logo = @import("../widgets/logo.zig");
 const InfoLines = @import("../widgets/info_lines.zig");
 const ProcessTable = @import("../widgets/process_table.zig");
+const Selection = @import("../selection.zig").Selection;
 
 const Overview = @This();
 
@@ -24,9 +25,10 @@ state: *const data.SystemState,
 device_cards: []DeviceCard = &.{},
 process_table: ?*ProcessTable = null, // maybe null if we decide not to print the process table in print mode
 viewing_device: *?u16 = undefined,
+selection: *Selection = undefined,
 use_braille: bool = false,
 
-pub fn init(allocator: std.mem.Allocator, state: *const data.SystemState, process_table: ?*ProcessTable, viewing_device: *?u16) !Overview {
+pub fn init(allocator: std.mem.Allocator, state: *const data.SystemState, process_table: ?*ProcessTable, viewing_device: *?u16, selection: *Selection) !Overview {
     const count = state.deviceCount();
     const cards = try allocator.alloc(DeviceCard, count);
     for (cards, 0..) |*card, i| {
@@ -40,6 +42,7 @@ pub fn init(allocator: std.mem.Allocator, state: *const data.SystemState, proces
         .device_cards = cards,
         .process_table = process_table,
         .viewing_device = viewing_device,
+        .selection = selection,
     };
 }
 
@@ -92,12 +95,11 @@ pub fn draw(self: *Overview, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw
     row += @intCast(banner_surf.size.height + 1);
 
     // ── Device Grid ─────────────────────────────────────────
-    for (self.device_cards) |*card| {
-        card.use_braille = self.use_braille;
-        card.viewing_device = self.viewing_device;
-    }
     const card_widgets = try ctx.arena.alloc(vxfw.Widget, self.device_cards.len);
     for (self.device_cards, card_widgets) |*card, *cw| {
+        card.use_braille = self.use_braille;
+        card.viewing_device = self.viewing_device;
+        card.selection = self.selection;
         cw.* = ui.widget(card);
     }
     const device_grid: ColumnLayout = .{

--- a/bin/zml-smi/tui/print.zig
+++ b/bin/zml-smi/tui/print.zig
@@ -5,6 +5,7 @@ const data = @import("data.zig");
 const ui = @import("lib/ui.zig");
 const image_cache = @import("image_cache.zig");
 const Overview = @import("pages/overview.zig");
+const Selection = @import("selection.zig").Selection;
 
 fn silentResize(vx: *vaxis.Vaxis, allocator: std.mem.Allocator, winsize: vaxis.Winsize) !void {
     vx.screen.deinit(allocator);
@@ -57,7 +58,8 @@ pub fn run(allocator: std.mem.Allocator, io: std.Io, state: *data.SystemState) !
     const content_w: u16 = @min(@as(u16, @intCast(vx.screen.width)), Overview.host_line_width + 2);
 
     var viewing_device: ?u16 = null;
-    var overview = try Overview.init(allocator, state, null, &viewing_device);
+    var selection: Selection = .{};
+    var overview = try Overview.init(allocator, state, null, &viewing_device, &selection);
     defer overview.deinit(allocator);
 
     const draw_ctx: vxfw.DrawContext = .{

--- a/bin/zml-smi/tui/selection.zig
+++ b/bin/zml-smi/tui/selection.zig
@@ -1,0 +1,34 @@
+pub const Selection = struct {
+    pub const Kind = enum { none, device, process };
+
+    kind: Kind = .none,
+    device: u16 = 0,
+    pid: u32 = 0,
+
+    /// Clear the selection
+    pub fn clear(self: *Selection) void {
+        self.* = .{};
+    }
+
+    pub fn deviceEq(self: Selection, id: u16) bool {
+        return self.kind == .device and self.device == id;
+    }
+
+    pub fn processEq(self: Selection, p: u32) bool {
+        return self.kind == .process and self.pid == p;
+    }
+
+    /// Select a device. Returns true if the selection actually changed.
+    pub fn setDevice(self: *Selection, id: u16) bool {
+        if (self.deviceEq(id)) return false;
+        self.* = .{ .kind = .device, .device = id };
+        return true;
+    }
+
+    /// Select a process by PID. Returns true if the selection actually changed.
+    pub fn setProcess(self: *Selection, p: u32) bool {
+        if (self.processEq(p)) return false;
+        self.* = .{ .kind = .process, .pid = p };
+        return true;
+    }
+};

--- a/bin/zml-smi/tui/top.zig
+++ b/bin/zml-smi/tui/top.zig
@@ -11,6 +11,7 @@ const ProcessTable = @import("widgets/process_table.zig");
 const Overview = @import("pages/overview.zig");
 const Detail = @import("pages/detail.zig");
 const StatusLine = @import("widgets/status_line.zig");
+const Selection = @import("selection.zig").Selection;
 
 const min_width: u16 = 45;
 const min_height: u16 = 24;
@@ -47,6 +48,9 @@ const Model = struct {
     tty: *vaxis.Tty,
     process_table: ProcessTable = .{},
     overview: Overview = undefined,
+    selection: Selection = .{},
+    /// One-shot: scroll the page to reveal the current selection on next draw.
+    pending_scroll_to_sel: bool = false,
 
     fn deinit(self: *Model) void {
         self.process_table.deinit(self.allocator);
@@ -57,7 +61,8 @@ const Model = struct {
     pub fn handleEvent(self: *Model, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
         switch (event) {
             .init => {
-                self.overview = try Overview.init(self.allocator, self.state, &self.process_table, &self.viewing_device);
+                self.process_table.selection = &self.selection;
+                self.overview = try Overview.init(self.allocator, self.state, &self.process_table, &self.viewing_device, &self.selection);
                 self.overview.use_braille = true;
                 image_cache.global.loadAll(self.vx, self.allocator, self.tty.writer());
                 try ctx.tick(1000, ui.widget(self));
@@ -73,39 +78,122 @@ const Model = struct {
                     return;
                 }
                 if (self.viewing_device != null) {
+                    // ── Detail page ──
                     if (key.matches(vaxis.Key.escape, .{}) or key.matches(vaxis.Key.backspace, .{})) {
                         self.viewing_device = null;
                         return ctx.consumeAndRedraw();
                     }
                 } else {
+                    // ── Overview page ──
                     if (key.matches('v', .{})) {
                         self.overview.use_braille = !self.overview.use_braille;
                         return ctx.consumeAndRedraw();
                     }
+                    if (key.matches(vaxis.Key.enter, .{})) {
+                        // Enter on a selected device opens it, just like a click.
+                        if (self.selection.kind == .device) {
+                            self.viewing_device = self.selection.device;
+                            return ctx.consumeAndRedraw();
+                        }
+                    }
                 }
-                if (key.matches(vaxis.Key.down, .{})) {
-                    self.scroll.scrollBy(1, 0);
-                } else if (key.matches(vaxis.Key.up, .{})) {
-                    self.scroll.scrollBy(-1, 0);
-                } else if (key.matches(vaxis.Key.right, .{})) {
-                    self.scroll.scrollBy(0, 1);
+                // ── Shared selection / kill / horizontal-scroll keys ──
+                if (key.matches('x', .{})) {
+                    self.process_table.killSelected(); // no-op unless a process is selected
+                    return ctx.consumeAndRedraw();
+                }
+                if (key.matches(vaxis.Key.down, .{}) or key.matches('j', .{}) or key.matches('n', .{ .ctrl = true })) {
+                    return self.moveSelection(ctx, 1);
+                }
+                if (key.matches(vaxis.Key.up, .{}) or key.matches('k', .{}) or key.matches('p', .{ .ctrl = true })) {
+                    return self.moveSelection(ctx, -1);
+                }
+
+                if (key.matches(vaxis.Key.right, .{})) {
+                    if (self.process_table.scrollCommand(1)) {
+                        ctx.consumeAndRedraw();
+                    }
                 } else if (key.matches(vaxis.Key.left, .{})) {
-                    self.scroll.scrollBy(0, -1);
-                } else return;
-                return ctx.consumeAndRedraw();
+                    if (self.process_table.scrollCommand(-1)) {
+                        ctx.consumeAndRedraw();
+                    }
+                }
+
+                return;
             },
             .mouse => |mouse| {
+                // remove selection
+                if (mouse.type == .press and mouse.button == .left) {
+                    if (self.selection.kind != .none) {
+                        self.selection.clear();
+                        return ctx.consumeAndRedraw();
+                    }
+                    return;
+                }
                 switch (mouse.button) {
                     .wheel_up => self.scroll.scrollBy(-3, 0),
                     .wheel_down => self.scroll.scrollBy(3, 0),
-                    .wheel_left => self.scroll.scrollBy(0, 3),
-                    .wheel_right => self.scroll.scrollBy(0, -3),
+                    .wheel_left => if (!self.process_table.scrollCommand(1)) return,
+                    .wheel_right => if (!self.process_table.scrollCommand(-1)) return,
                     else => return,
                 }
                 return ctx.consumeAndRedraw();
             },
             else => {},
         }
+    }
+
+    fn currentSelIndex(self: *const Model, dev_n: usize) ?usize {
+        switch (self.selection.kind) {
+            .device => if (self.viewing_device == null and self.selection.device < dev_n) return self.selection.device,
+            .process => if (self.process_table.rowIndexOfPid(self.selection.pid)) |r| return dev_n + r,
+            .none => {},
+        }
+        return null;
+    }
+
+    fn moveSelection(self: *Model, ctx: *vxfw.EventContext, delta: i32) void {
+        const dev_n = if (self.viewing_device == null) self.state.deviceCount() else 0;
+        const item_count = dev_n + self.process_table.merged.items.len;
+
+        if (item_count == 0) {
+            return ctx.consumeEvent();
+        }
+
+        // Pick the target index. With nothing selected yet, the first press
+        // selects the top item; otherwise step by delta, clamped to the list.
+        var next: usize = 0;
+        if (self.currentSelIndex(dev_n)) |cur| {
+            const last: i32 = @intCast(item_count - 1);
+            const moved: i32 = @as(i32, @intCast(cur)) + delta;
+
+            next = @intCast(std.math.clamp(moved, 0, last));
+        }
+
+        if (next < dev_n) { // A device card.
+            _ = self.selection.setDevice(@intCast(next));
+        } else { // A process row
+            const row = next - dev_n;
+
+            _ = self.selection.setProcess(self.process_table.merged.items[row].pid);
+            self.process_table.scroll_bars.scroll_view.cursor = @intCast(row);
+            self.process_table.scroll_bars.scroll_view.ensureScroll();
+        }
+
+        self.pending_scroll_to_sel = true;
+        return ctx.consumeAndRedraw();
+    }
+
+    /// Pointer to the widget the current selection lives on, for auto-scroll.
+    fn selectionTargetPtr(self: *Model) ?*anyopaque {
+        switch (self.selection.kind) {
+            .device => if (self.viewing_device == null and self.selection.device < self.overview.device_cards.len)
+                return @ptrCast(&self.overview.device_cards[self.selection.device]),
+            .process => if (self.process_table.rowIndexOfPid(self.selection.pid)) |r|
+                return @ptrCast(&self.process_table.rows.items[r]),
+            .none => {},
+        }
+        return null;
     }
 
     pub fn draw(self: *Model, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
@@ -115,6 +203,7 @@ const Model = struct {
         if (self.viewing_device != self.prev_viewing_device) {
             self.scroll.reset();
             self.process_table.resetScroll();
+            self.selection.clear();
             self.prev_viewing_device = self.viewing_device;
         }
 
@@ -136,11 +225,32 @@ const Model = struct {
         content_surf.size.height = @max(content_surf.size.height, min_height);
 
         const content_h = screen.height -| 1;
+
+        // Bring the keyboard selection into view
+        // TODO: maybe find another way of doing that, see `findWidgetY` func below
+        if (self.pending_scroll_to_sel) {
+            self.pending_scroll_to_sel = false;
+
+            if (self.selectionTargetPtr()) |target| {
+                if (findWidgetY(content_surf, target, 0)) |found| {
+                    const view_h: i17 = @intCast(content_h);
+                    const bot = found.y + @as(i17, @intCast(found.h));
+
+                    if (found.y < self.scroll.row) {
+                        self.scroll.row = found.y;
+                    } else if (bot > self.scroll.row + view_h) {
+                        self.scroll.row = bot - view_h;
+                    }
+                }
+            }
+        }
+
         self.scroll.clamp(content_surf.size.height, content_h, content_surf.size.width, screen.width);
 
         const status_line: StatusLine = .{
             .viewing_device = self.viewing_device,
             .use_braille = self.overview.use_braille,
+            .can_kill = self.process_table.killableSelected(),
         };
         const status_surf = try status_line.draw(ui.fixedSize(ctx, screen.width, 1));
 
@@ -150,6 +260,17 @@ const Model = struct {
         return sb.finish(screen, ui.widget(self));
     }
 };
+
+const FoundWidget = struct { y: i17, h: u16 };
+
+// TODO: probably not optimal but we'll see once we bump libvaxis
+fn findWidgetY(surface: vxfw.Surface, target: *anyopaque, base: i17) ?FoundWidget {
+    if (surface.widget.userdata == target) return .{ .y = base, .h = surface.size.height };
+    for (surface.children) |child| {
+        if (findWidgetY(child.surface, target, base + child.origin.row)) |found| return found;
+    }
+    return null;
+}
 
 pub fn run(allocator: std.mem.Allocator, io: std.Io, state: *data.SystemState) !void {
     var app = try vxfw.App.init(allocator, io);

--- a/bin/zml-smi/tui/widgets/device_card.zig
+++ b/bin/zml-smi/tui/widgets/device_card.zig
@@ -7,15 +7,16 @@ const utils = @import("../lib/utils.zig");
 const ui = @import("../lib/ui.zig");
 const image_cache = @import("../image_cache.zig");
 const MetricCard = @import("metric_card.zig");
+const Selection = @import("../selection.zig").Selection;
 
 const DeviceCard = @This();
 
 device_id: u16 = 0,
-highlighted: bool = false,
 
 state: *const data.SystemState = undefined,
 use_braille: bool = false,
 viewing_device: *?u16 = undefined,
+selection: *Selection = undefined,
 
 pub fn handleEvent(self: *DeviceCard, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
     switch (event) {
@@ -24,15 +25,17 @@ pub fn handleEvent(self: *DeviceCard, ctx: *vxfw.EventContext, event: vxfw.Event
                 self.viewing_device.* = self.device_id;
                 return ctx.consumeAndRedraw();
             }
+            // Any mouse movement over the card claims the selection (mouse wins).
+            if (self.selection.setDevice(self.device_id)) ctx.redraw = true;
         },
         .mouse_enter => {
-            self.highlighted = true;
+            _ = self.selection.setDevice(self.device_id);
             try ctx.setMouseShape(.pointer);
             return ctx.consumeAndRedraw();
         },
         .mouse_leave => {
-            self.highlighted = false;
             try ctx.setMouseShape(.default);
+            if (self.selection.deviceEq(self.device_id)) self.selection.clear();
             ctx.redraw = true;
         },
         else => {},
@@ -119,7 +122,7 @@ pub fn draw(self: *DeviceCard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vx
         }),
         .title_right = if (self.state.devices[i].isRemote()) "remote" else null,
         .cell_size = ctx.cell_size,
-        .highlighted = self.highlighted,
+        .highlighted = self.selection.deviceEq(self.device_id),
     };
 
     const util_hist = try self.state.history.util[i].sliceLast(ctx.arena, data.history_len);

--- a/bin/zml-smi/tui/widgets/process_table.zig
+++ b/bin/zml-smi/tui/widgets/process_table.zig
@@ -7,6 +7,7 @@ const ui = @import("../lib/ui.zig");
 const compose = @import("../lib/compose.zig");
 const TitledBorder = @import("titled_border.zig");
 const ColumnLayout = @import("column_layout.zig");
+const Selection = @import("../selection.zig").Selection;
 const pi = @import("zml-smi/info").process_info;
 const ProcessInfo = pi.ProcessInfo;
 
@@ -25,13 +26,163 @@ scroll_bars: vxfw.ScrollBars = .{
     .draw_horizontal_scrollbar = false,
 },
 merged: std.ArrayList(ProcessInfo) = .empty,
+rows: std.ArrayList(Row) = .empty,
+selection: *Selection = undefined,
+
+last_click_at: std.Io.Timestamp = .zero,
+last_click_idx: ?u32 = null,
+
+io: ?std.Io = null,
+
+cmd_scroll: u16 = 0,
+cmd_scroll_pid: u32 = 0,
+cmd_scroll_max: u16 = 0,
+
+/// Highlight background for the selected row.
+const sel_bg: vaxis.Color = .{ .rgb = .{ 45, 55, 80 } };
+
+const Row = struct {
+    table: *ProcessTable,
+    idx: u32,
+
+    pub fn handleEvent(self: *Row, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+        const table = self.table;
+
+        switch (event) {
+            .mouse => |mouse| {
+                if (mouse.type == .press and mouse.button == .left) {
+                    if (self.idx >= table.merged.items.len) {
+                        return;
+                    }
+
+                    table.scroll_bars.scroll_view.cursor = self.idx;
+                    _ = table.selection.setProcess(table.merged.items[self.idx].pid);
+
+                    // Double-click — the same row clicked again within 400ms — kills.
+                    var dbl = false;
+                    if (table.io) |io| {
+                        const now = std.Io.Timestamp.now(io, .awake);
+                        dbl = table.last_click_idx == self.idx and
+                            table.last_click_at.durationTo(now).toMilliseconds() < 400;
+                        table.last_click_at = now;
+                    }
+                    table.last_click_idx = self.idx;
+
+                    if (dbl) {
+                        table.killSelected();
+                    }
+
+                    return ctx.consumeAndRedraw();
+                }
+            },
+            else => {},
+        }
+    }
+
+    pub fn draw(self: *Row, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const table = self.table;
+        const vw: u16 = ctx.min.width;
+        if (self.idx >= table.merged.items.len) {
+            var empty_surf = try (RichText{ .text = &.{}, .softwrap = false, .overflow = .clip }).draw(ui.fixedSize(ctx, vw, 1));
+            empty_surf.widget = ui.widget(self);
+
+            return empty_surf;
+        }
+        const info = &table.merged.items[self.idx];
+        const selected = table.selection.processEq(info.pid);
+        const row_bg: vaxis.Color = if (selected) sel_bg else .default;
+        const val: vaxis.Style = .{ .fg = theme.text_primary, .bg = row_bg };
+        const dim: vaxis.Style = .{ .fg = theme.dim, .bg = row_bg };
+
+        const segs = try ctx.arena.alloc(Segment, 8);
+        segs[0] = .{ .style = val, .text = try col(ctx.arena, col_fmt.pid, "{d}", .{info.pid}) };
+        segs[1] = .{ .style = val, .text = try col(ctx.arena, col_fmt.user, "{s}", .{info.username[0..@min(info.username.len, 10)]}) };
+        segs[2] = .{ .style = val, .text = try col(ctx.arena, col_fmt.dev, "{d}", .{info.device_idx}) };
+        segs[3] = if (info.dev_util_percent) |util|
+            .{ .style = val, .text = try col(ctx.arena, col_fmt.util, "{d}%", .{util}) }
+        else
+            .{ .style = dim, .text = try col(ctx.arena, col_fmt.util, "-", .{}) };
+        segs[4] = if (info.dev_mem_kib) |mem|
+            .{ .style = val, .text = try col(ctx.arena, col_fmt.mem, "{s}", .{try fmtMem(ctx.arena, mem)}) }
+        else
+            .{ .style = dim, .text = try col(ctx.arena, col_fmt.mem, "-", .{}) };
+        segs[5] = .{ .style = val, .text = try col(ctx.arena, col_fmt.cpu, "{d}.{d}%", .{ info.cpu_percent / 10, info.cpu_percent % 10 }) };
+        segs[6] = .{ .style = val, .text = try col(ctx.arena, col_fmt.host_mem, "{s}", .{try fmtMem(ctx.arena, info.rss_kib)}) };
+        segs[7] = .{ .style = val, .text = info.comm };
+
+        const rich: RichText = .{ .text = segs, .softwrap = false, .overflow = .clip, .base_style = .{ .bg = row_bg } };
+
+        if (!selected) { // make it clipped
+            var surf = try rich.draw(ui.fixedSize(ctx, vw, 1));
+            surf.widget = ui.widget(self);
+            return surf;
+        }
+
+        const full = try rich.draw(ctx.withConstraints(
+            .{ .width = vw, .height = 1 },
+            .{ .width = null, .height = 1 },
+        ));
+        table.cmd_scroll_max = full.size.width -| vw;
+        const off: u16 = @min(table.cmd_scroll, table.cmd_scroll_max);
+
+        var sb = compose.surfaceBuilder(ctx.arena);
+        try sb.add(0, -@as(i17, off), full);
+        return sb.finish(.{ .width = vw, .height = 1 }, ui.widget(self));
+    }
+};
 
 pub fn deinit(self: *ProcessTable, allocator: std.mem.Allocator) void {
     self.merged.deinit(allocator);
+    self.rows.deinit(allocator);
+}
+
+pub fn rowIndexOfPid(self: *const ProcessTable, pid: u32) ?usize {
+    for (self.merged.items, 0..) |p, i| {
+        if (p.pid == pid) return i;
+    }
+
+    return null;
+}
+
+pub fn killableSelected(self: *const ProcessTable) bool {
+    if (self.selection.kind != .process) {
+        return false;
+    }
+
+    const idx = self.rowIndexOfPid(self.selection.pid) orelse return false;
+    const p = self.merged.items[idx];
+
+    return !p.remote and p.pid != 0;
+}
+
+pub fn killSelected(self: *ProcessTable) void {
+    if (!self.killableSelected()) {
+        return;
+    }
+
+    const idx = self.rowIndexOfPid(self.selection.pid).?;
+    std.posix.kill(@intCast(self.merged.items[idx].pid), std.posix.SIG.KILL) catch {};
+}
+
+pub fn scrollCommand(self: *ProcessTable, dir: i8) bool {
+    if (self.selection.kind != .process or self.cmd_scroll_max == 0) {
+        return false;
+    }
+
+    const step: u16 = 2;
+    const old = self.cmd_scroll;
+    if (dir > 0) {
+        self.cmd_scroll = @min(self.cmd_scroll + step, self.cmd_scroll_max);
+    } else {
+        self.cmd_scroll -|= step;
+    }
+
+    return self.cmd_scroll != old;
 }
 
 pub fn prepare(self: *ProcessTable, state: *data.SystemState, device_id: ?u16) void {
     self.scroll_bars.scroll_view.children.builder.userdata = self;
+    self.io = state.io;
     self.merged.clearRetainingCapacity();
 
     for (state.process_lists) |pl| {
@@ -61,6 +212,23 @@ pub fn prepare(self: *ProcessTable, state: *data.SystemState, device_id: ?u16) v
     const count: u32 = @intCast(self.merged.items.len);
     self.scroll_bars.estimated_content_height = count;
     self.scroll_bars.scroll_view.item_count = count;
+
+    if (self.rows.items.len != self.merged.items.len) {
+        self.rows.clearRetainingCapacity();
+        for (0..self.merged.items.len) |i| {
+            self.rows.append(state.gpa, .{ .table = self, .idx = @intCast(i) }) catch break;
+        }
+    }
+
+    if (self.selection.kind == .process) {
+        if (self.selection.pid != self.cmd_scroll_pid) {
+            self.cmd_scroll = 0;
+            self.cmd_scroll_pid = self.selection.pid;
+        }
+    } else {
+        self.cmd_scroll = 0;
+        self.cmd_scroll_pid = 0;
+    }
 }
 
 pub fn resetScroll(self: *ProcessTable) void {
@@ -104,10 +272,10 @@ pub fn draw(self: *ProcessTable, ctx: vxfw.DrawContext) std.mem.Allocator.Error!
 /// Builds only data rows (no header) for the scroll view.
 fn buildRow(ptr: *const anyopaque, idx: usize, _: usize) ?vxfw.Widget {
     const self: *ProcessTable = @ptrCast(@alignCast(@constCast(ptr)));
-    if (idx >= self.merged.items.len) {
+    if (idx >= self.merged.items.len or idx >= self.rows.items.len) {
         return null;
     }
-    return .{ .userdata = @ptrCast(&self.merged.items[idx]), .drawFn = drawProcessRow };
+    return ui.widget(&self.rows.items[idx]);
 }
 
 // Column format strings — shared between header (comptime) and row (runtime).
@@ -138,34 +306,6 @@ const header_segs = blk: {
 /// Format a value into a column: col(arena, col_fmt.pid, "{d}", .{pid})
 fn col(arena: std.mem.Allocator, comptime column: []const u8, comptime fmt: []const u8, args: anytype) std.mem.Allocator.Error![]const u8 {
     return std.fmt.allocPrint(arena, column, .{try std.fmt.allocPrint(arena, fmt, args)});
-}
-
-fn drawProcessRow(ptr: *anyopaque, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
-    const info: *const ProcessInfo = @ptrCast(@alignCast(ptr));
-    const val: vaxis.Style = .{ .fg = theme.text_primary };
-    const dim: vaxis.Style = .{ .fg = theme.dim };
-
-    const segs = try ctx.arena.alloc(Segment, 8);
-    segs[0] = .{ .style = val, .text = try col(ctx.arena, col_fmt.pid, "{d}", .{info.pid}) };
-    segs[1] = .{ .style = val, .text = try col(ctx.arena, col_fmt.user, "{s}", .{info.username[0..@min(info.username.len, 10)]}) };
-    segs[2] = .{ .style = val, .text = try col(ctx.arena, col_fmt.dev, "{d}", .{info.device_idx}) };
-    segs[3] = if (info.dev_util_percent) |util|
-        .{ .style = val, .text = try col(ctx.arena, col_fmt.util, "{d}%", .{util}) }
-    else
-        .{ .style = dim, .text = try col(ctx.arena, col_fmt.util, "-", .{}) };
-    segs[4] = if (info.dev_mem_kib) |mem|
-        .{ .style = val, .text = try col(ctx.arena, col_fmt.mem, "{s}", .{try fmtMem(ctx.arena, mem)}) }
-    else
-        .{ .style = dim, .text = try col(ctx.arena, col_fmt.mem, "-", .{}) };
-    segs[5] = .{ .style = val, .text = try col(ctx.arena, col_fmt.cpu, "{d}.{d}%", .{ info.cpu_percent / 10, info.cpu_percent % 10 }) };
-    segs[6] = .{ .style = val, .text = try col(ctx.arena, col_fmt.host_mem, "{s}", .{try fmtMem(ctx.arena, info.rss_kib)}) };
-    segs[7] = .{ .style = val, .text = info.comm };
-
-    const rich: RichText = .{ .text = segs, .softwrap = false, .overflow = .clip };
-    return rich.draw(ctx.withConstraints(
-        .{ .width = ctx.min.width, .height = 1 },
-        .{ .width = ctx.max.width, .height = 1 },
-    ));
 }
 
 fn fmtMem(arena: std.mem.Allocator, kib: u64) std.mem.Allocator.Error![]const u8 {

--- a/bin/zml-smi/tui/widgets/status_line.zig
+++ b/bin/zml-smi/tui/widgets/status_line.zig
@@ -8,6 +8,7 @@ const StatusLine = @This();
 
 viewing_device: ?u16,
 use_braille: bool,
+can_kill: bool,
 
 const Binding = struct {
     key: []const u8,
@@ -30,10 +31,18 @@ pub fn draw(self: *const StatusLine, ctx: vxfw.DrawContext) std.mem.Allocator.Er
     if (self.viewing_device != null) {
         bindings_buf[n] = .{ .key = "Esc", .desc = "back" };
         n += 1;
+        bindings_buf[n] = .{ .key = "\u{2191}\u{2193}/jk", .desc = "select" };
+        n += 1;
     } else {
         bindings_buf[n] = .{ .key = "v", .desc = chart_label };
         n += 1;
-        bindings_buf[n] = .{ .key = "click", .desc = "device details" };
+        bindings_buf[n] = .{ .key = "\u{2191}\u{2193}/jk", .desc = "select" };
+        n += 1;
+        bindings_buf[n] = .{ .key = "enter/click", .desc = "open device" };
+        n += 1;
+    }
+    if (self.can_kill) {
+        bindings_buf[n] = .{ .key = "x", .desc = "kill process" };
         n += 1;
     }
     bindings_buf[n] = .{ .key = "q", .desc = "quit" };
@@ -65,11 +74,9 @@ pub fn draw(self: *const StatusLine, ctx: vxfw.DrawContext) std.mem.Allocator.Er
     const surf = try rich.draw(ui.fixedSize(ctx, w, 1));
 
     // Fill background across full width
-    if (surf.buffer.len > 0) {
-        for (surf.buffer) |*cell| {
-            if (cell.style.bg == .default) {
-                cell.style.bg = bg_style.bg;
-            }
+    for (surf.buffer) |*cell| {
+        if (cell.style.bg == .default) {
+            cell.style.bg = bg_style.bg;
         }
     }
 


### PR DESCRIPTION
Add a single shared selection cursor (new tui/selection.zig) driven by both mouse and keyboard:

- Keyboard nav (↑↓ / jk / Ctrl-N/P) walks a unified list of devices
- Devices: mouse hover or nav selects. Enter or click opens the detail view.
- Processes: keyboard-selectable or click-to-select. double-click or`x` kills the process