### PR TITLE
zml/moe : Mosaic GMM EP TPU kernel. DSL update.

### DIFF
--- a/kernels/mosaic_tpu/builder.zig
+++ b/kernels/mosaic_tpu/builder.zig
@@ -297,6 +297,9 @@ pub const ArgSpec = struct {
         shape: []const i64,
         dtype: DType,
         memory_space: MemorySpace = .vmem,
+        /// Emit `{sc.persistent}` on this memref argument. Sparse-core Pallas
+        /// kernels mark persistent HBM operands this way.
+        persistent: bool = false,
         /// Block window. `null` ⇒ trivial window (block == operand shape);
         /// VMEM trivial windows auto-get `pipeline_mode = synchronous`.
         window: ?WindowSpec = null,
@@ -476,6 +479,10 @@ pub const Builder = struct {
     /// Whether to emit Pallas-style `transform_N` stubs at `finish` time.
     /// Set by `declareArgsLowOpts` from `Opts.pallas_window_params`.
     emit_transform_stubs: bool = false,
+    /// Optional prefix for generated transform function names.
+    transform_name_prefix: ?[]const u8 = null,
+    /// Whether generated transform functions carry `{sc.is_transform_indices}`.
+    sc_transform_indices: bool = false,
 
     /// Per-ref-arg snapshot for `finish`-time `transform_N` stub emission.
     /// `skipped` = ANY/HBM/SEMAPHORE memory space (empty window, no transform).
@@ -510,6 +517,9 @@ pub const Builder = struct {
         /// Pallas's `iteration_bounds = array<i64: …>` — the grid shape
         /// (one entry per `dimension_semantics`). `null` omits the attr.
         iteration_bounds: ?[]const i64 = null,
+        /// Emit `scalar_prefetch = N : i64`. Sparse-core kernels with no
+        /// scalar prefetches omit the zero-valued attr.
+        emit_scalar_prefetch_attr: bool = true,
         /// When `true`, auto-emit `window_params = [...]` and trailing
         /// `transform_N` stub funcs at `finish` time. Per-arg behavior
         /// matches `lowering.py:1014–1131`: ANY/HBM/SEMAPHORE refs get
@@ -517,6 +527,13 @@ pub const Builder = struct {
         /// auto-force `pipeline_mode = synchronous`. Override per-arg
         /// via `RefSpec.window`.
         pallas_window_params: bool = false,
+        /// Include HBM refs in Pallas-style `window_params`. Tensor-core
+        /// Pallas lowering skips HBM; sparse-core lowering includes it.
+        window_hbm_refs: bool = false,
+        /// Optional prefix for generated transform function names.
+        transform_name_prefix: ?[]const u8 = null,
+        /// Add `{sc.is_transform_indices}` to generated transform stubs.
+        sc_transform_indices: bool = false,
     };
 
     /// Create a sub-module containing a single public `func.func` of the
@@ -601,6 +618,7 @@ pub const Builder = struct {
                         .shape = inner.shape,
                         .dtype = inner.dtype,
                         .memory_space = if (@hasField(@TypeOf(inner), "memory_space")) inner.memory_space else .vmem,
+                        .persistent = if (@hasField(@TypeOf(inner), "persistent")) inner.persistent else false,
                         .window = if (@hasField(@TypeOf(inner), "window")) inner.window else null,
                         .role = if (@hasField(@TypeOf(inner), "role")) inner.role else .input,
                     } },
@@ -665,8 +683,7 @@ pub const Builder = struct {
 
         const entry = mlir.Block.init(arg_types, arg_locs);
 
-        // Build per-arg attribute dicts. The only ones we currently emit are
-        // `tpu.dimension_semantics` on iter args.
+        // Build per-arg attribute dicts.
         const arg_attrs = try scratch.alloc(*const mlir.Attribute, args.len);
         var any_arg_attr = false;
         for (args, 0..) |a, i| {
@@ -682,19 +699,31 @@ pub const Builder = struct {
                         arg_attrs[i] = empty_dict;
                     }
                 },
+                .ref => |r| {
+                    if (r.persistent) {
+                        arg_attrs[i] = .dict(ctx, &.{
+                            .named(ctx, "sc.persistent", .unit(ctx)),
+                        });
+                        any_arg_attr = true;
+                    } else {
+                        arg_attrs[i] = empty_dict;
+                    }
+                },
                 else => arg_attrs[i] = empty_dict,
             }
         }
 
         // Kernel-level func.func attributes. MLIR sorts attrs alphabetically on print.
-        var extra_attrs: stdx.BoundedArray(mlir.NamedAttribute, 8) = .empty;
+        var extra_attrs: stdx.BoundedArray(mlir.NamedAttribute, 12) = .empty;
         const dim_sem_buf = try scratch.alloc(*const mlir.Attribute, opts.dimension_semantics.len);
         for (opts.dimension_semantics, 0..) |s, i| dim_sem_buf[i] = s.attribute(ctx);
         extra_attrs.appendAssumeCapacity(.named(ctx, "dimension_semantics", .array(ctx, dim_sem_buf)));
         if (opts.iteration_bounds) |bounds| {
             extra_attrs.appendAssumeCapacity(.named(ctx, "iteration_bounds", .denseArray(ctx, .i64, bounds)));
         }
-        extra_attrs.appendAssumeCapacity(.named(ctx, "scalar_prefetch", .int(ctx, .i64, opts.scalar_prefetch)));
+        if (opts.emit_scalar_prefetch_attr) {
+            extra_attrs.appendAssumeCapacity(.named(ctx, "scalar_prefetch", .int(ctx, .i64, opts.scalar_prefetch)));
+        }
         extra_attrs.appendAssumeCapacity(.named(ctx, "scratch_operands", .int(ctx, .i64, opts.scratch_operands)));
         if (opts.core_type) |ct| {
             extra_attrs.appendAssumeCapacity(.named(ctx, "tpu.core_type", ct.attribute(ctx)));
@@ -714,9 +743,10 @@ pub const Builder = struct {
                         (w.block_shape orelse r.shape)
                     else
                         r.shape;
+                    const skipped = isSkippedWindowSpace(r.memory_space) and !(opts.window_hbm_refs and r.memory_space == .hbm);
                     try ref_args_buf.append(arena_alloc, .{
                         .block_rank = @intCast(block_shape.len),
-                        .skipped = isSkippedWindowSpace(r.memory_space),
+                        .skipped = skipped,
                         .role = r.role,
                         .transform_returns = if (r.window) |w| w.transform_returns else null,
                     });
@@ -730,6 +760,8 @@ pub const Builder = struct {
         self.prefetch_args = try arena_alloc.dupe(*const mlir.Type, prefetch_types_buf.items);
         self.grid_dim_count = opts.dimension_semantics.len;
         self.emit_transform_stubs = opts.pallas_window_params;
+        self.transform_name_prefix = opts.transform_name_prefix;
+        self.sc_transform_indices = opts.sc_transform_indices;
 
         // window_params: one entry per `.input` / `.output` ref.
         //   ANY/HBM/SEMAPHORE → empty dict, no transform_N.
@@ -741,7 +773,7 @@ pub const Builder = struct {
             for (args) |a| switch (a.kind) {
                 .ref => |r| {
                     if (r.role != .input and r.role != .output) continue;
-                    if (isSkippedWindowSpace(r.memory_space)) {
+                    if (isSkippedWindowSpace(r.memory_space) and !(opts.window_hbm_refs and r.memory_space == .hbm)) {
                         wp_buf[idx] = .dict(ctx, &.{});
                         idx += 1;
                         continue;
@@ -767,8 +799,10 @@ pub const Builder = struct {
                             break :blk null;
                         };
 
-                    var sym_buf: [32]u8 = undefined;
-                    const sym_name = std.fmt.bufPrint(&sym_buf, "transform_{d}", .{idx}) catch unreachable;
+                    const sym_name = if (opts.transform_name_prefix) |prefix|
+                        try std.fmt.allocPrint(scratch, "{s}_transform_{d}", .{ prefix, idx })
+                    else
+                        try std.fmt.allocPrint(scratch, "transform_{d}", .{idx});
 
                     var inner: stdx.BoundedArray(mlir.NamedAttribute, 5) = .empty;
                     if (resolved_pipeline) |pm| {
@@ -1433,6 +1467,23 @@ pub const Builder = struct {
         ));
     }
 
+    /// `tpu.vector_load` with an explicit result vector shape.
+    pub fn tpuVectorLoadShape(self: *Builder, ref: Value, indices: []const Value, shape: []const i64, opts: VectorLoadOpts) Value {
+        const ctx = self.ctx;
+        const result_ty = mlir.Type.vector(shape, ref.elemType());
+        const idx_inner = self.indicesOrZero(ref, indices);
+        const mask_inner: ?*const mlir.Value = if (opts.mask) |m| m.inner else null;
+        return self.emit(tpu.vector_load(
+            ctx,
+            ref.inner,
+            idx_inner,
+            mask_inner,
+            .{ .strides = opts.strides },
+            result_ty,
+            self.loc(),
+        ));
+    }
+
     /// `tpu.vector_store(value, ref)` — full-shape vector store.
     pub fn refStore(self: *Builder, ref: Value, value: Value) void {
         self.refStoreOpts(ref, value, &.{}, .{});
@@ -1606,6 +1657,16 @@ pub const Builder = struct {
         return self.emit(vector.extract(self.ctx, src.inner, position, &.{}, ty, self.loc()));
     }
 
+    /// `vector.extract_strided_slice` — statically slice a vector.
+    pub fn vectorExtractStridedSlice(self: *Builder, src: Value, offsets: []const i64, sizes: []const i64, strides: []const i64) Value {
+        const ty = mlir.Type.vector(sizes, src.elemType());
+        return self.emit(vector.extract_strided_slice(self.ctx, src.inner, .{
+            .offsets = offsets,
+            .sizes = sizes,
+            .strides = strides,
+        }, ty, self.loc()));
+    }
+
     /// `vector.reduction <kind>` — reduce a 1-D vector to a scalar.
     /// Emits the bare upstream op; on real TPU the layout pass may reject
     /// 1-D vectors, so prefer `reduceToScalar` for kernel-level reductions.
@@ -1726,7 +1787,7 @@ pub const Builder = struct {
         for (in_shape.constSlice(), 0..) |d, i| {
             if (@as(i32, @intCast(i)) != axis) out.appendAssumeCapacity(d);
         }
-        const ty = mlir.Type.vector(out.constSlice(), .integer(self.ctx, .i32));
+        const ty = mlir.Type.vector(out.constSlice(), .int(self.ctx, .i32));
         return self.emit(tpu.reduce_index(self.ctx, input.inner, axis, kind, ty, self.loc()));
     }
 
@@ -1791,6 +1852,10 @@ pub const Builder = struct {
         return self.emit(tpu.memref_reshape(self.ctx, mem_ref.inner, result_ty, self.loc()));
     }
 
+    pub fn memRefAlloca(self: *Builder, shape: []const i64, dtype: DType, memory_space: MemorySpace) Value {
+        return self.emit(memref.alloca(self.ctx, self.memRefTy(shape, dtype, memory_space), &.{}, &.{}, .{}, self.loc()));
+    }
+
     pub fn memRefBitcast(self: *Builder, mem_ref: Value, dt: DType) Value {
         const mr = mem_ref.type_().isA(mlir.MemRefType) orelse @panic("memRefBitcast: not a memref");
         var s: stdx.BoundedArray(i64, mlir.ShapedType.MAX_RANK) = .empty;
@@ -1847,15 +1912,16 @@ pub const Builder = struct {
     // ==================== Semaphores / DMA / barriers ====================
 
     pub fn semAlloc(self: *Builder, kind: ArgSpec.SemKind) Value {
-        const ty = switch (kind) {
+        const elem = switch (kind) {
             .regular => tpu.semaphoreType(self.ctx),
             .dma => tpu.dmaSemaphoreType(self.ctx),
         };
+        const ty = mlir.Type.memRef(elem, &.{}, null, MemorySpace.semaphore_mem.attribute(self.ctx));
         return self.emit(tpu.sem_alloc(self.ctx, ty, self.loc()));
     }
 
     pub fn semBarrier(self: *Builder) Value {
-        const ty = tpu.dmaSemaphoreType(self.ctx);
+        const ty = mlir.Type.memRef(tpu.semaphoreType(self.ctx), &.{}, null, MemorySpace.semaphore_mem.attribute(self.ctx));
         return self.emit(tpu.sem_barrier(self.ctx, ty, self.loc()));
     }
 
@@ -1949,6 +2015,22 @@ pub const Builder = struct {
     pub fn delay(self: *Builder, cycles: anytype) void {
         const c_ = if (@TypeOf(cycles) == Value) cycles else self.lift(cycles);
         _ = tpu.delay(self.ctx, c_.inner, self.loc()).appendTo(self.currentBlock());
+    }
+
+    pub fn assumeMultiple(self: *Builder, src: Value, multiple: i32) Value {
+        return self.emit(tpu.assume_multiple(self.ctx, src.inner, multiple, self.loc()));
+    }
+
+    pub fn openRegion(self: *Builder) *mlir.Block {
+        const block = mlir.Block.init(&.{}, &.{});
+        self.pushBlock(block);
+        return block;
+    }
+
+    pub fn closeRegion(self: *Builder, block: *mlir.Block) void {
+        _ = tpu.yield(self.ctx, &.{}, self.loc()).appendTo(block);
+        self.popBlock();
+        _ = tpu.region(self.ctx, block, &.{}, self.loc()).appendTo(self.currentBlock());
     }
 
     // ==================== SCF regions ====================
@@ -2191,8 +2273,17 @@ pub const Builder = struct {
             }
             _ = func.returns(ctx, ret_vals, unknown_loc).appendTo(block);
 
-            var name_buf: [32]u8 = undefined;
-            const name = std.fmt.bufPrint(&name_buf, "transform_{d}", .{idx}) catch unreachable;
+            const name = if (self.transform_name_prefix) |prefix|
+                std.fmt.allocPrint(arena_alloc, "{s}_transform_{d}", .{ prefix, idx }) catch @panic("OOM")
+            else blk: {
+                var name_buf: [32]u8 = undefined;
+                break :blk arena_alloc.dupe(u8, std.fmt.bufPrint(&name_buf, "transform_{d}", .{idx}) catch unreachable) catch @panic("OOM");
+            };
+
+            var extra_attrs: stdx.BoundedArray(mlir.NamedAttribute, 1) = .empty;
+            if (self.sc_transform_indices) {
+                extra_attrs.appendAssumeCapacity(.named(ctx, "sc.is_transform_indices", .unit(ctx)));
+            }
 
             const stub_op = func.func(ctx, .{
                 .name = name,
@@ -2202,6 +2293,7 @@ pub const Builder = struct {
                 .location = unknown_loc,
                 .visibility = null,
                 .verify = false,
+                .extra_attributes = extra_attrs.constSlice(),
             });
             _ = stub_op.appendTo(self.module.body());
         }

--- a/kernels/mosaic_tpu/pipeline.zig
+++ b/kernels/mosaic_tpu/pipeline.zig
@@ -1,7 +1,6 @@
 //! Zig port of `pltpu.emit_pipeline` (jax/_src/pallas/mosaic/pipeline.py) —
 //! emits lowered `tpu`-dialect IR byte-equivalent to `pallas_call`.
 //!
-//! 1-D dynamic-bound grid; VMEM operands; `buffer_count ∈ {1,2}`;
 //! `.blocked`/`.squeezed`/one `.bounded_slice` block dim; trivial-windowing
 //! inputs peeled as sync copy; `trace_scopes`. Unsupported features panic.
 
@@ -57,6 +56,8 @@ pub const BodyFn = *const fn (b: *Builder, grid_indices: []const Value, refs: []
 pub const PipeSpec = struct {
     full_shape: []const i64,
     dtype: DType,
+    /// Optional HBM source/result view to materialize at each DMA use site.
+    source_reshape_shape: ?[]const i64 = null,
     /// `null` ⇒ trivial windowing (the whole array).
     block_shape: ?[]const BlockDim = null,
     /// `null` only allowed with trivial windowing.
@@ -64,7 +65,7 @@ pub const PipeSpec = struct {
     index_map_ctx: ?*anyopaque = null,
     /// Only `.vmem` supported.
     memory_space: MemorySpace = .vmem,
-    /// `null` ⇒ 2 (or 1 if trivial).
+    
     buffer_count: ?usize = null,
     /// Tile that `_create_bounded_slice` rounds the DMA size up to.
     bounded_slice_tiling: i32 = 1,
@@ -92,7 +93,7 @@ pub fn emitPipeline(
     opts: PipelineOpts,
 ) FinishError!void {
     std.debug.assert(opts.grid.len >= 1);
-    if (opts.grid.len != 1) @panic("emitPipeline: only 1-D grids supported (TODO: N-D `_next_index`)");
+    if (opts.grid.len > 4) @panic("emitPipeline: grids with rank > 4 unsupported");
     const n_in = opts.in_specs.len;
     std.debug.assert(refs.len == n_in + opts.out_specs.len);
 
@@ -118,7 +119,7 @@ pub fn emitPipeline(
 
     for (brefs.items) |*br| br.allocate(b);
 
-    const num_steps = opts.grid[0];
+    const num_steps = gridSize(b, opts.grid);
     const c0_i32 = b.lift(@as(i32, 0));
     const c1_i32 = b.lift(@as(i32, 1));
     {
@@ -143,11 +144,11 @@ pub fn emitPipeline(
                 if (opts.trace_scopes) b.traceStop();
             }
 
-            // iter_args: each bref's slots in spec order (see appendSlotInits), then grid_idx.
-            var inits: std.ArrayList(*const mlir.Value) = try .initCapacity(a, brefs.items.len * 2 + 1);
+            // iter_args: each bref's slots in spec order (see appendSlotInits), then grid indices.
+            var inits: std.ArrayList(*const mlir.Value) = try .initCapacity(a, brefs.items.len * 2 + opts.grid.len);
             for (brefs.items) |*br| br.appendSlotInits(b, &inits);
-            inits.appendAssumeCapacity(c0_i32.inner);
-            const n_slots = inits.items.len - 1;
+            for (0..opts.grid.len) |_| inits.appendAssumeCapacity(c0_i32.inner);
+            const n_slots = inits.items.len - opts.grid.len;
 
             const i32_ty = b.scalarTy(.i32);
             const block_types = a.alloc(*const mlir.Type, inits.items.len + 1) catch unreachable;
@@ -163,10 +164,13 @@ pub fn emitPipeline(
                 for (brefs.items) |*br| cur = br.bindSlotsAt(b, for_body, cur);
                 std.debug.assert(cur == n_slots + 1);
             }
-            const grid_idx: Value = .{ .inner = for_body.argument(@intCast(n_slots + 1)), .kernel = b };
+            var grid_indices_buf: [4]Value = undefined;
+            for (0..opts.grid.len) |i| {
+                grid_indices_buf[i] = .{ .inner = for_body.argument(@intCast(n_slots + 1 + i)), .kernel = b };
+            }
 
             var sched = Scheduler.init(b, iv, opts.grid, num_steps, num_stages, opts.trace_scopes);
-            sched.indices_storage[0] = grid_idx;
+            for (0..opts.grid.len) |i| sched.indices_storage[i] = grid_indices_buf[i];
             sched.recomputeDerivedIndices(b);
 
             for (brefs.items) |*br| if (br.buffer_type == .input) sched.copyIn(b, br);
@@ -193,10 +197,10 @@ pub fn emitPipeline(
 
             for (brefs.items) |*br| if (br.buffer_type == .input) sched.advanceSlots(b, br);
 
-            var yields: std.ArrayList(*const mlir.Value) = try .initCapacity(a, brefs.items.len * 2 + 1);
+            var yields: std.ArrayList(*const mlir.Value) = try .initCapacity(a, brefs.items.len * 2 + opts.grid.len);
             for (brefs.items) |*br| br.appendSlotYields(b, &yields);
-            const next_idx = nextIndex1D(b, grid_idx, num_steps);
-            yields.appendAssumeCapacity(next_idx.inner);
+            const next_indices = nextIndexND(b, sched.indices(), opts.grid);
+            for (next_indices) |idx| yields.appendAssumeCapacity(idx.inner);
             _ = scf.yield(b.ctx, yields.items, b.loc()).appendTo(for_body);
             b.popBlock();
 
@@ -204,12 +208,15 @@ pub fn emitPipeline(
             _ = for_op.appendTo(b.currentBlock());
             var k: usize = 0;
             for (brefs.items) |*br| k = br.readbackSlots(b, for_op, k);
-            const final_grid_idx: Value = .{ .inner = for_op.result(@intCast(n_slots)), .kernel = b };
+            var final_grid_indices_buf: [4]Value = undefined;
+            for (0..opts.grid.len) |i| {
+                final_grid_indices_buf[i] = .{ .inner = for_op.result(@intCast(n_slots + i)), .kernel = b };
+            }
 
-            // prev_index BEFORE Scheduler.init so its inner `subi(num_steps,1)` CSEs with `step`.
-            const final_idx = prevIndex1D(b, final_grid_idx, num_steps);
+            // prev_index BEFORE Scheduler.init so common arithmetic CSEs with `step`.
+            const final_idx = prevIndexND(b, final_grid_indices_buf[0..opts.grid.len], opts.grid);
             var sched_fin = Scheduler.init(b, b.subi(num_steps, c1_i32), opts.grid, num_steps, num_stages, opts.trace_scopes);
-            sched_fin.indices_storage[0] = final_idx;
+            for (0..opts.grid.len) |i| sched_fin.indices_storage[i] = final_idx[i];
             sched_fin.recomputeDerivedIndices(b);
             for (brefs.items) |*br| sched_fin.finalize(b, br);
             for (brefs.items) |*br| if (br.is_trivial and br.buffer_type == .output) br.syncCopyOut(b);
@@ -315,13 +322,12 @@ const BufferedRef = struct {
 
     fn appendSlotInits(self: *BufferedRef, b: *Builder, out: *std.ArrayList(*const mlir.Value)) void {
         const c0 = b.lift(@as(i32, 0)).inner;
-        const c1 = b.lift(@as(i32, 1)).inner;
         switch (self.buffer_type) {
             .input => {
                 if (self.is_trivial) {
                     out.appendAssumeCapacity(c0);
                 } else {
-                    out.appendAssumeCapacity(c1); // copy_in_slot: initialize_step advanced 0→1
+                    out.appendAssumeCapacity((self.copy_in_slot orelse b.lift(@as(i32, 0))).inner);
                     out.appendAssumeCapacity(c0);
                 }
             },
@@ -488,6 +494,7 @@ const BufferedRef = struct {
     fn sliceSrc(self: *const BufferedRef, b: *Builder, dma: DmaSlice) Value {
         const a = b.arena.allocator();
         const bs = self.spec.block_shape.?;
+        const src = if (self.spec.source_reshape_shape) |shape| b.memRefReshape(self.src, shape) else self.src;
         var base = a.alloc(Value, bs.len) catch unreachable;
         var dyn = std.ArrayList(Value).initCapacity(a, bs.len) catch unreachable;
         var result_shape = a.alloc(i64, bs.len) catch unreachable;
@@ -504,7 +511,12 @@ const BufferedRef = struct {
                 };
             }
         }
-        return b.memRefSlice(self.src, base, result_shape, dyn.items);
+        const sliced = b.memRefSlice(src, base, result_shape, dyn.items);
+        if (self.block_keep.len == bs.len) return sliced;
+
+        const squeezed_shape = a.alloc(i64, self.block_compact.len) catch unreachable;
+        for (self.block_keep, 0..) |sd, ci| squeezed_shape[ci] = result_shape[sd];
+        return b.memRefSqueeze(sliced, squeezed_shape);
     }
 
     /// Slices `alloca[slot, 0…]` (non-squeezed dims) then squeezes the slot dim.
@@ -639,9 +651,12 @@ const Scheduler = struct {
     indices_storage: [4]Value = undefined,
     prev_storage: [4]Value = undefined,
     next_storage: [4]Value = undefined,
+    fetch_storage: [8][4]Value = undefined,
+    fetch_len: usize,
     indices_len: usize,
 
     fn init(b: *Builder, step: Value, grid: []const Value, num_steps: Value, num_stages: usize, trace_scopes: bool) Scheduler {
+        if (num_stages + 1 > 8) @panic("emitPipeline: buffer_count > 7 unsupported");
         const c0 = b.lift(@as(i32, 0));
         const c1 = b.lift(@as(i32, 1));
         var s: Scheduler = .{
@@ -652,6 +667,7 @@ const Scheduler = struct {
             .trace_scopes = trace_scopes,
             .first_step = b.cmpi(.eq, step, c0),
             .last_step = b.cmpi(.eq, step, b.subi(num_steps, c1)),
+            .fetch_len = num_stages + 1,
             .indices_len = grid.len,
         };
         for (0..grid.len) |i| s.indices_storage[i] = c0;
@@ -668,11 +684,26 @@ const Scheduler = struct {
     fn nextIndices(self: *Scheduler) []const Value {
         return self.next_storage[0..self.indices_len];
     }
+    fn fetchIndices(self: *Scheduler, lookahead: usize) []const Value {
+        std.debug.assert(lookahead < self.fetch_len);
+        return self.fetch_storage[lookahead][0..self.indices_len];
+    }
 
     fn recomputeDerivedIndices(self: *Scheduler, b: *Builder) void {
-        const i = self.indices_storage[0];
-        self.prev_storage[0] = prevIndex1D(b, i, self.num_steps);
-        self.next_storage[0] = nextIndex1D(b, i, self.num_steps);
+        const prev = prevIndexND(b, self.indices(), self.grid);
+        const next = nextIndexND(b, self.indices(), self.grid);
+        for (0..self.indices_len) |i| {
+            self.prev_storage[i] = prev[i];
+            self.next_storage[i] = next[i];
+            self.fetch_storage[0][i] = self.indices_storage[i];
+            self.fetch_storage[1][i] = next[i];
+        }
+        var fetch = next;
+        var lookahead: usize = 2;
+        while (lookahead < self.fetch_len) : (lookahead += 1) {
+            fetch = nextIndexND(b, fetch, self.grid);
+            for (0..self.indices_len) |i| self.fetch_storage[lookahead][i] = fetch[i];
+        }
     }
 
     fn namedScope(self: *Scheduler, b: *Builder, name: []const u8) void {
@@ -719,8 +750,7 @@ const Scheduler = struct {
     fn willChangeFetch(self: *Scheduler, b: *Builder, br: *const BufferedRef) Value {
         std.debug.assert(br.isBuffered() and !br.is_trivial);
         if (br.buffer_count < 2) return self.hasChanged(b, br);
-        std.debug.assert(br.buffer_count == 2);
-        return indicesDiffer(b, br, self.indices(), self.nextIndices());
+        return indicesDiffer(b, br, self.fetchIndices(br.buffer_count - 2), self.fetchIndices(br.buffer_count - 1));
     }
 
     fn advance(b: *Builder, slot: Value, pred: Value) Value {
@@ -730,9 +760,24 @@ const Scheduler = struct {
     fn initializeStep(self: *Scheduler, b: *Builder, br: *BufferedRef, step: usize) void {
         if (br.buffer_type != .input or !br.isBuffered() or br.is_trivial) return;
         if (step + 1 >= br.buffer_count) return;
-        if (step != 0) @panic("emitPipeline: num_stages>2 (multi-step initialize) unsupported (TODO)");
-        // static_zero_start=true: Python-int 0 grid indices enable folds in getDmaSlice.
-        br.copyIn(b, self.indices(), b.lift(@as(i32, 0)), true);
+        if (br.copy_in_slot == null) br.copy_in_slot = b.lift(@as(i32, 0));
+
+        const pred = if (step == 0) self.first_step else blk: {
+            const block_changed = indicesDiffer(b, br, self.fetchIndices(step), self.fetchIndices(step - 1));
+            break :blk b.andi(self.first_step, block_changed);
+        };
+        const fetch_indices = self.fetchIndices(step);
+        if (step == 0) {
+            // static_zero_start=true: Python-int 0 grid indices enable folds in getDmaSlice.
+            br.copyIn(b, fetch_indices, br.copy_in_slot.?, true);
+        } else {
+            var when = b.openIf(pred);
+            {
+                br.copyIn(b, fetch_indices, br.copy_in_slot.?, false);
+                when.yieldThen(.{});
+            }
+        }
+        br.copy_in_slot = advance(b, br.copy_in_slot.?, pred);
     }
 
     fn copyIn(self: *Scheduler, b: *Builder, br: *BufferedRef) void {
@@ -744,7 +789,7 @@ const Scheduler = struct {
             var when = b.openIf(pred);
             {
                 self.namedScope(b, "ep_copy_in");
-                br.copyIn(b, self.nextIndices(), br.copy_in_slot.?, false);
+                br.copyIn(b, self.fetchIndices(br.buffer_count - 1), br.copy_in_slot.?, false);
                 self.endScope(b);
                 when.yieldThen(.{});
             }
@@ -844,16 +889,54 @@ pub fn dmaSemRefTy(b: *Builder, n: ?usize) *const mlir.Type {
     return mlir.Type.memRef(tpu.dmaSemaphoreType(b.ctx), shape, null, MemorySpace.semaphore_mem.attribute(b.ctx));
 }
 
-fn nextIndex1D(b: *Builder, i: Value, n: Value) Value {
-    const inc = b.addi(i, b.lift(@as(i32, 1)));
-    const carry = b.cmpi(.eq, inc, n);
-    return b.select(carry, b.lift(@as(i32, 0)), inc);
+fn gridSize(b: *Builder, grid: []const Value) Value {
+    var acc = grid[0];
+    for (grid[1..]) |g| acc = b.muli(acc, g);
+    return acc;
 }
 
-fn prevIndex1D(b: *Builder, i: Value, n: Value) Value {
-    const dec = b.subi(i, b.lift(@as(i32, 1)));
-    const borrow = b.cmpi(.eq, dec, b.lift(@as(i32, -1)));
-    return b.select(borrow, b.subi(n, b.lift(@as(i32, 1))), dec);
+fn filterIndices(b: *Builder, indices: []const Value, grid: []const Value) [4]Value {
+    var out: [4]Value = undefined;
+    const c0 = b.lift(@as(i32, 0));
+    for (indices, grid, 0..) |i, g, pos| {
+        out[pos] = if (g.asConstantInt() == @as(?i64, 1)) c0 else i;
+    }
+    return out;
+}
+
+fn nextIndexND(b: *Builder, indices: []const Value, grid: []const Value) []const Value {
+    const a = b.arena.allocator();
+    const out = a.alloc(Value, indices.len) catch @panic("nextIndexND OOM");
+    const c0 = b.lift(@as(i32, 0));
+    var carry: Value = b.cmpi(.eq, c0, c0);
+    var rev: usize = 0;
+    while (rev < indices.len) : (rev += 1) {
+        const pos = indices.len - 1 - rev;
+        const inc = b.select(carry, b.addi(indices[pos], b.lift(@as(i32, 1))), indices[pos]);
+        carry = b.cmpi(.eq, inc, grid[pos]);
+        out[pos] = b.select(carry, c0, inc);
+    }
+    const filtered = filterIndices(b, out, grid);
+    for (0..indices.len) |i| out[i] = filtered[i];
+    return out;
+}
+
+fn prevIndexND(b: *Builder, indices: []const Value, grid: []const Value) []const Value {
+    const a = b.arena.allocator();
+    const out = a.alloc(Value, indices.len) catch @panic("prevIndexND OOM");
+    const c0 = b.lift(@as(i32, 0));
+    var borrow: Value = b.cmpi(.eq, c0, c0);
+    const cm1 = b.lift(@as(i32, -1));
+    var rev: usize = 0;
+    while (rev < indices.len) : (rev += 1) {
+        const pos = indices.len - 1 - rev;
+        const dec = b.select(borrow, b.subi(indices[pos], b.lift(@as(i32, 1))), indices[pos]);
+        borrow = b.cmpi(.eq, dec, cm1);
+        out[pos] = b.select(borrow, b.subi(grid[pos], b.lift(@as(i32, 1))), dec);
+    }
+    const filtered = filterIndices(b, out, grid);
+    for (0..indices.len) |i| out[i] = filtered[i];
+    return out;
 }
 
 /// `null` block_shape, or every dim is `.blocked(full_dim)`.

--- a/kernels/mosaic_tpu/pipeline.zig
+++ b/kernels/mosaic_tpu/pipeline.zig
@@ -65,7 +65,7 @@ pub const PipeSpec = struct {
     index_map_ctx: ?*anyopaque = null,
     /// Only `.vmem` supported.
     memory_space: MemorySpace = .vmem,
-    
+
     buffer_count: ?usize = null,
     /// Tile that `_create_bounded_slice` rounds the DMA size up to.
     bounded_slice_tiling: i32 = 1,

--- a/zml/BUILD.bazel
+++ b/zml/BUILD.bazel
@@ -150,6 +150,18 @@ zig_library(
     }),
 )
 
+zig_library(
+    name = "moe_mosaic_tpu_gmm_ep",
+    tags = ["manual"],
+    main = "moe/mosaic_tpu_kernels/gmm_ep.zig",
+    import_name = "zml/moe/mosaic_tpu_kernels/gmm_ep",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":zml",
+        "//kernels/mosaic_tpu:mosaic_tpu_builder",
+    ],
+)
+
 
 zig_test(
     name = "test",

--- a/zml/moe/mosaic_tpu_kernels/gmm_ep.zig
+++ b/zml/moe/mosaic_tpu_kernels/gmm_ep.zig
@@ -1,0 +1,450 @@
+const std = @import("std");
+
+const zml = @import("zml");
+const mtt = @import("kernels/mosaic_tpu/builder");
+const pipeline = mtt.pipeline;
+const mtt_kernel = zml.kernel.mosaic_tpu;
+
+fn cdiv(x: i64, y: i64) i64 {
+    return @divFloor(x + y - 1, y);
+}
+
+fn alignTo(x: i64, y: i64) i64 {
+    return cdiv(x, y) * y;
+}
+
+fn floorModI32(b: *mtt.Builder, x: mtt.Value, y: mtt.Value) mtt.Value {
+    const c0 = b.lift(@as(i32, 0));
+    const r = b.remsi(x, y);
+    const r_nz = b.cmpi(.ne, r, c0);
+    const r_neg = b.cmpi(.slt, r, c0);
+    return b.select(b.andi(r_neg, r_nz), b.addi(r, y), r);
+}
+
+fn floorDivPosI32(b: *mtt.Builder, x: mtt.Value, y: mtt.Value) mtt.Value {
+    const c0 = b.lift(@as(i32, 0));
+    const c1 = b.lift(@as(i32, 1));
+    const q = b.divsi(x, y);
+    const sign = b.subi(
+        b.extui(b.cmpi(.sgt, x, c0), .i32),
+        b.extui(b.cmpi(.slt, x, c0), .i32),
+    );
+    const sign_not_pos = b.cmpi(.ne, sign, c1);
+    const rem_nz = b.cmpi(.ne, b.remsi(x, y), c0);
+    return b.select(b.andi(sign_not_pos, rem_nz), b.subi(q, c1), q);
+}
+
+fn ceilDivPosI32(b: *mtt.Builder, x: mtt.Value, y: mtt.Value) mtt.Value {
+    return b.divsi(b.addi(x, b.subi(y, b.lift(@as(i32, 1)))), y);
+}
+
+pub const Cfg = struct {
+    size_m: i64,
+    size_k: i64,
+    size_n: i64,
+    size_group: i64,
+    size_lhs_group: i64,
+    tile_m: i64,
+    tile_k: i64,
+    tile_n: i64,
+    lhs_dtype: mtt.DType = .bf16,
+    rhs_dtype: mtt.DType = .bf16,
+    out_dtype: mtt.DType = .bf16,
+    acc_dtype: mtt.DType = .f32,
+    size_lhs_sublane: i64 = 8,
+
+    pub fn alignedN(self: Cfg) i64 {
+        return alignTo(self.size_n, 128);
+    }
+
+    pub fn maxNumGm(self: Cfg) i64 {
+        return self.size_group + cdiv(self.size_m, self.tile_m) - 1;
+    }
+};
+
+fn validateConfig(cfg: Cfg) void {
+    std.debug.assert(cfg.size_group <= cfg.size_lhs_group);
+    std.debug.assert(cfg.size_m > 0);
+    std.debug.assert(cfg.size_k > 0);
+    std.debug.assert(cfg.size_n > 0);
+    std.debug.assert(cfg.tile_m > 0);
+    std.debug.assert(cfg.tile_k > 0);
+    std.debug.assert(cfg.tile_n > 0);
+    std.debug.assert(cfg.size_lhs_sublane > 0);
+    std.debug.assert(@mod(cfg.size_m, cfg.size_lhs_sublane) == 0);
+    std.debug.assert(@mod(cfg.size_k, cfg.tile_k) == 0);
+    std.debug.assert(@mod(cfg.alignedN(), cfg.tile_n) == 0);
+    std.debug.assert(cfg.acc_dtype == .f32);
+}
+
+const Meta = struct {
+    group_id: mtt.Value,
+    m_offset: mtt.Value,
+};
+
+const PipeCtx = struct {
+    cfg: Cfg,
+    meta: Meta,
+    num_gm: mtt.Value,
+};
+
+fn winRef(b: *mtt.Builder, rw: pipeline.RefWindow, shape: []const i64) mtt.Value {
+    const buf = rw.buf.?;
+    const slot = rw.slot orelse return buf;
+    const a = b.arena.allocator();
+    const rank = shape.len + 1;
+    const base = a.alloc(mtt.Value, rank) catch @panic("gmm_ep winRef OOM");
+    const result_shape = a.alloc(i64, rank) catch @panic("gmm_ep winRef OOM");
+    base[0] = slot;
+    result_shape[0] = 1;
+    for (shape, 0..) |d, i| {
+        base[i + 1] = b.lift(@as(i32, 0));
+        result_shape[i + 1] = d;
+    }
+    const sliced = b.memRefSlice(buf, base, result_shape, &.{});
+    return b.memRefSqueeze(sliced, shape);
+}
+
+fn metaLoad(b: *mtt.Builder, ref: mtt.Value, idx: mtt.Value) mtt.Value {
+    return b.scalarLoad(ref, &.{b.toIndex(idx)});
+}
+
+fn lhsIndexMap(b: *mtt.Builder, indices: []const mtt.Value, ctx_opaque: ?*anyopaque) []const pipeline.BlockIndex {
+    const ctx: *PipeCtx = @ptrCast(@alignCast(ctx_opaque.?));
+    const cfg = ctx.cfg;
+    const gm_id = indices[1];
+    const k_id = indices[2];
+
+    const m_start = metaLoad(b, ctx.meta.m_offset, gm_id);
+    const m_end = metaLoad(b, ctx.meta.m_offset, b.addi(gm_id, b.lift(@as(i32, 1))));
+    const sublane = b.lift(@as(i32, @intCast(cfg.size_lhs_sublane)));
+    const row_start = floorDivPosI32(b, m_start, sublane);
+    const row_end = ceilDivPosI32(b, m_end, sublane);
+    const row_size = b.subi(row_end, row_start);
+
+    const out = b.arena.allocator().alloc(pipeline.BlockIndex, 3) catch @panic("gmm_ep lhsIndexMap OOM");
+    out[0] = .{ .slice = .{ .start = row_start, .size = row_size } };
+    out[1] = .{ .scalar = b.lift(@as(i32, 0)) };
+    out[2] = .{ .scalar = k_id };
+    return out;
+}
+
+fn rhsIndexMap(b: *mtt.Builder, indices: []const mtt.Value, ctx_opaque: ?*anyopaque) []const pipeline.BlockIndex {
+    const ctx: *PipeCtx = @ptrCast(@alignCast(ctx_opaque.?));
+    const group_id = metaLoad(b, ctx.meta.group_id, indices[1]);
+    const out = b.arena.allocator().alloc(pipeline.BlockIndex, 3) catch @panic("gmm_ep rhsIndexMap OOM");
+    out[0] = .{ .scalar = group_id };
+    out[1] = .{ .scalar = indices[2] };
+    out[2] = .{ .scalar = indices[0] };
+    return out;
+}
+
+fn outIndexMap(b: *mtt.Builder, indices: []const mtt.Value, ctx_opaque: ?*anyopaque) []const pipeline.BlockIndex {
+    const ctx: *PipeCtx = @ptrCast(@alignCast(ctx_opaque.?));
+    const cfg = ctx.cfg;
+    const gm_id = indices[1];
+    const n_id = indices[0];
+
+    const m_start = metaLoad(b, ctx.meta.m_offset, gm_id);
+    const m_end = metaLoad(b, ctx.meta.m_offset, b.addi(gm_id, b.lift(@as(i32, 1))));
+    const sublane = b.lift(@as(i32, @intCast(cfg.size_lhs_sublane)));
+    const row_start = floorDivPosI32(b, m_start, sublane);
+    const capped_row_end = floorDivPosI32(b, m_end, sublane);
+    const last_row_end = ceilDivPosI32(b, m_end, sublane);
+    const row_end = b.select(
+        b.cmpi(.eq, gm_id, b.subi(ctx.num_gm, b.lift(@as(i32, 1)))),
+        last_row_end,
+        capped_row_end,
+    );
+    const row_size = b.subi(row_end, row_start);
+
+    const out = b.arena.allocator().alloc(pipeline.BlockIndex, 3) catch @panic("gmm_ep outIndexMap OOM");
+    out[0] = .{ .slice = .{ .start = row_start, .size = row_size } };
+    out[1] = .{ .scalar = b.lift(@as(i32, 0)) };
+    out[2] = .{ .scalar = n_id };
+    return out;
+}
+
+fn indices1DTo3D(b: *mtt.Builder, indices: []const mtt.Value) []const mtt.Value {
+    const out = b.arena.allocator().alloc(mtt.Value, 3) catch @panic("gmm_ep indices1DTo3D OOM");
+    out[0] = b.lift(@as(i32, 0));
+    out[1] = indices[0];
+    out[2] = b.lift(@as(i32, 0));
+    return out;
+}
+
+fn lhsIndexMap1D(b: *mtt.Builder, indices: []const mtt.Value, ctx_opaque: ?*anyopaque) []const pipeline.BlockIndex {
+    return lhsIndexMap(b, indices1DTo3D(b, indices), ctx_opaque);
+}
+
+fn rhsIndexMap1D(b: *mtt.Builder, indices: []const mtt.Value, ctx_opaque: ?*anyopaque) []const pipeline.BlockIndex {
+    return rhsIndexMap(b, indices1DTo3D(b, indices), ctx_opaque);
+}
+
+fn outIndexMap1D(b: *mtt.Builder, indices: []const mtt.Value, ctx_opaque: ?*anyopaque) []const pipeline.BlockIndex {
+    return outIndexMap(b, indices1DTo3D(b, indices), ctx_opaque);
+}
+
+fn fillMetadata(b: *mtt.Builder, cfg: Cfg, a: anytype) mtt.Value {
+    const c0 = b.lift(@as(i32, 0));
+    const c1 = b.lift(@as(i32, 1));
+    const group_offset = b.scalarLoad(a.group_offset, &.{b.cIndex(0)});
+    const max_num_group = b.addi(group_offset, b.lift(@as(i32, @intCast(cfg.size_group))));
+    b.scalarStore(a.metadata_m_offset, c0, &.{b.cIndex(0)});
+
+    var outer = b.openFor(c0, max_num_group, c1, .{ c0, c0 });
+    {
+        b.traceStart(10, "outer_group_loop");
+        const lhs_group_id = outer.iv;
+        const num_gm = outer.carried[0];
+        const start_m_offset = outer.carried[1];
+        const group_id = b.subi(lhs_group_id, group_offset);
+        const group_size = b.scalarLoad(a.group_sizes, &.{b.toIndex(lhs_group_id)});
+        const end_m_offset = b.addi(start_m_offset, group_size);
+        const sublane = b.lift(@as(i32, @intCast(cfg.size_lhs_sublane)));
+        const local_offset = floorModI32(b, start_m_offset, sublane);
+        const aligned_group_size = b.addi(group_size, local_offset);
+        const tile_m = b.lift(@as(i32, @intCast(cfg.tile_m)));
+        var curr_num_gm = b.divsi(b.addi(aligned_group_size, b.subi(tile_m, c1)), tile_m);
+        const should_process = b.andi(b.cmpi(.sgt, group_size, c0), b.cmpi(.sge, group_id, c0));
+        curr_num_gm = b.select(should_process, curr_num_gm, c0);
+        const next_num_gm = b.addi(num_gm, curr_num_gm);
+
+        var inner = b.openFor(num_gm, next_num_gm, c1, .{start_m_offset});
+        {
+            b.traceStart(10, "inner_tm_loop");
+            const tm_id = inner.iv;
+            const curr_m_offset = inner.carried[0];
+            const local = floorModI32(b, curr_m_offset, sublane);
+            const tm_room = b.subi(tile_m, local);
+            const remaining = b.subi(end_m_offset, curr_m_offset);
+            const tm_size = b.minsi(tm_room, remaining);
+            const next_m_offset = b.addi(curr_m_offset, tm_size);
+            b.scalarStore(a.metadata_group_id, group_id, &.{b.toIndex(tm_id)});
+            b.scalarStore(a.metadata_m_offset, curr_m_offset, &.{b.toIndex(tm_id)});
+            b.scalarStore(a.metadata_m_offset, next_m_offset, &.{b.toIndex(b.addi(tm_id, c1))});
+            b.traceStop();
+            inner.yield(.{next_m_offset});
+        }
+
+        b.traceStop();
+        outer.yield(.{ next_num_gm, end_m_offset });
+    }
+    return outer.results[0];
+}
+
+fn matmulByMxuColumns(b: *mtt.Builder, cfg: Cfg, lhs: mtt.Value, rhs: mtt.Value, cols: i64) mtt.Value {
+    if (cols <= 128) {
+        return b.matmulOpts(lhs, rhs, b.zeros(&.{ cfg.tile_m, cols }, cfg.acc_dtype), .{
+            .dimension_numbers = b.dotDimensionNumbers(&.{1}, &.{0}, &.{0}, &.{1}, &.{ 0, 0, 1, 1 }, &.{}, &.{}),
+        });
+    }
+
+    std.debug.assert(@mod(cols, 128) == 0);
+    const chunks = @divExact(cols, 128);
+    const parts = b.arena.allocator().alloc(mtt.Value, @intCast(chunks)) catch @panic("gmm_ep matmul parts OOM");
+    var rev: i64 = 0;
+    while (rev < chunks) : (rev += 1) {
+        const chunk = chunks - 1 - rev;
+        const start_n = chunk * 128;
+        const rhs_chunk = b.vectorExtractStridedSlice(rhs, &.{ 0, start_n }, &.{ cfg.tile_k, 128 }, &.{ 1, 1 });
+        const zero = b.zeros(&.{ cfg.tile_m, 128 }, cfg.acc_dtype);
+        parts[@intCast(chunk)] = b.matmulOpts(lhs, rhs_chunk, zero, .{
+            .dimension_numbers = b.dotDimensionNumbers(&.{1}, &.{0}, &.{0}, &.{1}, &.{ 0, 0, 1, 1 }, &.{}, &.{}),
+        });
+    }
+
+    const max_concat_inputs = 16;
+    if (chunks <= max_concat_inputs) return b.concatenate(parts, 1);
+
+    const groups = cdiv(chunks, max_concat_inputs);
+    const group_parts = b.arena.allocator().alloc(mtt.Value, @intCast(groups)) catch @panic("gmm_ep matmul group parts OOM");
+    var group: i64 = 0;
+    while (group < groups) : (group += 1) {
+        const start = group * max_concat_inputs;
+        const end = @min(start + max_concat_inputs, chunks);
+        const start_usize: usize = @intCast(start);
+        const end_usize: usize = @intCast(end);
+        const group_slice = parts[start_usize..end_usize];
+        group_parts[@intCast(group)] = if (group_slice.len == 1) group_slice[0] else b.concatenate(group_slice, 1);
+    }
+    return b.concatenate(group_parts, 1);
+}
+
+fn innerBody(
+    b: *mtt.Builder,
+    indices: []const mtt.Value,
+    refs: []const pipeline.RefWindow,
+    scratches: []const mtt.Value,
+    ctx_opaque: ?*anyopaque,
+) mtt.FinishError!void {
+    const ctx: *PipeCtx = @ptrCast(@alignCast(ctx_opaque.?));
+    const cfg = ctx.cfg;
+    const gm_id = indices[1];
+
+    const lhs_shape = &.{ cdiv(cfg.tile_m, cfg.size_lhs_sublane), cfg.size_lhs_sublane, cfg.tile_k };
+    const out_shape = &.{ cdiv(cfg.tile_m, cfg.size_lhs_sublane), cfg.size_lhs_sublane, cfg.tile_n };
+
+    b.traceStart(10, "matmul_first_last");
+    const lhs_ref = winRef(b, refs[0], lhs_shape);
+    const lhs_ref_2d = b.memRefReshape(lhs_ref, &.{ cfg.tile_m, cfg.tile_k });
+    const lhs = b.refLoad(lhs_ref_2d);
+    const rhs_slot = b.toIndex(refs[1].slot.?);
+    const rhs = b.shapeCast(
+        b.vectorLoadShape(refs[1].buf.?, &.{ rhs_slot, b.cIndex(0), b.cIndex(0) }, &.{ 1, cfg.tile_k, cfg.tile_n }),
+        &.{ cfg.tile_k, cfg.tile_n },
+    );
+    var acc = matmulByMxuColumns(b, cfg, lhs, rhs, cfg.tile_n);
+
+    const m_start = metaLoad(b, ctx.meta.m_offset, gm_id);
+    const m_end = metaLoad(b, ctx.meta.m_offset, b.addi(gm_id, b.lift(@as(i32, 1))));
+    const sublane = b.lift(@as(i32, @intCast(cfg.size_lhs_sublane)));
+    const m_offset = b.subi(m_start, floorModI32(b, m_start, sublane));
+    const m_start_local = b.subi(m_start, m_offset);
+    const m_end_local = b.subi(m_end, m_offset);
+    const row_iota = b.iota(&.{ cfg.tile_m, cfg.tile_n }, .i32, &.{0});
+    const row_mask = b.andi(
+        b.cmpi(.sle, b.broadcastTo(m_start_local, &.{ cfg.tile_m, cfg.tile_n }), row_iota),
+        b.cmpi(.slt, row_iota, b.broadcastTo(m_end_local, &.{ cfg.tile_m, cfg.tile_n })),
+    );
+    acc = b.select(row_mask, acc, b.zeros(&.{ cfg.tile_m, cfg.tile_n }, cfg.acc_dtype));
+
+    const out_slot_i32 = refs[2].slot.?;
+    const out_slot = b.toIndex(out_slot_i32);
+    b.vectorStoreAt(
+        refs[2].buf.?,
+        b.shapeCast(b.shapeCast(acc, out_shape).to(cfg.out_dtype), &.{ 1, cdiv(cfg.tile_m, cfg.size_lhs_sublane), cfg.size_lhs_sublane, cfg.tile_n }),
+        &.{ out_slot, b.cIndex(0), b.cIndex(0), b.cIndex(0) },
+    );
+
+    const out_ref = winRef(b, refs[2], out_shape);
+    if (cfg.tile_m == cfg.size_lhs_sublane) {
+        const out_value = b.shapeCast(b.refLoad(out_ref), &.{ cfg.tile_m, cfg.tile_n });
+        const partial_zero = b.zeros(&.{ cfg.tile_m, cfg.tile_n }, cfg.out_dtype);
+        const partial_prev = b.select(
+            b.cmpi(.eq, gm_id, b.lift(@as(i32, 0))),
+            partial_zero,
+            b.refLoad(scratches[0]),
+        );
+        const out_accum = b.addf(out_value, partial_prev);
+        const out_ref_for_store = winRef(b, refs[2], out_shape);
+        b.refStore(out_ref_for_store, b.shapeCast(out_accum, out_shape));
+    } else {
+        const first_row = b.shapeCast(
+            b.vectorLoadShape(out_ref, &.{ b.cIndex(0), b.cIndex(0), b.cIndex(0) }, &.{ 1, cfg.size_lhs_sublane, cfg.tile_n }),
+            &.{ cfg.size_lhs_sublane, cfg.tile_n },
+        );
+        const partial_zero = b.zeros(&.{ cfg.size_lhs_sublane, cfg.tile_n }, cfg.out_dtype);
+        const partial_prev = b.select(
+            b.cmpi(.eq, gm_id, b.lift(@as(i32, 0))),
+            partial_zero,
+            b.refLoad(scratches[0]),
+        );
+        const out_accum = b.addf(first_row, partial_prev);
+        const out_ref_for_store = winRef(b, refs[2], out_shape);
+        b.vectorStoreAt(
+            out_ref_for_store,
+            b.shapeCast(out_accum, &.{ 1, cfg.size_lhs_sublane, cfg.tile_n }),
+            &.{ b.cIndex(0), b.cIndex(0), b.cIndex(0) },
+        );
+    }
+
+    const last_row = floorDivPosI32(b, m_end_local, sublane);
+    const m_end_mod = floorModI32(b, m_end_local, sublane);
+    const partial_complete = b.cmpi(.eq, m_end_mod, b.lift(@as(i32, 0)));
+    const out_ref_for_partial = winRef(b, refs[2], out_shape);
+    const partial_shape = if (cfg.tile_m == cfg.size_lhs_sublane)
+        &.{ cfg.tile_m, cfg.tile_n }
+    else
+        &.{ cfg.size_lhs_sublane, cfg.tile_n };
+    const partial_zero = b.zeros(partial_shape, cfg.out_dtype);
+    const partial_row = b.shapeCast(
+        b.vectorLoadShape(out_ref_for_partial, &.{ b.toIndex(last_row), b.cIndex(0), b.cIndex(0) }, &.{ 1, cfg.size_lhs_sublane, cfg.tile_n }),
+        partial_shape,
+    );
+    b.refStore(scratches[0], b.select(partial_complete, partial_zero, partial_row));
+    b.traceStop();
+}
+
+fn innerBody1D(
+    b: *mtt.Builder,
+    indices: []const mtt.Value,
+    refs: []const pipeline.RefWindow,
+    scratches: []const mtt.Value,
+    ctx_opaque: ?*anyopaque,
+) mtt.FinishError!void {
+    try innerBody(b, indices1DTo3D(b, indices), refs, scratches, ctx_opaque);
+}
+
+pub fn run(b: *mtt.Builder, cfg: Cfg) mtt.FinishError!void {
+    validateConfig(cfg);
+
+    const a = try b.declareArgsOpts(.{
+        .group_sizes = .{ .ref = .{ .shape = &.{cfg.size_lhs_group}, .dtype = .i32, .memory_space = .smem, .role = .scalar_prefetch } },
+        .group_offset = .{ .ref = .{ .shape = &.{1}, .dtype = .i32, .memory_space = .smem, .role = .scalar_prefetch } },
+        .lhs = .{ .ref = .{ .shape = &.{ cfg.size_m, cfg.size_k }, .dtype = cfg.lhs_dtype, .memory_space = .hbm } },
+        .rhs = .{ .ref = .{ .shape = &.{ cfg.size_group, cfg.size_k, cfg.size_n }, .dtype = cfg.rhs_dtype, .memory_space = .hbm } },
+        .out = .{ .ref = .{ .shape = &.{ cfg.size_m, cfg.alignedN() }, .dtype = cfg.out_dtype, .memory_space = .hbm, .role = .output } },
+        .partial_out = .{ .ref = .{ .shape = &.{ cfg.size_lhs_sublane, cfg.tile_n }, .dtype = cfg.out_dtype, .role = .scratch } },
+        .acc = .{ .ref = .{ .shape = &.{ cfg.tile_m, cfg.tile_n }, .dtype = cfg.acc_dtype, .role = .scratch } },
+        .metadata_group_id = .{ .ref = .{ .shape = &.{cfg.maxNumGm()}, .dtype = .i32, .memory_space = .smem, .role = .scratch } },
+        .metadata_m_offset = .{ .ref = .{ .shape = &.{cfg.maxNumGm() + 1}, .dtype = .i32, .memory_space = .smem, .role = .scratch } },
+    }, &.{}, .{
+        .dimension_semantics = &.{},
+        .scalar_prefetch = 2,
+        .scratch_operands = 4,
+    });
+
+    const num_k = b.lift(@as(i32, @intCast(cdiv(cfg.size_k, cfg.tile_k))));
+    const num_n = b.lift(@as(i32, @intCast(cdiv(cfg.alignedN(), cfg.tile_n))));
+    const num_gm = fillMetadata(b, cfg, a);
+
+    const ctx = b.arena.allocator().create(PipeCtx) catch @panic("gmm_ep PipeCtx OOM");
+    ctx.* = .{
+        .cfg = cfg,
+        .meta = .{ .group_id = a.metadata_group_id, .m_offset = a.metadata_m_offset },
+        .num_gm = num_gm,
+    };
+
+    const lhs_spec = pipeline.PipeSpec{
+        .full_shape = &.{ @divExact(cfg.size_m, cfg.size_lhs_sublane), cfg.size_lhs_sublane, cfg.size_k },
+        .dtype = cfg.lhs_dtype,
+        .source_reshape_shape = &.{ @divExact(cfg.size_m, cfg.size_lhs_sublane), cfg.size_lhs_sublane, cfg.size_k },
+        .block_shape = &.{ .{ .bounded_slice = cdiv(cfg.tile_m, cfg.size_lhs_sublane) }, .{ .blocked = cfg.size_lhs_sublane }, .{ .blocked = cfg.tile_k } },
+        .index_map = if (cdiv(cfg.alignedN(), cfg.tile_n) == 1 and cdiv(cfg.size_k, cfg.tile_k) == 1 and cfg.size_m > cfg.tile_m) lhsIndexMap1D else lhsIndexMap,
+        .index_map_ctx = ctx,
+        .bounded_slice_tiling = 1,
+    };
+    const rhs_spec = pipeline.PipeSpec{
+        .full_shape = &.{ cfg.size_group, cfg.size_k, cfg.size_n },
+        .dtype = cfg.rhs_dtype,
+        .block_shape = &.{ .squeezed, .{ .blocked = cfg.tile_k }, .{ .blocked = cfg.tile_n } },
+        .index_map = if (cdiv(cfg.alignedN(), cfg.tile_n) == 1 and cdiv(cfg.size_k, cfg.tile_k) == 1 and cfg.size_m > cfg.tile_m) rhsIndexMap1D else rhsIndexMap,
+        .index_map_ctx = ctx,
+        .buffer_count = 3,
+    };
+    const out_spec = pipeline.PipeSpec{
+        .full_shape = &.{ @divExact(cfg.size_m, cfg.size_lhs_sublane), cfg.size_lhs_sublane, cfg.alignedN() },
+        .dtype = cfg.out_dtype,
+        .source_reshape_shape = &.{ @divExact(cfg.size_m, cfg.size_lhs_sublane), cfg.size_lhs_sublane, cfg.alignedN() },
+        .block_shape = &.{ .{ .bounded_slice = cdiv(cfg.tile_m, cfg.size_lhs_sublane) }, .{ .blocked = cfg.size_lhs_sublane }, .{ .blocked = cfg.tile_n } },
+        .index_map = if (cdiv(cfg.alignedN(), cfg.tile_n) == 1 and cdiv(cfg.size_k, cfg.tile_k) == 1 and cfg.size_m > cfg.tile_m) outIndexMap1D else outIndexMap,
+        .index_map_ctx = ctx,
+        .bounded_slice_tiling = 1,
+    };
+    const use_1d_pipeline = cdiv(cfg.alignedN(), cfg.tile_n) == 1 and cdiv(cfg.size_k, cfg.tile_k) == 1 and cfg.size_m > cfg.tile_m;
+    try pipeline.emitPipeline(b, &.{ a.lhs, a.rhs, a.out }, &.{ a.partial_out, a.acc, a.metadata_group_id, a.metadata_m_offset }, .{
+        .body = if (use_1d_pipeline) innerBody1D else innerBody,
+        .body_ctx = ctx,
+        .grid = if (use_1d_pipeline) &.{num_gm} else &.{ num_n, num_gm, num_k },
+        .in_specs = &.{ lhs_spec, rhs_spec },
+        .out_specs = &.{out_spec},
+    });
+}
+
+pub const TpuKernel = mtt_kernel.Kernel(Cfg, .{
+    .name = "gmm_ep_kernel",
+    .inputs = &.{ "group_sizes", "group_offset", "lhs", "rhs" },
+    .outputs = &.{"out"},
+    .run = run,
+});


### PR DESCRIPTION
This PR introduce the new GMM Expert parallelism kernel (basis grouped gemm for moe on TPU). It induces some updates into the DSL mosaic TPU,
such as Builders helpers or Pipelines and schedulers :
- Buffer counts (for scheduling overlapping) > 2 allowed (until 7)
- source_reshape_shape reshaped at DMA slice/use sites to match Pallas IR placement
- More grid dimensionality for pipeline (up to 4)