### PR TITLE
zml/vfs/hf: Increased chunk size for HF

### DIFF
--- a/zml/io/vfs/gcs.zig
+++ b/zml/io/vfs/gcs.zig
@@ -317,7 +317,14 @@ pub const GCS = struct {
         } = null,
         endpoint_url: []const u8 = "https://storage.googleapis.com",
         region: []const u8 = "auto",
-        read_pool: parallel_read.InitOpts = .{},
+        read_pool: parallel_read.InitOpts = .{
+            .chunk_size = 16 << 20,
+            .num_workers = 32,
+            .queue_capacity = 128,
+            .max_retries = 5,
+            .retry_initial_delay = .fromMilliseconds(500),
+            .retry_max_delay = .fromSeconds(30),
+        },
     };
 
     pub const InitError = error{

--- a/zml/io/vfs/hf.zig
+++ b/zml/io/vfs/hf.zig
@@ -201,7 +201,15 @@ const RepoKey = struct {
 
 pub const HF = struct {
     pub const InitOpts = struct {
-        read_pool: parallel_read.InitOpts = .{},
+        read_pool: parallel_read.InitOpts = .{
+            // Chunk size needs to be big enough to avoid hitting the rate limits of HF.
+            .chunk_size = 32 << 20,
+            .num_workers = 32,
+            .queue_capacity = 128,
+            .max_retries = 5,
+            .retry_initial_delay = .fromMilliseconds(500),
+            .retry_max_delay = .fromSeconds(30),
+        },
     };
 
     pub const Repo = struct {

--- a/zml/io/vfs/parallel_read.zig
+++ b/zml/io/vfs/parallel_read.zig
@@ -3,12 +3,12 @@ const std = @import("std");
 const stdx = @import("stdx");
 
 pub const InitOpts = struct {
-    chunk_size: usize = 16 * 1024 * 1024,
-    num_workers: usize = 32,
-    queue_capacity: usize = 128,
-    max_retries: usize = 5,
-    retry_initial_delay: std.Io.Duration = .fromMilliseconds(500),
-    retry_max_delay: std.Io.Duration = .fromSeconds(30),
+    chunk_size: usize,
+    num_workers: usize,
+    queue_capacity: usize,
+    max_retries: usize,
+    retry_initial_delay: std.Io.Duration,
+    retry_max_delay: std.Io.Duration,
 };
 
 pub const Status = union(enum) {

--- a/zml/io/vfs/s3.zig
+++ b/zml/io/vfs/s3.zig
@@ -302,7 +302,14 @@ pub const S3 = struct {
     };
 
     pub const InitOpts = struct {
-        read_pool: parallel_read.InitOpts = .{},
+        read_pool: parallel_read.InitOpts = .{
+            .chunk_size = 16 << 20,
+            .num_workers = 32,
+            .queue_capacity = 128,
+            .max_retries = 5,
+            .retry_initial_delay = .fromMilliseconds(500),
+            .retry_max_delay = .fromSeconds(30),
+        },
     };
 
     pub const Config = struct {


### PR DESCRIPTION
With only 16MiB chunks, I'm hitting the authenticated user rate limits when loading Qwen3.6-27B sharded over two devices.