### PR TITLE
bin/zml-smi: fix memory & compute over-reporting for oneapi

### DIFF
--- a/bin/zml-smi/platforms/oneapi/monitor.zig
+++ b/bin/zml-smi/platforms/oneapi/monitor.zig
@@ -243,7 +243,7 @@ pub fn collectProcessUsage(allocator: std.mem.Allocator, io: std.Io, devices: []
     var result: ProcessUsage = .{};
     errdefer result.deinit(allocator);
 
-    var seen_device_clients: std.AutoHashMapUnmanaged(u128, void) = .{};
+    var seen_device_clients: std.AutoHashMapUnmanaged(struct { u16, u64 }, void) = .{};
     defer seen_device_clients.deinit(allocator);
 
     var proc_dir = try std.Io.Dir.openDirAbsolute(io, "/proc", .{ .iterate = true });
@@ -270,7 +270,7 @@ pub fn collectProcessUsage(allocator: std.mem.Allocator, io: std.Io, devices: []
             // Skip fd if DRM client has been seen for this device.
             // Summing after dup() / fork() over-reports memory and compute.
             if (parsed.drm_client_id) |cid| {
-                if (try markDrmClientSeen(allocator, &seen_device_clients, dev_idx, cid)) continue;
+                if ((try seen_device_clients.getOrPut(allocator, .{ dev_idx, cid })).found_existing) continue;
             }
 
             const key = processKey(pid, dev_idx);
@@ -671,19 +671,6 @@ fn processKey(pid: u32, device_idx: u16) u64 {
     return (@as(u64, device_idx) << 32) | pid;
 }
 
-inline fn drmClientKey(device_idx: u16, client_id: u64) u128 {
-    return (@as(u128, device_idx) << 64) | @as(u128, client_id);
-}
-
-fn markDrmClientSeen(
-    allocator: std.mem.Allocator,
-    seen_device_clients: *std.AutoHashMapUnmanaged(u128, void),
-    device_idx: u16,
-    client_id: u64,
-) !bool {
-    return (try seen_device_clients.getOrPut(allocator, drmClientKey(device_idx, client_id))).found_existing;
-}
-
 pub const BdfParts = struct {
     domain: u32,
     bus: u32,
@@ -817,13 +804,13 @@ test "oneAPI fdinfo parser falls back to total vram" {
 }
 
 test "oneAPI DRM clients dedup per device" {
-    var seen_device_clients: std.AutoHashMapUnmanaged(u128, void) = .{};
+    var seen_device_clients: std.AutoHashMapUnmanaged(struct { u16, u64 }, void) = .{};
     defer seen_device_clients.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(false, try markDrmClientSeen(std.testing.allocator, &seen_device_clients, 0, 42));
-    try std.testing.expectEqual(true, try markDrmClientSeen(std.testing.allocator, &seen_device_clients, 0, 42));
-    try std.testing.expectEqual(false, try markDrmClientSeen(std.testing.allocator, &seen_device_clients, 1, 42));
-    try std.testing.expectEqual(false, try markDrmClientSeen(std.testing.allocator, &seen_device_clients, 0, 43));
+    try std.testing.expectEqual(false, (try seen_device_clients.getOrPut(std.testing.allocator, .{ 0, 42 })).found_existing);
+    try std.testing.expectEqual(true, (try seen_device_clients.getOrPut(std.testing.allocator, .{ 0, 42 })).found_existing);
+    try std.testing.expectEqual(false, (try seen_device_clients.getOrPut(std.testing.allocator, .{ 1, 42 })).found_existing);
+    try std.testing.expectEqual(false, (try seen_device_clients.getOrPut(std.testing.allocator, .{ 0, 43 })).found_existing);
 }
 
 test "oneAPI process utilization delta" {

--- a/bin/zml-smi/platforms/oneapi/monitor.zig
+++ b/bin/zml-smi/platforms/oneapi/monitor.zig
@@ -243,8 +243,8 @@ pub fn collectProcessUsage(allocator: std.mem.Allocator, io: std.Io, devices: []
     var result: ProcessUsage = .{};
     errdefer result.deinit(allocator);
 
-    var seen_clients: std.AutoHashMapUnmanaged(u64, void) = .{};
-    defer seen_clients.deinit(allocator);
+    var seen_device_clients: std.AutoHashMapUnmanaged(u128, void) = .{};
+    defer seen_device_clients.deinit(allocator);
 
     var proc_dir = try std.Io.Dir.openDirAbsolute(io, "/proc", .{ .iterate = true });
     defer proc_dir.close(io);
@@ -267,9 +267,10 @@ pub fn collectProcessUsage(allocator: std.mem.Allocator, io: std.Io, devices: []
             const bus_device_identifier = parsed.bus_device_identifier orelse continue;
             const dev_idx = matchDevice(devices, bus_device_identifier) orelse continue;
 
-            // Skip fd if DRM client has been seen. Summing after dup() / fork() over-reports memory and compute.
+            // Skip fd if DRM client has been seen for this device.
+            // Summing after dup() / fork() over-reports memory and compute.
             if (parsed.drm_client_id) |cid| {
-                if ((try seen_clients.getOrPut(allocator, cid)).found_existing) continue;
+                if (try markDrmClientSeen(allocator, &seen_device_clients, dev_idx, cid)) continue;
             }
 
             const key = processKey(pid, dev_idx);
@@ -670,6 +671,19 @@ fn processKey(pid: u32, device_idx: u16) u64 {
     return (@as(u64, device_idx) << 32) | pid;
 }
 
+inline fn drmClientKey(device_idx: u16, client_id: u64) u128 {
+    return (@as(u128, device_idx) << 64) | @as(u128, client_id);
+}
+
+fn markDrmClientSeen(
+    allocator: std.mem.Allocator,
+    seen_device_clients: *std.AutoHashMapUnmanaged(u128, void),
+    device_idx: u16,
+    client_id: u64,
+) !bool {
+    return (try seen_device_clients.getOrPut(allocator, drmClientKey(device_idx, client_id))).found_existing;
+}
+
 pub const BdfParts = struct {
     domain: u32,
     bus: u32,
@@ -800,6 +814,16 @@ test "oneAPI fdinfo parser falls back to total vram" {
     finishFdinfo(&parsed);
 
     try std.testing.expectEqual(@as(?u64, 2048), parsed.sample.mem_kib);
+}
+
+test "oneAPI DRM clients dedup per device" {
+    var seen_device_clients: std.AutoHashMapUnmanaged(u128, void) = .{};
+    defer seen_device_clients.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(false, try markDrmClientSeen(std.testing.allocator, &seen_device_clients, 0, 42));
+    try std.testing.expectEqual(true, try markDrmClientSeen(std.testing.allocator, &seen_device_clients, 0, 42));
+    try std.testing.expectEqual(false, try markDrmClientSeen(std.testing.allocator, &seen_device_clients, 1, 42));
+    try std.testing.expectEqual(false, try markDrmClientSeen(std.testing.allocator, &seen_device_clients, 0, 43));
 }
 
 test "oneAPI process utilization delta" {

--- a/bin/zml-smi/platforms/oneapi/monitor.zig
+++ b/bin/zml-smi/platforms/oneapi/monitor.zig
@@ -243,6 +243,9 @@ pub fn collectProcessUsage(allocator: std.mem.Allocator, io: std.Io, devices: []
     var result: ProcessUsage = .{};
     errdefer result.deinit(allocator);
 
+    var seen_clients: std.AutoHashMapUnmanaged(u64, void) = .{};
+    defer seen_clients.deinit(allocator);
+
     var proc_dir = try std.Io.Dir.openDirAbsolute(io, "/proc", .{ .iterate = true });
     defer proc_dir.close(io);
 
@@ -263,6 +266,12 @@ pub fn collectProcessUsage(allocator: std.mem.Allocator, io: std.Io, devices: []
             const parsed = parseFdinfoFile(io, file_path, now_ns) catch continue;
             const bus_device_identifier = parsed.bus_device_identifier orelse continue;
             const dev_idx = matchDevice(devices, bus_device_identifier) orelse continue;
+
+            // Skip fd if DRM client has been seen. Summing after dup() / fork() over-reports memory and compute.
+            if (parsed.drm_client_id) |cid| {
+                if ((try seen_clients.getOrPut(allocator, cid)).found_existing) continue;
+            }
+
             const key = processKey(pid, dev_idx);
             const gop = try result.getOrPut(allocator, key);
             if (!gop.found_existing) {
@@ -505,6 +514,7 @@ const FdinfoSample = struct {
 
 const ParsedFdinfo = struct {
     bus_device_identifier: ?[bus_device_identifier_len]u8 = null,
+    drm_client_id: ?u64 = null,
     sample: FdinfoSample = .{},
     resident_vram_kib: u64 = 0,
     total_vram_kib: u64 = 0,
@@ -552,6 +562,11 @@ inline fn finishFdinfo(self: *ParsedFdinfo) void {
 inline fn parseFdinfoLine(parsed: *ParsedFdinfo, line: []const u8, timestamp_ns: u64) void {
     if (std.mem.startsWith(u8, line, "drm-pdev:")) {
         parsed.bus_device_identifier = parseBdf(line["drm-pdev:".len..]);
+        return;
+    }
+
+    if (std.mem.startsWith(u8, line, "drm-client-id:")) {
+        parsed.drm_client_id = firstInt(line["drm-client-id:".len..]);
         return;
     }
 
@@ -715,6 +730,7 @@ inline fn containsAsciiIgnoreCase(haystack: []const u8, needle: []const u8) bool
 test "oneAPI fdinfo parser" {
     var parsed: ParsedFdinfo = .{};
     parseFdinfoLine(&parsed, "drm-pdev:\t0000:03:00.0", 10);
+    parseFdinfoLine(&parsed, "drm-client-id:\t42", 10);
     parseFdinfoLine(&parsed, "drm-total-memory:\t2048 KiB", 10);
     parseFdinfoLine(&parsed, "drm-engine-render:\t100 ns", 10);
     parseFdinfoLine(&parsed, "drm-engine-compute:\t50 ns", 10);
@@ -722,6 +738,7 @@ test "oneAPI fdinfo parser" {
 
     try std.testing.expect(parsed.bus_device_identifier != null);
     try std.testing.expectEqualSlices(u8, "0000:03:00.0", &parsed.bus_device_identifier.?);
+    try std.testing.expectEqual(@as(?u64, 42), parsed.drm_client_id);
     try std.testing.expectEqual(@as(?u64, 2048), parsed.sample.mem_kib);
     try std.testing.expectEqual(@as(u64, 150), parsed.sample.engine.?.engine_ns);
     try std.testing.expectEqual(@as(?EngineSample, null), parsed.sample.encoder);


### PR DESCRIPTION
before:
<img width="1556" height="781" alt="before" src="https://github.com/user-attachments/assets/7520444c-234c-4fb1-aba0-c1413ad20e54" />
after:
<img width="1556" height="781" alt="after" src="https://github.com/user-attachments/assets/af478fb8-019a-4e20-8def-fa1f41f9c396" />

@neudinger 