### PR TITLE
zml/profiling/tracer: Add simpler infaillible span

### DIFF
--- a/zml/exe.zig
+++ b/zml/exe.zig
@@ -306,22 +306,22 @@ pub const Exe = struct {
     };
 
     pub fn callOpts(self: *const Exe, io: std.Io, arguments: Arguments, results_: *Results, opts: CallOpts) void {
-        var trace = tracer.scope("zml.exe.call", .{
+        var span = tracer.span("zml.exe.call", .{
             .wait = opts.wait,
             .arg_count = arguments.expected_shapes.len,
             .result_count = results_.expected_shapes.len,
-        }) catch unreachable;
-        defer trace.end();
+        });
+        defer span.end();
         return self.internalCall(io, arguments, results_, opts);
     }
 
     pub fn call(self: *const Exe, arguments: Arguments, results_: *Results) void {
-        var trace = tracer.scope("zml.exe.call", .{
+        var span = tracer.span("zml.exe.call", .{
             .wait = false,
             .arg_count = arguments.expected_shapes.len,
             .result_count = results_.expected_shapes.len,
-        }) catch unreachable;
-        defer trace.end();
+        });
+        defer span.end();
         return self.internalCall(null, arguments, results_, .{});
     }
 };

--- a/zml/io.zig
+++ b/zml/io.zig
@@ -1071,10 +1071,10 @@ pub fn load(
     store: *const TensorStore,
     opts: LoadOpts,
 ) !Bufferized(ModelType) {
-    var trace = try tracer.scope("zml.io.load", .{
+    var span = tracer.span("zml.io.load", .{
         .tensor_count = meta.count(Tensor, model),
     });
-    defer trace.end();
+    defer span.end();
 
     var bufferized = try mem.bufferize(allocator, ModelType, model);
 

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -209,11 +209,13 @@ pub fn compile(
     var st_io: std.Io.Threaded = .init_single_threaded;
     defer st_io.deinit();
 
-    var trace = try tracer.scope("zml.module.compile", .{
+    const span_name = try tracer.formatSpanName(allocator, "zml.module.compile", .{
         .program_name = opts.program_name,
         .arg_count = args.len,
     });
-    defer trace.end();
+    defer allocator.free(span_name);
+    var span = tracer.Span.start(span_name);
+    defer span.end();
 
     var compilation_context: CompilationContext = .init(allocator, st_io.io(), platform, opts);
     defer compilation_context.deinit();

--- a/zml/profiling/tracer.zig
+++ b/zml/profiling/tracer.zig
@@ -5,18 +5,21 @@ const c = @import("c");
 const platforms = @import("platforms");
 const zffi = @import("ffi");
 
-pub const Scope = struct {
+pub const Span = struct {
     inner: ?*c.zml_traceme = null,
 
-    pub fn end(self: *Scope) void {
+    /// Name is copied underneath
+    pub fn start(name: []const u8) Span {
+        return .{
+            .inner = c.zml_traceme_start(zffi.ZigSlice.from(name)),
+        };
+    }
+
+    pub fn end(self: *Span) void {
         if (self.inner) |inner| {
             c.zml_traceme_stop(inner);
             self.inner = null;
         }
-    }
-
-    pub fn deinit(self: *Scope) void {
-        self.end();
     }
 };
 
@@ -28,44 +31,55 @@ pub const supportsDeviceAnnotations = switch (builtin.os.tag) {
     .linux => platforms.target == .cuda or platforms.target == .rocm,
     else => false,
 };
-const inline_scope_name_buffer_size = 1024;
 
 pub fn enabled() bool {
     return c.zml_traceme_enabled();
 }
 
-pub fn scope(name: []const u8, metadata: anytype) !Scope {
-    const Metadata = @TypeOf(metadata);
-    comptime assertMetadataStruct(Metadata);
+/// Creates a Span with encoded metadata. The metadata encoded size must be known at compile time.
+/// If it's not your case, use `formatSpanName` to generate the span name before and use void for the metadata.
+pub fn span(comptime name: []const u8, metadata: anytype) Span {
+    switch (@typeInfo(@TypeOf(metadata))) {
+        .void => {
+            return .start(name);
+        },
+        .@"struct" => |info| {
+            if (info.fields.len == 0) {
+                return .start(name);
+            }
 
-    if (comptime metadataFieldCount(Metadata) == 0) {
-        return .{
-            .inner = c.zml_traceme_start(zffi.ZigSlice.from(name)),
-        };
+            var buffer: [computeEncodedNameLen(name, @TypeOf(metadata))]u8 = undefined;
+            var encoded: std.ArrayList(u8) = .initBuffer(&buffer);
+
+            appendEncodedName(&encoded, .failing, name, info, metadata) catch unreachable;
+            return .start(encoded.items);
+        },
+        else => @compileError("Unsupported metadata."),
     }
-
-    var inline_buffer: [inline_scope_name_buffer_size]u8 = undefined;
-    var fixed_buffer_allocator: std.heap.FixedBufferAllocator = .init(&inline_buffer);
-    const fixed_allocator = fixed_buffer_allocator.allocator();
-
-    var encoded: std.ArrayList(u8) = .empty;
-    defer encoded.deinit(fixed_allocator);
-
-    try appendEncodedName(&encoded, fixed_allocator, name, metadata);
-    return .{
-        .inner = c.zml_traceme_start(zffi.ZigSlice.from(encoded.items)),
-    };
 }
 
-fn appendEncodedName(buffer: *std.ArrayList(u8), allocator: std.mem.Allocator, name: []const u8, metadata: anytype) !void {
-    const Metadata = @TypeOf(metadata);
+/// Returns an allocator-owned encoded span name for metadata that cannot be
+/// bounded by `span` at comptime. The caller owns the returned slice.
+pub fn formatSpanName(allocator: std.mem.Allocator, name: []const u8, metadata: anytype) ![]const u8 {
+    switch (@typeInfo(@TypeOf(metadata))) {
+        .@"struct" => |info| {
+            var encoded: std.ArrayList(u8) = .empty;
+            errdefer encoded.deinit(allocator);
+
+            try appendEncodedName(&encoded, allocator, name, info, metadata);
+            return try encoded.toOwnedSlice(allocator);
+        },
+        else => @compileError("trace metadata must be a struct literal like .{ .step_num = 42 }"),
+    }
+}
+
+fn appendEncodedName(buffer: *std.ArrayList(u8), allocator: std.mem.Allocator, name: []const u8, info: std.builtin.Type.Struct, metadata: anytype) !void {
     try buffer.appendSlice(allocator, name);
-    if (comptime metadataFieldCount(Metadata) == 0) return;
 
     var field_count: usize = 0;
     try buffer.append(allocator, '#');
-    inline for (std.meta.fields(Metadata)) |field| {
-        if (shouldEncodeField(@TypeOf(@field(metadata, field.name)), @field(metadata, field.name), field.name)) {
+    inline for (info.fields) |field| {
+        if (shouldEncodeField(field, @field(metadata, field.name))) {
             if (field_count != 0) {
                 try buffer.append(allocator, ',');
             }
@@ -78,11 +92,13 @@ fn appendEncodedName(buffer: *std.ArrayList(u8), allocator: std.mem.Allocator, n
             try appendMetadataValue(buffer, allocator, @field(metadata, field.name), field.name);
         }
     }
+
+    // We may not have written any fields because of optional values.
     if (field_count == 0) {
         buffer.items.len = name.len;
-        return;
+    } else {
+        try buffer.append(allocator, '#');
     }
-    try buffer.append(allocator, '#');
 }
 
 fn validateMetadataToken(token: []const u8) void {
@@ -91,26 +107,59 @@ fn validateMetadataToken(token: []const u8) void {
     }
 }
 
-fn assertMetadataStruct(comptime T: type) void {
-    switch (@typeInfo(T)) {
-        .@"struct" => {},
-        else => @compileError("trace metadata must be a struct literal like .{ .step_num = 42 }"),
-    }
-}
-
-fn metadataFieldCount(comptime T: type) usize {
-    assertMetadataStruct(T);
-    return std.meta.fields(T).len;
-}
-
 fn metadataKey(comptime field_name: []const u8) []const u8 {
     return if (comptime std.mem.eql(u8, field_name, "root")) "_r" else field_name;
 }
 
-fn shouldEncodeField(comptime T: type, value: T, comptime field_name: []const u8) bool {
-    return switch (@typeInfo(T)) {
+fn computeEncodedNameLen(comptime name: []const u8, comptime Metadata: type) usize {
+    switch (@typeInfo(Metadata)) {
+        .@"struct" => |info| {
+            if (info.fields.len == 0) return name.len;
+
+            // name#[attrs]#
+            var max_len = name.len + 2;
+            inline for (info.fields) |field| {
+                const key = comptime metadataKey(field.name);
+                validateMetadataToken(key);
+
+                // [key]=[value],
+                max_len += key.len + 2;
+                max_len += switch (@typeInfo(field.type)) {
+                    .bool => 1,
+                    .int => @max(
+                        std.fmt.comptimePrint("{}", .{std.math.minInt(field.type)}).len,
+                        std.fmt.comptimePrint("{}", .{std.math.maxInt(field.type)}).len,
+                    ),
+                    .@"enum" => |ty| b: {
+                        var max_enum_len: usize = 0;
+                        for (ty.fields) |enum_field| {
+                            max_enum_len = @max(max_enum_len, enum_field.name.len);
+                        }
+                        break :b max_enum_len;
+                    },
+                    .comptime_int => std.fmt.comptimePrint("{}", .{defaultMetadataValue(field).?}).len,
+                    .comptime_float => std.fmt.comptimePrint("{d}", .{defaultMetadataValue(field).?}).len,
+                    .enum_literal => @tagName(defaultMetadataValue(field).?).len,
+                    else => @compileError("trace metadata field '" ++ field.name ++ "' is not statically bounded; use formatspanName"),
+                };
+            }
+            return max_len;
+        },
+        else => @compileError("trace metadata must be a struct literal like .{ .step_num = 42 }"),
+    }
+}
+
+fn defaultMetadataValue(comptime field: std.builtin.Type.StructField) ?field.type {
+    return if (field.default_value_ptr) |default_opaque|
+        @as(*const field.type, @ptrCast(@alignCast(default_opaque))).*
+    else
+        null;
+}
+
+fn shouldEncodeField(field: std.builtin.Type.StructField, value: anytype) bool {
+    return switch (@typeInfo(field.type)) {
         .optional => value != null,
-        .bool => if (comptime std.mem.eql(u8, field_name, "root")) value else true,
+        .bool => if (comptime std.mem.eql(u8, field.name, "root")) value else true,
         else => true,
     };
 }
@@ -162,4 +211,25 @@ fn appendMetadataValue(buffer: *std.ArrayList(u8), allocator: std.mem.Allocator,
         },
         else => @compileError("unsupported trace metadata type for field '" ++ field_name ++ "'"),
     }
+}
+
+test "formatspanName encodes metadata" {
+    const formatted = try formatSpanName(std.testing.allocator, "test.span", .{
+        .root = true,
+        .count = @as(u8, 42),
+        .label = "batch",
+    });
+    defer std.testing.allocator.free(formatted);
+
+    try std.testing.expectEqualStrings("test.span#_r=1,count=42,label=batch#", formatted);
+}
+
+test "formatspanName omits empty metadata" {
+    const formatted = try formatSpanName(std.testing.allocator, "test.span", .{
+        .root = false,
+        .optional = @as(?u8, null),
+    });
+    defer std.testing.allocator.free(formatted);
+
+    try std.testing.expectEqualStrings("test.span", formatted);
 }


### PR DESCRIPTION
Renamed `scope` to `span` to match OpenTelemetry convention I'm more familiar with. Traceme doesn't seem to use `Scope` explicitly but talks more about a scope object AFAIK.

Now `span` fails at compile time. if it cannot compute the appropriate buffer size for the name. In that case the caller should use `formatSpanName` which allocates. This makes `span` infaillible at runtime.