### PR TITLE
zml-smi/vaxis: reuse shared shiny logo art

### DIFF
--- a/bin/zml-smi/tui/BUILD.bazel
+++ b/bin/zml-smi/tui/BUILD.bazel
@@ -45,6 +45,7 @@ zig_library(
         "//bazel/stamp:zig",
         "//bin/zml-smi/info",
         "//bin/zml-smi/utils:double_buffer",
+        "//zml:logo",
         "@libvaxis//:vaxis",
     ] + select({
         "@platforms//os:macos": ["//bin/zml-smi/platforms/macos"],

--- a/bin/zml-smi/tui/pages/overview.zig
+++ b/bin/zml-smi/tui/pages/overview.zig
@@ -48,12 +48,11 @@ pub fn deinit(self: *Overview, allocator: std.mem.Allocator) void {
 }
 
 fn drawNarrowBanner(self: *const Overview, ctx: vxfw.DrawContext, content_w: u16) !vxfw.Surface {
-    const logo: Logo = .{ .image = image_cache.global.get("logo"), .compact = true };
+    const logo: Logo = .{ .image = image_cache.global.get("logo") };
     const info_lines: InfoLines = .{ .state = self.state };
 
-    const logo_h: u16 = if (logo.image != null) Logo.compact_image_height else Logo.compact_height;
     const children = [2]vxfw.Widget{
-        try compose.sized(ctx.arena, try compose.center(ctx.arena, ui.widget(&logo)), .{ .width = content_w, .height = logo_h }),
+        try compose.sized(ctx.arena, try compose.center(ctx.arena, ui.widget(&logo)), .{ .width = content_w, .height = Logo.logo_height }),
         ui.widget(&info_lines),
     };
     const layout: ColumnLayout = .{ .children = &children, .gap = 1 };
@@ -61,13 +60,12 @@ fn drawNarrowBanner(self: *const Overview, ctx: vxfw.DrawContext, content_w: u16
 }
 
 fn drawWideBanner(self: *const Overview, ctx: vxfw.DrawContext, content_w: u16) !vxfw.Surface {
-    const logo: Logo = .{ .image = image_cache.global.get("logo"), .compact = false };
+    const logo: Logo = .{ .image = image_cache.global.get("logo") };
     const info_lines: InfoLines = .{ .state = self.state };
 
-    const logo_h: u16 = if (logo.image != null) Logo.image_height else Logo.logo_height;
     const logo_box_w = Logo.logo_width + 6; // +4 centering + 2 absorbed page margin
     const info_max_w = @min(content_w -| logo_box_w, max_info_width);
-    const banner_h = @max(logo_h, InfoLines.entry_count);
+    const banner_h = @max(Logo.logo_height, InfoLines.entry_count);
 
     const flex_items = [2]vxfw.FlexItem{
         .{ .widget = try compose.sized(ctx.arena, try compose.center(ctx.arena, ui.widget(&logo)), .{ .width = logo_box_w, .height = banner_h }), .flex = 0 },

--- a/bin/zml-smi/tui/widgets/logo.zig
+++ b/bin/zml-smi/tui/widgets/logo.zig
@@ -28,20 +28,10 @@ pub fn draw(self: *const Logo, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vx
 }
 
 fn drawLogoRow(self: *const Logo, ctx: vxfw.DrawContext, row_index: usize) std.mem.Allocator.Error!vxfw.Surface {
-    const last_block = blk: {
-        var index = zml_logo.zml_art_blocks.len;
-        while (index > 0) {
-            index -= 1;
-            if (std.mem.trimEnd(u8, zml_logo.zml_art_blocks[index].rows[row_index].text, " \t\r\n").len != 0) break :blk index;
-        }
-        return vxfw.Surface.init(ctx.arena, ui.widget(self), .{ .width = logo_width, .height = 1 });
-    };
-
     var segments: std.ArrayList(vaxis.Cell.Segment) = .empty;
-    for (zml_logo.zml_art_blocks[0 .. last_block + 1], 0..) |block, block_index| {
-        const is_last_block = block_index == last_block;
+    for (zml_logo.zml_art_blocks[0..]) |block| {
         const row = block.rows[row_index];
-        const text = if (is_last_block) std.mem.trimEnd(u8, row.text, " \t\r\n") else row.text;
+        const text = row.text;
         if (text.len == 0) continue;
 
         var view: std.unicode.Utf8View = .initUnchecked(text);

--- a/bin/zml-smi/tui/widgets/logo.zig
+++ b/bin/zml-smi/tui/widgets/logo.zig
@@ -10,18 +10,14 @@ const Logo = @This();
 
 style: vaxis.Cell.Style = .{},
 image: ?vaxis.Image = null,
-compact: bool = false,
 
 pub const logo_width: u16 = 28;
 pub const logo_height: u16 = @intCast(zml_logo.zml_art_blocks[0].rows.len);
-
-pub const image_height: u16 = 11;
-pub const compact_image_height: u16 = 7;
+pub const image_height: u16 = logo_height;
 
 pub fn draw(self: *const Logo, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
     if (self.image) |img| {
-        const h = if (self.compact) compact_image_height else image_height;
-        const img_w: Image = .{ .image = img, .rows = h };
+        const img_w: Image = .{ .image = img, .rows = image_height };
         return img_w.draw(ctx);
     }
 

--- a/bin/zml-smi/tui/widgets/logo.zig
+++ b/bin/zml-smi/tui/widgets/logo.zig
@@ -13,11 +13,10 @@ image: ?vaxis.Image = null,
 
 pub const logo_width: u16 = 28;
 pub const logo_height: u16 = @intCast(zml_logo.zml_art_blocks[0].rows.len);
-pub const image_height: u16 = logo_height;
 
 pub fn draw(self: *const Logo, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
     if (self.image) |img| {
-        const img_w: Image = .{ .image = img, .rows = image_height };
+        const img_w: Image = .{ .image = img, .rows = logo_height };
         return img_w.draw(ctx);
     }
 

--- a/bin/zml-smi/tui/widgets/logo.zig
+++ b/bin/zml-smi/tui/widgets/logo.zig
@@ -31,10 +31,9 @@ fn drawLogoRow(self: *const Logo, ctx: vxfw.DrawContext, row_index: usize) std.m
     var segments: std.ArrayList(vaxis.Cell.Segment) = .empty;
     for (zml_logo.zml_art_blocks[0..]) |block| {
         const row = block.rows[row_index];
-        const text = row.text;
-        if (text.len == 0) continue;
+        if (row.text.len == 0) continue;
 
-        var view: std.unicode.Utf8View = .initUnchecked(text);
+        var view: std.unicode.Utf8View = .initUnchecked(row.text);
         var iter = view.iterator();
         while (iter.nextCodepointSlice()) |codepoint| {
             const shiny = zml_logo.isShineGlyph(codepoint);

--- a/bin/zml-smi/tui/widgets/logo.zig
+++ b/bin/zml-smi/tui/widgets/logo.zig
@@ -29,68 +29,47 @@ pub fn draw(self: *const Logo, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vx
 }
 
 fn drawLogoRow(self: *const Logo, ctx: vxfw.DrawContext, row_index: usize) std.mem.Allocator.Error!vxfw.Surface {
-    const last_block = findLastVisibleBlockIndex(row_index) orelse {
+    const last_block = blk: {
+        var index = zml_logo.zml_art_blocks.len;
+        while (index > 0) {
+            index -= 1;
+            if (std.mem.trimEnd(u8, zml_logo.zml_art_blocks[index].rows[row_index].text, " \t\r\n").len != 0) break :blk index;
+        }
         return vxfw.Surface.init(ctx.arena, ui.widget(self), .{ .width = logo_width, .height = 1 });
     };
 
     var segments: std.ArrayList(vaxis.Cell.Segment) = .empty;
     for (zml_logo.zml_art_blocks[0 .. last_block + 1], 0..) |block, block_index| {
         const is_last_block = block_index == last_block;
-        try self.appendRowSegments(ctx.arena, &segments, block.rows[row_index], is_last_block);
+        const row = block.rows[row_index];
+        const text = if (is_last_block) std.mem.trimEnd(u8, row.text, " \t\r\n") else row.text;
+        if (text.len == 0) continue;
+
+        var view: std.unicode.Utf8View = .initUnchecked(text);
+        var iter = view.iterator();
+        while (iter.nextCodepointSlice()) |codepoint| {
+            const shiny = zml_logo.isShineGlyph(codepoint);
+            try segments.append(ctx.arena, .{
+                .text = codepoint,
+                .style = .{
+                    .fg = switch (if (shiny) row.shine else row.color) {
+                        .reset => .default,
+                        .cyan => .{ .rgb = .{ 0, 255, 255 } },
+                        .sky => .{ .rgb = .{ 0, 221, 255 } },
+                        .blue => .{ .rgb = .{ 135, 143, 255 } },
+                        .violet => .{ .rgb = .{ 215, 90, 219 } },
+                        .pink => .{ .rgb = .{ 242, 48, 174 } },
+                        .shine_cyan => .{ .rgb = .{ 140, 255, 255 } },
+                        .shine_sky => .{ .rgb = .{ 128, 244, 255 } },
+                        .shine_blue => .{ .rgb = .{ 205, 210, 255 } },
+                        .shine_violet => .{ .rgb = .{ 255, 170, 255 } },
+                        .shine_pink => .{ .rgb = .{ 255, 150, 220 } },
+                    },
+                    .bg = self.style.bg,
+                    .bold = shiny,
+                },
+            });
+        }
     }
     return ui.drawRichLine(ctx, segments.items, logo_width);
-}
-
-fn appendRowSegments(
-    self: *const Logo,
-    arena: std.mem.Allocator,
-    segments: *std.ArrayList(vaxis.Cell.Segment),
-    row: zml_logo.Row,
-    rtrim_whitespace: bool,
-) std.mem.Allocator.Error!void {
-    const text = if (rtrim_whitespace) std.mem.trimEnd(u8, row.text, " \t\r\n") else row.text;
-    if (text.len == 0) return;
-
-    var view: std.unicode.Utf8View = .initUnchecked(text);
-    var iter = view.iterator();
-    while (iter.nextCodepointSlice()) |codepoint| {
-        const shiny = zml_logo.isShineGlyph(codepoint);
-        try segments.append(arena, .{
-            .text = codepoint,
-            .style = self.logoStyle(if (shiny) row.shine else row.color, shiny),
-        });
-    }
-}
-
-fn logoStyle(self: *const Logo, color: zml_logo.Color, shiny: bool) vaxis.Cell.Style {
-    return .{
-        .fg = logoColor(color),
-        .bg = self.style.bg,
-        .bold = shiny,
-    };
-}
-
-fn logoColor(color: zml_logo.Color) vaxis.Cell.Color {
-    return switch (color) {
-        .reset => .default,
-        .cyan => .{ .rgb = .{ 0, 255, 255 } },
-        .sky => .{ .rgb = .{ 0, 221, 255 } },
-        .blue => .{ .rgb = .{ 135, 143, 255 } },
-        .violet => .{ .rgb = .{ 215, 90, 219 } },
-        .pink => .{ .rgb = .{ 242, 48, 174 } },
-        .shine_cyan => .{ .rgb = .{ 140, 255, 255 } },
-        .shine_sky => .{ .rgb = .{ 128, 244, 255 } },
-        .shine_blue => .{ .rgb = .{ 205, 210, 255 } },
-        .shine_violet => .{ .rgb = .{ 255, 170, 255 } },
-        .shine_pink => .{ .rgb = .{ 255, 150, 220 } },
-    };
-}
-
-fn findLastVisibleBlockIndex(row_index: usize) ?usize {
-    var index = zml_logo.zml_art_blocks.len;
-    while (index > 0) {
-        index -= 1;
-        if (std.mem.trimEnd(u8, zml_logo.zml_art_blocks[index].rows[row_index].text, " \t\r\n").len != 0) return index;
-    }
-    return null;
 }

--- a/bin/zml-smi/tui/widgets/logo.zig
+++ b/bin/zml-smi/tui/widgets/logo.zig
@@ -1,29 +1,20 @@
 const std = @import("std");
 const vaxis = @import("vaxis");
 const vxfw = vaxis.vxfw;
-const theme = @import("../theme.zig");
 const ui = @import("../lib/ui.zig");
 const compose = @import("../lib/compose.zig");
 const Image = @import("../lib/image.zig");
+const zml_logo = @import("zml/logo");
 
 const Logo = @This();
 
-style: vaxis.Cell.Style = theme.header_style,
+style: vaxis.Cell.Style = .{},
 image: ?vaxis.Image = null,
 compact: bool = false,
 
-const ascii_lines = [_][]const u8{
-    "                      ",
-    "█████╗███╗   ███╗██╗  ",
-    "╚═██╔╝████╗ ████║██║  ",
-    " ██╔╝ ██╔████╔██║██║  ",
-    "█████╗██║ ╚═╝ ██║████╗",
-    "╚════╝╚═╝     ╚═╝╚═══╝",
-};
-
-pub const logo_width: u16 = 22;
-pub const logo_height: u16 = ascii_lines.len;
-pub const compact_height: u16 = ascii_lines.len - 1;
+pub const logo_width: u16 = 28;
+pub const logo_height: u16 = @intCast(zml_logo.zml_art_blocks[0].rows.len);
+pub const compact_height: u16 = logo_height - 1;
 pub const image_height: u16 = 11;
 pub const compact_image_height: u16 = 7;
 
@@ -34,18 +25,79 @@ pub fn draw(self: *const Logo, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vx
         return img_w.draw(ctx);
     }
 
-    const lines: []const []const u8 = if (self.compact) ascii_lines[1..] else &ascii_lines;
     const h: u16 = if (self.compact) compact_height else logo_height;
-    const logo_color: vaxis.Cell.Color = .{ .rgb = .{ 140, 180, 255 } };
+    const first_row: usize = if (self.compact) 1 else 0;
 
     var sb = compose.surfaceBuilder(ctx.arena);
-    for (lines, 0..) |line, row| {
-        const text: vxfw.Text = .{
-            .text = line,
-            .style = .{ .bold = self.style.bold, .fg = logo_color },
-            .softwrap = false,
-        };
-        try sb.add(@intCast(row), 0, try text.draw(ui.maxSize(ctx, logo_width, 1)));
+    for (first_row..logo_height, 0..) |logo_row, row| {
+        try sb.add(@intCast(row), 0, try self.drawLogoRow(ctx, logo_row));
     }
     return sb.finish(.{ .width = logo_width, .height = h }, ui.widget(self));
+}
+
+fn drawLogoRow(self: *const Logo, ctx: vxfw.DrawContext, row_index: usize) std.mem.Allocator.Error!vxfw.Surface {
+    const last_block = findLastVisibleBlockIndex(row_index) orelse {
+        return vxfw.Surface.init(ctx.arena, ui.widget(self), .{ .width = logo_width, .height = 1 });
+    };
+
+    var segments: std.ArrayList(vaxis.Cell.Segment) = .empty;
+    for (zml_logo.zml_art_blocks[0 .. last_block + 1], 0..) |block, block_index| {
+        const is_last_block = block_index == last_block;
+        try self.appendRowSegments(ctx.arena, &segments, block.rows[row_index], is_last_block);
+    }
+    return ui.drawRichLine(ctx, segments.items, logo_width);
+}
+
+fn appendRowSegments(
+    self: *const Logo,
+    arena: std.mem.Allocator,
+    segments: *std.ArrayList(vaxis.Cell.Segment),
+    row: zml_logo.Row,
+    rtrim_whitespace: bool,
+) std.mem.Allocator.Error!void {
+    const text = if (rtrim_whitespace) std.mem.trimEnd(u8, row.text, " \t\r\n") else row.text;
+    if (text.len == 0) return;
+
+    var view: std.unicode.Utf8View = .initUnchecked(text);
+    var iter = view.iterator();
+    while (iter.nextCodepointSlice()) |codepoint| {
+        const shiny = zml_logo.isShineGlyph(codepoint);
+        try segments.append(arena, .{
+            .text = codepoint,
+            .style = self.logoStyle(if (shiny) row.shine else row.color, shiny),
+        });
+    }
+}
+
+fn logoStyle(self: *const Logo, color: zml_logo.Color, shiny: bool) vaxis.Cell.Style {
+    return .{
+        .fg = logoColor(color),
+        .bg = self.style.bg,
+        .bold = shiny,
+    };
+}
+
+fn logoColor(color: zml_logo.Color) vaxis.Cell.Color {
+    return switch (color) {
+        .reset => .default,
+        .cyan => .{ .rgb = .{ 0, 255, 255 } },
+        .sky => .{ .rgb = .{ 0, 221, 255 } },
+        .blue => .{ .rgb = .{ 135, 143, 255 } },
+        .violet => .{ .rgb = .{ 215, 90, 219 } },
+        .pink => .{ .rgb = .{ 242, 48, 174 } },
+        .shine_cyan => .{ .rgb = .{ 140, 255, 255 } },
+        .shine_sky => .{ .rgb = .{ 128, 244, 255 } },
+        .shine_blue => .{ .rgb = .{ 205, 210, 255 } },
+        .shine_violet => .{ .rgb = .{ 255, 170, 255 } },
+        .shine_pink => .{ .rgb = .{ 255, 150, 220 } },
+    };
+}
+
+fn findLastVisibleBlockIndex(row_index: usize) ?usize {
+    var index = zml_logo.zml_art_blocks.len;
+    while (index > 0) {
+        index -= 1;
+        if (std.mem.trimEnd(u8, zml_logo.zml_art_blocks[index].rows[row_index].text, " \t\r\n").len != 0) return index;
+    }
+    return null;
 }

--- a/bin/zml-smi/tui/widgets/logo.zig
+++ b/bin/zml-smi/tui/widgets/logo.zig
@@ -14,7 +14,7 @@ compact: bool = false,
 
 pub const logo_width: u16 = 28;
 pub const logo_height: u16 = @intCast(zml_logo.zml_art_blocks[0].rows.len);
-pub const compact_height: u16 = logo_height - 1;
+
 pub const image_height: u16 = 11;
 pub const compact_image_height: u16 = 7;
 
@@ -25,14 +25,11 @@ pub fn draw(self: *const Logo, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vx
         return img_w.draw(ctx);
     }
 
-    const h: u16 = if (self.compact) compact_height else logo_height;
-    const first_row: usize = if (self.compact) 1 else 0;
-
     var sb = compose.surfaceBuilder(ctx.arena);
-    for (first_row..logo_height, 0..) |logo_row, row| {
+    for (0..logo_height, 0..) |logo_row, row| {
         try sb.add(@intCast(row), 0, try self.drawLogoRow(ctx, logo_row));
     }
-    return sb.finish(.{ .width = logo_width, .height = h }, ui.widget(self));
+    return sb.finish(.{ .width = logo_width, .height = logo_height }, ui.widget(self));
 }
 
 fn drawLogoRow(self: *const Logo, ctx: vxfw.DrawContext, row_index: usize) std.mem.Allocator.Error!vxfw.Surface {

--- a/zml/BUILD.bazel
+++ b/zml/BUILD.bazel
@@ -66,6 +66,14 @@ cc_library(
 )
 
 zig_library(
+    name = "logo",
+    srcs = ["logo.zig"],
+    import_name = "zml/logo",
+    main = "logo.zig",
+    visibility = ["//visibility:public"],
+)
+
+zig_library(
     name = "zml",
     tags = ["manual"],
     data = [


### PR DESCRIPTION
Render the zml-smi text logo fallback from the shared ZML logo data, including the shiny per-glyph colors. Add a lightweight //zml:logo target so the TUI can depend on the logo art without pulling in //zml.

Verified with:
- bazel test //bin/zml-smi/tui:test
- bazel build //bin/zml-smi:zml-smi