### PR TITLE
zml/tensor: respect tags in broad

### DIFF
--- a/zml/shape.zig
+++ b/zml/shape.zig
@@ -548,6 +548,10 @@ pub const Shape = struct {
 
     /// Broadcasts a Tensor to the given shape, extending dimensions if needed.
     pub fn canBroadcastTo(self: Shape, other: Shape) bool {
+        if (self.isFullyTagged() and other.isFullyTagged()) {
+            return self.canBroadcastToTagged(other);
+        }
+
         // Already the right shape
         if (std.mem.eql(i64, self.dims(), other.dims())) return true;
 
@@ -567,6 +571,24 @@ pub const Shape = struct {
             if (d != 1 and d != other.dim(other_ax)) return false;
         }
         return true;
+    }
+
+    fn canBroadcastToTagged(self: Shape, other: Shape) bool {
+        for (self.dims(), self.tags()) |d, t| {
+            const other_ax = other.hasTag(t) orelse return false;
+            if (d != 1 and d != other.dim(other_ax)) return false;
+        }
+        return true;
+    }
+
+    test "canBroadcastTo rejects fully tagged positional mismatch" {
+        const batch_len = 8;
+        const singleton_len = 1;
+        const hidden_len = 16;
+        const source = Shape.init(.{ .a = batch_len, .l = singleton_len, .k = hidden_len }, .f32);
+        const target = Shape.init(.{ .a = batch_len, .k = hidden_len, .v = hidden_len }, .f32);
+
+        try testing.expect(!source.canBroadcastTo(target));
     }
 
     pub fn reshape(self: Shape, new_shape_: anytype) Shape {

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -2444,10 +2444,15 @@ pub const Tensor = struct {
         // Note: if you code below, make sure to update Shape.canBroadcastTo.
         stdx.debug.assert(self._shape.canBroadcastTo(other), "Can't broadcast {f} to {f}", .{ self, other });
 
+        if (ops.LoweringCompatibility.preserveIntegerScalarBroadcast(self, other)) |rewritten| return rewritten;
+
+        if (shouldUseTaggedBroadcast(self._shape, other)) {
+            const axes_ = self.broadcastAxesForTags(other);
+            return self.broadcast(other, axes_.constSlice());
+        }
+
         // Already the right shape
         if (std.mem.eql(i64, self.dims(), other.dims())) return self;
-
-        if (ops.LoweringCompatibility.preserveIntegerScalarBroadcast(self, other)) |rewritten| return rewritten;
 
         // Non ambiguous broadcasting
         // TODO: broad is error prone because of this:
@@ -2462,6 +2467,54 @@ pub const Tensor = struct {
             axes_.appendAssumeCapacity(@intCast(other.axis(t)));
         }
         return self.broadcast(other, axes_.constSlice());
+    }
+
+    fn shouldUseTaggedBroadcast(self_shape: Shape, other: Shape) bool {
+        return self_shape.rank() != 0 and self_shape.isFullyTagged() and other.isFullyTagged();
+    }
+
+    fn broadcastAxesForTags(self: Tensor, other: Shape) stdx.BoundedArray(i64, constants.MAX_RANK) {
+        var axes_: stdx.BoundedArray(i64, constants.MAX_RANK) = .empty;
+        for (self._shape.tags()) |t| {
+            axes_.appendAssumeCapacity(@intCast(other.axis(t)));
+        }
+        return axes_;
+    }
+
+    test "Tensor.broad does not route rank-0 scalars through tagged broadcast" {
+        const batch_len = 8;
+        const scalar_shape = Shape.init(.{}, .i32);
+        const tagged = Shape.init(.{ .a = batch_len }, .i32);
+
+        try std.testing.expect(!shouldUseTaggedBroadcast(scalar_shape, tagged));
+    }
+
+    test "Tensor.broad maps fully tagged axes by tag" {
+        const zml = @import("zml.zig");
+        const platform = zml.testing.env();
+
+        const Local = struct {
+            const batch_len = 8;
+            const singleton_len = 1;
+            const hidden_len = 16;
+
+            pub fn _fwd(x: Tensor) Tensor {
+                const target = Shape.init(.{ .k = hidden_len, .a = batch_len }, .f32);
+                const res = x.broad(target);
+                std.debug.assert(res.shape().eql(target));
+                return res;
+            }
+        };
+
+        var exe = try zml.module.compile(
+            std.testing.allocator,
+            std.testing.io,
+            Local._fwd,
+            .{Tensor.init(.{ .a = Local.singleton_len, .k = Local.hidden_len }, .f32)},
+            platform,
+            .{},
+        );
+        defer exe.deinit();
     }
 
     pub fn optimizationBarrier(self: Tensor) Tensor {


### PR DESCRIPTION
## Summary

Make `Tensor.broad` respect tags when both input and output shapes are fully tagged, and make `Shape.canBroadcastTo` reject fully tagged positional matches that do not map by tag.

## Issues

Fix #68

## Why

The issue case `.{ .a = 8, .l = 1, .k = 16 }.broad(.{ .a = 8, .k = 16, .v = 16 })` was accepted by positional broadcasting even though the tags do not describe the same axes. Fully tagged shapes should match and broadcast by tag, not by position.

The implementation keeps the integer scalar broadcast compatibility hook ahead of tagged broadcasting and excludes rank-0 shapes from the tagged branch so backend compatibility behavior is preserved.

## Test verification (RED -> GREEN)

Command: `./bazel.sh test //zml:test`

RED with the production fix reverted while keeping the new tests:

```text
53/142 shape.Shape.test.canBroadcastTo rejects fully tagged positional mismatch...FAIL (TestUnexpectedResult)
114/142 tensor.Tensor.test.Tensor.broad maps fully tagged axes by tag...thread ... panic: Can't broadcast Tensor({a=1,k=16,f32}) to {k=16,a=8,f32}
//zml:test                                                               FAILED in 23.5s
Executed 1 out of 1 test: 1 fails locally.
```

GREEN on the final branch:

```text
INFO: Build completed successfully, 6 total actions
//zml:test                                                               PASSED in 7.5s
Executed 1 out of 1 test: 1 test passes.
```