### PR TITLE
attention: support `is_causal` option in Triton and Mosaic paged-attn kernels

### DIFF
--- a/platforms/tpu/ragged_paged.zig
+++ b/platforms/tpu/ragged_paged.zig
@@ -32,9 +32,12 @@ pub const Cfg = struct {
     k_scale: ?f32 = null,
     v_scale: ?f32 = null,
 
-    /// Sliding-window mask added on top of the causal mask: any `(row, col)`
-    /// with `row - sliding_window >= col` is masked out. Mirrors
-    /// `kernel.py:391-393`.
+    /// Whether to mask keys beyond the current query row.
+    is_causal: bool = true,
+
+    /// Sliding-window mask added on top of the validity/causal mask: any
+    /// `(row, col)` with `row - sliding_window >= col` is masked out. Mirrors
+    /// `kernel.py:391-393` in causal mode.
     sliding_window: ?i64 = null,
     vmem_limit_bytes: ?i64 = null,
 
@@ -395,11 +398,16 @@ fn flashAttention(
         k.broadcastTo(kv_len_start, &.{ flash_q, flash_k }),
         k.iota(&.{ flash_q, flash_k }, .i32, &.{1}),
     );
-    var causal_mask = k.cmpi(.slt, row_ids, col_ids);
+    var score_mask = if (cfg.is_causal)
+        k.cmpi(.slt, row_ids, col_ids)
+    else
+        // `row_ids < row_ids` is an all-false mask with the same bool shape
+        // as the causal mask; sliding-window masking can still be OR-ed below.
+        k.cmpi(.slt, row_ids, row_ids);
     if (cfg.sliding_window) |sw| {
         const sw_splat = k.splat(@as(i32, @intCast(sw)), &.{ flash_q, flash_k }, .i32);
         const window_mask = k.cmpi(.sge, k.subi(row_ids, sw_splat), col_ids);
-        causal_mask = k.ori(causal_mask, window_mask);
+        score_mask = k.ori(score_mask, window_mask);
     }
     if (cfg.soft_cap) |sc| {
         const sc_splat = k.splat(sc, &.{ flash_q, flash_k }, .f32);
@@ -407,7 +415,7 @@ fn flashAttention(
     }
     const qk_masked = k.addf(
         qk,
-        k.select(causal_mask, k.splat(cfg.mask_value, &.{ flash_q, flash_k }, .f32), k.zeros(&.{ flash_q, flash_k }, .f32)),
+        k.select(score_mask, k.splat(cfg.mask_value, &.{ flash_q, flash_k }, .f32), k.zeros(&.{ flash_q, flash_k }, .f32)),
     );
 
     // jnp.max → maximumf (NaN-propagating).

--- a/zml/attention/tpu_attention.zig
+++ b/zml/attention/tpu_attention.zig
@@ -240,13 +240,12 @@ pub const mosaic_tpu = struct {
             .q_dtype = cfgDtype(q_shape.dtype()),
             .kv_dtype = cfgDtype(kv_pages_shape.dtype()),
             .sm_scale = opts.scale orelse @floatCast(1.0 / @sqrt(logical_head_dim)),
+            .is_causal = opts.is_causal,
             .sliding_window = if (opts.sliding_window < 0) null else @intCast(opts.sliding_window),
         };
     }
 
     pub fn pagedAttention(parameters: Parameters, q: zml.Tensor, kv_cache: zml.Tensor, opts: AttentionOptions) zml.Tensor {
-        stdx.debug.assert(opts.is_causal, "mosaic_tpu ragged paged attention currently only supports causal attention", .{});
-
         const prepared = prepareInputs(parameters, q, kv_cache);
 
         const q_out = zml.ops.manualComputation(
@@ -328,9 +327,13 @@ test "mosaic_tpu cfg uses kernel head dim and logical scale" {
 
     const cfg = mosaic_tpu.buildCfg(prepared_inputs, parameters, .{});
     try std.testing.expectEqual(@as(i64, 128), cfg.head_dim);
+    try std.testing.expect(cfg.is_causal);
     try std.testing.expectApproxEqAbs(
         @as(f32, 1.0 / @sqrt(@as(f32, 64.0))),
         cfg.sm_scale,
         0.000001,
     );
+
+    const non_causal_cfg = mosaic_tpu.buildCfg(prepared_inputs, parameters, .{ .is_causal = false });
+    try std.testing.expect(!non_causal_cfg.is_causal);
 }

--- a/zml/attention/triton_attention.zig
+++ b/zml/attention/triton_attention.zig
@@ -293,7 +293,6 @@ pub const paged = struct {
     }
 
     pub fn pagedAttention2d(parameters: Parameters, q: zml.Tensor, k_cache: zml.Tensor, v_cache: zml.Tensor, opts: AttentionOptions, paged_attention_opts: PagedAttentionOptions) zml.Tensor {
-        _ = opts;
         const config = select2dConfig(paged_attention_opts);
 
         const kernel_config: kernels.KernelUnifiedAttention2dPtr.Config = .{
@@ -315,6 +314,7 @@ pub const paged = struct {
             .block_m = @intCast(config.block_m),
             .use_fp8 = false,
             .all_decode = paged_attention_opts.all_decode,
+            .is_causal = opts.is_causal,
         };
         log.debug("pagedAttention2d config: {any}", .{kernel_config});
 
@@ -379,8 +379,6 @@ pub const paged = struct {
     }
 
     pub fn pagedAttention3d(parameters: Parameters, q: zml.Tensor, k_cache: zml.Tensor, v_cache: zml.Tensor, opts: AttentionOptions, paged_attention_opts: PagedAttentionOptions) zml.Tensor {
-        _ = opts;
-
         const config = select3dConfig(paged_attention_opts);
 
         const head_size_padded: i64 = @intCast(std.math.ceilPowerOfTwoAssert(usize, paged_attention_opts.head_dim));
@@ -402,6 +400,7 @@ pub const paged = struct {
             .block_m = @intCast(config.attention.block_m),
             .num_segments_per_seq = @intCast(config.attention.num_segments_per_seq),
             .all_decode = paged_attention_opts.all_decode,
+            .is_causal = opts.is_causal,
         };
         log.debug("pagedAttention3d attention config: {any}", .{attn_kernel_config});
 

--- a/zml/attention/triton_kernels/unified_attention.zig
+++ b/zml/attention/triton_kernels/unified_attention.zig
@@ -48,6 +48,7 @@ pub const KernelUnifiedAttention2dPtr = struct {
         fp8_min: f32 = FP8_E4M3_MIN,
         fp8_max: f32 = FP8_E4M3_MAX,
         all_decode: bool = false,
+        is_causal: bool = true,
     };
 
     pub const Kernel = tri.Kernel(Config, .{
@@ -178,6 +179,7 @@ pub const KernelUnifiedAttention3dPtr = struct {
         block_m: i64,
         num_segments_per_seq: i64,
         all_decode: bool = false,
+        is_causal: bool = true,
     };
 
     pub const Kernel = tri.Kernel(Config, .{
@@ -547,10 +549,14 @@ fn kernelUnifiedAttention2d(
     else
         qq_bias_ptr.splatTo(&.{BLOCK_M});
 
-    // max_seq_prefix_len = context_len + q_block_local_idx*BLOCK_Q + (BLOCK_M-1)/NQ_PER_KV + 1
+    // In causal mode, each query block only scans keys up to the last query
+    // represented in this block. In non-causal mode, scan the whole sequence
+    // so draft rows can attend to all rows written for the same sequence.
     const pad_term: i32 = @intCast(@divTrunc(BLOCK_M - 1, NUM_QUERIES_PER_KV) + 1);
-    const max_prefix_raw = context_len.add(q_local_bq).add(pad_term);
-    const max_seq_prefix_len = max_prefix_raw.minimum(seq_len);
+    const max_seq_prefix_len = if (config.is_causal) b: {
+        const max_prefix_raw = context_len.add(q_local_bq).add(pad_term);
+        break :b max_prefix_raw.minimum(seq_len);
+    } else seq_len;
 
     const num_tiles = cdivFn(max_seq_prefix_len, @as(i32, @intCast(TILE_SIZE)));
 
@@ -559,12 +565,14 @@ fn kernelUnifiedAttention2d(
     var tile_end: Value = num_tiles;
     if (SLIDING_WINDOW > 0) {
         const qpos_lo = q_local_bq;
-        const qpos_hi_raw = qpos_lo.add(pad_term - 1);
-        const qpos_hi = qpos_hi_raw.minimum(cur_batch_query_len.sub(1));
         const first_allowed_key = context_len.add(qpos_lo).sub(@as(i32, @intCast(SLIDING_WINDOW - 1)));
-        const last_allowed_key = context_len.add(qpos_hi);
         tile_start = first_allowed_key.div(@as(i32, @intCast(TILE_SIZE))).maximum(0);
-        tile_end = last_allowed_key.div(@as(i32, @intCast(TILE_SIZE))).add(1).minimum(num_tiles);
+        if (config.is_causal) {
+            const qpos_hi_raw = qpos_lo.add(pad_term - 1);
+            const qpos_hi = qpos_hi_raw.minimum(cur_batch_query_len.sub(1));
+            const last_allowed_key = context_len.add(qpos_hi);
+            tile_end = last_allowed_key.div(@as(i32, @intCast(TILE_SIZE))).add(1).minimum(num_tiles);
+        }
     }
 
     const kv_cache_mod: ttir.CacheModifier =
@@ -626,11 +634,13 @@ fn kernelUnifiedAttention2d(
             S = applySoftcap(k, S, softcap).mul(RCP_LN2);
         }
 
-        // seq_mask = seq_offset[None, :] < context_len + query_pos[:, None] + 1
         const ql_2d_i32 = query_pos.expandDims(1);
         const so_2d = seq_offset.expandDims(0);
-        const rhs = ql_2d_i32.add(context_len).add(1);
-        const seq_mask = so_2d.lt(rhs);
+        const seq_mask = if (config.is_causal) b: {
+            // seq_offset[None, :] < context_len + query_pos[:, None] + 1
+            const rhs = ql_2d_i32.add(context_len).add(1);
+            break :b so_2d.lt(rhs);
+        } else k.broadcastTo(tile_mask.expandDims(0), &.{ BLOCK_M, TILE_SIZE });
 
         // S = tl.where(qmask_1 & qmask_0 & seq_mask, S, -inf)
         const qm0_2d = query_mask_0.expandDims(1);
@@ -857,8 +867,10 @@ fn kernelUnifiedAttention3d(
         qq_bias_ptr.splatTo(&.{BLOCK_M});
 
     const pad_term: i32 = @intCast(@divTrunc(BLOCK_M - 1, NUM_QUERIES_PER_KV) + 1);
-    const max_prefix_raw = context_len.add(q_local_bq).add(pad_term);
-    const max_seq_prefix_len = max_prefix_raw.minimum(seq_len);
+    const max_seq_prefix_len = if (config.is_causal) b: {
+        const max_prefix_raw = context_len.add(q_local_bq).add(pad_term);
+        break :b max_prefix_raw.minimum(seq_len);
+    } else seq_len;
     const num_tiles = cdivFn(max_seq_prefix_len, @as(i32, @intCast(TILE_SIZE)));
 
     const segm_tile_lo = segm_idx.mul(tiles_per_segment);
@@ -913,11 +925,13 @@ fn kernelUnifiedAttention3d(
         });
         const V = dequantKv(V_load, v_scale, isFp8(config.kv_dtype), config.q_dtype);
 
-        // seq_mask = seq_offset[None, :] < context_len + query_pos[:, None] + 1
         const ql_2d_i32 = query_pos.expandDims(1);
         const so_2d = seq_offset.expandDims(0);
-        const rhs = context_len.add(ql_2d_i32).add(1);
-        const seq_mask = so_2d.lt(rhs);
+        const seq_mask = if (config.is_causal) b: {
+            // seq_offset[None, :] < context_len + query_pos[:, None] + 1
+            const rhs = context_len.add(ql_2d_i32).add(1);
+            break :b so_2d.lt(rhs);
+        } else k.broadcastTo(tile_mask.expandDims(0), &.{ BLOCK_M, TILE_SIZE });
 
         const acc_zero = k.zeros(&.{ BLOCK_M, TILE_SIZE }, .f32);
         const qk = k.dot(Q, K, acc_zero);

--- a/zml/attention/triton_kernels/unified_attention.zig
+++ b/zml/attention/triton_kernels/unified_attention.zig
@@ -565,13 +565,16 @@ fn kernelUnifiedAttention2d(
     var tile_end: Value = num_tiles;
     if (SLIDING_WINDOW > 0) {
         const qpos_lo = q_local_bq;
-        const first_allowed_key = context_len.add(qpos_lo).sub(@as(i32, @intCast(SLIDING_WINDOW - 1)));
-        tile_start = first_allowed_key.div(@as(i32, @intCast(TILE_SIZE))).maximum(0);
         if (config.is_causal) {
             const qpos_hi_raw = qpos_lo.add(pad_term - 1);
             const qpos_hi = qpos_hi_raw.minimum(cur_batch_query_len.sub(1));
+            const first_allowed_key = context_len.add(qpos_lo).sub(@as(i32, @intCast(SLIDING_WINDOW - 1)));
             const last_allowed_key = context_len.add(qpos_hi);
+            tile_start = first_allowed_key.div(@as(i32, @intCast(TILE_SIZE))).maximum(0);
             tile_end = last_allowed_key.div(@as(i32, @intCast(TILE_SIZE))).add(1).minimum(num_tiles);
+        } else {
+            const first_allowed_key = context_len.add(qpos_lo).sub(@as(i32, @intCast(SLIDING_WINDOW - 1)));
+            tile_start = first_allowed_key.div(@as(i32, @intCast(TILE_SIZE))).maximum(0);
         }
     }
 


### PR DESCRIPTION
We add suport for is_causal option in Triton and Mosaic paged-attention kernels, by adapting the mask-generation logic