### PR TITLE
zml: introduce zml.Compiler

### DIFF
--- a/zml/module.zig
+++ b/zml/module.zig
@@ -20,6 +20,7 @@ const Sharding = @import("Sharding.zig");
 const Partitioning = Sharding.Partitioning;
 const Tensor = @import("tensor.zig").Tensor;
 
+const zml_module = @This();
 const log = std.log.scoped(.@"zml/module");
 
 var mlir_global_init_mutex: std.Io.Mutex = .init;
@@ -189,6 +190,20 @@ pub const CompilationContext = struct {
         return self.channel_id;
     }
 };
+
+pub fn Compiler(comptime func: anytype) type {
+    return struct {
+        pub fn compile(
+            allocator: std.mem.Allocator,
+            io: std.Io,
+            platform: *const Platform,
+            opts: CompilationOptions,
+            args: std.meta.ArgsTuple(@TypeOf(func)),
+        ) !Exe {
+            return zml_module.compile(allocator, io, func, args, platform, opts);
+        }
+    };
+}
 
 pub fn compile(
     allocator: std.mem.Allocator,

--- a/zml/zml.zig
+++ b/zml/zml.zig
@@ -30,6 +30,7 @@ pub const meta = @import("meta.zig");
 pub const mlir = @import("mlirx.zig");
 pub const module = @import("module.zig");
 pub const CompilationOptions = module.CompilationOptions;
+pub const Compiler = module.Compiler;
 pub const moe = @import("moe/moe.zig");
 pub const nn = @import("nn.zig");
 pub const ops = @import("ops.zig");


### PR DESCRIPTION
Move the type out of `zml.compile` signature so that we can call `io.async` more easily.

Sample code:

```
var layer_compile_future = io.async(zml.Compiler(TransformerLayer.forward).compile, .{
    allocator,
    io,
    platform,
    layer_compile_opts,
    .{
        model.model.layers[0],
        hidden,
        device_state.kv_cache.layers[0],
    },
});
```