### PR TITLE
zml/sharding: fix max_rank for TPU

### DIFF
--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -931,7 +931,7 @@ pub const PhysicalMesh = struct {
         const placements = try CoordsTopology.collect(allocator, platform_devices);
         defer allocator.free(placements);
 
-        const layout = try CoordsTopology.layout(placements, 3);
+        const layout = try CoordsTopology.layout(placements, 4);
         var rank = layout.rank;
         var axis_sizes = layout.axis_sizes;
 


### PR DESCRIPTION
Topology coords on TPU have rank 4 and not 3