### PR TITLE
zml/moe: fix - move allReduce into manual computation block

### DIFF
--- a/zml/moe/moe.zig
+++ b/zml/moe/moe.zig
@@ -160,7 +160,7 @@ pub fn forwardMoe(
             if (expert_partition.eql(.init(.experts))) {
                 const global_num_experts = weights_down.dim(.expert);
 
-                const partial_output = zml.ops.manualComputation(
+                break :b zml.ops.manualComputation(
                     .{ input, topk_ids, topk_weights, weights_gate_up, weights_down },
                     input.shape(),
                     .{
@@ -203,11 +203,11 @@ pub fn forwardMoe(
                                     .w2_bias = ctx.bias_down,
                                 },
                             ) catch |err| stdx.debug.panic("moe backend failed: {}", .{err});
-                            return local_output.reshape(sharded_inputs[0].shape().dims()).withTags(.{ .b, .s, .d });
+                            const local_reshaped = local_output.reshape(sharded_inputs[0].shape().dims()).withTags(.{ .b, .s, .d });
+                            return zml.ops.allReduce(local_reshaped, zml.Tensor.add);
                         }
                     }).body,
                 );
-                break :b zml.ops.allReduce(partial_output, zml.Tensor.add);
             }
 
             break :b try triton.fusedExpertsImpl(


### PR DESCRIPTION
# Description
This PR serves to fix an error found in Step 3.5 Flash and potentially other MoE models.

Error:
```
[PJRT_Client_Compile] RET_CHECK failure (xla/service/spmd/spmd_partitioner.cc:3601) hlo->sharding().IsManualSubgroup() Cross-partition allreduce must be in (partial) manual partitioning mode.
```

Previously, allReduce was placed outside of the manual computation block within `zml.moe.forwardMoe.` It should be placed within. 

Qwen 3.5 MoE worked without this change; I looked at HLO logs and Qwen's compiled HLO doesn't contain the allReduce so that's why it didn't fail before.