### PR TITLE
third_party/iree: match all added tokens

### DIFF
--- a/third_party/iree/fix-added-token-matching.patch
+++ b/third_party/iree/fix-added-token-matching.patch
@@ -1,0 +1,123 @@
+diff --git a/runtime/src/iree/tokenizer/format/huggingface/tokenizer_json.c b/runtime/src/iree/tokenizer/format/huggingface/tokenizer_json.c
+index 47d2a04c4d..66f1474c81 100644
+--- a/runtime/src/iree/tokenizer/format/huggingface/tokenizer_json.c
++++ b/runtime/src/iree/tokenizer/format/huggingface/tokenizer_json.c
+@@ -48,11 +48,12 @@ static const iree_string_view_t kTopLevelAllowedKeys[] = {
+ 
+ // Builds special_tokens collections from added_tokens.
+ //
+-// ALL added tokens with `normalized=true` are included (not just those with
+-// `special=true`) because they must be matched BEFORE the segmenter runs.
+-// Without this, ByteLevel segmentation transforms the input before these
+-// tokens can match, breaking tokenizers like GPT-NeoX that have multi-space
+-// tokens (e.g., "  " at ID 50276).
++// ALL added tokens are included (regardless of their `special` flag) because
++// they must be matched BEFORE the segmenter runs, mirroring HuggingFace's
++// AddedVocabulary. Without this, ByteLevel segmentation transforms the input
++// before these tokens can match, breaking tokenizers like GPT-NeoX that have
++// multi-space tokens (e.g., "  " at ID 50276) and dropping non-special added
++// tokens such as `<think>` or `<tool_call>`.
+ //
+ // Tokens are split by their normalized flag:
+ //   - out_special_tokens: normalized=false, matched in raw input before
+@@ -70,22 +71,10 @@ static iree_status_t iree_tokenizer_huggingface_build_special_tokens(
+   iree_tokenizer_special_tokens_initialize(out_special_tokens);
+   iree_tokenizer_special_tokens_initialize(out_special_tokens_post_norm);
+ 
+-  // Count tokens to process: special tokens OR tokens with normalized=true.
+-  // Non-special tokens with normalized=true must be matched before
+-  // segmentation.
+-  iree_host_size_t match_count = 0;
+-  for (iree_host_size_t i = 0; i < added_tokens->count; ++i) {
+-    const iree_tokenizer_huggingface_added_token_t* token =
+-        iree_tokenizer_huggingface_added_tokens_get(added_tokens, i);
+-    bool is_special = iree_any_bit_set(
+-        token->flags, IREE_TOKENIZER_HUGGINGFACE_ADDED_TOKEN_FLAG_SPECIAL);
+-    bool is_normalized = iree_any_bit_set(
+-        token->flags, IREE_TOKENIZER_HUGGINGFACE_ADDED_TOKEN_FLAG_NORMALIZED);
+-    // Include if special OR if normalized (needs pre-segmentation matching).
+-    if (is_special || is_normalized) {
+-      ++match_count;
+-    }
+-  }
++  // All added tokens are matched before segmentation, mirroring HuggingFace's
++  // AddedVocabulary which matches every added token regardless of its `special`
++  // flag. They are routed by their `normalized` flag below.
++  iree_host_size_t match_count = added_tokens->count;
+ 
+   // Early exit if nothing to process.
+   if (match_count == 0) {
+@@ -108,45 +97,38 @@ static iree_status_t iree_tokenizer_huggingface_build_special_tokens(
+        i < added_tokens->count && iree_status_is_ok(status); ++i) {
+     const iree_tokenizer_huggingface_added_token_t* token =
+         iree_tokenizer_huggingface_added_tokens_get(added_tokens, i);
+-    bool is_special = iree_any_bit_set(
+-        token->flags, IREE_TOKENIZER_HUGGINGFACE_ADDED_TOKEN_FLAG_SPECIAL);
+     bool is_normalized = iree_any_bit_set(
+         token->flags, IREE_TOKENIZER_HUGGINGFACE_ADDED_TOKEN_FLAG_NORMALIZED);
+ 
+-    // Process if special OR if normalized (needs pre-segmentation matching).
+-    if (is_special || is_normalized) {
+-      iree_string_view_t content =
+-          iree_tokenizer_huggingface_added_token_content(added_tokens, token);
+-
+-      // Convert HuggingFace flags to special_tokens flags.
+-      iree_tokenizer_special_token_flags_t special_flags =
+-          IREE_TOKENIZER_SPECIAL_TOKEN_FLAG_NONE;
+-      if (iree_any_bit_set(
+-              token->flags,
+-              IREE_TOKENIZER_HUGGINGFACE_ADDED_TOKEN_FLAG_LSTRIP)) {
+-        special_flags |= IREE_TOKENIZER_SPECIAL_TOKEN_FLAG_LSTRIP;
+-      }
+-      if (iree_any_bit_set(
+-              token->flags,
+-              IREE_TOKENIZER_HUGGINGFACE_ADDED_TOKEN_FLAG_RSTRIP)) {
+-        special_flags |= IREE_TOKENIZER_SPECIAL_TOKEN_FLAG_RSTRIP;
+-      }
+-      if (iree_any_bit_set(
+-              token->flags,
+-              IREE_TOKENIZER_HUGGINGFACE_ADDED_TOKEN_FLAG_SINGLE_WORD)) {
+-        special_flags |= IREE_TOKENIZER_SPECIAL_TOKEN_FLAG_SINGLE_WORD;
+-      }
++    iree_string_view_t content =
++        iree_tokenizer_huggingface_added_token_content(added_tokens, token);
+ 
+-      // Route to appropriate builder based on normalized flag.
+-      if (is_normalized) {
+-        // normalized=true: match after normalization but before segmentation.
+-        status = iree_tokenizer_special_tokens_builder_add(
+-            &builder_post_norm, content, token->id, special_flags);
+-      } else {
+-        // normalized=false (default): match before normalization.
+-        status = iree_tokenizer_special_tokens_builder_add(
+-            &builder_pre_norm, content, token->id, special_flags);
+-      }
++    // Convert HuggingFace flags to special_tokens flags.
++    iree_tokenizer_special_token_flags_t special_flags =
++        IREE_TOKENIZER_SPECIAL_TOKEN_FLAG_NONE;
++    if (iree_any_bit_set(token->flags,
++                         IREE_TOKENIZER_HUGGINGFACE_ADDED_TOKEN_FLAG_LSTRIP)) {
++      special_flags |= IREE_TOKENIZER_SPECIAL_TOKEN_FLAG_LSTRIP;
++    }
++    if (iree_any_bit_set(token->flags,
++                         IREE_TOKENIZER_HUGGINGFACE_ADDED_TOKEN_FLAG_RSTRIP)) {
++      special_flags |= IREE_TOKENIZER_SPECIAL_TOKEN_FLAG_RSTRIP;
++    }
++    if (iree_any_bit_set(
++            token->flags,
++            IREE_TOKENIZER_HUGGINGFACE_ADDED_TOKEN_FLAG_SINGLE_WORD)) {
++      special_flags |= IREE_TOKENIZER_SPECIAL_TOKEN_FLAG_SINGLE_WORD;
++    }
++
++    // Route to appropriate builder based on normalized flag.
++    if (is_normalized) {
++      // normalized=true: match after normalization but before segmentation.
++      status = iree_tokenizer_special_tokens_builder_add(
++          &builder_post_norm, content, token->id, special_flags);
++    } else {
++      // normalized=false (default): match before normalization.
++      status = iree_tokenizer_special_tokens_builder_add(
++          &builder_pre_norm, content, token->id, special_flags);
+     }
+   }
+ 

--- a/third_party/iree/repo.bzl
+++ b/third_party/iree/repo.bzl
@@ -14,6 +14,7 @@ def repo():
         patches = [
             "//third_party/iree:tokenizer-only.patch",
             "//third_party/iree:fix-gemma4-encode.patch",
+            "//third_party/iree:fix-added-token-matching.patch",
         ],
         patch_args = ["-p1"],
     )


### PR DESCRIPTION
IREE's tokenizer only registered added tokens for pre-segmentation matching if they were flagged special or normalized. Tokens that are neither (e.g. <think> was dropped)

The fix is to match all added tokens