### PR TITLE
platforms/metal: bump plugin & remove metadata from struct

### DIFF
--- a/examples/llm/models/lfm2/session.zig
+++ b/examples/llm/models/lfm2/session.zig
@@ -120,6 +120,13 @@ pub const Session = struct {
         var actual_seq_len_buf: zml.Buffer = try .fromSlice(self.io, self.platform, actual_seq_len_slice, .replicated);
         defer actual_seq_len_buf.deinit();
 
+        var num_tokens_buffer: zml.Buffer = try .scalar(self.io, self.platform, all_tokens.len, .u32);
+        defer num_tokens_buffer.deinit();
+        const attention_metadata_buffers: zml.Bufferized(attention.Metadata) = switch (self.attention_metadata_buffers) {
+            .metal_fa => .{ .metal_fa = .{ .num_tokens = num_tokens_buffer } },
+            else => self.attention_metadata_buffers,
+        };
+
         try self.compiled_model.prefill.run(.{
             .allocator = self.allocator,
             .io = self.io,
@@ -130,7 +137,7 @@ pub const Session = struct {
             .actual_seq_len_buf = &actual_seq_len_buf,
             .rng_buf = &self.rng_buf,
             .cache_buffers = &self.cache_buffers,
-            .attention_metadata_buffers = self.attention_metadata_buffers,
+            .attention_metadata_buffers = attention_metadata_buffers,
         });
 
         try tokens_buf.toSlice(self.io, tokens_slice);

--- a/examples/llm/models/lfm2/session.zig
+++ b/examples/llm/models/lfm2/session.zig
@@ -120,11 +120,14 @@ pub const Session = struct {
         var actual_seq_len_buf: zml.Buffer = try .fromSlice(self.io, self.platform, actual_seq_len_slice, .replicated);
         defer actual_seq_len_buf.deinit();
 
-        var num_tokens_buffer: zml.Buffer = try .scalar(self.io, self.platform, all_tokens.len, .u32);
-        defer num_tokens_buffer.deinit();
-        const attention_metadata_buffers: zml.Bufferized(attention.Metadata) = switch (self.attention_metadata_buffers) {
-            .metal_fa => .{ .metal_fa = .{ .num_tokens = num_tokens_buffer } },
+        var attention_metadata_buffers: zml.Bufferized(attention.Metadata) = switch (self.attention_metadata_buffers) {
+            .metal_fa => .{ .metal_fa = .{ .num_tokens = try .scalar(self.io, self.platform, all_tokens.len, .u32) } },
             else => self.attention_metadata_buffers,
+        };
+
+        defer switch (attention_metadata_buffers) {
+            .metal_fa => attention.Metadata.deinitBuffer(&attention_metadata_buffers),
+            else => {},
         };
 
         try self.compiled_model.prefill.run(.{

--- a/examples/llm/models/lfm2/session.zig
+++ b/examples/llm/models/lfm2/session.zig
@@ -15,7 +15,6 @@ pub const Session = struct {
     config: *const model.Config,
     seqlen: u32,
     cache_buffers: zml.Bufferized(model.Cache),
-    attention_metadata_buffers: zml.Bufferized(attention.Metadata),
     rng_buf: zml.Bufferized(zml.Tensor.Rng),
     generated_token_slice: zml.Slice,
     think_start: ?u32,
@@ -41,7 +40,6 @@ pub const Session = struct {
             .config = &compiled_model.loaded_model.parsed_config.value,
             .seqlen = compiled_model.params.seqlen,
             .cache_buffers = try compiled_model.params.cache.initBuffers(allocator, io, platform, compiled_model.params.shardings.model),
-            .attention_metadata_buffers = try compiled_model.params.attention_metadata.initBuffer(io, platform, compiled_model.params.shardings.model),
             .rng_buf = try zml.Tensor.Rng.initBuffer(io, platform, .replicated, seed),
             .generated_token_slice = try .alloc(allocator, zml.Shape.init(.{ .batch = 1, .seq = 1 }, .u32)),
             .think_start = tokenizer.tokenId("<think>") orelse unreachable,
@@ -51,7 +49,6 @@ pub const Session = struct {
 
     pub fn deinit(self: *Session) void {
         model.Cache.unloadBuffers(&self.cache_buffers);
-        attention.Metadata.deinitBuffer(&self.attention_metadata_buffers);
         zml.Tensor.Rng.deinitBuffer(&self.rng_buf);
         self.generated_token_slice.free(self.allocator);
     }
@@ -120,15 +117,12 @@ pub const Session = struct {
         var actual_seq_len_buf: zml.Buffer = try .fromSlice(self.io, self.platform, actual_seq_len_slice, .replicated);
         defer actual_seq_len_buf.deinit();
 
-        var attention_metadata_buffers: zml.Bufferized(attention.Metadata) = switch (self.attention_metadata_buffers) {
+        const params = self.compiled_model.params;
+        var attention_metadata_buffers: zml.Bufferized(attention.Metadata) = switch (params.attention_metadata) {
             .metal_fa => .{ .metal_fa = .{ .num_tokens = try .scalar(self.io, self.platform, all_tokens.len, .u32) } },
-            else => self.attention_metadata_buffers,
+            else => try params.attention_metadata.initBuffer(self.io, self.platform, params.shardings.model),
         };
-
-        defer switch (attention_metadata_buffers) {
-            .metal_fa => attention.Metadata.deinitBuffer(&attention_metadata_buffers),
-            else => {},
-        };
+        defer attention.Metadata.deinitBuffer(&attention_metadata_buffers);
 
         try self.compiled_model.prefill.run(.{
             .allocator = self.allocator,
@@ -160,6 +154,11 @@ pub const Session = struct {
 
         const out_tokens_buffer: []u8 = try self.allocator.alloc(u8, 1024);
         defer self.allocator.free(out_tokens_buffer);
+
+        const params = self.compiled_model.params;
+        var attention_metadata_buffers = try params.attention_metadata.initBuffer(self.io, self.platform, params.shardings.model);
+        defer attention.Metadata.deinitBuffer(&attention_metadata_buffers);
+
         generation: while (true) {
             const token_id = self.generated_token_slice.items(u32)[0];
 
@@ -192,7 +191,7 @@ pub const Session = struct {
                 .actual_seq_len_buf = &actual_seq_len_buf,
                 .rng_buf = &self.rng_buf,
                 .cache_buffers = &self.cache_buffers,
-                .attention_metadata_buffers = self.attention_metadata_buffers,
+                .attention_metadata_buffers = attention_metadata_buffers,
             });
 
             try current_token_buffer.toSlice(self.io, self.generated_token_slice);

--- a/examples/llm/models/llama/session.zig
+++ b/examples/llm/models/llama/session.zig
@@ -15,8 +15,6 @@ pub const Session = struct {
     decode_runner: inference.KernelExe.Runner,
     kv_cache_buffers: zml.Bufferized(model.KvCache),
     token_index_buffers: []zml.Buffer,
-    attention_metadata_buffers: zml.Bufferized(zml.attention.attention.Metadata),
-    decode_attention_metadata_buffers: ?zml.Bufferized(zml.attention.attention.Metadata),
     rng_buffers: zml.Bufferized(zml.Tensor.Rng),
     tokenizer: zml.tokenizer.Tokenizer,
     config: *const model.Config,
@@ -49,23 +47,7 @@ pub const Session = struct {
             initialized_token_index_buffers = i + 1;
         }
 
-        var attention_metadata_buffers = try compiled_model.params.attention_metadata.initBuffer(io, platform, shardings.model);
-        errdefer zml.attention.attention.Metadata.deinitBuffer(&attention_metadata_buffers);
-
         const conversation_id: u64 = @bitCast(std.Io.Clock.now(.real, io).toMicroseconds());
-
-        var decode_attention_metadata_buffers: ?zml.Bufferized(zml.attention.attention.Metadata) = switch (compiled_model.params.decode_attention_parameters) {
-            .attnd => b: {
-                const buffers: zml.Bufferized(zml.attention.attention.Metadata) = .{ .attnd = .{
-                    .conversation_id = try zml.Buffer.scalar(io, platform, conversation_id, .u64),
-                    .layer_id = try zml.Buffer.scalar(io, platform, 0, .u16),
-                    .num_tokens = try zml.Buffer.scalar(io, platform, 1, .u32),
-                } };
-                break :b buffers;
-            },
-            .vanilla, .cuda_fa2, .cuda_fa3, .nki, .metal_fa => null,
-        };
-        errdefer if (decode_attention_metadata_buffers) |*buffers| zml.attention.attention.Metadata.deinitBuffer(buffers);
 
         const seed: u128 = @intCast(std.Io.Clock.now(.real, io).toNanoseconds());
         var rng_buffers = try zml.Tensor.Rng.initBuffer(io, platform, .replicated, seed);
@@ -83,8 +65,6 @@ pub const Session = struct {
             .decode_runner = decode_runner,
             .kv_cache_buffers = kv_cache_buffers,
             .token_index_buffers = token_index_buffers,
-            .attention_metadata_buffers = attention_metadata_buffers,
-            .decode_attention_metadata_buffers = decode_attention_metadata_buffers,
             .rng_buffers = rng_buffers,
             .tokenizer = tokenizer,
             .config = &compiled_model.loaded_model.parsed_config.value,
@@ -100,8 +80,6 @@ pub const Session = struct {
             token_index_buffer.deinit();
         }
         self.allocator.free(self.token_index_buffers);
-        zml.attention.attention.Metadata.deinitBuffer(&self.attention_metadata_buffers);
-        if (self.decode_attention_metadata_buffers) |*buffers| zml.attention.attention.Metadata.deinitBuffer(buffers);
         zml.Tensor.Rng.deinitBuffer(&self.rng_buffers);
     }
 
@@ -162,20 +140,17 @@ pub const Session = struct {
         var prefill_tokens_buffer: zml.Buffer = try .fromSlice(self.io, self.platform, prefill_tokens_slice, .replicated);
         defer prefill_tokens_buffer.deinit();
 
-        var attention_metadata_buffers: zml.Bufferized(attention.Metadata) = switch (self.compiled_model.params.prefill_attention_parameters) {
+        const params = self.compiled_model.params;
+        var attention_metadata_buffers: zml.Bufferized(attention.Metadata) = switch (params.attention_metadata) {
             .attnd => .{ .attnd = .{
                 .conversation_id = try .scalar(self.io, self.platform, self.conversation_id, .u64),
                 .layer_id = try .scalar(self.io, self.platform, 0, .u16),
                 .num_tokens = try .scalar(self.io, self.platform, all_tokens.len, .u32),
             } },
             .metal_fa => .{ .metal_fa = .{ .num_tokens = try .scalar(self.io, self.platform, all_tokens.len, .u32) } },
-            .vanilla, .cuda_fa2, .cuda_fa3, .nki => self.attention_metadata_buffers,
+            .vanilla, .cuda_fa2, .cuda_fa3, .nki => try params.attention_metadata.initBuffer(self.io, self.platform, params.shardings.model),
         };
-
-        defer switch (self.compiled_model.params.prefill_attention_parameters) {
-            .attnd, .metal_fa => attention.Metadata.deinitBuffer(&attention_metadata_buffers),
-            .vanilla, .cuda_fa2, .cuda_fa3, .nki => {},
-        };
+        defer attention.Metadata.deinitBuffer(&attention_metadata_buffers);
 
         try self.compiled_model.prefill.run(.{
             .allocator = self.allocator,
@@ -204,6 +179,17 @@ pub const Session = struct {
         var current_token_buffer: zml.Buffer = try .fromBytes(self.io, self.platform, .init(.{ .s = 1 }, .u32), .replicated, @ptrCast(&last_token_id));
         defer current_token_buffer.deinit();
 
+        const params = self.compiled_model.params;
+        var attention_metadata_buffers: zml.Bufferized(attention.Metadata) = switch (params.attention_metadata) {
+            .attnd => .{ .attnd = .{
+                .conversation_id = try .scalar(self.io, self.platform, self.conversation_id, .u64),
+                .layer_id = try .scalar(self.io, self.platform, 0, .u16),
+                .num_tokens = try .scalar(self.io, self.platform, 1, .u32),
+            } },
+            .vanilla, .cuda_fa2, .cuda_fa3, .nki, .metal_fa => try params.attention_metadata.initBuffer(self.io, self.platform, params.shardings.model),
+        };
+        defer attention.Metadata.deinitBuffer(&attention_metadata_buffers);
+
         generation: while (true) {
             if (isEosToken(self.config, last_token_id)) break :generation;
 
@@ -212,9 +198,6 @@ pub const Session = struct {
 
             try all_tokens.append(self.allocator, last_token_id);
             if (all_tokens.items.len >= self.seqlen) break :generation;
-
-            const attention_metadata_buffers: zml.Bufferized(zml.attention.attention.Metadata) =
-                self.decode_attention_metadata_buffers orelse self.attention_metadata_buffers;
 
             try self.decode_runner.run(.{
                 .allocator = self.allocator,

--- a/examples/llm/models/llama/session.zig
+++ b/examples/llm/models/llama/session.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 
 const zml = @import("zml");
+const attention = zml.attention.attention;
 
 const inference = @import("inference.zig");
 const model = @import("model.zig");
@@ -161,17 +162,19 @@ pub const Session = struct {
         var prefill_tokens_buffer: zml.Buffer = try .fromSlice(self.io, self.platform, prefill_tokens_slice, .replicated);
         defer prefill_tokens_buffer.deinit();
 
-        var num_tokens_buffer: zml.Buffer = try .scalar(self.io, self.platform, all_tokens.len, .u32);
-        defer num_tokens_buffer.deinit();
-
-        const attention_metadata_buffers: zml.Bufferized(zml.attention.attention.Metadata) = switch (self.compiled_model.params.prefill_attention_parameters) {
+        var attention_metadata_buffers: zml.Bufferized(attention.Metadata) = switch (self.compiled_model.params.prefill_attention_parameters) {
             .attnd => .{ .attnd = .{
-                .conversation_id = try zml.Buffer.scalar(self.io, self.platform, self.conversation_id, .u64),
-                .layer_id = try zml.Buffer.scalar(self.io, self.platform, 0, .u16),
-                .num_tokens = try zml.Buffer.scalar(self.io, self.platform, all_tokens.len, .u32),
+                .conversation_id = try .scalar(self.io, self.platform, self.conversation_id, .u64),
+                .layer_id = try .scalar(self.io, self.platform, 0, .u16),
+                .num_tokens = try .scalar(self.io, self.platform, all_tokens.len, .u32),
             } },
-            .metal_fa => .{ .metal_fa = .{ .num_tokens = num_tokens_buffer } },
+            .metal_fa => .{ .metal_fa = .{ .num_tokens = try .scalar(self.io, self.platform, all_tokens.len, .u32) } },
             .vanilla, .cuda_fa2, .cuda_fa3, .nki => self.attention_metadata_buffers,
+        };
+
+        defer switch (self.compiled_model.params.prefill_attention_parameters) {
+            .attnd, .metal_fa => attention.Metadata.deinitBuffer(&attention_metadata_buffers),
+            .vanilla, .cuda_fa2, .cuda_fa3, .nki => {},
         };
 
         try self.compiled_model.prefill.run(.{

--- a/platforms/metal/metal.bzl
+++ b/platforms/metal/metal.bzl
@@ -4,8 +4,8 @@ def _metal_impl(mctx):
     http_archive(
         name = "libpjrt_metal",
         build_file = "libpjrt_metal.BUILD.bazel",
-        sha256 = "a94aaf5719fe14b2e1fd4e614df9e916443b778ced453eebea419ee479f245aa",
-        url = "https://github.com/zml/pjrt-artifacts/releases/download/manual-2026-06-23T00-20-00Z/pjrt-metal_macos-arm64.tar.zst",
+        sha256 = "f55356328d9d814c5a961b6c38741cff2f98b4043846a7ac3865e2a23549b767",
+        url = "https://github.com/zml/pjrt-artifacts/releases/download/manual-2026-06-30T00-16-30Z/pjrt-metal_macos-arm64.tar.zst",
     )
 
     return mctx.extension_metadata(

--- a/zml/attention/attention.zig
+++ b/zml/attention/attention.zig
@@ -86,7 +86,7 @@ pub const MetalFaMetadata = struct {
     pub fn initBuffer(self: MetalFaMetadata, io: std.Io, platform: *const zml.Platform, sharding: zml.Sharding) !zml.Bufferized(MetalFaMetadata) {
         _ = self;
         _ = sharding;
-        return .{ .num_tokens = try zml.Buffer.scalar(io, platform, 1, .u32) };
+        return .{ .num_tokens = try zml.Buffer.scalar(io, platform, 0, .u32) };
     }
 
     pub fn deinitBuffer(self: *zml.Bufferized(MetalFaMetadata)) void {


### PR DESCRIPTION
- Bump Metal plugin version
- Drop the attention metadata fields from the llama and lfm2 Sessions. Prefill and decode now each build their own metadata inline and free it.