### PR TITLE
zml/attention: tune triton kernel for oneAPI performance

### DIFF
--- a/zml/BUILD.bazel
+++ b/zml/BUILD.bazel
@@ -87,6 +87,7 @@ zig_library(
         "attention/tpu_attention.zig",
         "attention/triton_attention.zig",
         "attention/triton_kernels/unified_attention.zig",
+        "attention/triton_kernels/unified_attention_oneapi.zig",
         "moe/moe.zig",
         "moe/mosaic_tpu.zig",
         "moe/mosaic_tpu_kernels/gmm_ep.zig",

--- a/zml/attention/triton_attention.zig
+++ b/zml/attention/triton_attention.zig
@@ -6,16 +6,22 @@ const zml = @import("../zml.zig");
 const AttentionOptions = @import("paged_attention.zig").AttentionOptions;
 
 const kernels = @import("triton_kernels/unified_attention.zig");
+const kernels_oneapi = @import("triton_kernels/unified_attention_oneapi.zig");
 const tri = zml.kernel.triton;
 
 const log = std.log.scoped(.@"zml/attention/triton");
 
 const toDType = tri.from;
 
+fn isOneapiTarget() bool {
+    return zml.module.CompilationContext.current().platform.target == .oneapi;
+}
+
 fn use2dKernel(head_size: usize, sliding_window: usize, all_decode: bool, max_seqlen_q: usize, max_seqlen_k: usize, target_num_prgms: usize, num_2d_prgms: usize) bool {
     _ = head_size;
-    _ = all_decode;
     _ = max_seqlen_q;
+    // Intel decode spills the 2D whole-sequence kernel; force the 3D split-K path.
+    if (all_decode and isOneapiTarget()) return false;
     return sliding_window > 0 or max_seqlen_k <= 512 or num_2d_prgms > target_num_prgms;
 }
 
@@ -82,7 +88,8 @@ pub const Config3D = struct {
 
 fn select3dConfig(options: paged.PagedAttentionOptions) Config3D {
     var reduce_num_warps: usize = 2;
-    const attn_warps: usize = 2;
+    // Intel decode needs more warps to spread the work and avoid register spill.
+    const attn_warps: usize = if (options.all_decode and isOneapiTarget()) 8 else 2;
     const tile_size = options.block_size;
 
     //const MAX_SEGMENTS: usize = @min(128, std.math.divCeil(usize, max_seqlen_k, tile_size));
@@ -241,7 +248,11 @@ pub const paged = struct {
                     const num_heads: usize = @intCast(q_.dim(.hkv) * q_.dim(.hg));
                     const num_kv_heads: usize = @intCast(k_cache_.dim(.hkv));
                     const num_queries_per_kv: usize = num_heads / num_kv_heads;
-                    const block_m: usize = if (num_queries_per_kv <= 16) 16 else std.math.ceilPowerOfTwoAssert(usize, num_queries_per_kv);
+                    // Intel decode: pack exactly one GQA group per tile (block_q == 1) so the
+                    // single decode query token doesn't carry masked-out fp32 acc lanes.
+                    const block_m: usize = if (!ctx_.options.is_prefill and isOneapiTarget())
+                        num_queries_per_kv
+                    else if (num_queries_per_kv <= 16) 16 else std.math.ceilPowerOfTwoAssert(usize, num_queries_per_kv);
                     const block_q: usize = block_m / num_queries_per_kv;
                     const num_tokens: usize = @intCast(q_.dim(.b));
                     const num_seqs: usize = @intCast(parameters_.block_table.dim(.b));
@@ -281,6 +292,8 @@ pub const paged = struct {
                     );
                     const output = if (use_2d_kernel)
                         pagedAttention2d(parameters_, q_, k_cache_, v_cache_, ctx_.opts, paged_attention_opts)
+                    else if (isOneapiTarget())
+                        pagedAttention3dOneapi(parameters_, q_, k_cache_, v_cache_, ctx_.opts, paged_attention_opts)
                     else
                         pagedAttention3d(parameters_, q_, k_cache_, v_cache_, ctx_.opts, paged_attention_opts);
 
@@ -437,6 +450,150 @@ pub const paged = struct {
 
         const attn_grid: [3]i32 = .{ @intCast(config.attention.total_q_blocks), @intCast(paged_attention_opts.num_kv_heads), @intCast(config.attention.num_segments_per_seq) };
         const attn_output = kernels.KernelUnifiedAttention3dPtr.Kernel.call(
+            .{
+                .query_ptr = q,
+                .key_cache_ptr = k_cache,
+                .value_cache_ptr = v_cache,
+                .sink_ptr = dummy,
+                .block_tables_ptr = parameters.block_table,
+                .seq_lens_ptr = parameters.seq_lens,
+                .alibi_slopes_ptr = dummy,
+                .qq_bias_ptr = dummy,
+                .scale_ptr = scale_ptr,
+                .k_scale_ptr = dummy,
+                .v_scale_ptr = dummy,
+                .softcap_ptr = dummy,
+                .block_table_stride_ptr = block_table_strides_ptr,
+                .query_stride_0_ptr = q_strides_0_ptr,
+                .query_stride_1_ptr = q_strides_1_ptr,
+                .qq_bias_stride_0_ptr = dummy,
+                .stride_k_cache_0_ptr = k_strides_0_ptr,
+                .stride_k_cache_1_ptr = k_strides_1_ptr,
+                .stride_k_cache_2_ptr = k_strides_2_ptr,
+                .stride_v_cache_0_ptr = v_strides_0_ptr,
+                .stride_v_cache_1_ptr = v_strides_1_ptr,
+                .stride_v_cache_2_ptr = v_strides_2_ptr,
+                .query_start_len_ptr = parameters.query_start_len,
+                .num_seqs_ptr = num_seqs_ptr,
+            },
+            .{
+                .segm_output = zml.Shape.init(.{ paged_attention_opts.num_tokens, paged_attention_opts.num_heads, config.attention.num_segments_per_seq, std.math.ceilPowerOfTwoAssert(usize, paged_attention_opts.head_dim) }, .f32),
+                .segm_max = zml.Shape.init(.{ paged_attention_opts.num_tokens, paged_attention_opts.num_heads, config.attention.num_segments_per_seq }, .f32),
+                .segm_expsum = zml.Shape.init(.{ paged_attention_opts.num_tokens, paged_attention_opts.num_heads, config.attention.num_segments_per_seq }, .f32),
+            },
+            .{
+                .cfg = attn_kernel_config,
+                .grid = attn_grid,
+                .num_stages = @intCast(config.attention.num_stages),
+                .num_warps = @intCast(config.attention.num_warps),
+            },
+        );
+
+        const output = kernels.ReduceSegmentsPtr.Kernel.call(
+            .{
+                .segm_output_ptr = attn_output.segm_output,
+                .segm_max_ptr = attn_output.segm_max,
+                .segm_expsum_ptr = attn_output.segm_expsum,
+                .seq_lens_ptr = parameters.seq_lens,
+                .num_seqs_ptr = num_seqs_ptr,
+                .out_scale_inv_ptr = dummy,
+                .output_stride_0_ptr = q_strides_0_ptr,
+                .output_stride_1_ptr = q_strides_1_ptr,
+                .block_table_stride_ptr = block_table_strides_ptr,
+                .query_start_len_ptr = parameters.query_start_len,
+            },
+            .{ .output = q.shape() },
+            .{
+                .cfg = reduce_kernel_config,
+                .grid = .{ @intCast(paged_attention_opts.num_tokens), @intCast(paged_attention_opts.num_heads), 1 },
+                .num_stages = @intCast(config.reduce.num_stages),
+                .num_warps = @intCast(config.reduce.num_warps),
+            },
+        );
+
+        return output.output;
+    }
+
+    /// oneAPI/Intel specialization of pagedAttention3d: routes the attention pass to
+    /// the SIMD16-tuned kernel (compile-time KV strides, cached loads, same-page fast
+    /// path) while reusing the shared segment-reduce kernel. See unified_attention_oneapi.zig.
+    pub fn pagedAttention3dOneapi(parameters: Parameters, q: zml.Tensor, k_cache: zml.Tensor, v_cache: zml.Tensor, opts: AttentionOptions, paged_attention_opts: PagedAttentionOptions) zml.Tensor {
+        _ = opts;
+
+        const config = select3dConfig(paged_attention_opts);
+
+        const head_size_padded: i64 = @intCast(std.math.ceilPowerOfTwoAssert(usize, paged_attention_opts.head_dim));
+
+        const k_cache_shape_c = k_cache.shape();
+        const k_strides_c = k_cache_shape_c.computeElementStrides().constSlice();
+        const v_cache_shape_c = v_cache.shape();
+        const v_strides_c = v_cache_shape_c.computeElementStrides().constSlice();
+
+        const attn_kernel_config: kernels_oneapi.KernelUnifiedAttention3dPtr.Config = .{
+            .q_dtype = toDType(q.dtype()),
+            .kv_dtype = toDType(k_cache.dtype()),
+            .num_query_heads = @intCast(paged_attention_opts.num_heads),
+            .num_queries_per_kv = @intCast(paged_attention_opts.numQueriesPerKv()),
+            .block_size = @intCast(paged_attention_opts.block_size),
+            .tile_size = @intCast(config.attention.tile_size),
+            .head_size = @intCast(paged_attention_opts.head_dim),
+            .head_size_padded = head_size_padded,
+            .use_alibi_slopes = false,
+            .use_qq_bias = false,
+            .use_softcap = false,
+            .use_sinks = false,
+            .sliding_window = @intCast(paged_attention_opts.sliding_window),
+            .block_q = @intCast(config.attention.block_q),
+            .block_m = @intCast(config.attention.block_m),
+            .num_segments_per_seq = @intCast(config.attention.num_segments_per_seq),
+            .all_decode = paged_attention_opts.all_decode,
+            .stride_k_cache_0 = @intCast(k_strides_c[k_cache_shape_c.axis(.page)]),
+            .stride_k_cache_1 = @intCast(k_strides_c[k_cache_shape_c.axis(.k_chunk)]),
+            .stride_k_cache_2 = @intCast(k_strides_c[k_cache_shape_c.axis(.hkv)]),
+            .stride_v_cache_0 = @intCast(v_strides_c[v_cache_shape_c.axis(.page)]),
+            .stride_v_cache_1 = @intCast(v_strides_c[v_cache_shape_c.axis(.k_chunk)]),
+            .stride_v_cache_2 = @intCast(v_strides_c[v_cache_shape_c.axis(.hkv)]),
+            // Intel: keep KV loads cached (.none); the streaming .cg hint lowers to
+            // fully-uncached here and defeats the L2 prefetcher.
+            .kv_cache_modifier = .none,
+        };
+        log.debug("pagedAttention3dOneapi attention config: {any}", .{attn_kernel_config});
+
+        const reduce_kernel_config: kernels.ReduceSegmentsPtr.Config = .{
+            .o_dtype = toDType(q.dtype()),
+            .num_query_heads = @intCast(paged_attention_opts.num_heads),
+            .tile_size = @intCast(config.reduce.tile_size),
+            .head_size = @intCast(paged_attention_opts.head_dim),
+            .head_size_padded = head_size_padded,
+            .block_q = @intCast(config.reduce.block_q),
+            .num_segments_per_seq = @intCast(config.reduce.num_segments_per_seq),
+            .use_fp8 = false,
+        };
+        log.debug("pagedAttention3d reduce config: {any}", .{reduce_kernel_config});
+
+        const dummy = zml.Tensor.constant(zml.DataType.i8.zero());
+        const block_table_strides = parameters.block_table.shape().computeElementStrides().constSlice();
+        const block_table_strides_ptr = zml.Tensor.constant(zml.DataType.i64.constant(block_table_strides[0]));
+        const q_shape = q.shape().mergeAxes(.{ .h = .{ .hkv, .hg } });
+        const q_strides = q_shape.computeElementStrides().constSlice();
+        const q_strides_0_ptr = zml.Tensor.constant(zml.DataType.i64.constant(q_strides[0]));
+        const q_strides_1_ptr = zml.Tensor.constant(zml.DataType.i64.constant(q_strides[1]));
+        const k_cache_shape = k_cache.shape();
+        const k_strides = k_cache_shape.computeElementStrides().constSlice();
+        const k_strides_0_ptr = zml.Tensor.constant(zml.DataType.i64.constant(k_strides[k_cache_shape.axis(.page)]));
+        const k_strides_1_ptr = zml.Tensor.constant(zml.DataType.i64.constant(k_strides[k_cache_shape.axis(.k_chunk)]));
+        const k_strides_2_ptr = zml.Tensor.constant(zml.DataType.i64.constant(k_strides[k_cache_shape.axis(.hkv)]));
+        const v_cache_shape = v_cache.shape();
+        const v_strides = v_cache_shape.computeElementStrides().constSlice();
+        const v_strides_0_ptr = zml.Tensor.constant(zml.DataType.i64.constant(v_strides[v_cache_shape.axis(.page)]));
+        const v_strides_1_ptr = zml.Tensor.constant(zml.DataType.i64.constant(v_strides[v_cache_shape.axis(.k_chunk)]));
+        const v_strides_2_ptr = zml.Tensor.constant(zml.DataType.i64.constant(v_strides[v_cache_shape.axis(.hkv)]));
+        const num_seqs_ptr = zml.Tensor.constant(zml.DataType.i32.constant(parameters.block_table.dim(0)));
+        const scale: f32 = paged_attention_opts.scale orelse @floatCast(1.0 / @sqrt(@as(f64, @floatFromInt(q.dim(.hd)))));
+        const scale_ptr = zml.Tensor.constant(zml.DataType.f32.constant(scale));
+
+        const attn_grid: [3]i32 = .{ @intCast(config.attention.total_q_blocks), @intCast(paged_attention_opts.num_kv_heads), @intCast(config.attention.num_segments_per_seq) };
+        const attn_output = kernels_oneapi.KernelUnifiedAttention3dPtr.Kernel.call(
             .{
                 .query_ptr = q,
                 .key_cache_ptr = k_cache,

--- a/zml/attention/triton_kernels/unified_attention_oneapi.zig
+++ b/zml/attention/triton_kernels/unified_attention_oneapi.zig
@@ -1,0 +1,534 @@
+const std = @import("std");
+
+const mlir = @import("mlir");
+const dialects = @import("mlir/dialects");
+const ttir = dialects.ttir;
+
+const zml = @import("../../zml.zig");
+const tri = zml.kernel.triton;
+const Builder = tri.Builder;
+const Value = tri.Value;
+const DType = tri.DType;
+
+const log = std.log.scoped(.@"zml/attention/triton");
+
+// oneAPI/Intel (SIMD16) specialization of the 3D split-K paged-attention kernel.
+// Duplicated from unified_attention.zig so the shared kernel stays backend-neutral;
+// only the Intel decode path routes here (see triton_attention.zig pagedAttention3dOneapi).
+
+/// `log_2(e)` — pre-multiply with this to turn `exp(x)` into `exp2(x * RCP_LN2)`.
+const RCP_LN2: f32 = 1.4426950408889634;
+
+fn isFp8(dt: DType) bool {
+    return dt == .f8e4m3fn or dt == .f8e5m2;
+}
+
+fn cdivFn(x: Value, y: anytype) Value {
+    return switch (@typeInfo(@TypeOf(y))) {
+        .comptime_int, .comptime_float => x.add(y - 1).div(y),
+        else => x.add(y).sub(1).div(y),
+    };
+}
+
+fn applySoftcap(k: *Builder, s_val: Value, x: Value) Value {
+    const sdiv = s_val.div(x);
+    const p1 = k.exp2(sdiv);
+    const p2 = k.exp2(k.negf(sdiv));
+    return x.mul(p1.sub(p2)).div(p1.add(p2));
+}
+
+fn findSeqIdx(
+    k: *Builder,
+    query_start_len_ptr: Value,
+    target_idx: Value,
+    num_seqs: Value,
+    block_q: i64,
+    use_q_block_mode: bool,
+) Value {
+    const left_init = k.liftAs(0, .i32);
+
+    var w = k.openWhile(.{ left_init, num_seqs }, .{ k.scalarTy(.i32), k.scalarTy(.i32) });
+    {
+        const left = w.before_carried[0];
+        const right = w.before_carried[1];
+        w.yieldBefore(left.lt(right), .{ left, right });
+    }
+    {
+        const left = w.after_carried[0];
+        const right = w.after_carried[1];
+        const mid = left.add(right).div(2);
+        const val = k.load(query_start_len_ptr.addPtr(mid));
+        const mid_val = if (use_q_block_mode)
+            val.div(@as(i32, @intCast(block_q))).add(mid)
+        else
+            val;
+
+        var i = k.openIfElse(mid_val.le(target_idx), .{ k.scalarTy(.i32), k.scalarTy(.i32) });
+        {
+            i.yieldThen(.{ mid.add(1), right });
+        }
+        {
+            i.yieldElse(.{ left, mid });
+        }
+        w.yieldAfter(.{ i.results[0], i.results[1] });
+    }
+
+    return w.results[0].sub(1);
+}
+
+fn dequantKv(loaded: Value, scale: Value, kv_is_fp8: bool, q_dtype: DType) Value {
+    if (!kv_is_fp8 or isFp8(q_dtype)) return loaded;
+    return loaded.to(.f32).mul(scale).to(q_dtype);
+}
+
+pub const KernelUnifiedAttention3dPtr = struct {
+    pub const Config = struct {
+        q_dtype: DType,
+        kv_dtype: DType,
+        scale_dtype: DType = .f32,
+
+        num_query_heads: i64,
+        num_queries_per_kv: i64,
+
+        block_size: i64,
+        tile_size: i64,
+        head_size: i64,
+        head_size_padded: i64,
+
+        use_alibi_slopes: bool,
+        use_qq_bias: bool,
+        use_softcap: bool,
+        use_sinks: bool,
+        sliding_window: i64,
+
+        stride_k_cache_0: i64 = 0,
+        stride_k_cache_1: i64 = 0,
+        stride_k_cache_2: i64 = 0,
+        stride_k_cache_3: i64 = 1,
+        stride_v_cache_0: i64 = 0,
+        stride_v_cache_1: i64 = 0,
+        stride_v_cache_2: i64 = 0,
+        stride_v_cache_3: i64 = 1,
+
+        block_q: i64,
+        block_m: i64,
+        num_segments_per_seq: i64,
+        all_decode: bool = false,
+        kv_cache_modifier: ttir.CacheModifier = .none,
+    };
+
+    pub const Kernel = tri.Kernel(Config, .{
+        .name = "kernel_unified_attention_3d_ptr_oneapi",
+        .inputs = &.{
+            "query_ptr",              "key_cache_ptr",        "value_cache_ptr",      "sink_ptr",
+            "block_tables_ptr",       "seq_lens_ptr",         "alibi_slopes_ptr",     "qq_bias_ptr",
+            "scale_ptr",              "k_scale_ptr",          "v_scale_ptr",          "softcap_ptr",
+            "block_table_stride_ptr", "query_stride_0_ptr",   "query_stride_1_ptr",   "qq_bias_stride_0_ptr",
+            "stride_k_cache_0_ptr",   "stride_k_cache_1_ptr", "stride_k_cache_2_ptr", "stride_v_cache_0_ptr",
+            "stride_v_cache_1_ptr",   "stride_v_cache_2_ptr", "query_start_len_ptr",  "num_seqs_ptr",
+        },
+        .outputs = &.{ "segm_output", "segm_max", "segm_expsum" },
+        .run = run,
+    });
+    fn run(b: *Builder, cfg: Config) tri.FinishError!void {
+        const a = try b.declareArgs(.{
+            .query_ptr = .{ .ptr = cfg.q_dtype },
+            .key_cache_ptr = .{ .ptr = cfg.kv_dtype },
+            .value_cache_ptr = .{ .ptr = cfg.kv_dtype },
+            .sink_ptr = .{ .ptr = cfg.scale_dtype },
+            .block_tables_ptr = .{ .ptr = .i32 },
+            .seq_lens_ptr = .{ .ptr = .i32 },
+            .alibi_slopes_ptr = .{ .ptr = cfg.scale_dtype },
+            .qq_bias_ptr = .{ .ptr = cfg.scale_dtype },
+            .scale_ptr = .{ .ptr = .f32 },
+            .k_scale_ptr = .{ .ptr = .f32 },
+            .v_scale_ptr = .{ .ptr = .f32 },
+            .softcap_ptr = .{ .ptr = .f32 },
+            .block_table_stride_ptr = .{ .ptr = .i64 },
+            .query_stride_0_ptr = .{ .ptr = .i64 },
+            .query_stride_1_ptr = .{ .ptr = .i64 },
+            .qq_bias_stride_0_ptr = .{ .ptr = .i64 },
+            .stride_k_cache_0_ptr = .{ .ptr = .i64 },
+            .stride_k_cache_1_ptr = .{ .ptr = .i64 },
+            .stride_k_cache_2_ptr = .{ .ptr = .i64 },
+            .stride_v_cache_0_ptr = .{ .ptr = .i64 },
+            .stride_v_cache_1_ptr = .{ .ptr = .i64 },
+            .stride_v_cache_2_ptr = .{ .ptr = .i64 },
+            .query_start_len_ptr = .{ .ptr = .i32 },
+            .num_seqs_ptr = .{ .ptr = .i32 },
+            .segm_output_ptr = .{ .ptr = .f32 },
+            .segm_max_ptr = .{ .ptr = .f32 },
+            .segm_expsum_ptr = .{ .ptr = .f32 },
+        });
+
+        const scale = b.load(a.scale_ptr);
+        const k_scale = b.load(a.k_scale_ptr);
+        const v_scale = b.load(a.v_scale_ptr);
+        const softcap = b.load(a.softcap_ptr);
+        const block_table_stride = b.load(a.block_table_stride_ptr);
+        const query_stride_0 = b.load(a.query_stride_0_ptr);
+        const query_stride_1 = b.load(a.query_stride_1_ptr);
+        const qq_bias_stride_0 = b.load(a.qq_bias_stride_0_ptr);
+        const stride_k_cache_0 = b.liftAs(cfg.stride_k_cache_0, .i64);
+        const stride_k_cache_1 = b.liftAs(cfg.stride_k_cache_1, .i64);
+        const stride_k_cache_2 = b.liftAs(cfg.stride_k_cache_2, .i64);
+        const stride_v_cache_0 = b.liftAs(cfg.stride_v_cache_0, .i64);
+        const stride_v_cache_1 = b.liftAs(cfg.stride_v_cache_1, .i64);
+        const stride_v_cache_2 = b.liftAs(cfg.stride_v_cache_2, .i64);
+        const num_seqs = b.load(a.num_seqs_ptr);
+
+        kernelUnifiedAttention3d(
+            b,
+            a.segm_output_ptr,
+            a.segm_max_ptr,
+            a.segm_expsum_ptr,
+            a.query_ptr,
+            a.key_cache_ptr,
+            a.value_cache_ptr,
+            a.sink_ptr,
+            a.block_tables_ptr,
+            a.seq_lens_ptr,
+            a.alibi_slopes_ptr,
+            a.qq_bias_ptr,
+            scale,
+            k_scale,
+            v_scale,
+            softcap,
+            block_table_stride,
+            query_stride_0,
+            query_stride_1,
+            qq_bias_stride_0,
+            stride_k_cache_0,
+            stride_k_cache_1,
+            stride_k_cache_2,
+            stride_v_cache_0,
+            stride_v_cache_1,
+            stride_v_cache_2,
+            a.query_start_len_ptr,
+            num_seqs,
+            cfg,
+        );
+    }
+};
+
+fn kernelUnifiedAttention3d(
+    k: *Builder,
+    segm_output_ptr: Value,
+    segm_max_ptr: Value,
+    segm_expsum_ptr: Value,
+    query_ptr: Value,
+    key_cache_ptr: Value,
+    value_cache_ptr: Value,
+    sink_ptr: Value,
+    block_tables_ptr: Value,
+    seq_lens_ptr: Value,
+    alibi_slopes_ptr: Value,
+    qq_bias_ptr: Value,
+    scale: Value,
+    k_scale: Value,
+    v_scale: Value,
+    softcap: Value,
+    block_table_stride: Value,
+    query_stride_0: Value,
+    query_stride_1: Value,
+    qq_bias_stride_0: Value,
+    stride_k_cache_0: Value,
+    stride_k_cache_1: Value,
+    stride_k_cache_2: Value,
+    stride_v_cache_0: Value,
+    stride_v_cache_1: Value,
+    stride_v_cache_2: Value,
+    query_start_len_ptr: Value,
+    num_seqs: Value,
+    config: KernelUnifiedAttention3dPtr.Config,
+) void {
+    const BLOCK_M: i64 = config.block_m;
+    const BLOCK_Q: i64 = config.block_q;
+    const BLOCK_SIZE: i64 = config.block_size;
+    const TILE_SIZE: i64 = config.tile_size;
+    const HEAD_SIZE: i64 = config.head_size;
+    const HEAD_SIZE_PADDED: i64 = config.head_size_padded;
+    const NUM_QUERIES_PER_KV: i64 = config.num_queries_per_kv;
+    const NUM_QUERY_HEADS: i64 = config.num_query_heads;
+    const NUM_SEGMENTS_PER_SEQ: i64 = config.num_segments_per_seq;
+    const SLIDING_WINDOW: i64 = config.sliding_window;
+
+    const q_block_global_idx = k.programId(.x);
+    const kv_head_idx = k.programId(.y);
+    const segm_idx = k.programId(.z);
+
+    const qk_scale = scale.mul(RCP_LN2);
+
+    const seq_idx = findSeqIdx(k, query_start_len_ptr, q_block_global_idx, num_seqs, BLOCK_Q, true);
+
+    const q_start_raw = k.load(query_start_len_ptr.addPtr(seq_idx));
+    const q_block_start_idx = q_start_raw.div(@as(i32, @intCast(BLOCK_Q))).add(seq_idx);
+    const q_block_local_idx = q_block_global_idx.sub(q_block_start_idx);
+
+    const cur_batch_in_all_start_index = q_start_raw;
+    // Match Python's left-to-right `query_start_len_ptr + seq_idx + 1`: two `tt.addptr`s.
+    const cur_batch_in_all_stop_index = k.load(query_start_len_ptr.addPtr(seq_idx).addPtr(1));
+    const cur_batch_query_len = cur_batch_in_all_stop_index.sub(cur_batch_in_all_start_index);
+
+    const q_out_of_range = q_block_local_idx.mul(@as(i32, @intCast(BLOCK_Q))).ge(cur_batch_query_len);
+    k.returnIf(q_out_of_range, .{});
+
+    const seq_len = k.load(seq_lens_ptr.addPtr(seq_idx));
+    const tiles_per_segment = cdivFn(seq_len, @as(i32, @intCast(NUM_SEGMENTS_PER_SEQ * TILE_SIZE)));
+
+    const segm_lo = segm_idx.mul(tiles_per_segment).mul(@as(i32, @intCast(TILE_SIZE)));
+    const segm_out_of_range = segm_lo.ge(seq_len);
+    k.returnIf(segm_out_of_range, .{});
+
+    const offs_m = k.arange(0, BLOCK_M, .i32);
+    const offs_d = k.arange(0, HEAD_SIZE_PADDED, .i32);
+    const offs_t = k.arange(0, TILE_SIZE, .i32);
+
+    const q_local_bq = q_block_local_idx.mul(@as(i32, @intCast(BLOCK_Q)));
+    const query_pos = q_local_bq.add(offs_m.div(@as(i32, @intCast(NUM_QUERIES_PER_KV))));
+
+    const query_offset_0 = cur_batch_in_all_start_index.add(query_pos);
+    const query_offset_1 = kv_head_idx.mul(@as(i32, @intCast(NUM_QUERIES_PER_KV)))
+        .add(offs_m.rem(@as(i32, @intCast(NUM_QUERIES_PER_KV))));
+
+    // query_offset = qo_0[:, None]*qstride_0 + qo_1[:, None]*qstride_1 + offs_d[None, :]
+    // Inline `expandDims(offs_d, 0)` *inside* the chain so it's emitted after
+    // the qo0+qo1 addi
+    const qo0_2d = k.expandDims(query_offset_0, 1).mul(query_stride_0);
+    const qo1_2d = k.expandDims(query_offset_1, 1).mul(query_stride_1);
+    const query_offset = qo0_2d.add(qo1_2d).add(k.expandDims(offs_d, 0));
+
+    const dim_mask: Value = if (HEAD_SIZE_PADDED != HEAD_SIZE)
+        offs_d.lt(@as(i32, @intCast(HEAD_SIZE)))
+    else
+        k.full(&.{HEAD_SIZE_PADDED}, 1, .i1);
+    const query_mask_0 = query_pos.lt(cur_batch_query_len);
+    const query_mask_1 = query_offset_1.lt(@as(i32, @intCast(NUM_QUERY_HEADS)));
+
+    const q_mask_pre = k.expandDims(query_mask_0, 1).bitAnd(k.expandDims(query_mask_1, 1));
+    const q_mask_partial: Value = if (HEAD_SIZE_PADDED != HEAD_SIZE)
+        q_mask_pre.bitAnd(k.expandDims(dim_mask, 0))
+    else
+        q_mask_pre;
+    const q_ptrs = query_ptr.addPtr(query_offset);
+    const Q = k.loadOpts(q_ptrs, .{
+        .mask = k.broadcastTo(q_mask_partial, &.{ BLOCK_M, HEAD_SIZE_PADDED }),
+        .other = k.zeros(&.{ BLOCK_M, HEAD_SIZE_PADDED }, config.q_dtype),
+    });
+
+    const block_table_offset = seq_idx.to(.i64).mul(block_table_stride);
+
+    // M init: USE_SINKS + segm_idx==0 → loaded sinks; else -inf.
+    const segm_is_zero = segm_idx.eq(0);
+    const m_init: Value = if (config.use_sinks) mb: {
+        var mi = k.openIfElse(segm_is_zero, .{k.tensorTy(&.{BLOCK_M}, .f32)});
+        {
+            const loaded = k.loadOpts(sink_ptr.addPtr(query_offset_1), .{
+                .mask = query_mask_1,
+                .other = k.full(&.{BLOCK_M}, -std.math.inf(f32), config.scale_dtype),
+            });
+            mi.yieldThen(.{loaded.to(.f32).mul(RCP_LN2)});
+        }
+        {
+            mi.yieldElse(.{k.full(&.{BLOCK_M}, -std.math.inf(f32), .f32)});
+        }
+        break :mb mi.results[0];
+    } else k.full(&.{BLOCK_M}, -std.math.inf(f32), .f32);
+
+    const l_init = k.full(&.{BLOCK_M}, 1.0, .f32);
+    const acc_init = k.zeros(&.{ BLOCK_M, HEAD_SIZE_PADDED }, .f32);
+
+    const context_len = seq_len.sub(cur_batch_query_len);
+
+    const alibi_slope: Value = if (config.use_alibi_slopes)
+        k.loadOpts(alibi_slopes_ptr.addPtr(query_offset_1), .{
+            .mask = query_mask_1,
+            .other = k.full(&.{BLOCK_M}, 0.0, config.scale_dtype),
+        })
+    else
+        k.zeros(&.{BLOCK_M}, config.scale_dtype);
+
+    // See 2d-body note on qq_bias_row_ptrs: else branch needs an explicit splatTo
+    // (no sibling offset to auto-broadcast against).
+    const qq_bias_row_ptrs: Value = if (config.use_qq_bias)
+        qq_bias_ptr.addPtr(query_pos.to(.i64).mul(qq_bias_stride_0))
+    else
+        qq_bias_ptr.splatTo(&.{BLOCK_M});
+
+    const pad_term: i32 = @intCast(@divTrunc(BLOCK_M - 1, NUM_QUERIES_PER_KV) + 1);
+    const max_prefix_raw = context_len.add(q_local_bq).add(pad_term);
+    const max_seq_prefix_len = max_prefix_raw.minimum(seq_len);
+    const num_tiles = cdivFn(max_seq_prefix_len, @as(i32, @intCast(TILE_SIZE)));
+
+    const segm_tile_lo = segm_idx.mul(tiles_per_segment);
+    const segm_tile_hi = segm_idx.add(1).mul(tiles_per_segment).minimum(num_tiles);
+
+    const kv_cache_mod: ttir.CacheModifier = config.kv_cache_modifier;
+
+    var loop = k.openFor(segm_tile_lo, segm_tile_hi, 1, .{ m_init, l_init, acc_init });
+    {
+        const j = loop.iv;
+        const M = loop.carried[0];
+        const L = loop.carried[1];
+        const acc = loop.carried[2];
+
+        const seq_offset = j.mul(@as(i32, @intCast(TILE_SIZE))).add(offs_t);
+        const tile_mask: Value = seq_offset.lt(max_seq_prefix_len);
+
+        const same_block = TILE_SIZE == BLOCK_SIZE;
+        const in_block_offs: Value = if (same_block) offs_t else seq_offset.rem(@as(i32, @intCast(BLOCK_SIZE)));
+        const physical_block_idx: Value = if (same_block)
+            k.load(block_tables_ptr.addPtr(block_table_offset).addPtr(j)).to(.i64).splatTo(&.{TILE_SIZE})
+        else
+            k.load(
+                block_tables_ptr.addPtr(block_table_offset).addPtr(seq_offset.div(@as(i32, @intCast(BLOCK_SIZE)))),
+            ).to(.i64);
+
+        const v_offset = k.expandDims(physical_block_idx, 1).mul(stride_v_cache_0)
+            .add(kv_head_idx.to(.i64).mul(stride_v_cache_2))
+            .add(k.expandDims(offs_d, 0).mul(config.stride_v_cache_3))
+            .add(k.expandDims(in_block_offs, 1).mul(stride_v_cache_1));
+
+        const k_offset = k.expandDims(physical_block_idx, 0).mul(stride_k_cache_0)
+            .add(kv_head_idx.to(.i64).mul(stride_k_cache_2))
+            .add(k.expandDims(offs_d, 1).mul(config.stride_k_cache_3))
+            .add(k.expandDims(in_block_offs, 0).mul(stride_k_cache_1));
+
+        const block_io_loads = same_block and HEAD_SIZE_PADDED == HEAD_SIZE;
+
+        const K_load = if (block_io_loads)
+            k.loadOpts(key_cache_ptr.addPtr(k_offset), .{ .cache_modifier = kv_cache_mod })
+        else kb: {
+            const k_mask_partial: Value = if (HEAD_SIZE_PADDED != HEAD_SIZE)
+                k.expandDims(dim_mask, 1).bitAnd(k.expandDims(tile_mask, 0))
+            else
+                k.expandDims(tile_mask, 0);
+            break :kb k.loadOpts(key_cache_ptr.addPtr(k_offset), .{
+                .mask = k.broadcastTo(k_mask_partial, &.{ HEAD_SIZE_PADDED, TILE_SIZE }),
+                .other = k.zeros(&.{ HEAD_SIZE_PADDED, TILE_SIZE }, config.kv_dtype),
+                .cache_modifier = kv_cache_mod,
+            });
+        };
+        const K = dequantKv(K_load, k_scale, isFp8(config.kv_dtype), config.q_dtype);
+
+        const V_raw = if (block_io_loads)
+            k.loadOpts(value_cache_ptr.addPtr(v_offset), .{ .cache_modifier = kv_cache_mod })
+        else vb: {
+            const v_mask_partial: Value = if (HEAD_SIZE_PADDED != HEAD_SIZE)
+                k.expandDims(tile_mask, 1).bitAnd(k.expandDims(dim_mask, 0))
+            else
+                k.expandDims(tile_mask, 1);
+            break :vb k.loadOpts(value_cache_ptr.addPtr(v_offset), .{
+                .mask = k.broadcastTo(v_mask_partial, &.{ TILE_SIZE, HEAD_SIZE_PADDED }),
+                .other = k.zeros(&.{ TILE_SIZE, HEAD_SIZE_PADDED }, config.kv_dtype),
+                .cache_modifier = kv_cache_mod,
+            });
+        };
+        const V_load = if (block_io_loads)
+            k.where(
+                k.broadcastTo(k.expandDims(tile_mask, 1), &.{ TILE_SIZE, HEAD_SIZE_PADDED }),
+                V_raw,
+                k.zeros(&.{ TILE_SIZE, HEAD_SIZE_PADDED }, config.kv_dtype),
+            )
+        else
+            V_raw;
+        const V = dequantKv(V_load, v_scale, isFp8(config.kv_dtype), config.q_dtype);
+
+        // seq_mask = seq_offset[None, :] < context_len + query_pos[:, None] + 1
+        const ql_2d_i32 = query_pos.expandDims(1);
+        const so_2d = seq_offset.expandDims(0);
+        const rhs = context_len.add(ql_2d_i32).add(1);
+        const seq_mask = so_2d.lt(rhs);
+
+        const acc_zero = k.zeros(&.{ BLOCK_M, TILE_SIZE }, .f32);
+        const qk = k.dot(Q, K, acc_zero);
+        var S = qk_scale.mul(qk);
+
+        if (config.use_softcap) {
+            S = applySoftcap(k, S, softcap).mul(RCP_LN2);
+        }
+
+        const qm0_2d = query_mask_0.expandDims(1);
+        const qm1_2d = query_mask_1.expandDims(1);
+        const keep_mask = qm1_2d.bitAnd(qm0_2d).bitAnd(seq_mask);
+        S = k.where(keep_mask, S, k.full(&.{ BLOCK_M, TILE_SIZE }, -std.math.inf(f32), .f32));
+
+        if (SLIDING_WINDOW > 0) {
+            const diff = ql_2d_i32.add(context_len).sub(so_2d);
+            const in_win = diff.lt(@as(i32, @intCast(SLIDING_WINDOW)));
+            S = k.where(in_win, S, k.full(&.{ BLOCK_M, TILE_SIZE }, -std.math.inf(f32), .f32));
+        }
+
+        if (config.use_alibi_slopes) {
+            const alibi_2d = alibi_slope.expandDims(1);
+            const pos_diff = seq_offset.sub(context_len).to(config.scale_dtype).expandDims(0);
+            S = S.add(alibi_2d.mul(pos_diff).to(.f32).mul(RCP_LN2));
+        }
+
+        if (config.use_qq_bias) {
+            const key_rel_pos = seq_offset.sub(context_len);
+            const is_query_key = key_rel_pos.ge(0)
+                .bitAnd(key_rel_pos.to(.i64).lt(qq_bias_stride_0));
+            const qq_ptrs = qq_bias_row_ptrs.expandDims(1)
+                .addPtr(key_rel_pos.to(.i64).expandDims(0));
+            const qq_bias = k.loadOpts(qq_ptrs, .{
+                .mask = is_query_key.expandDims(0),
+                .other = k.zeros(&.{ BLOCK_M, TILE_SIZE }, config.scale_dtype),
+            });
+            S = S.add(qq_bias.to(.f32).mul(RCP_LN2));
+        }
+
+        var m_j = M.maximum(k.maxOpts(S, .{ .axis = 1 }));
+        m_j = k.where(m_j.gt(-std.math.inf(f32)), m_j, k.full(&.{BLOCK_M}, 0.0, .f32));
+
+        const mj_2d = m_j.expandDims(1);
+        const P = k.exp2(S.sub(mj_2d));
+        const l_j = k.sumOpts(P, .{ .axis = 1 });
+        const alpha = k.exp2(M.sub(m_j));
+
+        const alpha_2d = alpha.expandDims(1);
+        const acc_scaled = acc.mul(alpha_2d);
+        const new_L = L.mul(alpha).add(l_j);
+
+        const P_cast = P.to(config.q_dtype);
+        const new_acc = k.dot(P_cast, V, acc_scaled);
+
+        loop.yield(.{ m_j, new_L, new_acc });
+    }
+    const M_final = loop.results[0];
+    const L_final = loop.results[1];
+    const acc_final = loop.results[2];
+
+    // segm_output_offset = qo_0[:, None].to(i64) * (NUM_QUERY_HEADS * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
+    //                    + qo_1[:, None] * (NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
+    //                    + segm_idx * HEAD_SIZE_PADDED + offs_d[None, :]
+    const segm_out_head_stride_i32: i32 = @intCast(NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED);
+    const segm_out_token_stride_i64: i64 = NUM_QUERY_HEADS * NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED;
+
+    // Inline `segm_idx * HEAD_SIZE_PADDED` and `offs_d[None, :]` inside the chain
+    // so each term's ops emit in source order
+    const oo0_2d = k.expandDims(query_offset_0, 1).to(.i64).mul(segm_out_token_stride_i64);
+    const oo1_2d = k.expandDims(query_offset_1, 1).mul(segm_out_head_stride_i32);
+    const segm_output_offset = oo0_2d.add(oo1_2d)
+        .add(segm_idx.mul(@as(i32, @intCast(HEAD_SIZE_PADDED))))
+        .add(k.expandDims(offs_d, 0));
+
+    const store_mask_2d = k.mask2d(query_mask_0, dim_mask, BLOCK_M, HEAD_SIZE_PADDED)
+        .bitAnd(query_mask_1.expandDims(1));
+    k.storeOpts(
+        segm_output_ptr.addPtr(segm_output_offset),
+        acc_final,
+        .{ .mask = store_mask_2d },
+    );
+
+    // segm_offset = qo_0.to(i64) * (NUM_QUERY_HEADS * NUM_SEGMENTS_PER_SEQ)
+    //             + qo_1 * NUM_SEGMENTS_PER_SEQ + segm_idx
+    const segm_head_stride_i32: i32 = @intCast(NUM_SEGMENTS_PER_SEQ);
+    const segm_token_stride_i64: i64 = NUM_QUERY_HEADS * NUM_SEGMENTS_PER_SEQ;
+    const segm_offset = query_offset_0.to(.i64).mul(segm_token_stride_i64)
+        .add(query_offset_1.mul(segm_head_stride_i32))
+        .add(segm_idx);
+    const store_mask_1d = query_mask_0.bitAnd(query_mask_1);
+    k.storeOpts(segm_max_ptr.addPtr(segm_offset), M_final, .{ .mask = store_mask_1d });
+    k.storeOpts(segm_expsum_ptr.addPtr(segm_offset), L_final, .{ .mask = store_mask_1d });
+}


### PR DESCRIPTION
Speeds up paged-attention decode on the Intel/oneAPI backend