### PR TITLE
zml/testing: Do not pre-allocate memory for the zml.testing.env()

### DIFF
--- a/zml/testing.zig
+++ b/zml/testing.zig
@@ -18,7 +18,7 @@ pub fn env() *const Platform {
             std.heap.c_allocator,
             std.testing.io,
             .{
-                .xla_gpu = .{ .allocator = .{ .bfc = .{ .preallocate = true, .memory_fraction = 0.85 } } },
+                .xla_gpu = .{ .allocator = .{ .bfc = .{ .preallocate = false, .memory_fraction = 0.85 } } },
             },
         ) catch @panic("Pjrt not available");
 


### PR DESCRIPTION
Pre-allocating 85% of memory for simple tests is overkill, we'll just let the BFC grow as needed. That should hopefully limit the problem of having concurrent CI runs.