### PR TITLE
docs: explain build.zig integration status

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Ready to write some code? Try starting with [your first model in ZML](./tutorial
 - [Cross Compile and Deploy Models on a Server](./howtos/deploy_on_server.md)
 - [Dockerize Models](./howtos/dockerize_models.md)
 - [Profile ZML Programs](./howtos/profiling.md)
+- [Use ZML from a `build.zig` Project](./howtos/use_from_zig_build.md)
 
 ## Learn more...
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ Ready to write some code? Try starting with [your first model in ZML](./tutorial
 - [Cross Compile and Deploy Models on a Server](./howtos/deploy_on_server.md)
 - [Dockerize Models](./howtos/dockerize_models.md)
 - [Profile ZML Programs](./howtos/profiling.md)
-- [Use ZML from a `build.zig` Project](./howtos/use_from_zig_build.md)
+- [Use ZML alongside a `build.zig` Project](./howtos/use_from_zig_build.md)
 
 ## Learn more...
 

--- a/docs/howtos/use_from_zig_build.md
+++ b/docs/howtos/use_from_zig_build.md
@@ -1,33 +1,51 @@
-# Use ZML from a `build.zig` project
+# Use ZML alongside a `build.zig` project
 
 ZML is currently built and packaged with Bazel. A native Zig package that can be
 added directly to another project's `build.zig.zon` is not available yet.
 
-If your application already uses Zig's standard build system, keep the ZML build
-as a Bazel step and consume its output from your `build.zig` project. This keeps
-ZML's toolchain, MLIR, PJRT, and platform-specific dependencies under Bazel,
-while your application can stay on the standard Zig build flow.
+If your application already uses Zig's standard build system, keep the ZML
+component behind an explicit artifact boundary. Bazel is the source of truth for
+building ZML and for selecting its toolchain, MLIR, PJRT, and platform-specific
+dependencies.
 
-## Current integration model
+## Current options
 
-1. Build the ZML target you need with Bazel.
-2. Export the produced library or executable artifact from `bazel-bin`.
-3. Link or run that artifact from your Zig project.
-4. Keep the boundary explicit, usually through the C ABI or a command-line
-   executable, instead of trying to import ZML internals as Zig modules.
+The most isolated option is an executable boundary: build and run the ZML
+component with Bazel, then communicate with it through a command-line or
+application-specific interface.
 
-This is less ergonomic than a native Zig package, but it avoids duplicating the
-large Bazel-managed dependency graph in a second build system.
+A `build.zig` project may also consume a Bazel-built library through a C ABI
+facade. In that setup, the application owns the facade, invokes Bazel to build
+the target, and links the produced artifact from the Zig build. This is a
+workaround rather than a packaged integration: ZML does not currently provide a
+maintained C ABI package, generated manifest, or helper for discovering and
+packaging all required runtime dependencies.
+
+## Artifact-boundary repro shape
+
+A minimal external repro can exercise this shape today: a `build.zig` wrapper
+invokes Bazel, discovers the produced artifact with
+`bazel cquery --output=files`, stages the shared library and header, and
+links/tests a Zig consumer against the staged artifact. The same pattern can
+also stage a Bazel-built executable and run it from the `build.zig` project.
+
+Binary dependency discovery remains the important unresolved part. A repro can
+record the staged shared library's direct ELF `DT_NEEDED` entries with
+`readelf` into a text file or JSON manifest, which makes the artifact's declared
+dynamic dependencies visible to the consumer. That does not resolve transitive
+runtime dependencies and does not validate a real model execution path or PJRT
+runtime loading.
 
 ## Why not import ZML directly?
 
 ZML depends on generated MLIR/XLA/PJRT bindings, platform libraries, and Bazel
 toolchain setup. Those pieces are selected and wired by Bazel rules. Importing
-ZML source files directly from another `build.zig` skips that setup and is
-expected to fail or produce a different runtime environment.
+ZML source files directly from another `build.zig` project skips that setup and
+is not supported.
 
 ## Future direction
 
 A better integration could let Bazel generate a small manifest describing the
-artifacts and module paths needed by a `build.zig` project. Until such a
-manifest exists, treat Bazel as the source of truth for building ZML.
+artifacts, module paths, and runtime dependencies needed by a `build.zig`
+project. Until such a manifest exists, treat Bazel as the source of truth for
+building ZML.

--- a/docs/howtos/use_from_zig_build.md
+++ b/docs/howtos/use_from_zig_build.md
@@ -1,0 +1,33 @@
+# Use ZML from a `build.zig` project
+
+ZML is currently built and packaged with Bazel. A native Zig package that can be
+added directly to another project's `build.zig.zon` is not available yet.
+
+If your application already uses Zig's standard build system, keep the ZML build
+as a Bazel step and consume its output from your `build.zig` project. This keeps
+ZML's toolchain, MLIR, PJRT, and platform-specific dependencies under Bazel,
+while your application can stay on the standard Zig build flow.
+
+## Current integration model
+
+1. Build the ZML target you need with Bazel.
+2. Export the produced library or executable artifact from `bazel-bin`.
+3. Link or run that artifact from your Zig project.
+4. Keep the boundary explicit, usually through the C ABI or a command-line
+   executable, instead of trying to import ZML internals as Zig modules.
+
+This is less ergonomic than a native Zig package, but it avoids duplicating the
+large Bazel-managed dependency graph in a second build system.
+
+## Why not import ZML directly?
+
+ZML depends on generated MLIR/XLA/PJRT bindings, platform libraries, and Bazel
+toolchain setup. Those pieces are selected and wired by Bazel rules. Importing
+ZML source files directly from another `build.zig` skips that setup and is
+expected to fail or produce a different runtime environment.
+
+## Future direction
+
+A better integration could let Bazel generate a small manifest describing the
+artifacts and module paths needed by a `build.zig` project. Until such a
+manifest exists, treat Bazel as the source of truth for building ZML.


### PR DESCRIPTION
## Summary

Documents the current path for using ZML from a project that already uses Zig's standard `build.zig` flow. Explains that ZML is Bazel-first today, recommends keeping ZML behind a Bazel-built artifact boundary (C ABI / executable), and notes the future generated-manifest direction discussed in #67.

## Context

As discussed in #67, ZML is currently built with Bazel and there is no native Zig package consumable via `build.zig.zon`. The current recommended path is to build the target with Bazel and consume the resulting artifact from a `build.zig` project via C ABI / executable boundary.

## Prior art

@gwenzek already proposed a manifest-based approach in #67 (Bazel generating a `zml.zon` pointing to build artifacts, consumed by a generic `build.zig` helper), and started an early experiment in #262. That work is still exploratory and not merged, so this PR documents the current status quo rather than the proposed future direction — happy to update the "Future direction" section if there's been more recent progress I've missed.

This is docs-only, no code changes.

## Issues

Refs #67

