### PR TITLE
build: enforce LF for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+*.py text eol=lf


### PR DESCRIPTION
Summary
- add .gitattributes to keep checked-out shell and Python launcher files on LF line endings

Fixes #559

Validation
- git check-attr text eol -- tools/workspace_status.sh platforms/neuron/neuronx_cc_shim.py
