### PR TITLE
io/vfs: tweak default parameters for parallel read

### DIFF
--- a/examples/io/main.zig
+++ b/examples/io/main.zig
@@ -211,7 +211,7 @@ pub fn main(init: std.process.Init) !void {
                 .shardings = &.{sharded_sharding},
                 .parallelism = 8,
                 .dma_chunks = 16,
-                .dma_chunk_size = 64 * zml.MiB,
+                .dma_chunk_size = 256 * zml.MiB,
                 .progress = &progress,
                 .total_bytes = &total_bytes,
             });

--- a/examples/llm/models/lfm2/model.zig
+++ b/examples/llm/models/lfm2/model.zig
@@ -97,7 +97,7 @@ pub const LoadedModel = struct {
         const all_shardings = shardings.all();
         return zml.io.load(Model, &self.inner, allocator, io, platform, store, .{
             .dma_chunks = 32,
-            .dma_chunk_size = 128 * zml.MiB,
+            .dma_chunk_size = 256 * zml.MiB,
             .progress = progress,
             .shardings = &all_shardings,
             .parallelism = 16,
@@ -189,7 +189,7 @@ pub const Model = struct {
         const all_shardings = shardings.all();
         return zml.io.load(Model, self, allocator, io, platform, store, .{
             .dma_chunks = 8,
-            .dma_chunk_size = 128 * zml.MiB,
+            .dma_chunk_size = 256 * zml.MiB,
             .progress = progress,
             .parallelism = 16,
             .total_bytes = &total_bytes,

--- a/examples/llm/models/llama/model.zig
+++ b/examples/llm/models/llama/model.zig
@@ -83,7 +83,7 @@ pub const LoadedModel = struct {
 
         return zml.io.load(Model, &self.inner, allocator, io, platform, store, .{
             .dma_chunks = 32,
-            .dma_chunk_size = 128 * zml.MiB,
+            .dma_chunk_size = 256 * zml.MiB,
             .progress = progress,
             .shardings = &shardings.all(),
             .parallelism = 16,
@@ -174,7 +174,7 @@ pub const Model = struct {
 
         return zml.io.load(Model, self, allocator, io, platform, store, .{
             .dma_chunks = 32,
-            .dma_chunk_size = 128 * zml.MiB,
+            .dma_chunk_size = 256 * zml.MiB,
             .progress = progress,
             .shardings = shardings,
             .parallelism = 16,

--- a/examples/llm/models/qwen3_5/model.zig
+++ b/examples/llm/models/qwen3_5/model.zig
@@ -98,7 +98,7 @@ pub const LoadedModel = struct {
         const all_shardings = shardings.all();
         return zml.io.load(Model, &self.inner, allocator, io, platform, store, .{
             .dma_chunks = 32,
-            .dma_chunk_size = 128 * zml.MiB,
+            .dma_chunk_size = 256 * zml.MiB,
             .progress = progress,
             .shardings = &all_shardings,
             .parallelism = 16,
@@ -191,7 +191,7 @@ pub const Model = struct {
         }
         return zml.io.load(Model, self, allocator, io, platform, store, .{
             .dma_chunks = 32,
-            .dma_chunk_size = 128 * zml.MiB,
+            .dma_chunk_size = 256 * zml.MiB,
             .progress = progress,
             .shardings = shardings,
             .parallelism = 16,

--- a/examples/llm/models/qwen3_5_moe/model.zig
+++ b/examples/llm/models/qwen3_5_moe/model.zig
@@ -124,7 +124,7 @@ pub const LoadedModel = struct {
         const all_shardings = shardings.all();
         var buffers = try zml.io.load(Model, &self.inner, allocator, io, platform, store, .{
             .dma_chunks = 32,
-            .dma_chunk_size = 128 * zml.MiB,
+            .dma_chunk_size = 256 * zml.MiB,
             .progress = progress,
             .shardings = &all_shardings,
             .parallelism = 16,
@@ -209,7 +209,7 @@ pub const Model = struct {
         }
         return zml.io.load(Model, self, allocator, io, platform, store, .{
             .dma_chunks = 32,
-            .dma_chunk_size = 128 * zml.MiB,
+            .dma_chunk_size = 256 * zml.MiB,
             .progress = progress,
             .shardings = shardings,
             .parallelism = 16,

--- a/zml/io/vfs/parallel_read.zig
+++ b/zml/io/vfs/parallel_read.zig
@@ -3,8 +3,8 @@ const std = @import("std");
 const stdx = @import("stdx");
 
 pub const InitOpts = struct {
-    chunk_size: usize = 10 * 1024 * 1024,
-    num_workers: usize = 16,
+    chunk_size: usize = 16 * 1024 * 1024,
+    num_workers: usize = 32,
     queue_capacity: usize = 64,
 };
 

--- a/zml/io/vfs/parallel_read.zig
+++ b/zml/io/vfs/parallel_read.zig
@@ -5,7 +5,7 @@ const stdx = @import("stdx");
 pub const InitOpts = struct {
     chunk_size: usize = 16 * 1024 * 1024,
     num_workers: usize = 32,
-    queue_capacity: usize = 64,
+    queue_capacity: usize = 128,
 };
 
 pub const BatchExecutor = struct {


### PR DESCRIPTION
This PR just changes default parallel read parameters. 

Those values give better performance metrics. Instead of changing them every time, we materialize the proper values. 