### PR TITLE
build: disable default Xcode discovery

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -77,6 +77,7 @@ common          --workspace_status_command=./tools/workspace_status.sh
 common          --@rules_cc//cc/toolchains/args/archiver_flags:use_libtool_on_macos=false
 common          --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 common          --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
+common          --xcode_version_config=//:disable_xcode
 
 # Required for protobuf upb on Linux
 common:linux    --copt=-fPIC

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,12 @@
-load("@rules_zig//zig/zls:zls_completion.bzl", "zls_completion")
+load("@@apple_support+//xcode:xcode_config.bzl", "xcode_config")
 load("@rules_zig//zig/translate-c:toolchain.bzl", "translate_c_toolchain")
+load("@rules_zig//zig/zls:zls_completion.bzl", "zls_completion")
+
+# Dummy xcode_config so we don't need to build xcode_locator in the repository rule.
+xcode_config(
+    name = "disable_xcode",
+    visibility = ["//visibility:public"],
+)
 
 alias(
     name = "translate-c",


### PR DESCRIPTION
Define the public `//:disable_xcode` `xcode_config` target and select it with `common --xcode_version_config=//:disable_xcode`. This prevents `zig_binary` targets from resolving Bazel's default `@bazel_tools//tools/cpp:host_xcodes` alias, so configured analysis does not realize `local_config_xcode` or build `xcode_locator` when ZML does not need Xcode discovery.

Validation:

- `buildifier -mode=check BUILD.bazel`
- pinned Bazel `query --lockfile_mode=off //:disable_xcode`
- pinned Bazel `cquery --lockfile_mode=off --config=remote --platforms=//platforms:linux_amd64 --@zml//platforms:cuda=true //:disable_xcode`
