### PR TITLE
zml/io/vfs: add parallel read to GCS and S3

### DIFF
--- a/examples/llm/main.zig
+++ b/examples/llm/main.zig
@@ -67,10 +67,14 @@ pub fn main(init: std.process.Init) !void {
     var s3_vfs: zml.io.VFS.S3 = try .auto(allocator, init.io, &http_client, init.environ_map);
     defer s3_vfs.deinit();
 
+    var gcs_vfs: zml.io.VFS.GCS = try .auto(allocator, init.io, &http_client, init.environ_map);
+    defer gcs_vfs.deinit();
+
     var vfs: zml.io.VFS = try .init(allocator, init.io);
     defer vfs.deinit();
 
     try vfs.register("file", vfs_file.io());
+    try vfs.register("gs", gcs_vfs.io());
     try vfs.register("hf", hf_vfs.io());
     try vfs.register("s3", s3_vfs.io());
 

--- a/zml/io/vfs/BUILD.bazel
+++ b/zml/io/vfs/BUILD.bazel
@@ -8,6 +8,7 @@ zig_library(
         "gcs.zig",
         "hf.zig",
         "http.zig",
+        "parallel_read.zig",
         "s3.zig",
     ],
     main = "index.zig",

--- a/zml/io/vfs/gcs.zig
+++ b/zml/io/vfs/gcs.zig
@@ -129,6 +129,7 @@ pub const GCS = struct {
             backend: *GCS,
             uri: std.Uri,
             path: []const u8,
+            authorization: std.http.Client.Request.Headers.Value,
         };
 
         const Job = struct {
@@ -146,16 +147,13 @@ pub const GCS = struct {
                     .{ job.file_offset, job.file_offset + @as(u64, @intCast(job.chunk_len - 1)) },
                 ) catch unreachable;
 
-                var authorization_buf: ["Bearer ".len + OAuthToken.Size]u8 = undefined;
-                const authorization = job.batch.backend.getOrRefreshTokenInto(&authorization_buf) catch |err| return err;
-
                 var req = client.request(
                     .GET,
                     job.batch.uri,
                     .{
                         .headers = .{
                             .accept_encoding = .{ .override = "identity" },
-                            .authorization = authorization,
+                            .authorization = job.batch.authorization,
                         },
                         .extra_headers = &.{.{ .name = "Range", .value = range_header }},
                     },
@@ -191,14 +189,12 @@ pub const GCS = struct {
     };
 
     const Token = struct {
-        const ExpirySkewSeconds = 60;
-
         header: []u8,
         expires_at: std.Io.Timestamp,
 
         fn expired(self: *const Token, io_: std.Io) bool {
             const now: std.Io.Timestamp = .now(io_, .real);
-            return now.addDuration(.fromSeconds(ExpirySkewSeconds)).toSeconds() >= self.expires_at.toSeconds();
+            return now.toSeconds() >= self.expires_at.toSeconds();
         }
     };
 
@@ -233,7 +229,6 @@ pub const GCS = struct {
     allocator: std.mem.Allocator,
     arena: std.heap.ArenaAllocator,
     mutex: std.Io.Mutex = .init,
-    token_mutex: std.Io.Mutex = .init,
     client: *std.http.Client,
     config: Config,
     token: Token,
@@ -449,18 +444,15 @@ pub const GCS = struct {
         };
     }
 
-    fn getOrRefreshTokenInto(self: *GCS, out_buffer: []u8) !std.http.Client.Request.Headers.Value {
+    fn getOrRefreshToken(self: *GCS) !std.http.Client.Request.Headers.Value {
         if (self.config.credentials == null) {
             return .omit;
         }
 
-        self.token_mutex.lockUncancelable(self.base.inner);
-        defer self.token_mutex.unlock(self.base.inner);
-
         if (self.token.expired(self.base.inner)) {
             try self.refreshToken();
         }
-        return .{ .override = try std.fmt.bufPrint(out_buffer, "{s}", .{self.token.header}) };
+        return .{ .override = self.token.header };
     }
 
     pub fn deinit(self: *GCS) void {
@@ -959,12 +951,11 @@ pub const GCS = struct {
         var path_buffer: [8 * 1024]u8 = undefined;
         const path = try self.resolvePath(dir, sub_path, &path_buffer);
         const uri = self.gcsUri(path);
-        var authorization_buf: ["Bearer ".len + OAuthToken.Size]u8 = undefined;
         var req = try self.client.request(.HEAD, uri, .{
             .redirect_behavior = .not_allowed,
             .headers = .{
                 .accept_encoding = .{ .override = "identity" },
-                .authorization = try self.getOrRefreshTokenInto(&authorization_buf),
+                .authorization = try self.getOrRefreshToken(),
             },
             .extra_headers = &.{},
         });
@@ -1004,6 +995,7 @@ pub const GCS = struct {
             .backend = self,
             .uri = uri,
             .path = handle.uri,
+            .authorization = try self.getOrRefreshToken(),
         };
 
         for (jobs, 0..) |*job, i| {

--- a/zml/io/vfs/gcs.zig
+++ b/zml/io/vfs/gcs.zig
@@ -988,7 +988,7 @@ pub const GCS = struct {
         const job_count = std.math.divCeil(usize, read_size, self.read_pool.chunk_size) catch unreachable;
         const jobs = try self.allocator.alloc(ParallelRead.Job, job_count);
         defer self.allocator.free(jobs);
-        const pending: u32 = std.math.cast(u32, job_count) orelse return error.SystemResources;
+        const pending: u32 = @intCast(job_count);
 
         var batch: ParallelRead.Batch = .{
             .executor = .{ .pending = .init(pending) },

--- a/zml/io/vfs/gcs.zig
+++ b/zml/io/vfs/gcs.zig
@@ -125,7 +125,7 @@ pub const GCS = struct {
         const Pool = parallel_read.Pool(Job);
 
         const Batch = struct {
-            core: parallel_read.Batch,
+            executor: parallel_read.BatchExecutor,
             backend: *GCS,
             uri: std.Uri,
             path: []const u8,
@@ -1001,7 +1001,7 @@ pub const GCS = struct {
         const pending: u32 = std.math.cast(u32, job_count) orelse return error.SystemResources;
 
         var batch: ParallelRead.Batch = .{
-            .core = .{ .pending = .init(pending) },
+            .executor = .{ .pending = .init(pending) },
             .backend = self,
             .uri = uri,
             .path = handle.uri,
@@ -1019,8 +1019,8 @@ pub const GCS = struct {
         }
 
         try self.read_pool.job_queue.putAll(self.base.inner, jobs);
-        batch.core.waitUncancelable(self.base.inner);
-        if (batch.core.firstError()) |err| return err;
+        batch.executor.waitUncancelable(self.base.inner);
+        if (batch.executor.firstError()) |err| return err;
 
         return read_size;
     }

--- a/zml/io/vfs/gcs.zig
+++ b/zml/io/vfs/gcs.zig
@@ -4,6 +4,7 @@ const builtin = @import("builtin");
 const stdx = @import("stdx");
 
 const VFSBase = @import("base.zig").VFSBase;
+const parallel_read = @import("parallel_read.zig");
 
 const log = std.log.scoped(.@"zml/io/vfs/gcs");
 
@@ -120,13 +121,84 @@ const Credentials = union(enum) {
 const ReadState = struct { index: usize, objects: [][]const u8 };
 
 pub const GCS = struct {
+    const ParallelRead = struct {
+        const Pool = parallel_read.Pool(Job);
+
+        const Batch = struct {
+            core: parallel_read.Batch,
+            backend: *GCS,
+            uri: std.Uri,
+            path: []const u8,
+        };
+
+        const Job = struct {
+            data: []const []u8,
+            file_offset: u64,
+            chunk_offset: usize,
+            chunk_len: usize,
+            batch: *Batch,
+
+            pub fn perform(job: Job, client: *std.http.Client) ?anyerror {
+                var range_buf: [64]u8 = undefined;
+                const range_header = std.fmt.bufPrint(
+                    &range_buf,
+                    "bytes={d}-{d}",
+                    .{ job.file_offset, job.file_offset + @as(u64, @intCast(job.chunk_len - 1)) },
+                ) catch unreachable;
+
+                var authorization_buf: ["Bearer ".len + OAuthToken.Size]u8 = undefined;
+                const authorization = job.batch.backend.getOrRefreshTokenInto(&authorization_buf) catch |err| return err;
+
+                var req = client.request(
+                    .GET,
+                    job.batch.uri,
+                    .{
+                        .headers = .{
+                            .accept_encoding = .{ .override = "identity" },
+                            .authorization = authorization,
+                        },
+                        .extra_headers = &.{.{ .name = "Range", .value = range_header }},
+                    },
+                ) catch |err| return err;
+                defer req.deinit();
+
+                req.sendBodiless() catch |err| return err;
+
+                var redirect_buffer: [8 * 1024]u8 = undefined;
+                var res = req.receiveHead(&redirect_buffer) catch |err| return err;
+
+                if (res.head.status != .partial_content and res.head.status != .ok) {
+                    log.err("Failed to read {s}: {s}", .{ job.batch.path, res.head.bytes });
+                    return error.RequestFailed;
+                }
+
+                const content_range = blk: {
+                    var it = res.head.iterateHeaders();
+                    while (it.next()) |header| {
+                        if (std.ascii.eqlIgnoreCase(header.name, "Content-Range")) {
+                            break :blk parallel_read.parseContentRange(header.value);
+                        }
+                    }
+                    break :blk null;
+                };
+
+                const reader = res.reader(&.{});
+                parallel_read.readChunk(reader, content_range, job.file_offset, job.data, job.chunk_offset, job.chunk_len) catch |err| return err;
+
+                return null;
+            }
+        };
+    };
+
     const Token = struct {
+        const ExpirySkewSeconds = 60;
+
         header: []u8,
         expires_at: std.Io.Timestamp,
 
         fn expired(self: *const Token, io_: std.Io) bool {
             const now: std.Io.Timestamp = .now(io_, .real);
-            return now.toSeconds() >= self.expires_at.toSeconds();
+            return now.addDuration(.fromSeconds(ExpirySkewSeconds)).toSeconds() >= self.expires_at.toSeconds();
         }
     };
 
@@ -161,9 +233,11 @@ pub const GCS = struct {
     allocator: std.mem.Allocator,
     arena: std.heap.ArenaAllocator,
     mutex: std.Io.Mutex = .init,
+    token_mutex: std.Io.Mutex = .init,
     client: *std.http.Client,
     config: Config,
     token: Token,
+    read_pool: *ParallelRead.Pool,
     handles: stdx.SegmentedList(Handle, 0) = .{},
     closed_handles: std.ArrayList(u32) = .empty,
     dir_read_states: std.AutoHashMapUnmanaged(*std.Io.Dir.Reader, ReadState) = .{},
@@ -176,6 +250,7 @@ pub const GCS = struct {
         } = null,
         endpoint_url: []const u8 = "https://storage.googleapis.com",
         region: []const u8 = "auto",
+        read_pool: parallel_read.InitOpts = .{},
     };
 
     pub const InitError = error{
@@ -184,9 +259,15 @@ pub const GCS = struct {
         Unexpected,
     } || std.mem.Allocator.Error;
 
-    pub fn init(allocator: std.mem.Allocator, inner: std.Io, http_client: *std.http.Client, args: InitArgs) InitError!GCS {
+    pub fn init(allocator: std.mem.Allocator, inner: std.Io, http_client: *std.http.Client, args: InitArgs) !GCS {
         var arena: std.heap.ArenaAllocator = .init(allocator);
         errdefer arena.deinit();
+
+        const read_pool = try allocator.create(ParallelRead.Pool);
+        errdefer allocator.destroy(read_pool);
+
+        try read_pool.init(allocator, inner, http_client, args.read_pool);
+        errdefer read_pool.deinit(allocator, inner);
 
         const config: Config = .{
             .credentials = if (args.credentials) |creds| switch (creds) {
@@ -219,6 +300,7 @@ pub const GCS = struct {
             .client = http_client,
             .config = config,
             .token = token,
+            .read_pool = read_pool,
         };
     }
 
@@ -368,17 +450,24 @@ pub const GCS = struct {
         };
     }
 
-    fn getOrRefreshToken(self: *GCS) !std.http.Client.Request.Headers.Value {
+    fn getOrRefreshTokenInto(self: *GCS, out_buffer: []u8) !std.http.Client.Request.Headers.Value {
         if (self.config.credentials == null) {
             return .omit;
         }
+
+        self.token_mutex.lockUncancelable(self.base.inner);
+        defer self.token_mutex.unlock(self.base.inner);
+
         if (self.token.expired(self.base.inner)) {
             try self.refreshToken();
         }
-        return .{ .override = self.token.header };
+        return .{ .override = try std.fmt.bufPrint(out_buffer, "{s}", .{self.token.header}) };
     }
 
     pub fn deinit(self: *GCS) void {
+        self.read_pool.deinit(self.allocator, self.base.inner);
+        self.allocator.destroy(self.read_pool);
+
         var idx: usize = 0;
         while (idx < self.handles.len) : (idx += 1) {
             const is_closed = for (self.closed_handles.items) |closed_idx| {
@@ -871,11 +960,12 @@ pub const GCS = struct {
         var path_buffer: [8 * 1024]u8 = undefined;
         const path = try self.resolvePath(dir, sub_path, &path_buffer);
         const uri = self.gcsUri(path);
+        var authorization_buf: ["Bearer ".len + OAuthToken.Size]u8 = undefined;
         var req = try self.client.request(.HEAD, uri, .{
             .redirect_behavior = .not_allowed,
             .headers = .{
                 .accept_encoding = .{ .override = "identity" },
-                .authorization = try self.getOrRefreshToken(),
+                .authorization = try self.getOrRefreshTokenInto(&authorization_buf),
             },
             .extra_headers = &.{},
         });
@@ -901,80 +991,37 @@ pub const GCS = struct {
     }
 
     fn performRead(self: *GCS, handle: *Handle, data: []const []u8, offset: u64) !usize {
-        if (offset >= handle.size) return 0;
-
-        var range_buf: [64]u8 = undefined;
-        const range_header = blk: {
-            var total_bytes: u64 = 0;
-            for (data) |buf| {
-                total_bytes += @as(u64, buf.len);
-            }
-            const remaining = handle.size - offset;
-            const take = @min(remaining, total_bytes);
-            const end = offset + take - 1;
-            break :blk std.fmt.bufPrint(&range_buf, "bytes={d}-{d}", .{ offset, end }) catch unreachable;
-        };
+        const read_size = parallel_read.readSize(handle.size, offset, data);
+        if (read_size == 0) return 0;
 
         const uri = self.gcsUri(handle.uri);
-        var req = try self.client.request(
-            .GET,
-            uri,
-            .{
-                .headers = .{
-                    .accept_encoding = .{ .override = "identity" },
-                    .authorization = try self.getOrRefreshToken(),
-                },
-                .extra_headers = &.{.{ .name = "Range", .value = range_header }},
-            },
-        );
-        defer req.deinit();
+        const job_count = std.math.divCeil(usize, read_size, self.read_pool.chunk_size) catch unreachable;
+        const jobs = try self.allocator.alloc(ParallelRead.Job, job_count);
+        defer self.allocator.free(jobs);
+        const pending: u32 = std.math.cast(u32, job_count) orelse return error.SystemResources;
 
-        try req.sendBodiless();
-
-        var redirect_buffer: [8 * 1024]u8 = undefined;
-        var res = try req.receiveHead(&redirect_buffer);
-
-        if (res.head.status != .partial_content and res.head.status != .ok) {
-            log.err("Failed to read {s}: {s}", .{ handle.uri, res.head.bytes });
-            return error.RequestFailed;
-        }
-
-        const content_range = blk: {
-            var it = res.head.iterateHeaders();
-            while (it.next()) |header| {
-                if (std.ascii.eqlIgnoreCase(header.name, "Content-Range")) {
-                    break :blk parseContentRange(header.value);
-                }
-            }
-            break :blk null;
+        var batch: ParallelRead.Batch = .{
+            .core = .{ .pending = .init(pending) },
+            .backend = self,
+            .uri = uri,
+            .path = handle.uri,
         };
 
-        const reader = res.reader(&.{});
-
-        if (content_range) |cr| {
-            if (cr.start < offset) {
-                try reader.discardAll(offset - cr.start);
-            }
+        for (jobs, 0..) |*job, i| {
+            const chunk_offset = i * self.read_pool.chunk_size;
+            job.* = .{
+                .data = data,
+                .file_offset = offset + @as(u64, @intCast(chunk_offset)),
+                .chunk_offset = chunk_offset,
+                .chunk_len = @min(self.read_pool.chunk_size, read_size - chunk_offset),
+                .batch = &batch,
+            };
         }
 
-        return try reader.readSliceShort(data[0]);
-    }
+        try self.read_pool.job_queue.putAll(self.base.inner, jobs);
+        batch.core.waitUncancelable(self.base.inner);
+        if (batch.core.firstError()) |err| return err;
 
-    const ContentRange = struct {
-        start: u64,
-        end: u64,
-        total: u64,
-    };
-
-    fn parseContentRange(value: []const u8) ?ContentRange {
-        const space = std.mem.indexOfScalar(u8, value, ' ') orelse return null;
-        const dash = std.mem.indexOfScalar(u8, value, '-') orelse return null;
-        const slash = std.mem.indexOfScalar(u8, value, '/') orelse return null;
-
-        return .{
-            .start = std.fmt.parseInt(u64, value[space + 1 .. dash], 10) catch return null,
-            .end = std.fmt.parseInt(u64, value[dash + 1 .. slash], 10) catch return null,
-            .total = std.fmt.parseInt(u64, value[slash + 1 ..], 10) catch return null,
-        };
+        return read_size;
     }
 };

--- a/zml/io/vfs/gcs.zig
+++ b/zml/io/vfs/gcs.zig
@@ -238,7 +238,7 @@ pub const GCS = struct {
     dir_read_states: std.AutoHashMapUnmanaged(*std.Io.Dir.Reader, ReadState) = .{},
     base: VFSBase,
 
-    pub const InitArgs = struct {
+    pub const InitOpts = struct {
         credentials: ?union(enum) {
             json: *std.Io.Reader,
             metadata_server: void,
@@ -253,18 +253,18 @@ pub const GCS = struct {
         Unexpected,
     } || std.mem.Allocator.Error || std.Io.ConcurrentError;
 
-    pub fn init(allocator: std.mem.Allocator, inner: std.Io, http_client: *std.http.Client, args: InitArgs) InitError!GCS {
+    pub fn init(allocator: std.mem.Allocator, inner: std.Io, http_client: *std.http.Client, opts: InitOpts) InitError!GCS {
         var arena: std.heap.ArenaAllocator = .init(allocator);
         errdefer arena.deinit();
 
         const read_pool = try allocator.create(ParallelRead.Pool);
         errdefer allocator.destroy(read_pool);
 
-        try read_pool.init(allocator, inner, http_client, args.read_pool);
+        try read_pool.init(allocator, inner, http_client, opts.read_pool);
         errdefer read_pool.deinit(allocator, inner);
 
         const config: Config = .{
-            .credentials = if (args.credentials) |creds| switch (creds) {
+            .credentials = if (opts.credentials) |creds| switch (creds) {
                 .json => |reader| blk: {
                     var json_reader: std.json.Reader = .init(allocator, reader);
                     defer json_reader.deinit();
@@ -278,8 +278,8 @@ pub const GCS = struct {
                 },
                 .metadata_server => .{ .metadata_server = {} },
             } else null,
-            .endpoint_uri = std.Uri.parse(try arena.allocator().dupe(u8, args.endpoint_url)) catch return InitError.Unexpected,
-            .region = try arena.allocator().dupe(u8, args.region),
+            .endpoint_uri = std.Uri.parse(try arena.allocator().dupe(u8, opts.endpoint_url)) catch return InitError.Unexpected,
+            .region = try arena.allocator().dupe(u8, opts.region),
         };
 
         const token: Token = .{

--- a/zml/io/vfs/gcs.zig
+++ b/zml/io/vfs/gcs.zig
@@ -255,11 +255,10 @@ pub const GCS = struct {
 
     pub const InitError = error{
         InvalidCredentialJson,
-        RequestFailed,
         Unexpected,
-    } || std.mem.Allocator.Error;
+    } || std.mem.Allocator.Error || std.Io.ConcurrentError;
 
-    pub fn init(allocator: std.mem.Allocator, inner: std.Io, http_client: *std.http.Client, args: InitArgs) !GCS {
+    pub fn init(allocator: std.mem.Allocator, inner: std.Io, http_client: *std.http.Client, args: InitArgs) InitError!GCS {
         var arena: std.heap.ArenaAllocator = .init(allocator);
         errdefer arena.deinit();
 

--- a/zml/io/vfs/hf.zig
+++ b/zml/io/vfs/hf.zig
@@ -3,97 +3,18 @@ const std = @import("std");
 const stdx = @import("stdx");
 
 const VFSBase = @import("base.zig").VFSBase;
+const parallel_read = @import("parallel_read.zig");
 
 const log = std.log.scoped(.@"zml/io/vfs/hf");
 
 const ParallelRead = struct {
-    const Pool = struct {
-        pub const InitOpts = struct {
-            chunk_size: usize = 10 * 1024 * 1024,
-            num_workers: usize = 16,
-            queue_capacity: usize = 64,
-        };
-
-        group: std.Io.Group = .init,
-        job_queue: std.Io.Queue(Job),
-        queue_buf: []Job,
-        client: *std.http.Client,
-        chunk_size: usize,
-
-        fn init(self: *Pool, allocator: std.mem.Allocator, io: std.Io, client: *std.http.Client, opts: InitOpts) !void {
-            stdx.debug.assert(opts.num_workers > 0, "Pool must have at least one worker", .{});
-            stdx.debug.assert(opts.chunk_size > 0, "Pool must have a positive download chunk size", .{});
-            stdx.debug.assert(opts.queue_capacity > 0, "Pool must have a positive queue capacity", .{});
-
-            const queue_buf = try allocator.alloc(Job, opts.queue_capacity);
-            errdefer allocator.free(queue_buf);
-
-            self.* = .{
-                .client = client,
-                .chunk_size = opts.chunk_size,
-                .job_queue = .init(queue_buf),
-                .queue_buf = queue_buf,
-            };
-            errdefer self.group.cancel(io);
-
-            for (0..opts.num_workers) |_| {
-                try self.group.concurrent(io, worker, .{ self, io });
-            }
-        }
-
-        fn deinit(self: *Pool, allocator: std.mem.Allocator, io: std.Io) void {
-            self.job_queue.close(io);
-            self.group.cancel(io);
-
-            allocator.free(self.queue_buf);
-        }
-
-        fn worker(pool: *Pool, io: std.Io) std.Io.Cancelable!void {
-            while (true) {
-                const job = pool.job_queue.getOne(io) catch break;
-
-                if (!job.batch.failed()) {
-                    if (job.perform(pool.client)) |err| job.batch.fail(err);
-                }
-
-                job.batch.completeOne(io);
-            }
-        }
-    };
+    const Pool = parallel_read.Pool(Job);
 
     const Batch = struct {
+        core: parallel_read.Batch,
         uri: std.Uri,
         url: []const u8,
         authorization: std.http.Client.Request.Headers.Value,
-        pending: std.atomic.Value(u32),
-        err: std.atomic.Value(u16) = .init(0),
-
-        fn failed(batch: *Batch) bool {
-            return batch.err.load(.acquire) != 0;
-        }
-
-        fn fail(batch: *Batch, err: anyerror) void {
-            _ = batch.err.cmpxchgStrong(0, @intFromError(err), .release, .monotonic);
-        }
-
-        fn firstError(batch: *Batch) ?anyerror {
-            const err = batch.err.load(.acquire);
-            return if (err == 0) null else @errorFromInt(err);
-        }
-
-        fn completeOne(batch: *Batch, io: std.Io) void {
-            const previous = batch.pending.fetchSub(1, .release);
-            std.debug.assert(previous > 0);
-            if (previous == 1) io.futexWake(u32, &batch.pending.raw, 1);
-        }
-
-        fn waitUncancelable(batch: *Batch, io: std.Io) void {
-            while (true) {
-                const pending = batch.pending.load(.acquire);
-                if (pending == 0) return;
-                io.futexWaitUncancelable(u32, &batch.pending.raw, pending);
-            }
-        }
     };
 
     pub const Job = struct {
@@ -103,7 +24,7 @@ const ParallelRead = struct {
         chunk_len: usize,
         batch: *Batch,
 
-        fn perform(job: Job, client: *std.http.Client) ?anyerror {
+        pub fn perform(job: Job, client: *std.http.Client) ?anyerror {
             var range_buf: [64]u8 = undefined;
             const range_header = std.fmt.bufPrint(
                 &range_buf,
@@ -135,58 +56,18 @@ const ParallelRead = struct {
                 var it = res.head.iterateHeaders();
                 while (it.next()) |header| {
                     if (std.ascii.eqlIgnoreCase(header.name, "Content-Range")) {
-                        break :blk parseContentRange(header.value);
+                        break :blk parallel_read.parseContentRange(header.value);
                     }
                 }
                 break :blk null;
             };
 
             const reader = res.reader(&.{});
-
-            if (content_range) |cr| {
-                if (cr.start > job.file_offset) return error.InvalidContentRange;
-                if (cr.start < job.file_offset) {
-                    reader.discardAll(job.file_offset - cr.start) catch |err| return err;
-                }
-            }
-
-            var remaining = job.chunk_len;
-            var skip = job.chunk_offset;
-
-            for (job.data) |buf| {
-                if (skip >= buf.len) {
-                    skip -= buf.len;
-                    continue;
-                }
-
-                const destination = buf[skip..][0..@min(remaining, buf.len - skip)];
-                reader.readSliceAll(destination) catch |err| return err;
-                remaining -= destination.len;
-                if (remaining == 0) break;
-                skip = 0;
-            }
+            parallel_read.readChunk(reader, content_range, job.file_offset, job.data, job.chunk_offset, job.chunk_len) catch |err| return err;
 
             return null;
         }
     };
-
-    const ContentRange = struct {
-        start: u64,
-        end: u64,
-        total: u64,
-    };
-
-    fn parseContentRange(value: []const u8) ?ContentRange {
-        const space = std.mem.indexOfScalar(u8, value, ' ') orelse return null;
-        const dash = std.mem.indexOfScalar(u8, value, '-') orelse return null;
-        const slash = std.mem.indexOfScalar(u8, value, '/') orelse return null;
-
-        return .{
-            .start = std.fmt.parseInt(u64, value[space + 1 .. dash], 10) catch return null,
-            .end = std.fmt.parseInt(u64, value[dash + 1 .. slash], 10) catch return null,
-            .total = std.fmt.parseInt(u64, value[slash + 1 ..], 10) catch return null,
-        };
-    }
 };
 
 pub const API = struct {
@@ -234,7 +115,7 @@ const RepoKey = struct {
 
 pub const HF = struct {
     pub const InitOpts = struct {
-        read_pool: ParallelRead.Pool.InitOpts = .{},
+        read_pool: parallel_read.InitOpts = .{},
     };
 
     pub const Repo = struct {
@@ -919,10 +800,10 @@ pub const HF = struct {
         const uri: std.Uri = try .parse(url);
 
         var batch: ParallelRead.Batch = .{
+            .core = .{ .pending = .init(pending) },
             .uri = uri,
             .url = url,
             .authorization = self.authorization,
-            .pending = .init(pending),
         };
 
         for (jobs, 0..) |*job, i| {
@@ -937,8 +818,8 @@ pub const HF = struct {
         }
 
         try self.read_pool.job_queue.putAll(self.base.inner, jobs);
-        batch.waitUncancelable(self.base.inner);
-        if (batch.firstError()) |err| return err;
+        batch.core.waitUncancelable(self.base.inner);
+        if (batch.core.firstError()) |err| return err;
 
         return read_size;
     }

--- a/zml/io/vfs/hf.zig
+++ b/zml/io/vfs/hf.zig
@@ -792,7 +792,7 @@ pub const HF = struct {
 
         const jobs = try self.allocator.alloc(ParallelRead.Job, job_count);
         defer self.allocator.free(jobs);
-        const pending: u32 = std.math.cast(u32, job_count) orelse return error.SystemResources;
+        const pending: u32 = @intCast(job_count);
 
         const repo: Repo = try .parse(handle.uri);
         var url_buffer: [8 * 1024]u8 = undefined;

--- a/zml/io/vfs/hf.zig
+++ b/zml/io/vfs/hf.zig
@@ -11,7 +11,7 @@ const ParallelRead = struct {
     const Pool = parallel_read.Pool(Job);
 
     const Batch = struct {
-        core: parallel_read.Batch,
+        executor: parallel_read.BatchExecutor,
         uri: std.Uri,
         url: []const u8,
         authorization: std.http.Client.Request.Headers.Value,
@@ -800,7 +800,7 @@ pub const HF = struct {
         const uri: std.Uri = try .parse(url);
 
         var batch: ParallelRead.Batch = .{
-            .core = .{ .pending = .init(pending) },
+            .executor = .{ .pending = .init(pending) },
             .uri = uri,
             .url = url,
             .authorization = self.authorization,
@@ -818,8 +818,8 @@ pub const HF = struct {
         }
 
         try self.read_pool.job_queue.putAll(self.base.inner, jobs);
-        batch.core.waitUncancelable(self.base.inner);
-        if (batch.core.firstError()) |err| return err;
+        batch.executor.waitUncancelable(self.base.inner);
+        if (batch.executor.firstError()) |err| return err;
 
         return read_size;
     }

--- a/zml/io/vfs/parallel_read.zig
+++ b/zml/io/vfs/parallel_read.zig
@@ -8,30 +8,30 @@ pub const InitOpts = struct {
     queue_capacity: usize = 64,
 };
 
-pub const Batch = struct {
+pub const BatchExecutor = struct {
     pending: std.atomic.Value(u32),
     err: std.atomic.Value(u16) = .init(0),
 
-    pub fn failed(batch: *Batch) bool {
+    pub fn failed(batch: *BatchExecutor) bool {
         return batch.err.load(.acquire) != 0;
     }
 
-    pub fn fail(batch: *Batch, err: anyerror) void {
+    pub fn fail(batch: *BatchExecutor, err: anyerror) void {
         _ = batch.err.cmpxchgStrong(0, @intFromError(err), .release, .monotonic);
     }
 
-    pub fn firstError(batch: *Batch) ?anyerror {
+    pub fn firstError(batch: *BatchExecutor) ?anyerror {
         const err = batch.err.load(.acquire);
         return if (err == 0) null else @errorFromInt(err);
     }
 
-    pub fn completeOne(batch: *Batch, io: std.Io) void {
+    pub fn completeOne(batch: *BatchExecutor, io: std.Io) void {
         const previous = batch.pending.fetchSub(1, .release);
         std.debug.assert(previous > 0);
         if (previous == 1) io.futexWake(u32, &batch.pending.raw, 1);
     }
 
-    pub fn waitUncancelable(batch: *Batch, io: std.Io) void {
+    pub fn waitUncancelable(batch: *BatchExecutor, io: std.Io) void {
         while (true) {
             const pending = batch.pending.load(.acquire);
             if (pending == 0) return;
@@ -82,11 +82,11 @@ pub fn Pool(comptime Job: type) type {
             while (true) {
                 const job = pool.job_queue.getOne(io) catch break;
 
-                if (!job.batch.core.failed()) {
-                    if (job.perform(pool.client)) |err| job.batch.core.fail(err);
+                if (!job.batch.executor.failed()) {
+                    if (job.perform(pool.client)) |err| job.batch.executor.fail(err);
                 }
 
-                job.batch.core.completeOne(io);
+                job.batch.executor.completeOne(io);
             }
         }
     };

--- a/zml/io/vfs/parallel_read.zig
+++ b/zml/io/vfs/parallel_read.zig
@@ -119,7 +119,7 @@ pub fn readSize(file_size: u64, offset: u64, data: []const []u8) usize {
 }
 
 pub fn readChunk(
-    reader: anytype,
+    reader: *std.Io.Reader,
     content_range: ?ContentRange,
     file_offset: u64,
     data: []const []u8,

--- a/zml/io/vfs/parallel_read.zig
+++ b/zml/io/vfs/parallel_read.zig
@@ -1,0 +1,151 @@
+const std = @import("std");
+
+const stdx = @import("stdx");
+
+pub const InitOpts = struct {
+    chunk_size: usize = 10 * 1024 * 1024,
+    num_workers: usize = 16,
+    queue_capacity: usize = 64,
+};
+
+pub const Batch = struct {
+    pending: std.atomic.Value(u32),
+    err: std.atomic.Value(u16) = .init(0),
+
+    pub fn failed(batch: *Batch) bool {
+        return batch.err.load(.acquire) != 0;
+    }
+
+    pub fn fail(batch: *Batch, err: anyerror) void {
+        _ = batch.err.cmpxchgStrong(0, @intFromError(err), .release, .monotonic);
+    }
+
+    pub fn firstError(batch: *Batch) ?anyerror {
+        const err = batch.err.load(.acquire);
+        return if (err == 0) null else @errorFromInt(err);
+    }
+
+    pub fn completeOne(batch: *Batch, io: std.Io) void {
+        const previous = batch.pending.fetchSub(1, .release);
+        std.debug.assert(previous > 0);
+        if (previous == 1) io.futexWake(u32, &batch.pending.raw, 1);
+    }
+
+    pub fn waitUncancelable(batch: *Batch, io: std.Io) void {
+        while (true) {
+            const pending = batch.pending.load(.acquire);
+            if (pending == 0) return;
+            io.futexWaitUncancelable(u32, &batch.pending.raw, pending);
+        }
+    }
+};
+
+pub fn Pool(comptime Job: type) type {
+    return struct {
+        const Self = @This();
+
+        group: std.Io.Group = .init,
+        job_queue: std.Io.Queue(Job),
+        queue_buf: []Job,
+        client: *std.http.Client,
+        chunk_size: usize,
+
+        pub fn init(self: *Self, allocator: std.mem.Allocator, io: std.Io, client: *std.http.Client, opts: InitOpts) !void {
+            stdx.debug.assert(opts.num_workers > 0, "Pool must have at least one worker", .{});
+            stdx.debug.assert(opts.chunk_size > 0, "Pool must have a positive download chunk size", .{});
+            stdx.debug.assert(opts.queue_capacity > 0, "Pool must have a positive queue capacity", .{});
+
+            const queue_buf = try allocator.alloc(Job, opts.queue_capacity);
+            errdefer allocator.free(queue_buf);
+
+            self.* = .{
+                .client = client,
+                .chunk_size = opts.chunk_size,
+                .job_queue = .init(queue_buf),
+                .queue_buf = queue_buf,
+            };
+            errdefer self.group.cancel(io);
+
+            for (0..opts.num_workers) |_| {
+                try self.group.concurrent(io, worker, .{ self, io });
+            }
+        }
+
+        pub fn deinit(self: *Self, allocator: std.mem.Allocator, io: std.Io) void {
+            self.job_queue.close(io);
+            self.group.cancel(io);
+
+            allocator.free(self.queue_buf);
+        }
+
+        fn worker(pool: *Self, io: std.Io) std.Io.Cancelable!void {
+            while (true) {
+                const job = pool.job_queue.getOne(io) catch break;
+
+                if (!job.batch.core.failed()) {
+                    if (job.perform(pool.client)) |err| job.batch.core.fail(err);
+                }
+
+                job.batch.core.completeOne(io);
+            }
+        }
+    };
+}
+
+pub const ContentRange = struct {
+    start: u64,
+    end: u64,
+    total: u64,
+};
+
+pub fn parseContentRange(value: []const u8) ?ContentRange {
+    const space = std.mem.indexOfScalar(u8, value, ' ') orelse return null;
+    const dash = std.mem.indexOfScalar(u8, value, '-') orelse return null;
+    const slash = std.mem.indexOfScalar(u8, value, '/') orelse return null;
+
+    return .{
+        .start = std.fmt.parseInt(u64, value[space + 1 .. dash], 10) catch return null,
+        .end = std.fmt.parseInt(u64, value[dash + 1 .. slash], 10) catch return null,
+        .total = std.fmt.parseInt(u64, value[slash + 1 ..], 10) catch return null,
+    };
+}
+
+pub fn readSize(file_size: u64, offset: u64, data: []const []u8) usize {
+    if (offset >= file_size) return 0;
+
+    var requested: usize = 0;
+    for (data) |buf| requested += buf.len;
+    return @intCast(@min(file_size - offset, requested));
+}
+
+pub fn readChunk(
+    reader: anytype,
+    content_range: ?ContentRange,
+    file_offset: u64,
+    data: []const []u8,
+    chunk_offset: usize,
+    chunk_len: usize,
+) !void {
+    if (content_range) |cr| {
+        if (cr.start > file_offset) return error.InvalidContentRange;
+        if (cr.start < file_offset) {
+            try reader.discardAll(file_offset - cr.start);
+        }
+    }
+
+    var remaining = chunk_len;
+    var skip = chunk_offset;
+
+    for (data) |buf| {
+        if (skip >= buf.len) {
+            skip -= buf.len;
+            continue;
+        }
+
+        const destination = buf[skip..][0..@min(remaining, buf.len - skip)];
+        try reader.readSliceAll(destination);
+        remaining -= destination.len;
+        if (remaining == 0) break;
+        skip = 0;
+    }
+}

--- a/zml/io/vfs/s3.zig
+++ b/zml/io/vfs/s3.zig
@@ -145,7 +145,7 @@ pub const S3 = struct {
         const Pool = parallel_read.Pool(Job);
 
         const Batch = struct {
-            core: parallel_read.Batch,
+            executor: parallel_read.BatchExecutor,
             backend: *S3,
             uri: std.Uri,
             url: []const u8,
@@ -889,7 +889,7 @@ pub const S3 = struct {
         const pending: u32 = std.math.cast(u32, job_count) orelse return error.SystemResources;
 
         var batch: ParallelRead.Batch = .{
-            .core = .{ .pending = .init(pending) },
+            .executor = .{ .pending = .init(pending) },
             .backend = self,
             .uri = uri,
             .url = url,
@@ -907,8 +907,8 @@ pub const S3 = struct {
         }
 
         try self.read_pool.job_queue.putAll(self.base.inner, jobs);
-        batch.core.waitUncancelable(self.base.inner);
-        if (batch.core.firstError()) |err| return err;
+        batch.executor.waitUncancelable(self.base.inner);
+        if (batch.executor.firstError()) |err| return err;
 
         return read_size;
     }

--- a/zml/io/vfs/s3.zig
+++ b/zml/io/vfs/s3.zig
@@ -886,7 +886,7 @@ pub const S3 = struct {
         const job_count = std.math.divCeil(usize, read_size, self.read_pool.chunk_size) catch unreachable;
         const jobs = try self.allocator.alloc(ParallelRead.Job, job_count);
         defer self.allocator.free(jobs);
-        const pending: u32 = std.math.cast(u32, job_count) orelse return error.SystemResources;
+        const pending: u32 = @intCast(job_count);
 
         var batch: ParallelRead.Batch = .{
             .executor = .{ .pending = .init(pending) },

--- a/zml/io/vfs/s3.zig
+++ b/zml/io/vfs/s3.zig
@@ -275,15 +275,6 @@ pub const S3 = struct {
         inner: std.Io,
         http_client: *std.http.Client,
         config: Config,
-    ) !S3 {
-        return initWithOpts(allocator, inner, http_client, config, .{});
-    }
-
-    pub fn initWithOpts(
-        allocator: std.mem.Allocator,
-        inner: std.Io,
-        http_client: *std.http.Client,
-        config: Config,
         opts: InitOpts,
     ) !S3 {
         const read_pool = try allocator.create(ParallelRead.Pool);
@@ -344,7 +335,7 @@ pub const S3 = struct {
             log.warn("{s}", .{writer.buffered()});
         }
 
-        return initWithOpts(allocator, inner, http_client, .{
+        return init(allocator, inner, http_client, .{
             .access_key = access_key,
             .secret_key = secret_key,
             .endpoint_url = endpoint,

--- a/zml/io/vfs/s3.zig
+++ b/zml/io/vfs/s3.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 const stdx = @import("stdx");
 
 const VFSBase = @import("base.zig").VFSBase;
+const parallel_read = @import("parallel_read.zig");
 
 const log = std.log.scoped(.@"zml/io/vfs/s3");
 
@@ -140,6 +141,95 @@ pub const AwsSigV4 = struct {
 const ReadState = struct { index: usize, objects: [][]const u8 };
 
 pub const S3 = struct {
+    const ParallelRead = struct {
+        const Pool = parallel_read.Pool(Job);
+
+        const Batch = struct {
+            core: parallel_read.Batch,
+            backend: *S3,
+            uri: std.Uri,
+            url: []const u8,
+        };
+
+        const Job = struct {
+            data: []const []u8,
+            file_offset: u64,
+            chunk_offset: usize,
+            chunk_len: usize,
+            batch: *Batch,
+
+            pub fn perform(job: Job, client: *std.http.Client) ?anyerror {
+                var range_buf: [64]u8 = undefined;
+                const range_header = std.fmt.bufPrint(
+                    &range_buf,
+                    "bytes={d}-{d}",
+                    .{ job.file_offset, job.file_offset + @as(u64, @intCast(job.chunk_len - 1)) },
+                ) catch unreachable;
+
+                var timestamp_buf: [16]u8 = undefined;
+                const timestamp = job.batch.backend.getTimestamp(&timestamp_buf) catch |err| return err;
+
+                const signer: AwsSigV4 = .{
+                    .access_key = job.batch.backend.config.access_key,
+                    .secret_key = job.batch.backend.config.secret_key,
+                    .region = job.batch.backend.config.region,
+                    .service = job.batch.backend.config.auth_service,
+                };
+
+                var authorization_buffer: [512]u8 = undefined;
+                const authorization = signer.generateAuthHeader(
+                    &authorization_buffer,
+                    .GET,
+                    job.batch.uri,
+                    timestamp,
+                    &.{.{ .name = "Range", .value = range_header }},
+                ) catch |err| return err;
+
+                var req = client.request(.GET, job.batch.uri, .{
+                    .headers = .{
+                        .accept_encoding = .{ .override = "identity" },
+                        .authorization = if (authorization) |auth| .{ .override = auth } else .omit,
+                    },
+                    .extra_headers = &.{
+                        .{ .name = "x-amz-date", .value = timestamp },
+                        .{ .name = "x-amz-content-sha256", .value = AwsSigV4.UNSIGNED_PAYLOAD },
+                        .{ .name = "Range", .value = range_header },
+                    },
+                }) catch |err| return err;
+                defer req.deinit();
+
+                req.sendBodiless() catch |err| return err;
+
+                var redirect_buffer: [8 * 1024]u8 = undefined;
+                var res = req.receiveHead(&redirect_buffer) catch |err| return err;
+
+                if (res.head.status != .partial_content and res.head.status != .ok) {
+                    log.err("Failed to read {s}: {s}", .{ job.batch.url, res.head.bytes });
+                    return error.RequestFailed;
+                }
+
+                const content_range = blk: {
+                    var it = res.head.iterateHeaders();
+                    while (it.next()) |header| {
+                        if (std.ascii.eqlIgnoreCase(header.name, "Content-Range")) {
+                            break :blk parallel_read.parseContentRange(header.value);
+                        }
+                    }
+                    break :blk null;
+                };
+
+                const reader = res.reader(&.{});
+                parallel_read.readChunk(reader, content_range, job.file_offset, job.data, job.chunk_offset, job.chunk_len) catch |err| return err;
+
+                return null;
+            }
+        };
+    };
+
+    pub const InitOpts = struct {
+        read_pool: parallel_read.InitOpts = .{},
+    };
+
     pub const Config = struct {
         access_key: ?[]const u8 = null,
         secret_key: ?[]const u8 = null,
@@ -174,6 +264,7 @@ pub const S3 = struct {
     mutex: std.Io.Mutex = .init,
     client: *std.http.Client,
     config: Config,
+    read_pool: *ParallelRead.Pool,
     handles: stdx.SegmentedList(Handle, 0) = .{},
     closed_handles: std.ArrayList(u32) = .empty,
     dir_read_states: std.AutoHashMapUnmanaged(*std.Io.Dir.Reader, ReadState) = .{},
@@ -185,10 +276,27 @@ pub const S3 = struct {
         http_client: *std.http.Client,
         config: Config,
     ) !S3 {
+        return initWithOpts(allocator, inner, http_client, config, .{});
+    }
+
+    pub fn initWithOpts(
+        allocator: std.mem.Allocator,
+        inner: std.Io,
+        http_client: *std.http.Client,
+        config: Config,
+        opts: InitOpts,
+    ) !S3 {
+        const read_pool = try allocator.create(ParallelRead.Pool);
+        errdefer allocator.destroy(read_pool);
+
+        try read_pool.init(allocator, inner, http_client, opts.read_pool);
+        errdefer read_pool.deinit(allocator, inner);
+
         return .{
             .allocator = allocator,
             .base = .init(inner),
             .client = http_client,
+            .read_pool = read_pool,
             .config = .{
                 .access_key = if (config.access_key) |k| try allocator.dupe(u8, k) else null,
                 .secret_key = if (config.secret_key) |k| try allocator.dupe(u8, k) else null,
@@ -236,15 +344,18 @@ pub const S3 = struct {
             log.warn("{s}", .{writer.buffered()});
         }
 
-        return init(allocator, inner, http_client, .{
+        return initWithOpts(allocator, inner, http_client, .{
             .access_key = access_key,
             .secret_key = secret_key,
             .endpoint_url = endpoint,
             .region = region,
-        });
+        }, .{});
     }
 
     pub fn deinit(self: *S3) void {
+        self.read_pool.deinit(self.allocator, self.base.inner);
+        self.allocator.destroy(self.read_pool);
+
         var idx: usize = 0;
         while (idx < self.handles.len) : (idx += 1) {
             const is_closed = for (self.closed_handles.items) |closed_idx| {
@@ -765,95 +876,40 @@ pub const S3 = struct {
     }
 
     fn performRead(self: *S3, handle: *Handle, data: []const []u8, offset: u64) !usize {
-        if (offset >= handle.size) return 0;
+        const read_size = parallel_read.readSize(handle.size, offset, data);
+        if (read_size == 0) return 0;
 
         var url_buf: [8 * 1024]u8 = undefined;
         const url = try self.s3Url(handle.uri, &url_buf);
-
         const uri = std.Uri.parse(url) catch return error.BadPathName;
 
-        var range_buf: [64]u8 = undefined;
-        const range_header = blk: {
-            var total_bytes: u64 = 0;
-            for (data) |buf| {
-                total_bytes += @as(u64, buf.len);
-            }
-            const remaining = handle.size - offset;
-            const take = @min(remaining, total_bytes);
-            const end = offset + take - 1;
-            break :blk std.fmt.bufPrint(&range_buf, "bytes={d}-{d}", .{ offset, end }) catch unreachable;
+        const job_count = std.math.divCeil(usize, read_size, self.read_pool.chunk_size) catch unreachable;
+        const jobs = try self.allocator.alloc(ParallelRead.Job, job_count);
+        defer self.allocator.free(jobs);
+        const pending: u32 = std.math.cast(u32, job_count) orelse return error.SystemResources;
+
+        var batch: ParallelRead.Batch = .{
+            .core = .{ .pending = .init(pending) },
+            .backend = self,
+            .uri = uri,
+            .url = url,
         };
 
-        var timestamp_buf: [16]u8 = undefined;
-        const timestamp = try self.getTimestamp(&timestamp_buf);
-
-        const signer: AwsSigV4 = .{
-            .access_key = self.config.access_key,
-            .secret_key = self.config.secret_key,
-            .region = self.config.region,
-            .service = self.config.auth_service,
-        };
-
-        var authorization_buffer: [512]u8 = undefined;
-        const authorization = try signer.generateAuthHeader(&authorization_buffer, .GET, uri, timestamp, &.{});
-
-        var req = try self.client.request(.GET, uri, .{ .headers = .{
-            .accept_encoding = .{ .override = "identity" },
-            .authorization = if (authorization) |auth| .{ .override = auth } else .omit,
-        }, .extra_headers = &.{
-            .{ .name = "x-amz-date", .value = timestamp },
-            .{ .name = "x-amz-content-sha256", .value = AwsSigV4.UNSIGNED_PAYLOAD },
-            .{ .name = "Range", .value = range_header },
-        } });
-        defer req.deinit();
-
-        try req.sendBodiless();
-
-        var redirect_buffer: [8 * 1024]u8 = undefined;
-        var res = try req.receiveHead(&redirect_buffer);
-
-        if (res.head.status != .partial_content and res.head.status != .ok) {
-            log.err("Failed to read {s}: {s}", .{ handle.uri, res.head.bytes });
-            return error.RequestFailed;
+        for (jobs, 0..) |*job, i| {
+            const chunk_offset = i * self.read_pool.chunk_size;
+            job.* = .{
+                .data = data,
+                .file_offset = offset + @as(u64, @intCast(chunk_offset)),
+                .chunk_offset = chunk_offset,
+                .chunk_len = @min(self.read_pool.chunk_size, read_size - chunk_offset),
+                .batch = &batch,
+            };
         }
 
-        const content_range = blk: {
-            var it = res.head.iterateHeaders();
-            while (it.next()) |header| {
-                if (std.ascii.eqlIgnoreCase(header.name, "Content-Range")) {
-                    break :blk parseContentRange(header.value);
-                }
-            }
-            break :blk null;
-        };
+        try self.read_pool.job_queue.putAll(self.base.inner, jobs);
+        batch.core.waitUncancelable(self.base.inner);
+        if (batch.core.firstError()) |err| return err;
 
-        const reader = res.reader(&.{});
-
-        if (content_range) |cr| {
-            if (cr.start < offset) {
-                try reader.discardAll(offset - cr.start);
-            }
-        }
-
-        return try reader.readSliceShort(data[0]);
-    }
-
-    const ContentRange = struct {
-        start: u64,
-        end: u64,
-        total: u64,
-    };
-
-    fn parseContentRange(value: []const u8) ?ContentRange {
-        // Format: "bytes start-end/total"
-        const space = std.mem.indexOfScalar(u8, value, ' ') orelse return null;
-        const dash = std.mem.indexOfScalar(u8, value, '-') orelse return null;
-        const slash = std.mem.indexOfScalar(u8, value, '/') orelse return null;
-
-        return .{
-            .start = std.fmt.parseInt(u64, value[space + 1 .. dash], 10) catch return null,
-            .end = std.fmt.parseInt(u64, value[dash + 1 .. slash], 10) catch return null,
-            .total = std.fmt.parseInt(u64, value[slash + 1 ..], 10) catch return null,
-        };
+        return read_size;
     }
 };


### PR DESCRIPTION
# Summary

This PR extends the support to chunked parallel read introduced initially  for HF in the VFS, to GCS and S3. 

It:
- Adds a shared `zml/io/vfs/parallel_read.zig` helper for chunked parallel HTTP range reads
- Add configurable read pool options for S3/GCS initialization
- Register the `gs://` VFS backend in `examples/llm`.


# Tests

## S3

We used [MINIO](https://hub.docker.com/r/minio/minio) docker image from the `5090` GPU machine. From there, we mirror the `meta-llama/Llama-3.1-8B-Instruct` model  through the S3 server. 

Then from the `4090` GPU machine, we run 

```bash
bazel run --@zml//platforms:cuda=true --@zml//platforms:cpu=false --config=release --config=native //examples/llm -- --model=s3://zml-test/Llama-3.1-8B-Instruct --prompt="hello, how are you ?"
```

It works both on 1 and 2 GPU. 

## GCS

In the same spirit, we put the `meta-llama/Llama-3.1-8B-Instruct` in a GCS bucket we own. Then, on the `4090`, we run

```bash
bazel run --@zml//platforms:cuda=true --@zml//platforms:cpu=false --config=release --config=native //examples/llm -- --model=gs://zml-mirror2/models/meta-llama/Llama-3.1-8B-Instruct --prompt="hello, how are you ?"
```

It works both on 1 and 2 GPU. 

### Performance

As a reference, we run:
```bash
gcloud storage cp gs://zml-mirror2/models/meta-llama/Llama-3.1-8B-Instruct/model-00001-of-00004.safetensors gs://zml-mirror2/models/meta-llama/Llama-3.1-8B-Instruct/model-00002-of-00004.safetensors gs://zml-mirror2/models/meta-llama/Llama-3.1-8B-Instruct/model-00003-of-00004.safetensors gs://zml-mirror2/models/meta-llama/Llama-3.1-8B-Instruct/model-00004-of-00004.safetensors /tmp/gcs-gcloud-llama-shards/
```

It gives:
```
Completed files 4/4 | 15.0GiB/15.0GiB | 942.7MiB/s 
Average throughput: 918.8MiB/s
```

Using the VFS in various setups:

* `dma_chunks = 32`, `dma_chunk_size = 128`, `parallelism = 16`, `chunk_size = 10 MiB`, `num_workers = 16`, `queue_capacity = 64`

```bash
info (llama): Loaded weights [14.96GiB, 21.302s, 719.02MiB/s]
```

* `dma_chunks = 32`, `dma_chunk_size = 256`, `parallelism = 16`, `chunk_size = 10 MiB`, `num_workers = 16`, `queue_capacity = 64`

```bash
info (llama): Loaded weights [14.96GiB, 18.227s, 840.32MiB/s]
```

* `dma_chunks = 32`, `dma_chunk_size = 256`, `parallelism = 16`, `chunk_size = 16 MiB`, `num_workers = 16`, `queue_capacity = 64`

```bash
info (llama): Loaded weights [14.96GiB, 17.376s, 881.43MiB/s]
```

* `dma_chunks = 32`, `dma_chunk_size = 256`, `parallelism = 16`, `chunk_size = 16 MiB`, `num_workers = 32`, `queue_capacity = 64`

```bash
info (llama): Loaded weights [14.96GiB, 17.28s, 886.36MiB/s]
```

* `dma_chunks = 32`, `dma_chunk_size = 512`, `parallelism = 16`, `chunk_size = 16 MiB`, `num_workers = 16`, `queue_capacity = 64`

```bash
info (llama): Loaded weights [14.96GiB, 18.658s, 820.90MiB/s]
```