### PR TITLE
platforms: set linux amd64 legacy cpu

### DIFF
--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -76,6 +76,7 @@ platform(
     ],
     flags = [
         "--force_pic=true",  # required for protobuf upb on Linux
+        "--cpu=x86_64",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
part of highway XLA target selects which header to include based on legacy --cpu flags but the rest not...
So even if we targeted linux amd64, the top part of the highway would be used correctly, but the extension specific part would fallback to --cpu darwin_arm64 and would not include hh_avx2.h resulting in compilation errors.

The normal solution here is to use platform_mappings but since we pass `--force_pic=true` in platforms, this takes precedence and the mappings are ignored.

The temporary solution while https://github.com/openxla/xla/pull/44823 is merged, is to pass `--cpu` in all platforms we use for cross compilation.