### PR TITLE
zml: allow PJRT compilation to fail

### DIFF
--- a/zml/module.zig
+++ b/zml/module.zig
@@ -266,7 +266,7 @@ pub fn compile(
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
 
-    const loaded_executable = compileModuleToPjrtExecutable(arena.allocator(), st_io.io(), platform, compilation_context.module, compilation_context.partitioning, opts) catch unreachable;
+    const loaded_executable = try compileModuleToPjrtExecutable(arena.allocator(), st_io.io(), platform, compilation_context.module, compilation_context.partitioning, opts);
     log.debug("\n******** ZML generated MLIR ********\n{f}", .{compilation_context.module.operation()});
 
     const exe = try Exe.init(


### PR DESCRIPTION
We used to panic when PJRT compilation failed.

I now think it's better to return an error, since we introduced the WIP Metal plugin that can fail on legitimate programs.
This will make it possible to run the ZML test suite on the Metal plugin and seeing all failing tests.

```
bazel run --@zml//platforms:metal=true --@zml//platforms:cpu=false //zml:test

33/138 nn.decltest.sampleTokens...FAIL (Internal)
...
34/138 nn.decltest.sampleTokensDynamic...FAIL (Internal)
...
102/138 tensor.Tensor.decltest.convert...FAIL (Internal)
...
115/138 tensor.Tensor.decltest.argsort...FAIL (Internal)
```