### PR TITLE
examples/llm: cover Llama EOS token ids

### DIFF
--- a/examples/llm/BUILD.bazel
+++ b/examples/llm/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
-load("@rules_zig//zig:defs.bzl", "zig_binary")
+load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_test")
 load("@tar.bzl//tar:mtree.bzl", "mtree_spec")
 load("@tar.bzl//tar:tar.bzl", "tar")
 
@@ -10,7 +10,10 @@ zig_binary(
     srcs = glob(["**/*.zig"]),
     main = "main.zig",
     visibility = ["//visibility:public"],
-    deps = ["//zml", "@linenoise"],
+    deps = [
+        "//zml",
+        "@linenoise",
+    ],
 )
 
 zig_binary(
@@ -29,6 +32,12 @@ zig_binary(
     deps = ["//zml"],
 )
 
+zig_test(
+    name = "llama_eos_test",
+    main = "models/llama/eos.zig",
+    deps = ["//stdx"],
+)
+
 build_test(
     name = "test",
     targets = [":llm"],
@@ -37,7 +46,7 @@ build_test(
 mtree_spec(
     name = "mtree",
     srcs = [":llm"],
-    tags = ["manual"]
+    tags = ["manual"],
 )
 
 tar(
@@ -52,19 +61,19 @@ tar(
     ],
     compress = "zstd",
     mtree = ":mtree",
-    tags = ["manual"]
+    tags = ["manual"],
 )
 
 oci_image(
     name = "image_",
     base = "@distroless_cc_debian12",
     entrypoint = ["./{}/llm".format(package_name())],
+    tags = ["manual"],
     target_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ],
     tars = [":archive"],
-    tags = ["manual"]
 )
 
 platform_transition_filegroup(
@@ -89,17 +98,16 @@ oci_push(
     tags = ["manual"],
 )
 
-
 oci_image(
     name = "image_debug_",
     base = "@debian_12",
     entrypoint = ["./examples/llm/llm"],
+    tags = ["manual"],
     target_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ],
     tars = [":archive"],
-    tags = ["manual"],
 )
 
 platform_transition_filegroup(

--- a/examples/llm/models/llama/eos.zig
+++ b/examples/llm/models/llama/eos.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+
+pub fn contains(token_ids: anytype, token_id: u32) bool {
+    return switch (token_ids.value) {
+        .int => |eos| token_id == eos,
+        .ints => |eos_list| for (eos_list) |eos| {
+            if (token_id == eos) break true;
+        } else false,
+    };
+}
+
+const scalarEosTokenId: u32 = 128001;
+const eotTokenId: u32 = 128008;
+const pythonTagTokenId: u32 = 128009;
+const nonEosTokenId: u32 = 42;
+
+const TestTokenIds = union(enum) {
+    int: u32,
+    ints: []u32,
+};
+
+const TestConfigTokenIds = struct {
+    value: TestTokenIds,
+};
+
+test "contains accepts scalar EOS token ids" {
+    const token_ids: TestConfigTokenIds = .{ .value = .{ .int = scalarEosTokenId } };
+
+    try std.testing.expect(contains(token_ids, scalarEosTokenId));
+    try std.testing.expect(!contains(token_ids, nonEosTokenId));
+}
+
+test "contains accepts every configured EOS token id" {
+    var eos_token_ids = [_]u32{ scalarEosTokenId, eotTokenId, pythonTagTokenId };
+    const token_ids: TestConfigTokenIds = .{ .value = .{ .ints = &eos_token_ids } };
+
+    for (eos_token_ids) |eos_token_id| {
+        try std.testing.expect(contains(token_ids, eos_token_id));
+    }
+    try std.testing.expect(!contains(token_ids, nonEosTokenId));
+}

--- a/examples/llm/models/llama/session.zig
+++ b/examples/llm/models/llama/session.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 const zml = @import("zml");
 const attention = zml.attention.attention;
 
+const eos = @import("eos.zig");
 const inference = @import("inference.zig");
 const model = @import("model.zig");
 
@@ -219,10 +220,5 @@ pub const Session = struct {
 };
 
 fn isEosToken(config: *const model.Config, token_id: u32) bool {
-    return switch (config.eos_token_id.value) {
-        .int => |eos| token_id == eos,
-        .ints => |eos_list| for (eos_list) |eos| {
-            if (token_id == eos) break true;
-        } else false,
-    };
+    return eos.contains(config.eos_token_id, token_id);
 }


### PR DESCRIPTION
## Summary
- move Llama EOS token matching into a focused helper used by decode stop logic
- add focused coverage for scalar and list-shaped `eos_token_id` values, including multi-EOS configs such as Llama 3
- add a lightweight Bazel test target for the EOS helper

Fixes #119.

## Tokenizer note
The issue mentions older tokenizer-side EOS discovery via `</s>` / `<|end_of_text|>`. In current `master`, the Llama decode loop stops from `config.eos_token_id` (`examples/llm/models/llama/session.zig`) rather than `Tokenizer.special_tokens.eos`, and the prompt path looks up Llama chat tokens such as `<|eot_id|>` directly through `tokenizer.tokenId(...)`. This PR therefore guards the current Llama stop-token path without changing tokenizer initialization.

## Test verification (RED -> GREEN)
RED, with the list matching branch temporarily reverted to `false`:
```
//examples/llm:llama_eos_test FAILED
2/2 eos.test.contains accepts every configured EOS token id...FAIL (TestUnexpectedResult)
Executed 1 out of 1 test: 1 fails locally.
```

GREEN, with this patch:
```
npx -y @bazel/bazelisk@1.28.1 --batch test --cache_test_results=no //examples/llm:llama_eos_test
//examples/llm:llama_eos_test PASSED in 0.1s
Executed 1 out of 1 test: 1 test passes.
```

## Notes
- Ran `@buildifier_prebuilt//:buildifier` via Bazelisk on `examples/llm/BUILD.bazel`.
- `zig fmt --check` could not be run directly because `zig` is not installed on PATH in this environment.
