### PR TITLE
zml: ground work to support Poolside's Laguna models

### DIFF
--- a/third_party/iree/laguna-tokenizer-compat.patch
+++ b/third_party/iree/laguna-tokenizer-compat.patch
@@ -1,0 +1,78 @@
+diff --git a/runtime/src/iree/tokenizer/format/huggingface/segmenter_json.c b/runtime/src/iree/tokenizer/format/huggingface/segmenter_json.c
+--- a/runtime/src/iree/tokenizer/format/huggingface/segmenter_json.c
++++ b/runtime/src/iree/tokenizer/format/huggingface/segmenter_json.c
+@@ -217,0 +218,10 @@
++  // Some code-oriented tokenizers use this lookahead split only to attach
++  // single-newline runs to the next segment. The IREE regex compiler does not
++  // support lookahead; the following ByteLevel/GPT split still preserves the
++  // input bytes, so treat this grouping hint as a no-op instead of rejecting
++  // the tokenizer at load time.
++  if (iree_string_view_equal(
++          pattern, IREE_SV("(?:\\r?\\n)+(?!\\r?\\n)")) &&
++      behavior == IREE_TOKENIZER_UTIL_REGEX_SPLIT_MERGED_WITH_NEXT && !invert) {
++    return iree_ok_status();
++  }
+diff --git a/runtime/src/iree/tokenizer/format/huggingface/model_json.c b/runtime/src/iree/tokenizer/format/huggingface/model_json.c
+--- a/runtime/src/iree/tokenizer/format/huggingface/model_json.c
++++ b/runtime/src/iree/tokenizer/format/huggingface/model_json.c
+@@ -444,0 +445,46 @@
++static char iree_tokenizer_ascii_upper(char c) {
++  return c >= 'a' && c <= 'z' ? (char)(c - ('a' - 'A')) : c;
++}
++
++static bool iree_tokenizer_string_view_contains_ascii_case(
++    iree_string_view_t value, iree_string_view_t needle) {
++  if (needle.size == 0 || needle.size > value.size) return false;
++  for (iree_host_size_t i = 0; i <= value.size - needle.size; ++i) {
++    bool match = true;
++    for (iree_host_size_t j = 0; j < needle.size; ++j) {
++      if (iree_tokenizer_ascii_upper(value.data[i + j]) !=
++          iree_tokenizer_ascii_upper(needle.data[j])) {
++        match = false;
++        break;
++      }
++    }
++    if (match) return true;
++  }
++  return false;
++}
++
++static bool iree_tokenizer_huggingface_find_added_unk_token(
++    const iree_tokenizer_huggingface_added_tokens_t* added_tokens,
++    iree_tokenizer_token_id_t* out_token_id) {
++  *out_token_id = IREE_TOKENIZER_TOKEN_ID_INVALID;
++  if (!added_tokens) return false;
++  for (iree_host_size_t i = 0; i < added_tokens->count; ++i) {
++    const iree_tokenizer_huggingface_added_token_t* token =
++        iree_tokenizer_huggingface_added_tokens_get(added_tokens, i);
++    if (!iree_any_bit_set(
++            token->flags,
++            IREE_TOKENIZER_HUGGINGFACE_ADDED_TOKEN_FLAG_SPECIAL)) {
++      continue;
++    }
++    iree_string_view_t content =
++        iree_tokenizer_huggingface_added_token_content(added_tokens, token);
++    if (!iree_tokenizer_string_view_contains_ascii_case(content,
++                                                        IREE_SV("unk"))) {
++      continue;
++    }
++    *out_token_id = token->id;
++    return true;
++  }
++  return false;
++}
++
+@@ -584,3 +630,10 @@
+-        status = iree_make_status(IREE_STATUS_NOT_FOUND,
+-                                  "unk_token '%.*s' not found in vocabulary",
+-                                  (int)unk_length, unk_buffer);
++        // Some tokenizer.json files keep a stale default `unk_token` in the BPE
++        // model section while declaring the real unknown token in added_tokens
++        // (for example, custom bracketed forms such as `〈|UNK|〉`). Prefer that
++        // explicit special added token before failing the whole tokenizer load.
++        if (!iree_tokenizer_huggingface_find_added_unk_token(added_tokens,
++                                                             &unk_token_id)) {
++          status = iree_make_status(IREE_STATUS_NOT_FOUND,
++                                    "unk_token '%.*s' not found in vocabulary",
++                                    (int)unk_length, unk_buffer);
++        }

--- a/third_party/iree/repo.bzl
+++ b/third_party/iree/repo.bzl
@@ -16,6 +16,7 @@ def repo():
             "//third_party/iree:tokenizer-only.patch",
             "//third_party/iree:fix-added-token-matching.patch",
             "//third_party/iree:match-hf-tokenizer.patch",
+            "//third_party/iree:laguna-tokenizer-compat.patch",
         ],
         patch_args = ["-p1"],
     )

--- a/zml/io.zig
+++ b/zml/io.zig
@@ -447,8 +447,9 @@ pub const Loader = struct {
         defer for (buffers, loaded) |*b, l| if (l) b.deinit();
 
         for (sources, 0..) |source, i| {
-            self.loadSingle(io, source, source.shape, &buffers[i], &loaded[i], shardings, .{});
+            self.group.async(io, loadSingle, .{ self, io, source, source.shape, &buffers[i], &loaded[i], shardings, .{} });
         }
+        try self.group.await(io);
 
         if (std.mem.findScalar(bool, loaded, false)) |_| {
             return error.LoadFailed;

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -550,6 +550,27 @@ test "RopeOpts.Scaling parses proportional" {
     }
 }
 
+test "RopeOpts.Scaling parses yarn partial rotary factor" {
+    const json =
+        \\{
+        \\  "rope_type": "yarn",
+        \\  "factor": 32.0,
+        \\  "original_max_position_embeddings": 4096,
+        \\  "partial_rotary_factor": 0.5
+        \\}
+    ;
+    var value = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, json, .{});
+    defer value.deinit();
+
+    const scaling = try RopeOpts.Scaling.jsonParseFromValue(std.testing.allocator, value.value, .{});
+    switch (scaling) {
+        .yarn => |y| {
+            try std.testing.expectApproxEqRel(0.5, y.partial_rotary_factor, 1e-6);
+        },
+        else => try std.testing.expect(false),
+    }
+}
+
 test "RopeOpts.Scaling parses default rope type" {
     const json =
         \\{

--- a/zml/tokenizer/iree/tokenizer.zig
+++ b/zml/tokenizer/iree/tokenizer.zig
@@ -67,6 +67,11 @@ inline fn statusCode(status: c.iree_status_t) u32 {
 fn checkOk(status: c.iree_status_t) !void {
     if (status == null) return;
     const code = statusCode(status);
+    var buffer: [1024]u8 = undefined;
+    var buffer_length: usize = 0;
+    if (c.iree_status_format(status, buffer.len, &buffer, &buffer_length)) {
+        log.err("IREE tokenizer error: {s}", .{buffer[0..@min(buffer_length, buffer.len - 1)]});
+    }
     _ = c.iree_status_ignore(status);
     return switch (code) {
         c.IREE_STATUS_CANCELLED => Error.Cancelled,
@@ -530,6 +535,67 @@ test "huggingface json encode/decode" {
     defer decoded.deinit();
     try decoder.decode(token_ids, &decoded.writer);
     try std.testing.expectEqualStrings("hello world", decoded.written());
+}
+
+test "loads bpe tokenizer with newline lookahead split and added unk" {
+    const allocator = std.testing.allocator;
+    const json =
+        \\{
+        \\  "model": {
+        \\    "type": "BPE",
+        \\    "unk_token": "[UNK]",
+        \\    "vocab": {
+        \\      "<|UNK|>": 0,
+        \\      "h": 1,
+        \\      "e": 2,
+        \\      "l": 3,
+        \\      "o": 4,
+        \\      "he": 5,
+        \\      "ll": 6,
+        \\      "lo": 7,
+        \\      "hel": 8,
+        \\      "hello": 9
+        \\    },
+        \\    "merges": ["h e", "l l", "l o", "he l", "hel lo"]
+        \\  },
+        \\  "added_tokens": [
+        \\    {
+        \\      "id": 0,
+        \\      "content": "<|UNK|>",
+        \\      "single_word": false,
+        \\      "lstrip": false,
+        \\      "rstrip": false,
+        \\      "normalized": false,
+        \\      "special": true
+        \\    }
+        \\  ],
+        \\  "pre_tokenizer": {
+        \\    "type": "Sequence",
+        \\    "pretokenizers": [
+        \\      {
+        \\        "type": "Split",
+        \\        "pattern": {"Regex": "(?:\\r?\\n)+(?!\\r?\\n)"},
+        \\        "behavior": "MergedWithNext",
+        \\        "invert": false
+        \\      },
+        \\      {"type": "ByteLevel", "add_prefix_space": false, "trim_offsets": true, "use_regex": true}
+        \\    ]
+        \\  },
+        \\  "decoder": {"type": "ByteLevel", "add_prefix_space": false, "trim_offsets": true}
+        \\}
+    ;
+
+    var tokenizer = try Tokenizer.fromBytes(allocator, json);
+    defer tokenizer.deinit();
+
+    try std.testing.expectEqual(@as(u32, 0), tokenizer.tokenId("<|UNK|>").?);
+
+    var encoder = try tokenizer.encoder();
+    defer encoder.deinit();
+
+    const ids = try encoder.encodeAlloc(allocator, "hello");
+    defer allocator.free(ids);
+    try std.testing.expectEqualSlices(u32, &.{ 5, 6, 4 }, ids);
 }
 
 test "writer" {


### PR DESCRIPTION
This PR contains two main changes:
* A patch for the tokenizer to support the tokenizer config file
* A temporary workaround to speed-up loading of the model when executing arbitrary executable at load time