### PR TITLE
workspace: replace deprecated new_git_repository

### DIFF
--- a/third_party/arocc/repo.bzl
+++ b/third_party/arocc/repo.bzl
@@ -1,7 +1,7 @@
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def repo():
-    new_git_repository(
+    git_repository(
         name = "arocc",
         remote = "https://github.com/Vexu/arocc.git",
         commit = "5f5a050569a95ecc40a426f0c3666ae7ef987ede",

--- a/third_party/libvaxis/repo.bzl
+++ b/third_party/libvaxis/repo.bzl
@@ -1,7 +1,7 @@
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def repo():
-    new_git_repository(
+    git_repository(
         name = "libvaxis",
         remote = "https://github.com/rockorager/libvaxis.git",
         commit = "a3ae1d53feeeeaeb6218de3d38837559811acae4",

--- a/third_party/linenoise/repo.bzl
+++ b/third_party/linenoise/repo.bzl
@@ -1,7 +1,7 @@
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def repo():
-    new_git_repository(
+    git_repository(
         name = "linenoise",
         remote = "https://github.com/antirez/linenoise.git",
         commit = "dc83cc373ac2058030eb3cf5e404959a26fef112",

--- a/third_party/translate-c/repo.bzl
+++ b/third_party/translate-c/repo.bzl
@@ -1,7 +1,7 @@
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def repo():
-    new_git_repository(
+    git_repository(
         name = "translate-c",
         remote = "https://codeberg.org/ziglang/translate-c",
         commit = "46b5609b5ac4c0a896217d1d984f3ae50e4810b5",


### PR DESCRIPTION
## Summary

- replace the legacy `new_git_repository` alias with `git_repository` for `arocc`, `libvaxis`, `linenoise`, and `translate-c`

## Why

`git_repository` is the canonical Bazel repository rule. `new_git_repository` doesn't exist at bazel HEAD