### PR TITLE
zml/vfs: treat scheme:// paths as absolute in the router

### DIFF
--- a/zml/io/vfs.zig
+++ b/zml/io/vfs.zig
@@ -137,6 +137,20 @@ pub const VFS = struct {
     }
 
     fn lookupDir(self: *VFS, dir: std.Io.Dir, sub_path: ?[]const u8) !struct { ?usize, std.Io.Dir, std.Io } {
+        // A scheme-qualified path (e.g. "hf://owner/model/file") is absolute: it
+        // is resolved from the scheme's root regardless of `dir`. Without this,
+        // opening such a path relative to an already-open dir of the same
+        // backend double-prefixes the dir's path.
+        if (sub_path) |sp| {
+            if (std.mem.indexOf(u8, sp, "://") != null) {
+                const uri = std.Uri.parse(sp) catch return error.VFSNotRegistered;
+                const backend_idx: usize = for (self.backends.entries.items(.key), 0..) |s, idx| {
+                    if (std.mem.eql(u8, uri.scheme, s)) break idx;
+                } else return error.VFSNotRegistered;
+                return .{ backend_idx, std.Io.Dir.cwd(), self.getBackend(backend_idx) };
+            }
+        }
+
         if (std.meta.eql(dir, std.Io.Dir.cwd())) {
             if (sub_path == null) return .{ null, dir, self.base.inner };
             if (std.fs.path.isAbsolutePosix(sub_path.?)) return .{ null, dir, self.base.inner };


### PR DESCRIPTION
## The bug

In the VFS router, a scheme-qualified path like `hf://owner/model/file` is meant to be absolute: it should resolve from the scheme's root. But `lookupDir` only treated it as absolute when the base directory was `cwd`.

When such a path is opened *relative to an already-open directory* of the same backend, the router kept the directory's path and glued the new path after it, duplicating it. So `hf://owner/model` + `hf://owner/model/file` became `owner/model/owner/model/file`, and the lookup failed with `FileNotFound`.

## Why it matters

That is exactly the pattern `safetensors.fromPath` uses: it opens the model directory (`hf://owner/model`), then opens the full file path (`hf://owner/model/file.safetensors`) under it. The doubled path meant **no `hf://` model could be loaded** through `zml.io`.

## The fix

In `lookupDir`, any `scheme://` sub-path resolves from the scheme's root regardless of the base directory, the same way an absolute POSIX path already does. About four lines.