### PR TITLE
pjrt: better error message on dlopen failure

### DIFF
--- a/pjrt/pjrt.zig
+++ b/pjrt/pjrt.zig
@@ -111,20 +111,20 @@ pub const Api = struct {
                 break :blk .{
                     .inner = .{
                         .handle = std.c.dlopen(library, rtld) orelse {
-                            log.err("Unable to dlopen plugin: {s}", .{library});
+                            log.err("Unable to dlopen plugin {s}\n{s}", .{ library, std.c.dlerror() orelse "" });
                             return error.FileNotFound;
                         },
                     },
                 };
             },
             else => std.DynLib.open(library) catch |err| {
-                log.err("Unable to dlopen plugin: {s}", .{library});
+                log.err("Unable to dlopen plugin {s}: {}", .{ library, err });
                 return err;
             },
         };
 
         const api = fromDynLib(&lib) catch |err| {
-            log.err("Unable to load PJRT API from plugin: {s}: {}", .{ library, err });
+            log.err("Unable to load PJRT API from plugin {s}: {}", .{ library, err });
             return err;
         };
         log.info("Loaded: {s}", .{basename});


### PR DESCRIPTION
I hit an issue with the plugin refusing to load on macos.
There was no information.
After adding this I saw that the the file was apparently not existing in the bazel sandbox, 
so I could reduce the bug to a Bazel issue. 