### PR TITLE
zml/sharding : introduce shardableDim api

### DIFF
--- a/examples/llm/models/qwen3_5/inference.zig
+++ b/examples/llm/models/qwen3_5/inference.zig
@@ -19,12 +19,11 @@ pub const CompilationParameters = struct {
 
     pub fn init(mdl: model.Model, config: model.Config, seqlen: u32, shardings: common.Shardings) CompilationParameters {
         const dtype = mdl.text_model.embed_tokens.weight.dtype();
-        const model_partitions = shardings.model.numPartitionsForLogicalAxis(.model);
         return .{
             .prefill_tokens = .init(.{ .b = 1, .s = seqlen }, .u32),
             .decode_tokens = .init(.{ .b = 1, .s = 1 }, .u32),
             .token_index = .init(.{}, .u32),
-            .kv_cache = .init(config, 1, seqlen, dtype, .f32, model_partitions),
+            .kv_cache = .init(config, 1, seqlen, dtype, .f32, shardings.model),
             .rng = .init(),
             .seqlen = seqlen,
             .shardings = shardings,

--- a/examples/llm/models/qwen3_5/model.zig
+++ b/examples/llm/models/qwen3_5/model.zig
@@ -536,8 +536,7 @@ pub const SelfAttn = struct {
         return .{ k, v };
     }
 
-    fn partitionProjectedKv(tensor: zml.Tensor, kv_head_sharding: zml.Sharding.DimSharding) zml.Tensor {
-        var kv = tensor;
+    fn partitionProjectedKv(kv: zml.Tensor, kv_head_sharding: zml.Sharding.DimSharding) zml.Tensor {
         return switch (kv_head_sharding) {
             .sharded => |heads| blk: {
                 if (heads.factor != 1) {

--- a/examples/llm/models/qwen3_5/model.zig
+++ b/examples/llm/models/qwen3_5/model.zig
@@ -44,18 +44,6 @@ pub const RopeParameters = struct {
     rope_theta: f32,
 };
 
-fn kvHeadsAreReplicated(axis_size: i64, model_partitions: i64) bool {
-    return axis_size > 0 and axis_size < model_partitions and @rem(model_partitions, axis_size) == 0;
-}
-
-fn partitionKvCacheShape(kv_shape: zml.Shape, kv_heads: i64, model_partitions: i64) zml.Shape {
-    if (kvHeadsAreReplicated(kv_heads, model_partitions)) {
-        return kv_shape.withPartitioning(.{ .h = .replicated });
-    }
-
-    return kv_shape.withPartitioning(.{ .h = .model });
-}
-
 pub const LoadedModel = struct {
     inner: Model,
     parsed_config: std.json.Parsed(Config),
@@ -548,21 +536,30 @@ pub const SelfAttn = struct {
         return .{ k, v };
     }
 
-    fn partitionProjectedKv(tensor: zml.Tensor, replicate_kv_heads: bool) zml.Tensor {
-        if (replicate_kv_heads) {
-            return tensor.withPartitioning(.{ .s = .replicated, .h = .replicated, .hd = .replicated });
-        }
-
-        return tensor.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
+    fn partitionProjectedKv(tensor: zml.Tensor, kv_head_sharding: zml.Sharding.DimSharding) zml.Tensor {
+        var kv = tensor;
+        return switch (kv_head_sharding) {
+            .sharded => |heads| blk: {
+                if (heads.factor != 1) {
+                    kv = kv.stutter1d(kv.axis(.h), heads.factor);
+                }
+                break :blk kv.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
+            },
+            .replicated => kv.withPartitioning(.{ .s = .replicated, .h = .replicated, .hd = .replicated }),
+        };
     }
 
-    fn partitionCachedKv(tensor: zml.Tensor, replicate_kv_heads: bool) zml.Tensor {
-        const cache_tensor = tensor.rename(.{ .s = .k });
-        if (replicate_kv_heads) {
-            return cache_tensor.withPartitioning(.{ .k = .replicated, .h = .replicated, .hd = .replicated });
-        }
-
-        return cache_tensor.withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated });
+    fn partitionCachedKv(tensor: zml.Tensor, kv_head_sharding: zml.Sharding.DimSharding) zml.Tensor {
+        var cache_tensor = tensor.rename(.{ .s = .k });
+        return switch (kv_head_sharding) {
+            .sharded => |heads| blk: {
+                if (heads.factor != 1) {
+                    cache_tensor = cache_tensor.stutter1d(cache_tensor.axis(.h), heads.factor);
+                }
+                break :blk cache_tensor.withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated });
+            },
+            .replicated => cache_tensor.withPartitioning(.{ .k = .replicated, .h = .replicated, .hd = .replicated }),
+        };
     }
 
     pub fn forward(
@@ -571,14 +568,18 @@ pub const SelfAttn = struct {
         token_index: zml.Tensor,
         kv_cache: KvCache.SelfAttnCache,
     ) struct { zml.Tensor, KvCache.SelfAttnCache } {
-        const model_partitions = zml.module.CompilationContext.current().partitioning.numPartitionsForLogicalAxis(self.q_proj.weight.shape(), .model) catch unreachable;
-        const replicate_kv_heads = kvHeadsAreReplicated(self.num_kv_heads, model_partitions);
         const x_qkv = x.withPartitioning(.{ .d = .replicated });
 
         var q, var gate = self.projectQAndGate(x_qkv);
         var k, var v = self.projectKV(x_qkv);
-        k = partitionProjectedKv(k, replicate_kv_heads);
-        v = partitionProjectedKv(v, replicate_kv_heads);
+        const kv_head_sharding = zml.module.CompilationContext.current().partitioning.shardableDim(
+            k.shape().withPartitioning(.{ .h = .model }),
+            .h,
+            q.dim(.h),
+        ) catch unreachable;
+
+        k = partitionProjectedKv(k, kv_head_sharding);
+        v = partitionProjectedKv(v, kv_head_sharding);
         q = self.q_norm.forward(q.rename(.{ .hd = .d })).rename(.{ .d = .hd });
         k = self.k_norm.forward(k.rename(.{ .hd = .d })).rename(.{ .d = .hd });
 
@@ -590,15 +591,15 @@ pub const SelfAttn = struct {
         const cos, const sin = self.rotary_embed.getCosAndSin(position_ids, dtype);
         q = self.rotary_embed.applyRope(q, cos, sin);
         k = self.rotary_embed.applyRope(k, cos, sin);
-        k = partitionProjectedKv(k, replicate_kv_heads);
-        v = partitionProjectedKv(v, replicate_kv_heads);
+        k = partitionProjectedKv(k, kv_head_sharding);
+        v = partitionProjectedKv(v, kv_head_sharding);
 
         const new_kv_cache = kv_cache.update(k, v, token_index.convert(.u32));
         k = new_kv_cache.keys().convert(dtype);
         v = new_kv_cache.values().convert(dtype);
         q = q.rename(.{ .s = .q });
-        k = partitionCachedKv(k, replicate_kv_heads);
-        v = partitionCachedKv(v, replicate_kv_heads);
+        k = partitionCachedKv(k, kv_head_sharding);
+        v = partitionCachedKv(v, kv_head_sharding);
 
         const attn_output = zml.attention.attention.attention(
             q,
@@ -710,7 +711,7 @@ pub const GatedDeltaNet = struct {
 
     num_k_heads: i64,
     num_v_heads: i64,
-    qk_head_repetition: i64,
+    qk_head_repetition: u32,
     head_k_dim: i64,
     head_v_dim: i64,
     conv_kernel_size: i64,
@@ -720,8 +721,8 @@ pub const GatedDeltaNet = struct {
     }
 
     pub fn init(store: zml.io.TensorStore.View, config: Config) GatedDeltaNet {
-        const qk_head_repetition =
-            @divExact(config.text_config.linear_num_value_heads, config.text_config.linear_num_key_heads);
+        const qk_head_repetition: u32 =
+            @intCast(@divExact(config.text_config.linear_num_value_heads, config.text_config.linear_num_key_heads));
         return .{
             .in_proj_qkv = initProj(store.withPrefix("in_proj_qkv"), .{ .dout = .model, .d = .replicated }),
             .in_proj_z = initProj(store.withPrefix("in_proj_z"), .{ .dout = .model, .d = .replicated }),
@@ -873,11 +874,11 @@ pub const GatedDeltaNet = struct {
 
         const query_for_rule = b: {
             if (self.qk_head_repetition == 1) break :b query;
-            break :b query.stutter1d(@intCast(query.axis(.kh)), @intCast(self.qk_head_repetition));
+            break :b query.stutter1d(query.axis(.kh), self.qk_head_repetition);
         };
         const key_for_rule = b: {
             if (self.qk_head_repetition == 1) break :b key;
-            break :b key.stutter1d(@intCast(key.axis(.kh)), @intCast(self.qk_head_repetition));
+            break :b key.stutter1d(key.axis(.kh), self.qk_head_repetition);
         };
 
         const core_attn_out, const last_recurrent_state = recurrentGatedDeltaRule(
@@ -968,7 +969,7 @@ pub const KvCache = struct {
 
         pub const Buffers = zml.Bufferized(SelfAttnCache);
 
-        pub fn init(config: Config, batch_dim: i64, max_seq_len: i64, dtype: zml.DataType, model_partitions: i64) SelfAttnCache {
+        pub fn init(config: Config, batch_dim: i64, max_seq_len: i64, dtype: zml.DataType, model_sharding: zml.Sharding) SelfAttnCache {
             const num_self_attn_layers = countLayers(config.text_config.layer_types, .full_attention);
             const kv_shape = zml.Shape.init(.{
                 .b = batch_dim,
@@ -977,7 +978,11 @@ pub const KvCache = struct {
                 .h = config.text_config.num_key_value_heads,
                 .hd = config.text_config.head_dim,
             }, dtype);
-            const sharded_kv_shape = partitionKvCacheShape(kv_shape, config.text_config.num_key_value_heads, model_partitions);
+            const kv_head_sharding = model_sharding.shardableDim(kv_shape.dim(.h), .model, config.text_config.num_attention_heads);
+            const sharded_kv_shape = switch (kv_head_sharding) {
+                .sharded => |heads| kv_shape.setDim(.h, heads.dim).withPartitioning(.{ .h = .model }),
+                .replicated => kv_shape.withPartitioning(.{ .h = .replicated }),
+            };
             return .{
                 .k = .fromShape(sharded_kv_shape),
                 .v = .fromShape(sharded_kv_shape),
@@ -1169,11 +1174,11 @@ pub const KvCache = struct {
         max_seq_len: i64,
         cache_dtype: zml.DataType,
         recurrent_dtype: zml.DataType,
-        model_partitions: i64,
+        model_sharding: zml.Sharding,
     ) KvCache {
         return .{
             .layer_types = config.text_config.layer_types,
-            .self_attn = .init(config, batch_dim, max_seq_len, cache_dtype, model_partitions),
+            .self_attn = .init(config, batch_dim, max_seq_len, cache_dtype, model_sharding),
             .gated_delta_net = .init(config, batch_dim, cache_dtype, recurrent_dtype),
         };
     }

--- a/examples/llm/models/qwen3_5/model.zig
+++ b/examples/llm/models/qwen3_5/model.zig
@@ -539,10 +539,8 @@ pub const SelfAttn = struct {
     fn partitionProjectedKv(kv: zml.Tensor, kv_head_sharding: zml.Sharding.DimSharding) zml.Tensor {
         return switch (kv_head_sharding) {
             .sharded => |heads| blk: {
-                if (heads.factor != 1) {
-                    kv = kv.stutter1d(kv.axis(.h), heads.factor);
-                }
-                break :blk kv.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
+                const sharded_kv = if (heads.factor != 1) kv.stutter1d(kv.axis(.h), heads.factor) else kv;
+                break :blk sharded_kv.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
             },
             .replicated => kv.withPartitioning(.{ .s = .replicated, .h = .replicated, .hd = .replicated }),
         };

--- a/examples/llm/models/qwen3_5_moe/inference.zig
+++ b/examples/llm/models/qwen3_5_moe/inference.zig
@@ -30,9 +30,8 @@ pub const CompilationParameters = struct {
 
     pub fn init(mdl: model.Model, config: model.Config, seqlen: u32, moe_backend: zml.moe.Backend, shardings: common.Shardings) CompilationParameters {
         const dtype = mdl.text_model.embed_tokens.weight.dtype();
-        const model_partitions = shardings.model.numPartitionsForLogicalAxis(.model);
         return .{
-            .kv_cache = .init(config, 1, seqlen, dtype, .f32, model_partitions),
+            .kv_cache = .init(config, 1, seqlen, dtype, .f32, shardings.model),
             .rng = .init(),
             .prefill_moe_metadata = initMoeMetadata(mdl, @intCast(seqlen), 1, moe_backend),
             .decode_moe_metadata = initMoeMetadata(mdl, 1, 1, moe_backend),

--- a/examples/llm/models/qwen3_5_moe/model.zig
+++ b/examples/llm/models/qwen3_5_moe/model.zig
@@ -49,34 +49,41 @@ pub const RopeParameters = struct {
     rope_theta: f32,
 };
 
-fn kvHeadRepeatFactor(axis_size: i64, model_partitions: i64) ?u32 {
-    if (axis_size <= 0 or axis_size >= model_partitions or @rem(model_partitions, axis_size) != 0) return null;
-    return @intCast(@divExact(model_partitions, axis_size));
+fn repeatFactor(dim: i64, repeated_dim: i64) ?u63 {
+    if (dim == repeated_dim) return null;
+    return @intCast(@divExact(repeated_dim, dim));
 }
 
-fn partitionProjectedKv(tensor: zml.Tensor, repeat_factor: ?u32) zml.Tensor {
-    return if (repeat_factor) |factor|
-        tensor.stutter1d(tensor.axis(.h), @as(u63, factor)).withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated })
-    else
-        tensor.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
+fn partitionProjectedKv(tensor: zml.Tensor, repeated_kv_heads: i64) zml.Tensor {
+    const factor = repeatFactor(tensor.dim(.h), repeated_kv_heads) orelse
+        return tensor.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
+
+    return tensor
+        .stutter1d(tensor.axis(.h), factor)
+        .withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
 }
 
-fn partitionCachedKv(tensor: zml.Tensor, repeat_factor: ?u32) zml.Tensor {
-    return if (repeat_factor) |factor|
-        tensor.rename(.{ .s = .k }).stutter1d(tensor.axis(.h), @as(u63, factor)).withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated })
-    else
-        tensor.rename(.{ .s = .k }).withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated });
+fn partitionCachedKv(tensor: zml.Tensor, repeated_kv_heads: i64) zml.Tensor {
+    const renamed = tensor.rename(.{ .s = .k });
+    const factor = repeatFactor(renamed.dim(.h), repeated_kv_heads) orelse
+        return renamed.withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated });
+
+    return renamed
+        .stutter1d(renamed.axis(.h), factor)
+        .withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated });
 }
 
 fn partitionKvCacheShape(kv_shape: zml.Shape, kv_heads: i64, model_partitions: i64) zml.Shape {
-    if (kvHeadRepeatFactor(kv_heads, model_partitions)) |repeat_factor| {
-        const repeated_h = kv_shape.dim(.h) * @as(i64, @intCast(repeat_factor));
-        return kv_shape
-            .setDim(.h, repeated_h)
-            .withPartitioning(.{ .h = .model });
-    }
+    if (model_partitions <= 1 or @mod(kv_heads, model_partitions) == 0) return kv_shape;
 
-    return kv_shape.withPartitioning(.{ .h = .model });
+    const gcd: u64 = std.math.gcd(@as(u64, @intCast(kv_heads)), @as(u64, @intCast(model_partitions)));
+    const repeated_h: i64 = @intCast(@divExact(@as(u64, @intCast(kv_heads)), gcd) * @as(u64, @intCast(model_partitions)));
+
+    if (repeated_h == kv_shape.dim(.h)) return kv_shape.withPartitioning(.{ .h = .model });
+
+    return kv_shape
+        .setDim(.h, repeated_h)
+        .withPartitioning(.{ .h = .model });
 }
 
 pub const LoadedModel = struct {
@@ -575,16 +582,18 @@ pub const SelfAttn = struct {
         token_index: zml.Tensor,
         kv_cache: KvCache.SelfAttnCache,
     ) struct { zml.Tensor, KvCache.SelfAttnCache } {
-        const model_partitions = zml.module.CompilationContext.current().partitioning.numPartitionsForLogicalAxis(self.q_proj.weight.shape(), .model) catch unreachable;
-        const repeat_factor = kvHeadRepeatFactor(self.num_kv_heads, model_partitions);
         const x_qkv = x.withPartitioning(.{ .d = .replicated });
-
         var q, var gate = self.projectQAndGate(x_qkv);
         var k, var v = self.projectKV(x_qkv);
+
+        const kv_shape = k.shape().withPartitioning(.{ .h = .model });
+        const kv_sharding = CompilationContext.current().partitioning.selectSharding(kv_shape) catch unreachable;
+        const repeated_kv_heads = kv_sharding.repeatedDimShardable(k.dim(.h), .model);
+
         q = q.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
         gate = gate.withPartitioning(.{ .s = .replicated, .d_out_proj = .model });
-        k = partitionProjectedKv(k, repeat_factor);
-        v = partitionProjectedKv(v, repeat_factor);
+        k = partitionProjectedKv(k, repeated_kv_heads);
+        v = partitionProjectedKv(v, repeated_kv_heads);
         q = self.q_norm.forward(q.rename(.{ .hd = .d })).rename(.{ .d = .hd });
         k = self.k_norm.forward(k.rename(.{ .hd = .d })).rename(.{ .d = .hd });
 
@@ -597,15 +606,15 @@ pub const SelfAttn = struct {
         q = self.rotary_embed.applyRope(q, cos, sin);
         k = self.rotary_embed.applyRope(k, cos, sin);
         q = q.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
-        k = partitionProjectedKv(k, null);
-        v = partitionProjectedKv(v, null);
+        k = partitionProjectedKv(k, k.dim(.h));
+        v = partitionProjectedKv(v, v.dim(.h));
 
         const new_kv_cache = kv_cache.update(k, v, token_index.convert(.u32));
         k = new_kv_cache.keys().convert(dtype);
         v = new_kv_cache.values().convert(dtype);
         q = q.rename(.{ .s = .q }).withPartitioning(.{ .q = .replicated, .h = .model, .hd = .replicated });
-        k = partitionCachedKv(k, repeat_factor);
-        v = partitionCachedKv(v, repeat_factor);
+        k = partitionCachedKv(k, repeated_kv_heads);
+        v = partitionCachedKv(v, repeated_kv_heads);
 
         const attn_output = zml.attention.attention.attention(
             q,

--- a/examples/llm/models/qwen3_5_moe/model.zig
+++ b/examples/llm/models/qwen3_5_moe/model.zig
@@ -47,8 +47,7 @@ pub const RopeParameters = struct {
     rope_theta: f32,
 };
 
-fn partitionProjectedKv(tensor: zml.Tensor, kv_head_sharding: zml.Sharding.DimSharding) zml.Tensor {
-    var kv = tensor;
+fn partitionProjectedKv(kv: zml.Tensor, kv_head_sharding: zml.Sharding.DimSharding) zml.Tensor {
     return switch (kv_head_sharding) {
         .sharded => |heads| blk: {
             if (heads.factor != 1) {

--- a/examples/llm/models/qwen3_5_moe/model.zig
+++ b/examples/llm/models/qwen3_5_moe/model.zig
@@ -50,10 +50,8 @@ pub const RopeParameters = struct {
 fn partitionProjectedKv(kv: zml.Tensor, kv_head_sharding: zml.Sharding.DimSharding) zml.Tensor {
     return switch (kv_head_sharding) {
         .sharded => |heads| blk: {
-            if (heads.factor != 1) {
-                kv = kv.stutter1d(kv.axis(.h), heads.factor);
-            }
-            break :blk kv.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
+            const sharded_kv = if (heads.factor != 1) kv.stutter1d(kv.axis(.h), heads.factor) else kv;
+            break :blk sharded_kv.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
         },
         .replicated => kv.withPartitioning(.{ .s = .replicated, .h = .replicated, .hd = .replicated }),
     };

--- a/examples/llm/models/qwen3_5_moe/model.zig
+++ b/examples/llm/models/qwen3_5_moe/model.zig
@@ -1,8 +1,6 @@
 const std = @import("std");
 
 const zml = @import("zml");
-const CompilationContext = zml.module.CompilationContext;
-
 const stdx = zml.stdx;
 
 const common = @import("../common.zig");
@@ -49,41 +47,30 @@ pub const RopeParameters = struct {
     rope_theta: f32,
 };
 
-fn repeatFactor(dim: i64, repeated_dim: i64) ?u63 {
-    if (dim == repeated_dim) return null;
-    return @intCast(@divExact(repeated_dim, dim));
+fn partitionProjectedKv(tensor: zml.Tensor, kv_head_sharding: zml.Sharding.DimSharding) zml.Tensor {
+    var kv = tensor;
+    return switch (kv_head_sharding) {
+        .sharded => |heads| blk: {
+            if (heads.factor != 1) {
+                kv = kv.stutter1d(kv.axis(.h), heads.factor);
+            }
+            break :blk kv.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
+        },
+        .replicated => kv.withPartitioning(.{ .s = .replicated, .h = .replicated, .hd = .replicated }),
+    };
 }
 
-fn partitionProjectedKv(tensor: zml.Tensor, repeated_kv_heads: i64) zml.Tensor {
-    const factor = repeatFactor(tensor.dim(.h), repeated_kv_heads) orelse
-        return tensor.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
-
-    return tensor
-        .stutter1d(tensor.axis(.h), factor)
-        .withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
-}
-
-fn partitionCachedKv(tensor: zml.Tensor, repeated_kv_heads: i64) zml.Tensor {
-    const renamed = tensor.rename(.{ .s = .k });
-    const factor = repeatFactor(renamed.dim(.h), repeated_kv_heads) orelse
-        return renamed.withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated });
-
-    return renamed
-        .stutter1d(renamed.axis(.h), factor)
-        .withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated });
-}
-
-fn partitionKvCacheShape(kv_shape: zml.Shape, kv_heads: i64, model_partitions: i64) zml.Shape {
-    if (model_partitions <= 1 or @mod(kv_heads, model_partitions) == 0) return kv_shape;
-
-    const gcd: u64 = std.math.gcd(@as(u64, @intCast(kv_heads)), @as(u64, @intCast(model_partitions)));
-    const repeated_h: i64 = @intCast(@divExact(@as(u64, @intCast(kv_heads)), gcd) * @as(u64, @intCast(model_partitions)));
-
-    if (repeated_h == kv_shape.dim(.h)) return kv_shape.withPartitioning(.{ .h = .model });
-
-    return kv_shape
-        .setDim(.h, repeated_h)
-        .withPartitioning(.{ .h = .model });
+fn partitionCachedKv(tensor: zml.Tensor, kv_head_sharding: zml.Sharding.DimSharding) zml.Tensor {
+    var kv = tensor.rename(.{ .s = .k });
+    return switch (kv_head_sharding) {
+        .sharded => |heads| blk: {
+            if (heads.factor != 1) {
+                kv = kv.stutter1d(kv.axis(.h), heads.factor);
+            }
+            break :blk kv.withPartitioning(.{ .k = .replicated, .h = .model, .hd = .replicated });
+        },
+        .replicated => kv.withPartitioning(.{ .k = .replicated, .h = .replicated, .hd = .replicated }),
+    };
 }
 
 pub const LoadedModel = struct {
@@ -585,15 +572,16 @@ pub const SelfAttn = struct {
         const x_qkv = x.withPartitioning(.{ .d = .replicated });
         var q, var gate = self.projectQAndGate(x_qkv);
         var k, var v = self.projectKV(x_qkv);
-
-        const kv_shape = k.shape().withPartitioning(.{ .h = .model });
-        const kv_sharding = CompilationContext.current().partitioning.selectSharding(kv_shape) catch unreachable;
-        const repeated_kv_heads = kv_sharding.repeatedDimShardable(k.dim(.h), .model);
+        const kv_head_sharding = zml.module.CompilationContext.current().partitioning.shardableDim(
+            k.shape().withPartitioning(.{ .h = .model }),
+            .h,
+            q.dim(.h),
+        ) catch unreachable;
 
         q = q.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
         gate = gate.withPartitioning(.{ .s = .replicated, .d_out_proj = .model });
-        k = partitionProjectedKv(k, repeated_kv_heads);
-        v = partitionProjectedKv(v, repeated_kv_heads);
+        k = partitionProjectedKv(k, kv_head_sharding);
+        v = partitionProjectedKv(v, kv_head_sharding);
         q = self.q_norm.forward(q.rename(.{ .hd = .d })).rename(.{ .d = .hd });
         k = self.k_norm.forward(k.rename(.{ .hd = .d })).rename(.{ .d = .hd });
 
@@ -606,15 +594,15 @@ pub const SelfAttn = struct {
         q = self.rotary_embed.applyRope(q, cos, sin);
         k = self.rotary_embed.applyRope(k, cos, sin);
         q = q.withPartitioning(.{ .s = .replicated, .h = .model, .hd = .replicated });
-        k = partitionProjectedKv(k, k.dim(.h));
-        v = partitionProjectedKv(v, v.dim(.h));
+        k = partitionProjectedKv(k, kv_head_sharding);
+        v = partitionProjectedKv(v, kv_head_sharding);
 
         const new_kv_cache = kv_cache.update(k, v, token_index.convert(.u32));
         k = new_kv_cache.keys().convert(dtype);
         v = new_kv_cache.values().convert(dtype);
         q = q.rename(.{ .s = .q }).withPartitioning(.{ .q = .replicated, .h = .model, .hd = .replicated });
-        k = partitionCachedKv(k, repeated_kv_heads);
-        v = partitionCachedKv(v, repeated_kv_heads);
+        k = partitionCachedKv(k, kv_head_sharding);
+        v = partitionCachedKv(v, kv_head_sharding);
 
         const attn_output = zml.attention.attention.attention(
             q,
@@ -880,7 +868,7 @@ pub const GatedDeltaNet = struct {
 
     num_k_heads: i64,
     num_v_heads: i64,
-    qk_head_repetition: i64,
+    qk_head_repetition: u32,
     head_k_dim: i64,
     head_v_dim: i64,
     conv_kernel_size: i64,
@@ -890,8 +878,8 @@ pub const GatedDeltaNet = struct {
     }
 
     pub fn init(store: zml.io.TensorStore.View, config: Config) GatedDeltaNet {
-        const qk_head_repetition =
-            @divExact(config.text_config.linear_num_value_heads, config.text_config.linear_num_key_heads);
+        const qk_head_repetition: u32 =
+            @intCast(@divExact(config.text_config.linear_num_value_heads, config.text_config.linear_num_key_heads));
         return .{
             .in_proj_qkv = initProj(store.withPrefix("in_proj_qkv"), .{ .dout = .model, .d = .replicated }),
             .in_proj_qkv_scale = null,
@@ -1059,8 +1047,8 @@ pub const GatedDeltaNet = struct {
             g = setPaddingToZero(g, valid_mask.broad(g.shape()));
         }
 
-        const query_for_rule = if (self.qk_head_repetition == 1) query else query.stutter1d(@intCast(query.axis(.kh)), @intCast(self.qk_head_repetition));
-        const key_for_rule = if (self.qk_head_repetition == 1) key else key.stutter1d(@intCast(key.axis(.kh)), @intCast(self.qk_head_repetition));
+        const query_for_rule = if (self.qk_head_repetition == 1) query else query.stutter1d(query.axis(.kh), self.qk_head_repetition);
+        const key_for_rule = if (self.qk_head_repetition == 1) key else key.stutter1d(key.axis(.kh), self.qk_head_repetition);
 
         const core_attn_out, const last_recurrent_state = recurrentGatedDeltaRule(
             query_for_rule,
@@ -1144,7 +1132,7 @@ pub const KvCache = struct {
         v: zml.Tensor,
         layer_index: zml.Tensor,
 
-        pub fn init(config: Config, batch_dim: i64, max_seq_len: i64, dtype: zml.DataType, model_partitions: i64) SelfAttnCache {
+        pub fn init(config: Config, batch_dim: i64, max_seq_len: i64, dtype: zml.DataType, model_sharding: zml.Sharding) SelfAttnCache {
             const num_self_attn_layers = countLayers(config.text_config.layer_types, .full_attention);
             const kv_shape = zml.Shape.init(.{
                 .b = batch_dim,
@@ -1153,7 +1141,11 @@ pub const KvCache = struct {
                 .h = config.text_config.num_key_value_heads,
                 .hd = config.text_config.head_dim,
             }, dtype);
-            const sharded_kv_shape = partitionKvCacheShape(kv_shape, config.text_config.num_key_value_heads, model_partitions);
+            const kv_head_sharding = model_sharding.shardableDim(kv_shape.dim(.h), .model, config.text_config.num_attention_heads);
+            const sharded_kv_shape = switch (kv_head_sharding) {
+                .sharded => |heads| kv_shape.setDim(.h, heads.dim).withPartitioning(.{ .h = .model }),
+                .replicated => kv_shape.withPartitioning(.{ .h = .replicated }),
+            };
             return .{
                 .k = .fromShape(sharded_kv_shape),
                 .v = .fromShape(sharded_kv_shape),
@@ -1333,11 +1325,11 @@ pub const KvCache = struct {
         max_seq_len: i64,
         cache_dtype: zml.DataType,
         recurrent_dtype: zml.DataType,
-        model_partitions: i64,
+        model_sharding: zml.Sharding,
     ) KvCache {
         return .{
             .layer_types = config.text_config.layer_types,
-            .self_attn = SelfAttnCache.init(config, batch_dim, max_seq_len, cache_dtype, model_partitions),
+            .self_attn = SelfAttnCache.init(config, batch_dim, max_seq_len, cache_dtype, model_sharding),
             .gated_delta_net = GatedDeltaNetCache.init(config, batch_dim, cache_dtype, recurrent_dtype),
         };
     }

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -33,6 +33,14 @@ pub fn numPartitionsForLogicalAxis(sharding: Sharding, logical_axis: anytype) i6
     return sharding.data.numPartitionsForLogicalAxis(logical_axis);
 }
 
+pub fn repeatedDimShardable(sharding: Sharding, dim: i64, logical_axis: anytype) i64 {
+    const partitions = sharding.numPartitionsForLogicalAxis(logical_axis);
+    if (partitions <= 1 or @mod(dim, partitions) == 0) return dim;
+
+    const gcd = std.math.gcd(@as(u64, @intCast(dim)), @as(u64, @intCast(partitions)));
+    return @intCast(@divExact(@as(u64, @intCast(dim)), gcd) * @as(u64, @intCast(partitions)));
+}
+
 pub fn devicesInCanonicalOrder(sharding: Sharding) []const Device {
     return sharding.data.physical.devices_in_canonical_order;
 }

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -1,5 +1,6 @@
 //! Explain how to split a buffer across different devices.
 const std = @import("std");
+const builtin = @import("builtin");
 
 const dialects = @import("mlir/dialects");
 const mlir = @import("mlir");
@@ -12,7 +13,6 @@ const PlatformDevice = @import("platform.zig").Device;
 const Shape = @import("shape.zig").Shape;
 const Slice = @import("slice.zig").Slice;
 const Target = @import("platform.zig").Target;
-const builtin = @import("builtin");
 
 const Sharding = @This();
 
@@ -31,14 +31,6 @@ pub fn resolve(sharding: Sharding, platform: *const Platform) Sharding {
 
 pub fn numPartitionsForLogicalAxis(sharding: Sharding, logical_axis: anytype) i64 {
     return sharding.data.numPartitionsForLogicalAxis(logical_axis);
-}
-
-pub fn repeatedDimShardable(sharding: Sharding, dim: i64, logical_axis: anytype) i64 {
-    const partitions = sharding.numPartitionsForLogicalAxis(logical_axis);
-    if (partitions <= 1 or @mod(dim, partitions) == 0) return dim;
-
-    const gcd = std.math.gcd(@as(u64, @intCast(dim)), @as(u64, @intCast(partitions)));
-    return @intCast(@divExact(@as(u64, @intCast(dim)), gcd) * @as(u64, @intCast(partitions)));
 }
 
 pub fn devicesInCanonicalOrder(sharding: Sharding) []const Device {
@@ -123,6 +115,15 @@ pub const Partitioning = struct {
     pub fn numPartitionsForLogicalAxis(self: Partitioning, shape: Shape, logical_axis: anytype) !i64 {
         const sharding = try self.selectSharding(shape);
         return sharding.data.numPartitionsForLogicalAxis(logical_axis);
+    }
+
+    pub fn shardableDim(self: Partitioning, shape: Shape, axis: anytype, must_divide: i64) !DimSharding {
+        const ax = shape.axis(axis);
+        const spec = shape.partition(ax);
+        if (spec != .axis) return .replicated;
+
+        const sharding = try self.selectSharding(shape);
+        return sharding.shardableDim(shape.dim(ax), spec.axis, must_divide);
     }
 
     pub fn sdyPerValueShardingAttr(self: Partitioning, allocator: std.mem.Allocator, ctx: *mlir.Context, shapes: []const Shape) !*const mlir.Attribute {
@@ -214,6 +215,31 @@ fn shapeHasAxisPartition(shape: Shape) bool {
         if (shape.partition(ax) == .axis) return true;
     }
     return false;
+}
+
+pub const DimSharding = union(enum) {
+    sharded: struct {
+        dim: i64,
+        factor: u32,
+    },
+    replicated,
+};
+
+pub fn shardableDim(sharding: Sharding, dim: i64, logical_axis: anytype, must_divide: i64) DimSharding {
+    const partitions = sharding.numPartitionsForLogicalAxis(logical_axis);
+
+    if (@mod(dim, partitions) == 0) {
+        return if (@mod(must_divide, dim) == 0) .{ .sharded = .{ .dim = dim, .factor = 1 } } else .replicated;
+    }
+
+    const gcd: i64 = @intCast(std.math.gcd(@as(u64, @intCast(dim)), @as(u64, @intCast(partitions))));
+    const repeat_factor: u32 = @intCast(@divExact(partitions, gcd));
+    const materialized_dim = std.math.mul(i64, dim, @as(i64, repeat_factor)) catch return .replicated;
+    if (@mod(must_divide, materialized_dim) == 0) {
+        return .{ .sharded = .{ .dim = materialized_dim, .factor = repeat_factor } };
+    } else {
+        return .replicated;
+    }
 }
 
 /// Device as part of a PhysicalMesh.

--- a/zml/moe/mosaic_tpu.zig
+++ b/zml/moe/mosaic_tpu.zig
@@ -1,12 +1,11 @@
 const std = @import("std");
 
+const mtt = @import("kernels/mosaic_tpu/builder");
 const stdx = @import("stdx");
 
 const zml = @import("../zml.zig");
 const Tensor = zml.Tensor;
-
 pub const gmm_ep = @import("mosaic_tpu_kernels/gmm_ep.zig");
-const mtt = @import("kernels/mosaic_tpu/builder");
 
 const log = std.log.scoped(.moe_mosaic_tpu);
 
@@ -225,7 +224,7 @@ pub fn callGmmEp(
     };
     const aligned_k = @divFloor(k + 127, 128) * 128;
     const aligned_n = if (fuse_act == .none) @divFloor(out_n + 127, 128) * 128 else out_n;
-    // const tile_n = if (fuse_act == .none) 128 else out_n;
+
     const cfg: gmm_ep.Cfg = .{
         .size_m = lhs.dim(.token),
         .size_k = k,
@@ -256,6 +255,7 @@ pub fn callGmmEp(
         .{
             .cfg = cfg,
             .extras = .{
+                // todo leverage tpu api like this https://github.com/openxla/tokamax/blob/f65135e85acd7571531be91d4d3241e1929421f0/tokamax/_src/ops/ragged_dot/pallas_mosaic_tpu_v2_tgmm_kernel.py#L692
                 .vmem_limit_bytes = 32 * 1024 * 1024,
             },
         },

--- a/zml/moe/mosaic_tpu.zig
+++ b/zml/moe/mosaic_tpu.zig
@@ -225,6 +225,7 @@ pub fn callGmmEp(
     };
     const aligned_k = @divFloor(k + 127, 128) * 128;
     const aligned_n = if (fuse_act == .none) @divFloor(out_n + 127, 128) * 128 else out_n;
+    // const tile_n = if (fuse_act == .none) 128 else out_n;
     const cfg: gmm_ep.Cfg = .{
         .size_m = lhs.dim(.token),
         .size_k = k,
@@ -252,7 +253,12 @@ pub fn callGmmEp(
         .{
             .out = zml.Shape.init(.{ .token = lhs.dim(.token), .out = aligned_n }, out_dtype),
         },
-        .{ .cfg = cfg },
+        .{
+            .cfg = cfg,
+            .extras = .{
+                .vmem_limit_bytes = 32 * 1024 * 1024,
+            },
+        },
     ).out;
 
     return out.slice1d(.out, .{ .end = out_n });

--- a/zml/moe/mosaic_tpu_kernels/gmm_ep.zig
+++ b/zml/moe/mosaic_tpu_kernels/gmm_ep.zig
@@ -290,6 +290,8 @@ fn matmulByMxuColumns(b: *mtt.Builder, cfg: Cfg, lhs: mtt.Value, rhs: mtt.Value,
             });
         }
 
+        if (chunks == 1) return parts[0];
+
         const max_concat_inputs = 16;
         if (chunks <= max_concat_inputs) return b.concatenate(parts, 1);
 
@@ -326,6 +328,8 @@ fn matmulByMxuColumns(b: *mtt.Builder, cfg: Cfg, lhs: mtt.Value, rhs: mtt.Value,
             .dimension_numbers = b.dotDimensionNumbers(&.{1}, &.{0}, &.{0}, &.{1}, &.{ 0, 0, 1, 1 }, &.{}, &.{}),
         });
     }
+
+    if (chunks == 1) return parts[0];
 
     const max_concat_inputs = 16;
     if (chunks <= max_concat_inputs) return b.concatenate(parts, 1);

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1979,17 +1979,18 @@ pub const Tensor = struct {
     ///
     /// * stutter1d([0, 1, 2, 3], -1, 2) = [0, 0, 1, 1, 2, 2, 3, 3]
     /// This is equivalent to repeat(ax+1) unless ax is the last axis.
-    pub fn stutter1d(self: Tensor, axis_: i8, n_rep: u63) Tensor {
+    pub fn stutter1d(self: Tensor, axis_: i8, n_rep: u32) Tensor {
+        stdx.debug.assert(n_rep > 0, "stutter1d expects a positive repeat count, got {}", .{n_rep});
         const a = self.axis(axis_);
         const broadshape = self._shape.insert(a + 1, .{n_rep});
-        const res_shape = self._shape.setDim(a, self.dim(a) * n_rep);
+        const res_shape = self._shape.setDim(a, self.dim(a) * @as(i64, n_rep));
 
         const stutter_dims = Shape.range(self.rank() + 1, self.dtype()).remove(a + 1);
         return self.broadcast(broadshape, stutter_dims.dims()).reshape(res_shape);
     }
 
     /// Repeats in line each value along the given axes.
-    pub fn stutter(self: Tensor, n_reps: []const u63) Tensor {
+    pub fn stutter(self: Tensor, n_reps: []const u32) Tensor {
         // TODO: this should support the tagged syntax: x.repeat(.{ .a = 3, .b = 2});
         stdx.debug.assert(n_reps.len == self.rank(), "stutter expects tensor rank and 'n_reps' length to be equal, got {} and {}", .{ self.rank(), n_reps.len });
 


### PR DESCRIPTION
This PR introduces shardableDim helper in Sharding to handle the case where :
(dimension % number of sharding axes) != 0

Useful to stutter and shard correctly kv heads dim for example.