### PR TITLE
docs/tutorials: fix 'write_first_model' example code

### DIFF
--- a/docs/tutorials/write_first_model.md
+++ b/docs/tutorials/write_first_model.md
@@ -135,7 +135,7 @@ pub fn main(init: std.process.Init) !void {
     const io = init.io;
 
     var platform: *zml.Platform = try .auto(allocator, io, .{});
-    defer platform.deinit(allocator);
+    defer platform.deinit(allocator, io);
     
     ...
 }


### PR DESCRIPTION
Updates  `defer platform.deinit(allocator);` -->  `defer platform.deinit(allocator, io);` in `docs/tutorials/write_first_model.md`.

This makes the **Adding a main() function** section code match the corresponding (correct) code in the **The complete example** section