### PR TITLE
zml/module: expose autotune cache dir through an env var

### DIFF
--- a/zml/module.zig
+++ b/zml/module.zig
@@ -663,6 +663,13 @@ fn compileModuleToPjrtExecutable(arena: std.mem.Allocator, io: std.Io, platform:
             }
         }
 
+        switch (platform.target) {
+            .rocm, .cuda => if (std.c.getenv("ZML_AUTOTUNE_CACHE_DIR")) |path| {
+                try setXlaOverrideFlag(overrides_map, "xla_gpu_experimental_autotuner_cache_dir", std.mem.span(path), upb_arena);
+            },
+            else => {},
+        }
+
         break :blk options;
     };
 


### PR DESCRIPTION
This opt-in flag allows XLA to save the autotuning resulting from previous runs in a folder, greatly speeding up the compilation.

It's not meant to be used at all times, so it's undocumented and opt-in.