### PR TITLE
pjrt: fix misleading pjrt plugin load success log

### DIFF
--- a/pjrt/pjrt.zig
+++ b/pjrt/pjrt.zig
@@ -99,7 +99,6 @@ pub const Api = struct {
     pub fn loadFrom(library: [:0]const u8) !*const Api {
         const basename = std.Io.Dir.path.basename(library);
         log.info("Loading: {s}...", .{basename});
-        defer log.info("Loaded: {s}", .{basename});
 
         var lib: std.DynLib = switch (builtin.os.tag) {
             .linux, .macos => blk: {
@@ -124,16 +123,21 @@ pub const Api = struct {
             },
         };
 
-        return fromDynLib(&lib);
+        const api = fromDynLib(&lib) catch |err| {
+            log.err("Unable to load PJRT API from plugin: {s}: {}", .{ library, err });
+            return err;
+        };
+        log.info("Loaded: {s}", .{basename});
+        return api;
     }
 
     pub fn fromDynLib(lib: *std.DynLib) !*const Api {
         const DynGetPjrtApi = lib.lookup(*const fn () callconv(.c) *const Api, "GetPjrtApi") orelse {
-            std.debug.panic("Unable to find GetPjrtApi symbol in library", .{});
+            return error.MissingGetPjrtApi;
         };
 
         const api = DynGetPjrtApi();
-        _ = api.call(.PJRT_Plugin_Initialize, .{}) catch unreachable;
+        _ = try api.call(.PJRT_Plugin_Initialize, .{});
 
         return api;
     }


### PR DESCRIPTION
Move the PJRT plugin “Loaded” log so it is only emitted after the dynamic library `.so` is opened and the PJRT API is initialized successfully.

Previously, `Api.loadFrom` used a `defer` for the success log. Failed plugin load attempts could still print `Loaded: ...`. This was misleading during platform auto-detection, for example when probing TPU before falling back to CUDA. Example:

```
2026-07-01 13:12:17   ███████╗███╗   ███╗██╗             ██╗    ██╗     ██╗     ███╗   ███╗██████╗
2026-07-01 13:12:17   ╚══███╔╝████╗ ████║██║            ██╔╝    ██║     ██║     ████╗ ████║██╔══██╗
2026-07-01 13:12:17     ███╔╝ ██╔████╔██║██║           ██╔╝     ██║     ██║     ██╔████╔██║██║  ██║
2026-07-01 13:12:17    ███╔╝  ██║╚██╔╝██║██║  .ai     ██╔╝      ██║     ██║     ██║╚██╔╝██║██║  ██║
2026-07-01 13:12:17   ███████╗██║ ╚═╝ ██║███████╗    ██╔╝       ███████╗███████╗██║ ╚═╝ ██║██████╔╝
2026-07-01 13:12:17   ╚══════╝╚═╝     ╚═╝╚══════╝    ╚═╝        ╚══════╝╚══════╝╚═╝     ╚═╝╚═════╝
2026-07-01 13:12:17                                                          Copyright (c) 2026 ZML
2026-07-01 13:12:17 warning(zml/io/vfs/s3): S3 initialized without full credentials (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY). Access will be unauthenticated. Using default endpoint: https://s3.amazonaws.com (set AWS_ENDPOINT_URL or AWS_ENDPOINT_URL_S3). Using default region: us-east-1 (set AWS_REGION or AWS_DEFAULT_REGION).
2026-07-01 13:12:17 info(pjrt): Loading: libpjrt_tpu.so...
2026-07-01 13:12:17 info(llmd): Loading tokenizer
2026-07-01 13:12:17 error(pjrt): Unable to dlopen plugin: /llmd/llmd.runfiles/zml++tpu_packages+libpjrt_tpu/sandbox/lib/libpjrt_tpu.so
2026-07-01 13:12:17 info(pjrt): Loaded: libpjrt_tpu.so           #################### HERE ####################
2026-07-01 13:12:17 info(llmd): Resolving model repo
2026-07-01 13:12:17 info(llmd): Loading model config
2026-07-01 13:12:17 info(llmd): Loaded model config [67.405ms]
2026-07-01 13:12:18 info(pjrt): Loading: libpjrt_cuda.so...
2026-07-01 13:12:18 warning(zml/platforms/cuda): Detected NVIDIA GPU that requires CUDA compatibility libraries.
2026-07-01 13:12:18 info(zml/platforms/cuda): Loaded CUDA compatibility libraries.
2026-07-01 13:12:18 info(pjrt): Loaded: libpjrt_cuda.so
2026-07-01 13:12:18 info(llmd): Loaded tokenizer [334.168ms]
2026-07-01 13:12:20 info(llmd): Devices:
2026-07-01 13:12:20 info(llmd):         - NVIDIA RTX PRO 6000 Blackwell Server Edition (cuda:0)
2026-07-01 13:12:20 info: Using 31711 pages for the KvCache
2026-07-01 13:12:20 info: sizes: { 256 }
2026-07-01 13:12:27 info: Compiled all models [7.336s]
2026-07-01 13:12:50 info: Listening on 0.0.0.0:8000
2026-07-01 13:12:50 info(llama): Loaded weights [14.96GiB, 22.778s, 672.41MiB/s]
```

Moreover make `fromDynLib` return errors for missing `GetPjrtApi` and failed `PJRT_Plugin_Initialize` instead of panicking or using `catch unreachable`. So that `Api.loadFrom()` can catch it. 

After the change, the output is:
```
2026-07-01 14:50:50   ███████╗███╗   ███╗██╗             ██╗    ██╗     ██╗     ███╗   ███╗██████╗
2026-07-01 14:50:50   ╚══███╔╝████╗ ████║██║            ██╔╝    ██║     ██║     ████╗ ████║██╔══██╗
2026-07-01 14:50:50     ███╔╝ ██╔████╔██║██║           ██╔╝     ██║     ██║     ██╔████╔██║██║  ██║
2026-07-01 14:50:50    ███╔╝  ██║╚██╔╝██║██║  .ai     ██╔╝      ██║     ██║     ██║╚██╔╝██║██║  ██║
2026-07-01 14:50:50   ███████╗██║ ╚═╝ ██║███████╗    ██╔╝       ███████╗███████╗██║ ╚═╝ ██║██████╔╝
2026-07-01 14:50:50   ╚══════╝╚═╝     ╚═╝╚══════╝    ╚═╝        ╚══════╝╚══════╝╚═╝     ╚═╝╚═════╝
2026-07-01 14:50:50                                                          Copyright (c) 2026 ZML
2026-07-01 14:50:51 warning(zml/io/vfs/s3): S3 initialized without full credentials (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY). Access will be unauthenticated. Using default endpoint: https://s3.amazonaws.com (set AWS_ENDPOINT_URL or AWS_ENDPOINT_URL_S3). Using default region: us-east-1 (set AWS_REGION or AWS_DEFAULT_REGION).
2026-07-01 14:50:51 info(llmd): Resolving model repo
2026-07-01 14:50:51 info(llmd): Loading model config
2026-07-01 14:50:51 info(llmd): Loaded model config [101.024ms]
2026-07-01 14:50:51 info(llmd): Loading tokenizer
2026-07-01 14:50:51 info(pjrt): Loading: libpjrt_tpu.so...
2026-07-01 14:50:51 error(pjrt): Unable to dlopen plugin: /llmd/llmd.runfiles/zml++tpu_packages+libpjrt_tpu/sandbox/lib/libpjrt_tpu.so
2026-07-01 14:50:52 info(llmd): Loaded tokenizer [349.499ms]
2026-07-01 14:50:53 info(pjrt): Loading: libpjrt_cuda.so...
2026-07-01 14:50:53 warning(zml/platforms/cuda): Detected NVIDIA GPU that requires CUDA compatibility libraries.
2026-07-01 14:50:53 info(zml/platforms/cuda): Loaded CUDA compatibility libraries.
2026-07-01 14:51:11 info(pjrt): Loaded: libpjrt_cuda.so
2026-07-01 14:51:14 info: Using 31711 pages for the KvCache
2026-07-01 14:51:14 info: sizes: { 256 }
2026-07-01 14:51:14 info(llmd): Devices:
2026-07-01 14:51:14 info(llmd):         - NVIDIA RTX PRO 6000 Blackwell Server Edition (cuda:0)
2026-07-01 14:51:22 info: Compiled all models [8.395s]
2026-07-01 14:51:46 info: Listening on 0.0.0.0:8000
2026-07-01 14:51:46 info(llama): Loaded weights [14.96GiB, 23.629s, 648.20MiB/s]
```
