### PR TITLE
zml/tensor: fix IRFFT output shape

### DIFF
--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -559,24 +559,59 @@ pub const Tensor = struct {
                     .f32 => .c64,
                     else => .c128,
                 };
-                const shape_ = self._shape.setDim(-1, @divExact(self.dim(-1), 2) + 1);
+                const shape_ = self._shape.setDim(-1, rfftOutputLen(self.dim(-1)));
                 break :blk shape_.withDtype(dt);
             },
             .IRFFT => blk: {
                 stdx.debug.assert(self.dtype().isComplex(), "fft({any}) expects tensor type to be complex, got {}", .{ opts, self.dtype() });
-                stdx.debug.assert(std.mem.eql(i64, self.dims()[self.rank() - opts.length.len ..], opts.length), "fft({any}) expects tensor last dimensions to match given lengths, got {} and {}", .{ opts, self.dims()[self.rank() - opts.length.len ..].len, opts.length.len });
+                const fft_dims = self.dims()[self.rank() - opts.length.len ..];
+                const fft_last_dim_index = opts.length.len - 1;
+                stdx.debug.assert(std.mem.eql(i64, fft_dims[0..fft_last_dim_index], opts.length[0..fft_last_dim_index]), "fft({any}) expects non-innermost tensor FFT dimensions to match given lengths, got {any} and {any}", .{ opts, fft_dims[0..fft_last_dim_index], opts.length[0..fft_last_dim_index] });
+                stdx.debug.assert(self.dim(-1) == rfftOutputLen(opts.length[fft_last_dim_index]), "fft({any}) expects IRFFT innermost dimension to match the RFFT output length, got {} for FFT length {}", .{ opts, self.dim(-1), opts.length[fft_last_dim_index] });
 
                 const dt: DataType = switch (self.dtype()) {
                     .c64 => .f32,
                     else => .f64,
                 };
-                const shape_ = self._shape.setDim(-1, @divExact(self.dim(-1) - 1, 2));
+                const shape_ = self._shape.setDim(-1, opts.length[fft_last_dim_index]);
                 break :blk shape_.withDtype(dt);
             },
         };
 
         const op = dialects.stablehlo.fft(mlirCtx(), self.value(), opts, .unknown(mlirCtx())).appendTo(currentBlock());
         return _result(sh, op.result(0));
+    }
+
+    fn rfftOutputLen(input_len: i64) i64 {
+        const rfft_len_divisor = 2;
+        const rfft_edge_bin_count = 1;
+        return @divTrunc(input_len, rfft_len_divisor) + rfft_edge_bin_count;
+    }
+
+    test "Tensor.fft IRFFT restores RFFT last dimension" {
+        const zml = @import("zml.zig");
+        const platform = zml.testing.env();
+        const rfft_input_len: i64 = 10;
+
+        const Local = struct {
+            pub fn _fwd(x: Tensor) Tensor {
+                const freq = x.fft(.{ .kind = .RFFT, .length = &.{rfft_input_len} });
+                std.debug.assert(freq.dim(-1) == rfftOutputLen(rfft_input_len));
+                const time = freq.fft(.{ .kind = .IRFFT, .length = &.{rfft_input_len} });
+                std.debug.assert(time.dim(-1) == x.dim(-1));
+                return time;
+            }
+        };
+
+        var exe = try zml.module.compile(
+            std.testing.allocator,
+            std.testing.io,
+            Local._fwd,
+            .{Tensor.init(.{rfft_input_len}, .f32)},
+            platform,
+            .{},
+        );
+        defer exe.deinit();
     }
 
     pub const Rng = struct {


### PR DESCRIPTION
## Summary

Fix IRFFT shape inference so it uses the requested FFT output length and validates that the complex input length matches the corresponding RFFT output length.

Fixes #411.

## Why

RFFT changes the innermost real dimension `n` into `n / 2 + 1` complex bins. IRFFT receives those complex bins plus the requested real FFT length, so its output shape should restore that requested length instead of deriving a smaller value from the complex input dimension.

## Test verification (RED -> GREEN)

Command used for all runs:

```bash
npx -y @bazel/bazelisk@1.25.0 test //zml:test --test_output=errors
```

RED, with the new regression test before the fix:

```text
102/139 tensor.Tensor.test.Tensor.fft IRFFT restores RFFT last dimension...thread 1701155 panic: exact division produced remainder
INFO: Build completed, 1 test FAILED, 5355 total actions
//zml:test                                                               FAILED in 24.9s
Executed 1 out of 1 test: 1 fails locally.
```

GREEN, with the fix applied:

```text
INFO: Build completed successfully, 6 total actions
//zml:test                                                               PASSED in 8.1s
Executed 1 out of 1 test: 1 test passes.
```

Revert RED, with the production fix reverted while keeping the test:

```text
102/139 tensor.Tensor.test.Tensor.fft IRFFT restores RFFT last dimension...thread 1711292 panic: fft(.{ .kind = .IRFFT, .length = { 10 } }) expects tensor last dimensions to match given lengths, got 1 and 1
INFO: Build completed, 1 test FAILED, 6 total actions
//zml:test                                                               FAILED in 22.9s
Executed 1 out of 1 test: 1 fails locally.
```

## Additional checks

```text
zig fmt --check zml/tensor.zig
fmt_status=0
```