### PR TITLE
zml/attention: test paged attention

### DIFF
--- a/zml/attention/flashattn.zig
+++ b/zml/attention/flashattn.zig
@@ -578,20 +578,6 @@ pub const paged_fa2 = struct {
                 .mixed => |v| .{ .mixed = v.options },
             };
         }
-
-        pub fn onMemory(self: Parameters, memory: zml.platform.Memory.Kind) Parameters {
-            return switch (self) {
-                .mixed => |s| .{ .mixed = s.onMemory(memory) },
-                .decode => |s| .{ .decode = s.onMemory(memory) },
-            };
-        }
-
-        pub fn toMemory(self: Parameters, memory: zml.platform.Memory.Kind) Parameters {
-            return switch (self) {
-                .mixed => |s| .{ .mixed = s.toMemory(memory) },
-                .decode => |s| .{ .decode = s.toMemory(memory) },
-            };
-        }
     };
 
     pub const DecodeOptions = struct {
@@ -652,24 +638,6 @@ pub const paged_fa2 = struct {
             allocation_size += softmax_lse_accum_shape.byteSize();
 
             return allocation_size;
-        }
-
-        pub fn onMemory(self: DecodeParameters, memory: zml.platform.Memory.Kind) DecodeParameters {
-            return .{
-                .block_table = self.block_table.onMemory(memory),
-                .cu_seqlens_q = self.cu_seqlens_q.onMemory(memory),
-                .seqused_k = self.seqused_k.onMemory(memory),
-                .options = self.options,
-            };
-        }
-
-        pub fn toMemory(self: DecodeParameters, memory: zml.platform.Memory.Kind) DecodeParameters {
-            return .{
-                .block_table = self.block_table.toMemory(memory),
-                .cu_seqlens_q = self.cu_seqlens_q.toMemory(memory),
-                .seqused_k = self.seqused_k.toMemory(memory),
-                .options = self.options,
-            };
         }
     };
 
@@ -774,32 +742,6 @@ pub const paged_fa2 = struct {
 
             return allocation_size;
         }
-
-        pub fn onMemory(self: MixedParameters, memory: zml.platform.Memory.Kind) MixedParameters {
-            return .{
-                .block_table_prefill = self.block_table_prefill.onMemory(memory),
-                .cu_seqlens_q_prefill = self.cu_seqlens_q_prefill.onMemory(memory),
-                .seqused_k_prefill = self.seqused_k_prefill.onMemory(memory),
-                .block_table_decode = self.block_table_decode.onMemory(memory),
-                .cu_seqlens_q_decode = self.cu_seqlens_q_decode.onMemory(memory),
-                .seqused_k_decode = self.seqused_k_decode.onMemory(memory),
-                .metadata = self.metadata.onMemory(memory),
-                .options = self.options,
-            };
-        }
-
-        pub fn toMemory(self: MixedParameters, memory: zml.platform.Memory.Kind) MixedParameters {
-            return .{
-                .block_table_prefill = self.block_table_prefill.toMemory(memory),
-                .cu_seqlens_q_prefill = self.cu_seqlens_q_prefill.toMemory(memory),
-                .seqused_k_prefill = self.seqused_k_prefill.toMemory(memory),
-                .block_table_decode = self.block_table_decode.toMemory(memory),
-                .cu_seqlens_q_decode = self.cu_seqlens_q_decode.toMemory(memory),
-                .seqused_k_decode = self.seqused_k_decode.toMemory(memory),
-                .metadata = self.metadata.toMemory(memory),
-                .options = self.options,
-            };
-        }
     };
 
     pub const MixedMetadata = struct {
@@ -816,18 +758,6 @@ pub const paged_fa2 = struct {
             var allocation_size: usize = 0;
             allocation_size += self.decode_offset.byteSize();
             return allocation_size;
-        }
-
-        pub fn onMemory(self: MixedMetadata, memory: zml.platform.Memory.Kind) MixedMetadata {
-            return .{
-                .decode_offset = self.decode_offset.onMemory(memory),
-            };
-        }
-
-        pub fn toMemory(self: MixedMetadata, memory: zml.platform.Memory.Kind) MixedMetadata {
-            return .{
-                .decode_offset = self.decode_offset.toMemory(memory),
-            };
         }
     };
 
@@ -1254,20 +1184,6 @@ pub const paged_fa3 = struct {
                 .mixed => |v| .{ .mixed = v.options },
             };
         }
-
-        pub fn onMemory(self: Parameters, memory: zml.platform.Memory.Kind) Parameters {
-            return switch (self) {
-                .mixed => |s| .{ .mixed = s.onMemory(memory) },
-                .decode => |s| .{ .decode = s.onMemory(memory) },
-            };
-        }
-
-        pub fn toMemory(self: Parameters, memory: zml.platform.Memory.Kind) Parameters {
-            return switch (self) {
-                .mixed => |s| .{ .mixed = s.toMemory(memory) },
-                .decode => |s| .{ .decode = s.toMemory(memory) },
-            };
-        }
     };
 
     pub const DecodeOptions = struct {
@@ -1328,24 +1244,6 @@ pub const paged_fa3 = struct {
             allocation_size += softmax_lse_accum_shape.byteSize();
 
             return allocation_size;
-        }
-
-        pub fn onMemory(self: DecodeParameters, memory: zml.platform.Memory.Kind) DecodeParameters {
-            return .{
-                .block_table = self.block_table.onMemory(memory),
-                .cu_seqlens_q = self.cu_seqlens_q.onMemory(memory),
-                .seqused_k = self.seqused_k.onMemory(memory),
-                .options = self.options,
-            };
-        }
-
-        pub fn toMemory(self: DecodeParameters, memory: zml.platform.Memory.Kind) DecodeParameters {
-            return .{
-                .block_table = self.block_table.toMemory(memory),
-                .cu_seqlens_q = self.cu_seqlens_q.toMemory(memory),
-                .seqused_k = self.seqused_k.toMemory(memory),
-                .options = self.options,
-            };
         }
     };
 
@@ -1447,32 +1345,6 @@ pub const paged_fa3 = struct {
 
             return allocation_size;
         }
-
-        pub fn onMemory(self: MixedParameters, memory: zml.platform.Memory.Kind) MixedParameters {
-            return .{
-                .block_table_prefill = self.block_table_prefill.onMemory(memory),
-                .cu_seqlens_q_prefill = self.cu_seqlens_q_prefill.onMemory(memory),
-                .seqused_k_prefill = self.seqused_k_prefill.onMemory(memory),
-                .block_table_decode = self.block_table_decode.onMemory(memory),
-                .cu_seqlens_q_decode = self.cu_seqlens_q_decode.onMemory(memory),
-                .seqused_k_decode = self.seqused_k_decode.onMemory(memory),
-                .metadata = self.metadata.onMemory(memory),
-                .options = self.options,
-            };
-        }
-
-        pub fn toMemory(self: MixedParameters, memory: zml.platform.Memory.Kind) MixedParameters {
-            return .{
-                .block_table_prefill = self.block_table_prefill.toMemory(memory),
-                .cu_seqlens_q_prefill = self.cu_seqlens_q_prefill.toMemory(memory),
-                .seqused_k_prefill = self.seqused_k_prefill.toMemory(memory),
-                .block_table_decode = self.block_table_decode.toMemory(memory),
-                .cu_seqlens_q_decode = self.cu_seqlens_q_decode.toMemory(memory),
-                .seqused_k_decode = self.seqused_k_decode.toMemory(memory),
-                .metadata = self.metadata.toMemory(memory),
-                .options = self.options,
-            };
-        }
     };
 
     pub const MixedMetadata = struct {
@@ -1489,18 +1361,6 @@ pub const paged_fa3 = struct {
             var allocation_size: usize = 0;
             allocation_size += self.decode_offset.byteSize();
             return allocation_size;
-        }
-
-        pub fn onMemory(self: MixedMetadata, memory: zml.platform.Memory.Kind) MixedMetadata {
-            return .{
-                .decode_offset = self.decode_offset.onMemory(memory),
-            };
-        }
-
-        pub fn toMemory(self: MixedMetadata, memory: zml.platform.Memory.Kind) MixedMetadata {
-            return .{
-                .decode_offset = self.decode_offset.toMemory(memory),
-            };
         }
     };
 

--- a/zml/attention/metal_attention.zig
+++ b/zml/attention/metal_attention.zig
@@ -83,24 +83,6 @@ pub const paged = struct {
         pub fn options(self: Parameters) Options {
             return self.options_;
         }
-
-        pub fn onMemory(self: Parameters, memory: zml.platform.Memory.Kind) Parameters {
-            return .{
-                .options_ = self.options_,
-                .block_table = self.block_table.onMemory(memory),
-                .seq_lens = self.seq_lens.onMemory(memory),
-                .query_start_len = self.query_start_len.onMemory(memory),
-            };
-        }
-
-        pub fn toMemory(self: Parameters, memory: zml.platform.Memory.Kind) Parameters {
-            return .{
-                .options_ = self.options_,
-                .block_table = self.block_table.toMemory(memory),
-                .seq_lens = self.seq_lens.toMemory(memory),
-                .query_start_len = self.query_start_len.toMemory(memory),
-            };
-        }
     };
 
     pub fn pagedAttention(parameters: Parameters, q: zml.Tensor, k_cache: zml.Tensor, v_cache: zml.Tensor, opts: AttentionOptions) zml.Tensor {

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -272,3 +272,143 @@ test "Backend.auto selects triton on oneAPI" {
 
     try std.testing.expectEqual(Backend.triton, Backend.auto(&platform));
 }
+
+test pagedAttention {
+    const platform = zml.testing.env();
+    const io = std.testing.io;
+    const allocator = std.testing.allocator;
+    var arena_state: std.heap.ArenaAllocator = .init(allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const batch_size = 8;
+    const num_pages = 64;
+    const page_size = 16;
+    const tensors: struct { q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, kv_cache: KvCache, token_index: zml.Tensor } = .{
+        .q = .init(.{ .b = 8, .hkv = 2, .hg = 4, .hd = 32 }, .f32),
+        .k = .init(.{ .b = 8, .hkv = 2, .k = 16, .hd = 32 }, .f32),
+        .v = .init(.{ .b = 8, .hkv = 2, .k = 16, .hd = 32 }, .f32),
+        .kv_cache = .{
+            .split = .{
+                .k = .init(.{ .page = num_pages, .hkv = 2, .k_chunk = page_size, .hd = 32 }, .f32),
+                .v = .init(.{ .page = num_pages, .hkv = 2, .k_chunk = page_size, .hd = 32 }, .f32),
+            },
+        },
+        .token_index = .init(.{}, .u32),
+    };
+
+    const rng_q = try platform.compileFn(allocator, io, zml.Tensor.Rng.normal, .{ tensors.q.shape(), .{} }, .{});
+    defer rng_q.deinit();
+    const rng_kv_cache = try platform.compileFn(allocator, io, zml.Tensor.Rng.normal, .{ tensors.kv_cache.split.k.shape(), .{} }, .{});
+    defer rng_kv_cache.deinit();
+
+    const triton_options: Options.Args = .{
+        .backend = .triton,
+        .is_prefill = true,
+        .batch_size = batch_size,
+        .seq_len = 64,
+        .max_num_pages = 16,
+        .max_token_count = 16 * page_size,
+        .num_heads = 8,
+        .num_kv_heads = 2,
+        .head_dim = 32,
+        .max_seqlen_q = 16 * 2,
+    };
+    const triton_parameters: Parameters = .init(.fromBackend(triton_options));
+    const attn_opts: AttentionOptions = .{ .is_causal = true };
+    var q = try zml.testing.autoCall(allocator, io, &rng_q, zml.Tensor.Rng.normal, {});
+    defer q.deinit();
+
+    var kv_cache_k = try zml.testing.autoCall(allocator, io, &rng_kv_cache, zml.Tensor.Rng.normal, {});
+    defer kv_cache_k.deinit();
+    var kv_cache_v = try zml.testing.autoCall(allocator, io, &rng_kv_cache, zml.Tensor.Rng.normal, {});
+    defer kv_cache_v.deinit();
+    const kv_cache_d: zml.Bufferized(KvCache) = .{ .split = .{ .k = kv_cache_k, .v = kv_cache_v } };
+
+    var token_index = try zml.Buffer.scalar(io, platform, 64, .u32);
+    defer token_index.deinit();
+
+    const triton_exe = try platform.compileFn(allocator, io, pagedAttention, .{ triton_parameters, tensors.q, tensors.k, tensors.v, tensors.kv_cache, attn_opts }, .{ .program_name = "paged_attention_triton" });
+    defer triton_exe.deinit();
+
+    const triton_parameters_d: zml.Bufferized(Parameters) = .{ .triton = .{
+        .block_table = try .fromBytes(io, platform, triton_parameters.triton.block_table.shape(), .replicated, @ptrCast(&[batch_size][16]i32{
+            .{ 0, 1, 2, 3, 4, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
+            .{ 0, 1, 2, 3, 4, 6, 7, 8, -1, -1, -1, -1, -1, -1, -1, -1 },
+            .{ 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63 },
+            .{ 0, 1, 2, 3, 4, 9, 10, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
+            .{ 0, 1, 2, 3, 4, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
+            .{ 0, 1, 2, 3, 4, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
+            .{ 0, 1, 2, 3, 4, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
+            .{ 0, 1, 2, 3, 4, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
+        })),
+        .seq_lens = try .fromBytes(io, platform, triton_parameters.triton.seq_lens.shape(), .replicated, @ptrCast(&[batch_size]i32{
+            4 * page_size + 3,
+            7 * page_size + 11,
+            15 * page_size + 9,
+            4 * page_size,
+            4 * page_size + 3,
+            4 * page_size + 3,
+            4 * page_size + 3,
+            4 * page_size + 3,
+        })),
+        .query_start_len = try .fromBytes(io, platform, triton_parameters.triton.query_start_len.shape(), .replicated, @ptrCast(&[batch_size]i32{
+            1,
+            1,
+            1,
+            32,
+            1,
+            1,
+            1,
+            1,
+        })),
+    } };
+
+    const triton_d = try zml.testing.autoCall(allocator, io, &triton_exe, pagedAttention, .{ triton_parameters_d, q, undefined, undefined, kv_cache_d });
+    const triton_h: zml.Slice = try triton_d.toSliceAlloc(allocator, io);
+    defer triton_h.free(allocator);
+
+    for (std.enums.values(Backend)) |backend| {
+        switch (backend) {
+            .triton => continue,
+            else => {},
+        }
+
+        var backend_options = triton_options;
+        backend_options.backend = backend;
+        const parameters: Parameters = .init(.fromBackend(backend_options));
+
+        const exe = try platform.compileFn(
+            allocator,
+            io,
+            pagedAttention,
+            .{ parameters, tensors.q, tensors.k, tensors.v, tensors.kv_cache, attn_opts },
+            .{ .program_name = try std.fmt.allocPrint(arena, "paged_attention_{t}", .{backend}) },
+        );
+        defer exe.deinit();
+
+        const parameters_d: zml.Bufferized(Parameters) = switch (backend) {
+            // No materializer implemented for cuda fa2/fa3
+            .cuda_fa2, .cuda_fa3 => return error.SkipZigTest,
+            .triton => unreachable,
+            .metal => .{ .metal = .{
+                .block_table = triton_parameters_d.triton.block_table,
+                .seq_lens = triton_parameters_d.triton.seq_lens,
+                .query_start_len = triton_parameters_d.triton.query_start_len,
+            } },
+            .mosaic_tpu => .{ .mosaic_tpu = .{
+                .block_table = triton_parameters_d.triton.block_table,
+                .seq_lens = triton_parameters_d.triton.seq_lens,
+                .query_start_len = triton_parameters_d.triton.query_start_len,
+            } },
+        };
+        // defer Parameters.deinitBuffer(&parameters_d);
+
+        const output_d = try zml.testing.autoCall(allocator, io, &exe, pagedAttention, .{ parameters_d, q, undefined, undefined, kv_cache_d });
+        try zml.testing.expectClose(io, triton_h, output_d, .{
+            .absolute_tolerance = 1e-3,
+            .relative_tolerance = 1e-2,
+            .epsilon_relative = 1e-6,
+        });
+    }
+}

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -284,6 +284,7 @@ test pagedAttention {
     const batch_size = 8;
     const num_pages = 64;
     const page_size = 16;
+    const max_num_pages = 16;
     const tensors: struct { q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, kv_cache: KvCache, token_index: zml.Tensor } = .{
         .q = .init(.{ .b = 8, .hkv = 2, .hg = 4, .hd = 32 }, .f32),
         .k = .init(.{ .b = 8, .hkv = 2, .k = 16, .hd = 32 }, .f32),
@@ -307,7 +308,7 @@ test pagedAttention {
         .is_prefill = true,
         .batch_size = batch_size,
         .seq_len = 64,
-        .max_num_pages = 16,
+        .max_num_pages = max_num_pages,
         .max_token_count = 16 * page_size,
         .num_heads = 8,
         .num_kv_heads = 2,
@@ -331,37 +332,38 @@ test pagedAttention {
     const triton_exe = try platform.compileFn(allocator, io, pagedAttention, .{ triton_parameters, tensors.q, tensors.k, tensors.v, tensors.kv_cache, attn_opts }, .{ .program_name = "paged_attention_triton" });
     defer triton_exe.deinit();
 
+    const num_prefill = 1;
+    const num_decode = batch_size - num_prefill;
+    const block_table: [batch_size][max_num_pages]i32 = .{
+        // prefilling pages 9-10
+        .{ 0, 1, 2, 3, 4, 9, 10, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
+        // generation
+        .{ 0, 1, 2, 3, 4, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
+        .{ 0, 1, 2, 3, 4, 6, 7, 8, -1, -1, -1, -1, -1, -1, -1, -1 },
+        .{ 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63 },
+        .{ 0, 1, 2, 3, 4, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
+        .{ 0, 1, 2, 3, 4, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
+        .{ 0, 1, 2, 3, 4, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
+        @splat(-1),
+    };
+
+    const seq_lens: [batch_size]i32 = .{
+        4 * page_size,
+        4 * page_size + 3,
+        7 * page_size + 11,
+        15 * page_size + 9,
+        4 * page_size + 3,
+        4 * page_size + 3,
+        4 * page_size + 3,
+        4 * page_size + 3,
+    };
+
+    const query_start_len: [batch_size + 1]i32 = .{ 0, 32, 33, 34, 35, 36, 37, 37, 37 };
+
     const triton_parameters_d: zml.Bufferized(Parameters) = .{ .triton = .{
-        .block_table = try .fromBytes(io, platform, triton_parameters.triton.block_table.shape(), .replicated, @ptrCast(&[batch_size][16]i32{
-            .{ 0, 1, 2, 3, 4, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
-            .{ 0, 1, 2, 3, 4, 6, 7, 8, -1, -1, -1, -1, -1, -1, -1, -1 },
-            .{ 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63 },
-            .{ 0, 1, 2, 3, 4, 9, 10, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
-            .{ 0, 1, 2, 3, 4, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
-            .{ 0, 1, 2, 3, 4, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
-            .{ 0, 1, 2, 3, 4, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
-            .{ 0, 1, 2, 3, 4, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
-        })),
-        .seq_lens = try .fromBytes(io, platform, triton_parameters.triton.seq_lens.shape(), .replicated, @ptrCast(&[batch_size]i32{
-            4 * page_size + 3,
-            7 * page_size + 11,
-            15 * page_size + 9,
-            4 * page_size,
-            4 * page_size + 3,
-            4 * page_size + 3,
-            4 * page_size + 3,
-            4 * page_size + 3,
-        })),
-        .query_start_len = try .fromBytes(io, platform, triton_parameters.triton.query_start_len.shape(), .replicated, @ptrCast(&[batch_size]i32{
-            1,
-            1,
-            1,
-            32,
-            1,
-            1,
-            1,
-            1,
-        })),
+        .block_table = try .fromBytes(io, platform, triton_parameters.triton.block_table.shape(), .replicated, @ptrCast(&block_table)),
+        .seq_lens = try .fromBytes(io, platform, triton_parameters.triton.seq_lens.shape(), .replicated, @ptrCast(&seq_lens)),
+        .query_start_len = try .fromBytes(io, platform, triton_parameters.triton.query_start_len.shape(), .replicated, @ptrCast(&query_start_len)),
     } };
 
     const triton_d = try zml.testing.autoCall(allocator, io, &triton_exe, pagedAttention, .{ triton_parameters_d, q, undefined, undefined, kv_cache_d });
@@ -388,9 +390,40 @@ test pagedAttention {
         defer exe.deinit();
 
         const parameters_d: zml.Bufferized(Parameters) = switch (backend) {
-            // No materializer implemented for cuda fa2/fa3
-            .cuda_fa2, .cuda_fa3 => return error.SkipZigTest,
             .triton => unreachable,
+            // No materializer implemented for cuda fa3
+            .cuda_fa3 => return error.SkipZigTest,
+            .cuda_fa2 => cuda_fa2: {
+                var block_table_prefill: @TypeOf(block_table) = @splat(@splat(-1));
+                @memcpy(block_table_prefill[0..num_prefill], block_table[0..num_prefill]);
+                var block_table_decode: @TypeOf(block_table) = @splat(@splat(-1));
+                @memcpy(block_table_decode[0..num_decode], block_table[num_prefill..]);
+
+                var seq_lens_prefill: @TypeOf(seq_lens) = @splat(0);
+                @memcpy(seq_lens_prefill[0..num_prefill], seq_lens[0..num_prefill]);
+                var seq_lens_decode: @TypeOf(seq_lens) = @splat(0);
+                @memcpy(seq_lens_decode[0..num_decode], seq_lens[num_prefill..]);
+
+                var seqused_k_prefill: @TypeOf(query_start_len) = @splat(query_start_len[num_prefill]);
+                @memcpy(seqused_k_prefill[0..num_prefill], query_start_len[0..num_prefill]);
+                var seqused_k_decode: @TypeOf(query_start_len) = @splat(query_start_len[batch_size - 1]);
+                @memcpy(seqused_k_decode[0 .. num_decode + 1], query_start_len[num_prefill..]);
+
+                const prefill_token_count = query_start_len[num_prefill];
+                for (&seqused_k_decode) |*q_start| q_start.* -= prefill_token_count;
+
+                break :cuda_fa2 .{ .cuda_fa2 = .{ .mixed = .{
+                    .block_table_prefill = try .fromBytes(io, platform, parameters.cuda_fa2.mixed.block_table_prefill.shape(), .replicated, @ptrCast(&block_table_prefill)),
+                    .cu_seqlens_q_prefill = try .fromBytes(io, platform, parameters.cuda_fa2.mixed.cu_seqlens_q_prefill.shape(), .replicated, @ptrCast(&seq_lens_prefill)),
+                    .seqused_k_prefill = try .fromBytes(io, platform, parameters.cuda_fa2.mixed.seqused_k_prefill.shape(), .replicated, @ptrCast(&seqused_k_prefill)),
+
+                    .block_table_decode = try .fromBytes(io, platform, parameters.cuda_fa2.mixed.block_table_decode.shape(), .replicated, @ptrCast(&block_table_decode)),
+                    .cu_seqlens_q_decode = try .fromBytes(io, platform, parameters.cuda_fa2.mixed.cu_seqlens_q_decode.shape(), .replicated, @ptrCast(&seq_lens_decode)),
+                    .seqused_k_decode = try .fromBytes(io, platform, parameters.cuda_fa2.mixed.seqused_k_decode.shape(), .replicated, @ptrCast(&seqused_k_decode)),
+
+                    .metadata = .{ .decode_offset = try .scalar(io, platform, prefill_token_count, .i32) },
+                } } };
+            },
             .metal => .{ .metal = .{
                 .block_table = triton_parameters_d.triton.block_table,
                 .seq_lens = triton_parameters_d.triton.seq_lens,

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -16,6 +16,7 @@ pub const Backend = enum {
     triton,
     mosaic_tpu,
     metal,
+    // vanilla,
 
     pub fn auto(platform: *const zml.Platform) Backend {
         return switch (platform.target) {
@@ -24,7 +25,24 @@ pub const Backend = enum {
             .oneapi => .triton,
             .tpu => .mosaic_tpu,
             .metal => .metal,
-            else => stdx.debug.panic("Paged attention is not supported on {s} yet", .{@tagName(platform.target)}),
+            // .cpu => .vanilla
+            .cpu, .neuron => stdx.debug.panic("Paged attention is not supported on {s} yet", .{@tagName(platform.target)}),
+        };
+    }
+
+    pub fn isAvailable(backend: Backend, platform: *const zml.Platform) bool {
+        return switch (backend) {
+            // .vanilla => true,
+            .triton => true,
+            .metal => platform.target == .metal,
+            .mosaic_tpu => platform.target == .tpu,
+            .cuda_fa2 => platform.target == .cuda,
+            .cuda_fa3 => {
+                if (platform.target != .cuda) return false;
+                const first_device = platform.pjrt_client.devices(platform.pjrt_api)[0];
+                const cc = zml.platform.cuda.tryGetComputeCapabilities(platform, first_device) orelse return false;
+                return std.mem.eql(u8, cc, "9.0");
+            },
         };
     }
 };
@@ -158,21 +176,13 @@ pub const Parameters = union(Backend) {
 
     pub fn init(options_: Options) Parameters {
         return switch (options_) {
-            .cuda_fa2 => |cuda_fa2_options| .{ .cuda_fa2 = flashattn.paged_fa2.Parameters.init(cuda_fa2_options) },
-            .cuda_fa3 => |cuda_fa3_options| .{ .cuda_fa3 = flashattn.paged_fa3.Parameters.init(cuda_fa3_options) },
-            .triton => |triton_options| .{ .triton = triton.paged.Parameters.init(triton_options) },
-            .mosaic_tpu => |mosaic_tpu_options| .{ .mosaic_tpu = tpu.mosaic_tpu.Parameters.init(mosaic_tpu_options) },
-            .metal => |metal_options| .{ .metal = metal.paged.Parameters.init(metal_options) },
+            inline else => |opts, backend| @unionInit(Parameters, @tagName(backend), .init(opts)),
         };
     }
 
     pub fn options(self: Parameters) Options {
         return switch (self) {
-            .cuda_fa2 => |v| .{ .cuda_fa2 = v.options() },
-            .cuda_fa3 => |v| .{ .cuda_fa3 = v.options() },
-            .triton => |v| .{ .triton = v.options() },
-            .mosaic_tpu => |v| .{ .mosaic_tpu = v.options() },
-            .metal => |v| .{ .metal = v.options() },
+            inline else => |v, backend| @unionInit(Options, @tagName(backend), v.options()),
         };
     }
 
@@ -215,6 +225,44 @@ pub const KvCache = union(enum) {
         v: zml.Tensor,
     },
     dense: zml.Tensor,
+
+    pub fn update(
+        self: KvCache,
+        new_k: zml.Tensor,
+        new_v: zml.Tensor,
+        slot_mapping: zml.Tensor,
+        chunk_size: u32,
+        backend: Backend,
+    ) KvCache {
+        const active_page, const k_chunk = getPageAndOffsetFromSlotMapping(slot_mapping, chunk_size);
+
+        var kv: KvCache = switch (self) {
+            .split => |split| switch (backend) {
+                .cuda_fa2, .cuda_fa3, .triton, .mosaic_tpu, .metal => .{ .split = .{
+                    .k = split.k.scatterSlices(
+                        .{ .page = active_page, .k_chunk = k_chunk },
+                        new_k,
+                        .{ .update_fn = zml.Tensor.ScatterOpts.override, .indices_are_unique = false, .indices_are_sorted = false },
+                    ),
+                    .v = split.v.scatterSlices(
+                        .{ .page = active_page, .k_chunk = k_chunk },
+                        new_v,
+                        .{ .update_fn = zml.Tensor.ScatterOpts.override, .indices_are_unique = false, .indices_are_sorted = false },
+                    ),
+                } },
+            },
+            .dense => @panic("TODO"),
+        };
+        kv.split.k = kv.split.k.reuseBuffer(self.split.k);
+        kv.split.v = kv.split.v.reuseBuffer(self.split.v);
+        return kv;
+    }
+
+    pub fn getPageAndOffsetFromSlotMapping(slot_mapping: zml.Tensor, page_size: u32) [2]zml.Tensor {
+        const page_index = slot_mapping.divByConst(page_size);
+        const offset = slot_mapping.remainder(.scalar(page_size, slot_mapping.dtype()));
+        return .{ page_index, offset };
+    }
 };
 
 pub fn pagedAttention(parameters: Parameters, q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, kv_cache: KvCache, opts: AttentionOptions) zml.Tensor {
@@ -275,6 +323,8 @@ test "Backend.auto selects triton on oneAPI" {
 
 test pagedAttention {
     const platform = zml.testing.env();
+    // Check the reference implem is available
+    if (!Backend.triton.isAvailable(platform)) return error.SkipZigTest;
     const io = std.testing.io;
     const allocator = std.testing.allocator;
     var arena_state: std.heap.ArenaAllocator = .init(allocator);
@@ -285,40 +335,51 @@ test pagedAttention {
     const num_pages = 64;
     const page_size = 16;
     const max_num_pages = 16;
-    const tensors: struct { q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, kv_cache: KvCache, token_index: zml.Tensor } = .{
-        .q = .init(.{ .b = 8, .hkv = 2, .hg = 4, .hd = 32 }, .f32),
-        .k = .init(.{ .b = 8, .hkv = 2, .k = 16, .hd = 32 }, .f32),
-        .v = .init(.{ .b = 8, .hkv = 2, .k = 16, .hd = 32 }, .f32),
+    const dt: zml.DataType = .bf16;
+    const tensors: struct { q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, kv_cache: KvCache, token_index: zml.Tensor, slot_mapping: zml.Tensor } = .{
+        .q = .init(.{ .b = 8, .hkv = 2, .hg = 4, .hd = 32 }, dt),
+        .k = .init(.{ .b = 8, .hkv = 2, .hd = 32 }, dt),
+        .v = .init(.{ .b = 8, .hkv = 2, .hd = 32 }, dt),
         .kv_cache = .{
             .split = .{
-                .k = .init(.{ .page = num_pages, .hkv = 2, .k_chunk = page_size, .hd = 32 }, .f32),
-                .v = .init(.{ .page = num_pages, .hkv = 2, .k_chunk = page_size, .hd = 32 }, .f32),
+                .k = .init(.{ .page = num_pages, .hkv = 2, .k_chunk = page_size, .hd = 32 }, dt),
+                .v = .init(.{ .page = num_pages, .hkv = 2, .k_chunk = page_size, .hd = 32 }, dt),
             },
         },
         .token_index = .init(.{}, .u32),
+        .slot_mapping = .init(.{ .b = 8 }, .u32),
     };
 
     const rng_q = try platform.compileFn(allocator, io, zml.Tensor.Rng.normal, .{ tensors.q.shape(), .{} }, .{});
     defer rng_q.deinit();
+    const rng_k = try platform.compileFn(allocator, io, zml.Tensor.Rng.normal, .{ tensors.k.shape(), .{} }, .{});
+    defer rng_k.deinit();
     const rng_kv_cache = try platform.compileFn(allocator, io, zml.Tensor.Rng.normal, .{ tensors.kv_cache.split.k.shape(), .{} }, .{});
     defer rng_kv_cache.deinit();
 
-    const triton_options: Options.Args = .{
+    const update_exe = try platform.compileFn(allocator, io, KvCache.update, .{ tensors.kv_cache, tensors.k, tensors.v, tensors.slot_mapping, page_size, .triton }, .{});
+    defer update_exe.deinit();
+
+    const triton_options_args: Options.Args = .{
         .backend = .triton,
         .is_prefill = true,
         .batch_size = batch_size,
         .seq_len = 64,
         .max_num_pages = max_num_pages,
         .max_token_count = 16 * page_size,
-        .num_heads = 8,
-        .num_kv_heads = 2,
-        .head_dim = 32,
+        .num_heads = @intCast(tensors.q.dim(.hg) * tensors.q.dim(.hkv)),
+        .num_kv_heads = @intCast(tensors.q.dim(.hkv)),
+        .head_dim = @intCast(tensors.q.dim(.hd)),
         .max_seqlen_q = 16 * 2,
     };
-    const triton_parameters: Parameters = .init(.fromBackend(triton_options));
+    const triton_parameters: Parameters = .init(.fromBackend(triton_options_args));
     const attn_opts: AttentionOptions = .{ .is_causal = true };
     var q = try zml.testing.autoCall(allocator, io, &rng_q, zml.Tensor.Rng.normal, {});
     defer q.deinit();
+    var new_k = try zml.testing.autoCall(allocator, io, &rng_k, zml.Tensor.Rng.normal, {});
+    defer new_k.deinit();
+    var new_v = try zml.testing.autoCall(allocator, io, &rng_k, zml.Tensor.Rng.normal, {});
+    defer new_v.deinit();
 
     var kv_cache_k = try zml.testing.autoCall(allocator, io, &rng_kv_cache, zml.Tensor.Rng.normal, {});
     defer kv_cache_k.deinit();
@@ -326,10 +387,14 @@ test pagedAttention {
     defer kv_cache_v.deinit();
     const kv_cache_d: zml.Bufferized(KvCache) = .{ .split = .{ .k = kv_cache_k, .v = kv_cache_v } };
 
-    var token_index = try zml.Buffer.scalar(io, platform, 64, .u32);
-    defer token_index.deinit();
-
-    const triton_exe = try platform.compileFn(allocator, io, pagedAttention, .{ triton_parameters, tensors.q, tensors.k, tensors.v, tensors.kv_cache, attn_opts }, .{ .program_name = "paged_attention_triton" });
+    const shardings: []const zml.Sharding = &.{ platform.replicated_sharding, platform.shardings.get("model").? };
+    const triton_exe = try platform.compileFn(
+        allocator,
+        io,
+        pagedAttention,
+        .{ triton_parameters, tensors.q, tensors.k, tensors.v, tensors.kv_cache, attn_opts },
+        .{ .program_name = "paged_attention_triton", .shardings = shardings },
+    );
     defer triton_exe.deinit();
 
     const num_prefill = 1;
@@ -358,6 +423,22 @@ test pagedAttention {
         4 * page_size + 3,
     };
 
+    // TODO: fix me. Currently this work cause all implementation ready k and v directly from the kv cache.
+    // update kv cache
+    // {
+    //     const slot_mapping: [batch_size]u32 = .{
+    //         10 * page_size,
+    //         5 * page_size + 3,
+    //         8 * page_size + 11,
+    //         63 * page_size + 9,
+    //         5 * page_size + 3,
+    //         5 * page_size + 3,
+    //         5 * page_size + 3,
+    //         5 * page_size + 3,
+    //     };
+    //     const slot_mapping_d: zml.Buffer = try .fromBytes(io, platform, tensors.slot_mapping.shape(), .replicated, @ptrCast(&slot_mapping));
+    //     kv_cache_d = try zml.testing.autoCall(allocator, io, &update_exe, KvCache.update, .{ kv_cache_d, new_k, new_v, slot_mapping_d });
+    // }
     const query_start_len: [batch_size + 1]i32 = .{ 0, 32, 33, 34, 35, 36, 37, 37, 37 };
 
     const triton_parameters_d: zml.Bufferized(Parameters) = .{ .triton = .{
@@ -366,26 +447,23 @@ test pagedAttention {
         .query_start_len = try .fromBytes(io, platform, triton_parameters.triton.query_start_len.shape(), .replicated, @ptrCast(&query_start_len)),
     } };
 
-    const triton_d = try zml.testing.autoCall(allocator, io, &triton_exe, pagedAttention, .{ triton_parameters_d, q, undefined, undefined, kv_cache_d });
+    const triton_d = try zml.testing.autoCall(allocator, io, &triton_exe, pagedAttention, .{ triton_parameters_d, q, new_k, new_v, kv_cache_d });
     const triton_h: zml.Slice = try triton_d.toSliceAlloc(allocator, io);
     defer triton_h.free(allocator);
 
     for (std.enums.values(Backend)) |backend| {
-        switch (backend) {
-            .triton => continue,
-            else => {},
-        }
+        if (!backend.isAvailable(platform)) continue;
 
-        var backend_options = triton_options;
-        backend_options.backend = backend;
-        const parameters: Parameters = .init(.fromBackend(backend_options));
+        var backend_options_args = triton_options_args;
+        backend_options_args.backend = backend;
+        const parameters: Parameters = .init(.fromBackend(backend_options_args));
 
         const exe = try platform.compileFn(
             allocator,
             io,
             pagedAttention,
             .{ parameters, tensors.q, tensors.k, tensors.v, tensors.kv_cache, attn_opts },
-            .{ .program_name = try std.fmt.allocPrint(arena, "paged_attention_{t}", .{backend}) },
+            .{ .program_name = try std.fmt.allocPrint(arena, "paged_attention_{t}", .{backend}), .shardings = shardings },
         );
         defer exe.deinit();
 
@@ -399,14 +477,14 @@ test pagedAttention {
                 var block_table_decode: @TypeOf(block_table) = @splat(@splat(-1));
                 @memcpy(block_table_decode[0..num_decode], block_table[num_prefill..]);
 
-                var seq_lens_prefill: @TypeOf(seq_lens) = @splat(0);
-                @memcpy(seq_lens_prefill[0..num_prefill], seq_lens[0..num_prefill]);
-                var seq_lens_decode: @TypeOf(seq_lens) = @splat(0);
-                @memcpy(seq_lens_decode[0..num_decode], seq_lens[num_prefill..]);
+                var seq_lens_prefill: [batch_size + 1]i32 = @splat(0);
+                @memcpy(seq_lens_prefill[1 .. num_prefill + 1], seq_lens[0..num_prefill]);
+                var seq_lens_decode: [batch_size + 1]i32 = @splat(0);
+                @memcpy(seq_lens_decode[1 .. num_decode + 1], seq_lens[num_prefill..]);
 
-                var seqused_k_prefill: @TypeOf(query_start_len) = @splat(query_start_len[num_prefill]);
+                var seqused_k_prefill: [batch_size]i32 = @splat(query_start_len[num_prefill]);
                 @memcpy(seqused_k_prefill[0..num_prefill], query_start_len[0..num_prefill]);
-                var seqused_k_decode: @TypeOf(query_start_len) = @splat(query_start_len[batch_size - 1]);
+                var seqused_k_decode: [batch_size]i32 = @splat(query_start_len[batch_size - 1]);
                 @memcpy(seqused_k_decode[0 .. num_decode + 1], query_start_len[num_prefill..]);
 
                 const prefill_token_count = query_start_len[num_prefill];
@@ -437,7 +515,7 @@ test pagedAttention {
         };
         // defer Parameters.deinitBuffer(&parameters_d);
 
-        const output_d = try zml.testing.autoCall(allocator, io, &exe, pagedAttention, .{ parameters_d, q, undefined, undefined, kv_cache_d });
+        const output_d = try zml.testing.autoCall(allocator, io, &exe, pagedAttention, .{ parameters_d, q, new_k, new_v, kv_cache_d });
         try zml.testing.expectClose(io, triton_h, output_d, .{
             .absolute_tolerance = 1e-3,
             .relative_tolerance = 1e-2,

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -58,6 +58,8 @@ pub const Options = union(Backend) {
         backend: Backend,
         is_prefill: bool,
         batch_size: u32,
+        batch_size_prefill: ?u32 = null,
+        batch_size_decode: ?u32 = null,
         seq_len: u32,
         max_num_pages: u32,
         max_token_count: u32,
@@ -72,8 +74,8 @@ pub const Options = union(Backend) {
             .cuda_fa2 => if (args.is_prefill) .{
                 .cuda_fa2 = .{
                     .mixed = .{
-                        .batch_size_decode = args.batch_size,
-                        .batch_size_prefill = args.batch_size,
+                        .batch_size_decode = args.batch_size_decode orelse args.batch_size,
+                        .batch_size_prefill = args.batch_size_prefill orelse args.batch_size,
                         .max_num_pages = args.max_num_pages,
                         .max_seqlen_k = args.seq_len,
                         .max_seqlen_q = args.max_seqlen_q,
@@ -99,8 +101,8 @@ pub const Options = union(Backend) {
             .cuda_fa3 => if (args.is_prefill) .{
                 .cuda_fa3 = .{
                     .mixed = .{
-                        .batch_size_decode = args.batch_size,
-                        .batch_size_prefill = args.batch_size,
+                        .batch_size_decode = args.batch_size_decode orelse args.batch_size,
+                        .batch_size_prefill = args.batch_size_prefill orelse args.batch_size,
                         .max_num_pages = args.max_num_pages,
                         .max_seqlen_k = args.seq_len,
                         .max_seqlen_q = args.max_seqlen_q,
@@ -335,15 +337,19 @@ test pagedAttention {
     const num_pages = 64;
     const page_size = 16;
     const max_num_pages = 16;
+    const num_prefill = 1;
+    const prefill_token_count = 32;
+    const num_decode = 5;
+    const query_token_count = prefill_token_count + num_decode;
     const dt: zml.DataType = .bf16;
     const tensors: struct { q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, kv_cache: KvCache, token_index: zml.Tensor, slot_mapping: zml.Tensor } = .{
-        .q = .init(.{ .b = 8, .hkv = 2, .hg = 4, .hd = 32 }, dt),
+        .q = .init(.{ .b = query_token_count, .hkv = 2, .hg = 4, .hd = 32 }, dt),
         .k = .init(.{ .b = 8, .hkv = 2, .hd = 32 }, dt),
         .v = .init(.{ .b = 8, .hkv = 2, .hd = 32 }, dt),
         .kv_cache = .{
             .split = .{
-                .k = .init(.{ .page = num_pages, .hkv = 2, .k_chunk = page_size, .hd = 32 }, dt),
-                .v = .init(.{ .page = num_pages, .hkv = 2, .k_chunk = page_size, .hd = 32 }, dt),
+                .k = .init(.{ .page = num_pages, .k_chunk = page_size, .hkv = 2, .hd = 32 }, dt),
+                .v = .init(.{ .page = num_pages, .k_chunk = page_size, .hkv = 2, .hd = 32 }, dt),
             },
         },
         .token_index = .init(.{}, .u32),
@@ -364,6 +370,8 @@ test pagedAttention {
         .backend = .triton,
         .is_prefill = true,
         .batch_size = batch_size,
+        .batch_size_prefill = num_prefill,
+        .batch_size_decode = num_decode,
         .seq_len = 64,
         .max_num_pages = max_num_pages,
         .max_token_count = 16 * page_size,
@@ -397,8 +405,6 @@ test pagedAttention {
     );
     defer triton_exe.deinit();
 
-    const num_prefill = 1;
-    const num_decode = batch_size - num_prefill;
     const block_table: [batch_size][max_num_pages]i32 = .{
         // prefilling pages 9-10
         .{ 0, 1, 2, 3, 4, 9, 10, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
@@ -453,6 +459,7 @@ test pagedAttention {
 
     for (std.enums.values(Backend)) |backend| {
         if (!backend.isAvailable(platform)) continue;
+        if (backend == .triton) continue;
 
         var backend_options_args = triton_options_args;
         backend_options_args.backend = backend;
@@ -472,31 +479,30 @@ test pagedAttention {
             // No materializer implemented for cuda fa3
             .cuda_fa3 => return error.SkipZigTest,
             .cuda_fa2 => cuda_fa2: {
-                var block_table_prefill: @TypeOf(block_table) = @splat(@splat(-1));
-                @memcpy(block_table_prefill[0..num_prefill], block_table[0..num_prefill]);
-                var block_table_decode: @TypeOf(block_table) = @splat(@splat(-1));
-                @memcpy(block_table_decode[0..num_decode], block_table[num_prefill..]);
+                var block_table_prefill: [num_prefill][max_num_pages]i32 = undefined;
+                @memcpy(&block_table_prefill, block_table[0..num_prefill]);
+                var block_table_decode: [num_decode][max_num_pages]i32 = undefined;
+                @memcpy(&block_table_decode, block_table[num_prefill .. num_prefill + num_decode]);
 
-                var seq_lens_prefill: [batch_size + 1]i32 = @splat(0);
-                @memcpy(seq_lens_prefill[1 .. num_prefill + 1], seq_lens[0..num_prefill]);
-                var seq_lens_decode: [batch_size + 1]i32 = @splat(0);
-                @memcpy(seq_lens_decode[1 .. num_decode + 1], seq_lens[num_prefill..]);
+                var cu_seqlens_q_prefill: [num_prefill + 1]i32 = undefined;
+                @memcpy(&cu_seqlens_q_prefill, query_start_len[0 .. num_prefill + 1]);
+                var cu_seqlens_q_decode: [num_decode + 1]i32 = undefined;
+                for (&cu_seqlens_q_decode, query_start_len[num_prefill .. num_prefill + num_decode + 1]) |*decode_len, query_start| {
+                    decode_len.* = query_start - prefill_token_count;
+                }
 
-                var seqused_k_prefill: [batch_size]i32 = @splat(query_start_len[num_prefill]);
-                @memcpy(seqused_k_prefill[0..num_prefill], query_start_len[0..num_prefill]);
-                var seqused_k_decode: [batch_size]i32 = @splat(query_start_len[batch_size - 1]);
-                @memcpy(seqused_k_decode[0 .. num_decode + 1], query_start_len[num_prefill..]);
-
-                const prefill_token_count = query_start_len[num_prefill];
-                for (&seqused_k_decode) |*q_start| q_start.* -= prefill_token_count;
+                var seqused_k_prefill: [num_prefill]i32 = undefined;
+                @memcpy(&seqused_k_prefill, seq_lens[0..num_prefill]);
+                var seqused_k_decode: [num_decode]i32 = undefined;
+                @memcpy(&seqused_k_decode, seq_lens[num_prefill .. num_prefill + num_decode]);
 
                 break :cuda_fa2 .{ .cuda_fa2 = .{ .mixed = .{
                     .block_table_prefill = try .fromBytes(io, platform, parameters.cuda_fa2.mixed.block_table_prefill.shape(), .replicated, @ptrCast(&block_table_prefill)),
-                    .cu_seqlens_q_prefill = try .fromBytes(io, platform, parameters.cuda_fa2.mixed.cu_seqlens_q_prefill.shape(), .replicated, @ptrCast(&seq_lens_prefill)),
+                    .cu_seqlens_q_prefill = try .fromBytes(io, platform, parameters.cuda_fa2.mixed.cu_seqlens_q_prefill.shape(), .replicated, @ptrCast(&cu_seqlens_q_prefill)),
                     .seqused_k_prefill = try .fromBytes(io, platform, parameters.cuda_fa2.mixed.seqused_k_prefill.shape(), .replicated, @ptrCast(&seqused_k_prefill)),
 
                     .block_table_decode = try .fromBytes(io, platform, parameters.cuda_fa2.mixed.block_table_decode.shape(), .replicated, @ptrCast(&block_table_decode)),
-                    .cu_seqlens_q_decode = try .fromBytes(io, platform, parameters.cuda_fa2.mixed.cu_seqlens_q_decode.shape(), .replicated, @ptrCast(&seq_lens_decode)),
+                    .cu_seqlens_q_decode = try .fromBytes(io, platform, parameters.cuda_fa2.mixed.cu_seqlens_q_decode.shape(), .replicated, @ptrCast(&cu_seqlens_q_decode)),
                     .seqused_k_decode = try .fromBytes(io, platform, parameters.cuda_fa2.mixed.seqused_k_decode.shape(), .replicated, @ptrCast(&seqused_k_decode)),
 
                     .metadata = .{ .decode_offset = try .scalar(io, platform, prefill_token_count, .i32) },

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -218,18 +218,18 @@ pub const KvCache = union(enum) {
         chunk_size: u32,
         backend: Backend,
     ) KvCache {
-        const active_page, const k_chunk = getPageAndOffsetFromSlotMapping(slot_mapping, chunk_size);
+        const page_index, const offset = getPageAndOffsetFromSlotMapping(slot_mapping, chunk_size);
 
         var kv: KvCache = switch (self) {
             .split => |split| switch (backend) {
                 .cuda_fa2, .cuda_fa3, .triton, .mosaic_tpu, .metal => .{ .split = .{
                     .k = split.k.scatterSlices(
-                        .{ .page = active_page, .k_chunk = k_chunk },
+                        .{ .page = page_index, .k_chunk = offset },
                         new_k,
                         .{ .update_fn = zml.Tensor.ScatterOpts.override, .indices_are_unique = false, .indices_are_sorted = false },
                     ),
                     .v = split.v.scatterSlices(
-                        .{ .page = active_page, .k_chunk = k_chunk },
+                        .{ .page = page_index, .k_chunk = offset },
                         new_v,
                         .{ .update_fn = zml.Tensor.ScatterOpts.override, .indices_are_unique = false, .indices_are_sorted = false },
                     ),

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -8,6 +8,8 @@ const metal = @import("metal_attention.zig");
 const tpu = @import("tpu_attention.zig");
 const triton = @import("triton_attention.zig");
 
+const log = std.log.scoped(.@"zml/attention");
+
 const PagedAttention = @This();
 
 pub const Backend = enum {
@@ -462,6 +464,7 @@ test pagedAttention {
         if (backend == .triton) continue;
         // No materializer implemented for cuda fa3
         if (backend == .cuda_fa3) continue;
+        log.warn("pagedAttention, testing backend {t}", .{backend});
 
         var backend_options_args = triton_options_args;
         backend_options_args.backend = backend;

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -367,11 +367,11 @@ test pagedAttention {
     var new_v = try zml.testing.autoCall(allocator, io, &rng_k, zml.Tensor.Rng.normal, {});
     defer new_v.deinit();
 
-    var kv_cache_k = try zml.testing.autoCall(allocator, io, &rng_kv_cache, zml.Tensor.Rng.normal, {});
-    defer kv_cache_k.deinit();
-    var kv_cache_v = try zml.testing.autoCall(allocator, io, &rng_kv_cache, zml.Tensor.Rng.normal, {});
-    defer kv_cache_v.deinit();
-    const kv_cache_d: zml.Bufferized(KvCache) = .{ .split = .{ .k = kv_cache_k, .v = kv_cache_v } };
+    var kv_cache_d: zml.Bufferized(KvCache) = .{ .split = .{
+        .k = try zml.testing.autoCall(allocator, io, &rng_kv_cache, zml.Tensor.Rng.normal, {}),
+        .v = try zml.testing.autoCall(allocator, io, &rng_kv_cache, zml.Tensor.Rng.normal, {}),
+    } };
+    defer zml.Buffer.deinitAll(KvCache, &kv_cache_d);
 
     const block_table: [batch_size][max_num_pages]i32 = .{
         // prefilling pages 9-10
@@ -398,11 +398,12 @@ test pagedAttention {
     };
 
     const query_start_len: [batch_size + 1]i32 = .{ 0, 32, 33, 34, 35, 36, 37, 38, 38 };
-    const triton_parameters_d: zml.Bufferized(Parameters) = .{ .triton = .{
+    var triton_parameters_d: zml.Bufferized(Parameters) = .{ .triton = .{
         .block_table = try .fromBytes(io, platform, triton_parameters.triton.block_table.shape(), .replicated, @ptrCast(&block_table)),
         .seq_lens = try .fromBytes(io, platform, triton_parameters.triton.seq_lens.shape(), .replicated, @ptrCast(&seq_lens)),
         .query_start_len = try .fromBytes(io, platform, triton_parameters.triton.query_start_len.shape(), .replicated, @ptrCast(&query_start_len)),
     } };
+    defer zml.Buffer.deinitAll(Parameters, &triton_parameters_d);
 
     var results_per_backend: std.enums.EnumArray(Backend, ?zml.Slice) = .initFill(null);
     defer {
@@ -431,10 +432,10 @@ test pagedAttention {
         );
         defer exe.deinit();
 
-        const parameters_d: zml.Bufferized(Parameters) = switch (parameters) {
+        var parameters_d: zml.Bufferized(Parameters) = switch (parameters) {
             // No materializer implemented for cuda fa3
             .cuda_fa3 => continue,
-            inline .cuda_fa2 => |params, t| cuda_fa2: {
+            .cuda_fa2 => |params| cuda_fa2: {
                 var block_table_prefill: [num_prefill][max_num_pages]i32 = undefined;
                 @memcpy(&block_table_prefill, block_table[0..num_prefill]);
                 var block_table_decode: [num_decode][max_num_pages]i32 = undefined;
@@ -452,7 +453,7 @@ test pagedAttention {
                 var seqused_k_decode: [num_decode]i32 = undefined;
                 @memcpy(&seqused_k_decode, seq_lens[num_prefill .. num_prefill + num_decode]);
 
-                break :cuda_fa2 @unionInit(zml.Bufferized(Parameters), @tagName(t), .{ .mixed = .{
+                break :cuda_fa2 .{ .cuda_fa2 = .{ .mixed = .{
                     .block_table_prefill = try .fromBytes(io, platform, params.mixed.block_table_prefill.shape(), .replicated, @ptrCast(&block_table_prefill)),
                     .cu_seqlens_q_prefill = try .fromBytes(io, platform, params.mixed.cu_seqlens_q_prefill.shape(), .replicated, @ptrCast(&cu_seqlens_q_prefill)),
                     .seqused_k_prefill = try .fromBytes(io, platform, params.mixed.seqused_k_prefill.shape(), .replicated, @ptrCast(&seqused_k_prefill)),
@@ -462,7 +463,7 @@ test pagedAttention {
                     .seqused_k_decode = try .fromBytes(io, platform, params.mixed.seqused_k_decode.shape(), .replicated, @ptrCast(&seqused_k_decode)),
 
                     .metadata = .{ .decode_offset = try .scalar(io, platform, prefill_token_count, .i32) },
-                } });
+                } } };
             },
             .triton => triton_parameters_d,
             inline .metal, .mosaic_tpu => |_, t| @unionInit(zml.Bufferized(Parameters), @tagName(t), .{
@@ -471,11 +472,11 @@ test pagedAttention {
                 .query_start_len = triton_parameters_d.triton.query_start_len,
             }),
         };
+        // cu_fa2 creates new buffers while other reuse triton buffers.
+        defer if (backend == .cuda_fa2) zml.Buffer.deinitAll(Parameters, &parameters_d);
 
-        // defer Parameters.deinitBuffer(&parameters_d);
         var output_d = try zml.testing.autoCall(allocator, io, &exe, pagedAttention, .{ parameters_d, q, new_k, new_v, kv_cache_d });
-        // defer output_d.deinit();
-        try output_d.await(io);
+        defer output_d.deinit();
         results_per_backend.set(backend, try output_d.toSliceAlloc(allocator, io));
     }
 

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -323,23 +323,25 @@ test pagedAttention {
     const batch_size = active_batch_size + 1;
     const query_token_count = prefill_token_count + num_decode;
     const dt: zml.DataType = .bf16;
+    const partition = .{ .hkv = .model };
     const tensors: struct { q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, kv_cache: KvCache } = .{
-        .q = .init(.{ .b = query_token_count, .hkv = 2, .hg = 4, .hd = 32 }, dt),
-        .k = .init(.{ .b = query_token_count, .hkv = 2, .hd = 32 }, dt),
-        .v = .init(.{ .b = query_token_count, .hkv = 2, .hd = 32 }, dt),
+        .q = .withPartitioning(.init(.{ .b = query_token_count, .hkv = 2, .hg = 4, .hd = 32 }, dt), partition),
+        .k = .withPartitioning(.init(.{ .b = query_token_count, .hkv = 2, .hd = 32 }, dt), partition),
+        .v = .withPartitioning(.init(.{ .b = query_token_count, .hkv = 2, .hd = 32 }, dt), partition),
         .kv_cache = .{
             .split = .{
-                .k = .init(.{ .page = num_pages, .k_chunk = page_size, .hkv = 2, .hd = 32 }, dt),
-                .v = .init(.{ .page = num_pages, .k_chunk = page_size, .hkv = 2, .hd = 32 }, dt),
+                .k = .withPartitioning(.init(.{ .page = num_pages, .k_chunk = page_size, .hkv = 2, .hd = 32 }, dt), partition),
+                .v = .withPartitioning(.init(.{ .page = num_pages, .k_chunk = page_size, .hkv = 2, .hd = 32 }, dt), partition),
             },
         },
     };
 
-    const rng_q = try platform.compileFn(allocator, io, zml.Tensor.Rng.normal, .{ tensors.q.shape(), .{} }, .{});
+    const shardings: []const zml.Sharding = &.{ platform.replicated_sharding, platform.shardings.get("model").? };
+    const rng_q = try platform.compileFn(allocator, io, zml.Tensor.Rng.normal, .{ tensors.q.shape(), .{} }, .{ .shardings = shardings });
     defer rng_q.deinit();
-    const rng_k = try platform.compileFn(allocator, io, zml.Tensor.Rng.normal, .{ tensors.k.shape(), .{} }, .{});
+    const rng_k = try platform.compileFn(allocator, io, zml.Tensor.Rng.normal, .{ tensors.k.shape(), .{} }, .{ .shardings = shardings });
     defer rng_k.deinit();
-    const rng_kv_cache = try platform.compileFn(allocator, io, zml.Tensor.Rng.normal, .{ tensors.kv_cache.split.k.shape(), .{} }, .{});
+    const rng_kv_cache = try platform.compileFn(allocator, io, zml.Tensor.Rng.normal, .{ tensors.kv_cache.split.k.shape(), .{} }, .{ .shardings = shardings });
     defer rng_kv_cache.deinit();
 
     const triton_options_args: Options.Args = .{
@@ -370,8 +372,6 @@ test pagedAttention {
     var kv_cache_v = try zml.testing.autoCall(allocator, io, &rng_kv_cache, zml.Tensor.Rng.normal, {});
     defer kv_cache_v.deinit();
     const kv_cache_d: zml.Bufferized(KvCache) = .{ .split = .{ .k = kv_cache_k, .v = kv_cache_v } };
-
-    const shardings: []const zml.Sharding = &.{ platform.replicated_sharding, platform.shardings.get("model").? };
 
     const block_table: [batch_size][max_num_pages]i32 = .{
         // prefilling pages 9-10

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -10,6 +10,12 @@ const triton = @import("triton_attention.zig");
 
 const PagedAttention = @This();
 
+test {
+    std.testing.refAllDecls(Backend);
+    std.testing.refAllDecls(Options);
+    std.testing.refAllDecls(Parameters);
+}
+
 pub const Backend = enum {
     cuda_fa2,
     cuda_fa3,
@@ -185,15 +191,12 @@ pub const Parameters = union(Backend) {
     }
 
     pub fn onMemory(self: Parameters, memory: zml.platform.Memory.Kind) Parameters {
-        return switch (self) {
-            else => |v, t| @unionInit(Parameters, @tagName(t), v.onMemory(memory)),
-        };
+        zml.Tensor.onMemoryAll(&self, memory);
+        return self;
     }
 
     pub fn toMemory(self: Parameters, memory: zml.platform.Memory.Kind) Parameters {
-        return switch (self) {
-            else => |v, t| @unionInit(Parameters, @tagName(t), v.toMemory(memory)),
-        };
+        return zml.Tensor.toMemoryAll(self, memory);
     }
 };
 

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -8,8 +8,6 @@ const metal = @import("metal_attention.zig");
 const tpu = @import("tpu_attention.zig");
 const triton = @import("triton_attention.zig");
 
-const log = std.log.scoped(.@"zml/attention");
-
 const PagedAttention = @This();
 
 pub const Backend = enum {
@@ -127,22 +125,6 @@ pub const Options = union(Backend) {
                     },
                 },
             },
-            .triton => .{
-                .triton = .{
-                    .batch_size = args.batch_size,
-                    .max_num_pages = args.max_num_pages,
-                    .max_seqlen_q = args.max_seqlen_q,
-                    .is_prefill = args.is_prefill,
-                },
-            },
-            .metal => .{
-                .metal = .{
-                    .batch_size = args.batch_size,
-                    .max_num_pages = args.max_num_pages,
-                    .max_seqlen_q = args.max_seqlen_q,
-                    .is_prefill = args.is_prefill,
-                },
-            },
             .mosaic_tpu => .{
                 .mosaic_tpu = .{
                     .is_prefill = args.is_prefill,
@@ -155,6 +137,12 @@ pub const Options = union(Backend) {
                     .head_dim = args.head_dim,
                 },
             },
+            inline .triton, .metal => |t| @unionInit(Options, @tagName(t), .{
+                .batch_size = args.batch_size,
+                .max_num_pages = args.max_num_pages,
+                .max_seqlen_q = args.max_seqlen_q,
+                .is_prefill = args.is_prefill,
+            }),
         };
     }
 
@@ -198,21 +186,13 @@ pub const Parameters = union(Backend) {
 
     pub fn onMemory(self: Parameters, memory: zml.platform.Memory.Kind) Parameters {
         return switch (self) {
-            .cuda_fa2 => |v| .{ .cuda_fa2 = v.onMemory(memory) },
-            .cuda_fa3 => |v| .{ .cuda_fa3 = v.onMemory(memory) },
-            .triton => |v| .{ .triton = v.onMemory(memory) },
-            .mosaic_tpu => |v| .{ .mosaic_tpu = v.onMemory(memory) },
-            .metal => |v| .{ .metal = v.onMemory(memory) },
+            else => |v, t| @unionInit(Parameters, @tagName(t), v.onMemory(memory)),
         };
     }
 
     pub fn toMemory(self: Parameters, memory: zml.platform.Memory.Kind) Parameters {
         return switch (self) {
-            .cuda_fa2 => |v| .{ .cuda_fa2 = v.toMemory(memory) },
-            .cuda_fa3 => |v| .{ .cuda_fa3 = v.toMemory(memory) },
-            .triton => |v| .{ .triton = v.toMemory(memory) },
-            .mosaic_tpu => |v| .{ .mosaic_tpu = v.toMemory(memory) },
-            .metal => |v| .{ .metal = v.toMemory(memory) },
+            else => |v, t| @unionInit(Parameters, @tagName(t), v.toMemory(memory)),
         };
     }
 };
@@ -327,35 +307,32 @@ test "Backend.auto selects triton on oneAPI" {
 
 test pagedAttention {
     const platform = zml.testing.env();
-    // Check the reference implem is available
-    if (!Backend.triton.isAvailable(platform)) return error.SkipZigTest;
     const io = std.testing.io;
     const allocator = std.testing.allocator;
     var arena_state: std.heap.ArenaAllocator = .init(allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const batch_size = 8;
     const num_pages = 64;
     const page_size = 16;
     const max_num_pages = 16;
-    const num_prefill = 1;
     const prefill_token_count = 32;
-    const num_decode = 5;
+    const num_prefill = 1;
+    const num_decode = 6;
+    const active_batch_size = num_prefill + num_decode;
+    const batch_size = active_batch_size + 1;
     const query_token_count = prefill_token_count + num_decode;
     const dt: zml.DataType = .bf16;
-    const tensors: struct { q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, kv_cache: KvCache, token_index: zml.Tensor, slot_mapping: zml.Tensor } = .{
+    const tensors: struct { q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, kv_cache: KvCache } = .{
         .q = .init(.{ .b = query_token_count, .hkv = 2, .hg = 4, .hd = 32 }, dt),
-        .k = .init(.{ .b = 8, .hkv = 2, .hd = 32 }, dt),
-        .v = .init(.{ .b = 8, .hkv = 2, .hd = 32 }, dt),
+        .k = .init(.{ .b = query_token_count, .hkv = 2, .hd = 32 }, dt),
+        .v = .init(.{ .b = query_token_count, .hkv = 2, .hd = 32 }, dt),
         .kv_cache = .{
             .split = .{
                 .k = .init(.{ .page = num_pages, .k_chunk = page_size, .hkv = 2, .hd = 32 }, dt),
                 .v = .init(.{ .page = num_pages, .k_chunk = page_size, .hkv = 2, .hd = 32 }, dt),
             },
         },
-        .token_index = .init(.{}, .u32),
-        .slot_mapping = .init(.{ .b = 8 }, .u32),
     };
 
     const rng_q = try platform.compileFn(allocator, io, zml.Tensor.Rng.normal, .{ tensors.q.shape(), .{} }, .{});
@@ -365,16 +342,13 @@ test pagedAttention {
     const rng_kv_cache = try platform.compileFn(allocator, io, zml.Tensor.Rng.normal, .{ tensors.kv_cache.split.k.shape(), .{} }, .{});
     defer rng_kv_cache.deinit();
 
-    const update_exe = try platform.compileFn(allocator, io, KvCache.update, .{ tensors.kv_cache, tensors.k, tensors.v, tensors.slot_mapping, page_size, .triton }, .{});
-    defer update_exe.deinit();
-
     const triton_options_args: Options.Args = .{
         .backend = .triton,
         .is_prefill = true,
         .batch_size = batch_size,
         .batch_size_prefill = num_prefill,
         .batch_size_decode = num_decode,
-        .seq_len = 64,
+        .seq_len = max_num_pages * page_size,
         .max_num_pages = max_num_pages,
         .max_token_count = 16 * page_size,
         .num_heads = @intCast(tensors.q.dim(.hg) * tensors.q.dim(.hkv)),
@@ -398,26 +372,18 @@ test pagedAttention {
     const kv_cache_d: zml.Bufferized(KvCache) = .{ .split = .{ .k = kv_cache_k, .v = kv_cache_v } };
 
     const shardings: []const zml.Sharding = &.{ platform.replicated_sharding, platform.shardings.get("model").? };
-    const triton_exe = try platform.compileFn(
-        allocator,
-        io,
-        pagedAttention,
-        .{ triton_parameters, tensors.q, tensors.k, tensors.v, tensors.kv_cache, attn_opts },
-        .{ .program_name = "paged_attention_triton", .shardings = shardings },
-    );
-    defer triton_exe.deinit();
 
     const block_table: [batch_size][max_num_pages]i32 = .{
         // prefilling pages 9-10
-        .{ 0, 1, 2, 3, 4, 9, 10, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
+        .{ 0, 1, 9, 10, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
         // generation
-        .{ 0, 1, 2, 3, 4, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
+        .{ 0, 1, 2, 3, 4, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
         .{ 0, 1, 2, 3, 4, 6, 7, 8, -1, -1, -1, -1, -1, -1, -1, -1 },
         .{ 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63 },
-        .{ 0, 1, 2, 3, 4, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
-        .{ 0, 1, 2, 3, 4, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
-        .{ 0, 1, 2, 3, 4, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
-        @splat(-1),
+        .{ 0, 1, 2, 3, 4, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
+        .{ 0, 1, 2, 3, 4, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
+        .{ 0, 1, 2, 3, 4, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
+        .{ -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
     };
 
     const seq_lens: [batch_size]i32 = .{
@@ -428,43 +394,29 @@ test pagedAttention {
         4 * page_size + 3,
         4 * page_size + 3,
         4 * page_size + 3,
-        4 * page_size + 3,
+        0,
     };
 
-    // TODO: fix me. Currently this work cause all implementation ready k and v directly from the kv cache.
-    // update kv cache
-    // {
-    //     const slot_mapping: [batch_size]u32 = .{
-    //         10 * page_size,
-    //         5 * page_size + 3,
-    //         8 * page_size + 11,
-    //         63 * page_size + 9,
-    //         5 * page_size + 3,
-    //         5 * page_size + 3,
-    //         5 * page_size + 3,
-    //         5 * page_size + 3,
-    //     };
-    //     const slot_mapping_d: zml.Buffer = try .fromBytes(io, platform, tensors.slot_mapping.shape(), .replicated, @ptrCast(&slot_mapping));
-    //     kv_cache_d = try zml.testing.autoCall(allocator, io, &update_exe, KvCache.update, .{ kv_cache_d, new_k, new_v, slot_mapping_d });
-    // }
-    const query_start_len: [batch_size + 1]i32 = .{ 0, 32, 33, 34, 35, 36, 37, 37, 37 };
-
+    const query_start_len: [batch_size + 1]i32 = .{ 0, 32, 33, 34, 35, 36, 37, 38, 38 };
     const triton_parameters_d: zml.Bufferized(Parameters) = .{ .triton = .{
         .block_table = try .fromBytes(io, platform, triton_parameters.triton.block_table.shape(), .replicated, @ptrCast(&block_table)),
         .seq_lens = try .fromBytes(io, platform, triton_parameters.triton.seq_lens.shape(), .replicated, @ptrCast(&seq_lens)),
         .query_start_len = try .fromBytes(io, platform, triton_parameters.triton.query_start_len.shape(), .replicated, @ptrCast(&query_start_len)),
     } };
 
-    const triton_d = try zml.testing.autoCall(allocator, io, &triton_exe, pagedAttention, .{ triton_parameters_d, q, new_k, new_v, kv_cache_d });
-    const triton_h: zml.Slice = try triton_d.toSliceAlloc(allocator, io);
-    defer triton_h.free(allocator);
+    var results_per_backend: std.enums.EnumArray(Backend, ?zml.Slice) = .initFill(null);
+    defer {
+        for (std.enums.values(Backend)) |backend| {
+            if (results_per_backend.get(backend)) |slice| slice.free(allocator);
+        }
+    }
 
     for (std.enums.values(Backend)) |backend| {
-        if (!backend.isAvailable(platform)) continue;
-        if (backend == .triton) continue;
-        // No materializer implemented for cuda fa3
-        if (backend == .cuda_fa3) continue;
-        log.warn("pagedAttention, testing backend {t}", .{backend});
+        if (!backend.isAvailable(platform)) {
+            std.log.warn("paged_attention backend {t} not available", .{backend});
+            continue;
+        }
+        std.log.warn("Testing paged_attention with backend {t}", .{backend});
 
         var backend_options_args = triton_options_args;
         backend_options_args.backend = backend;
@@ -479,10 +431,10 @@ test pagedAttention {
         );
         defer exe.deinit();
 
-        const parameters_d: zml.Bufferized(Parameters) = switch (backend) {
-            .triton => unreachable,
-            .cuda_fa3 => unreachable,
-            .cuda_fa2 => cuda_fa2: {
+        const parameters_d: zml.Bufferized(Parameters) = switch (parameters) {
+            // No materializer implemented for cuda fa3
+            .cuda_fa3 => continue,
+            inline .cuda_fa2 => |params, t| cuda_fa2: {
                 var block_table_prefill: [num_prefill][max_num_pages]i32 = undefined;
                 @memcpy(&block_table_prefill, block_table[0..num_prefill]);
                 var block_table_decode: [num_decode][max_num_pages]i32 = undefined;
@@ -500,36 +452,60 @@ test pagedAttention {
                 var seqused_k_decode: [num_decode]i32 = undefined;
                 @memcpy(&seqused_k_decode, seq_lens[num_prefill .. num_prefill + num_decode]);
 
-                break :cuda_fa2 .{ .cuda_fa2 = .{ .mixed = .{
-                    .block_table_prefill = try .fromBytes(io, platform, parameters.cuda_fa2.mixed.block_table_prefill.shape(), .replicated, @ptrCast(&block_table_prefill)),
-                    .cu_seqlens_q_prefill = try .fromBytes(io, platform, parameters.cuda_fa2.mixed.cu_seqlens_q_prefill.shape(), .replicated, @ptrCast(&cu_seqlens_q_prefill)),
-                    .seqused_k_prefill = try .fromBytes(io, platform, parameters.cuda_fa2.mixed.seqused_k_prefill.shape(), .replicated, @ptrCast(&seqused_k_prefill)),
+                break :cuda_fa2 @unionInit(zml.Bufferized(Parameters), @tagName(t), .{ .mixed = .{
+                    .block_table_prefill = try .fromBytes(io, platform, params.mixed.block_table_prefill.shape(), .replicated, @ptrCast(&block_table_prefill)),
+                    .cu_seqlens_q_prefill = try .fromBytes(io, platform, params.mixed.cu_seqlens_q_prefill.shape(), .replicated, @ptrCast(&cu_seqlens_q_prefill)),
+                    .seqused_k_prefill = try .fromBytes(io, platform, params.mixed.seqused_k_prefill.shape(), .replicated, @ptrCast(&seqused_k_prefill)),
 
-                    .block_table_decode = try .fromBytes(io, platform, parameters.cuda_fa2.mixed.block_table_decode.shape(), .replicated, @ptrCast(&block_table_decode)),
-                    .cu_seqlens_q_decode = try .fromBytes(io, platform, parameters.cuda_fa2.mixed.cu_seqlens_q_decode.shape(), .replicated, @ptrCast(&cu_seqlens_q_decode)),
-                    .seqused_k_decode = try .fromBytes(io, platform, parameters.cuda_fa2.mixed.seqused_k_decode.shape(), .replicated, @ptrCast(&seqused_k_decode)),
+                    .block_table_decode = try .fromBytes(io, platform, params.mixed.block_table_decode.shape(), .replicated, @ptrCast(&block_table_decode)),
+                    .cu_seqlens_q_decode = try .fromBytes(io, platform, params.mixed.cu_seqlens_q_decode.shape(), .replicated, @ptrCast(&cu_seqlens_q_decode)),
+                    .seqused_k_decode = try .fromBytes(io, platform, params.mixed.seqused_k_decode.shape(), .replicated, @ptrCast(&seqused_k_decode)),
 
                     .metadata = .{ .decode_offset = try .scalar(io, platform, prefill_token_count, .i32) },
-                } } };
+                } });
             },
-            .metal => .{ .metal = .{
+            .triton => triton_parameters_d,
+            inline .metal, .mosaic_tpu => |_, t| @unionInit(zml.Bufferized(Parameters), @tagName(t), .{
                 .block_table = triton_parameters_d.triton.block_table,
                 .seq_lens = triton_parameters_d.triton.seq_lens,
                 .query_start_len = triton_parameters_d.triton.query_start_len,
-            } },
-            .mosaic_tpu => .{ .mosaic_tpu = .{
-                .block_table = triton_parameters_d.triton.block_table,
-                .seq_lens = triton_parameters_d.triton.seq_lens,
-                .query_start_len = triton_parameters_d.triton.query_start_len,
-            } },
+            }),
         };
-        // defer Parameters.deinitBuffer(&parameters_d);
 
-        const output_d = try zml.testing.autoCall(allocator, io, &exe, pagedAttention, .{ parameters_d, q, new_k, new_v, kv_cache_d });
-        try zml.testing.expectClose(io, triton_h, output_d, .{
-            .absolute_tolerance = 1e-3,
+        // defer Parameters.deinitBuffer(&parameters_d);
+        var output_d = try zml.testing.autoCall(allocator, io, &exe, pagedAttention, .{ parameters_d, q, new_k, new_v, kv_cache_d });
+        // defer output_d.deinit();
+        try output_d.await(io);
+        results_per_backend.set(backend, try output_d.toSliceAlloc(allocator, io));
+    }
+
+    const reference_backend: Backend = .triton;
+    const reference = results_per_backend.get(reference_backend) orelse return error.SkipZigTest;
+
+    var num_failed: u32 = 0;
+    for (std.enums.values(Backend)) |backend| {
+        if (backend == reference_backend) continue;
+        const output_h = results_per_backend.get(backend) orelse continue;
+
+        const tolerance: zml.testing.CompareOpts = .{
+            .absolute_tolerance = 1e-2,
             .relative_tolerance = 1e-2,
             .epsilon_relative = 1e-6,
-        });
+        };
+
+        zml.testing.expectClose(io, reference, output_h, tolerance) catch |err| switch (err) {
+            error.TestUnexpectedResult => {
+                num_failed += 1;
+                std.log.err("test pagedAttention failed on backend {0t}\n--> reference ({1t}): {2d:32.3}\n--> pagedAttention({0t}): {3d:32.3}", .{
+                    backend,
+                    reference_backend,
+                    reference.subSlice(1, 0, 1).subSlice(2, 0, 1),
+                    output_h.subSlice(1, 0, 1).subSlice(2, 0, 1),
+                });
+            },
+            else => |e| return e,
+        };
     }
+
+    if (num_failed > 0) return error.TestUnexpectedResult;
 }

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -33,7 +33,7 @@ pub const Backend = enum {
     pub fn isAvailable(backend: Backend, platform: *const zml.Platform) bool {
         return switch (backend) {
             // .vanilla => true,
-            .triton => true,
+            .triton => platform.target != .cpu,
             .metal => platform.target == .metal,
             .mosaic_tpu => platform.target == .tpu,
             .cuda_fa2 => platform.target == .cuda,
@@ -460,6 +460,8 @@ test pagedAttention {
     for (std.enums.values(Backend)) |backend| {
         if (!backend.isAvailable(platform)) continue;
         if (backend == .triton) continue;
+        // No materializer implemented for cuda fa3
+        if (backend == .cuda_fa3) continue;
 
         var backend_options_args = triton_options_args;
         backend_options_args.backend = backend;
@@ -476,8 +478,7 @@ test pagedAttention {
 
         const parameters_d: zml.Bufferized(Parameters) = switch (backend) {
             .triton => unreachable,
-            // No materializer implemented for cuda fa3
-            .cuda_fa3 => return error.SkipZigTest,
+            .cuda_fa3 => unreachable,
             .cuda_fa2 => cuda_fa2: {
                 var block_table_prefill: [num_prefill][max_num_pages]i32 = undefined;
                 @memcpy(&block_table_prefill, block_table[0..num_prefill]);

--- a/zml/attention/tpu_attention.zig
+++ b/zml/attention/tpu_attention.zig
@@ -78,24 +78,6 @@ pub const mosaic_tpu = struct {
             allocation_size += self.query_start_len.byteSize();
             return allocation_size;
         }
-
-        pub fn onMemory(self: Parameters, memory: zml.platform.Memory.Kind) Parameters {
-            return .{
-                .opts = self.opts,
-                .block_table = self.block_table.onMemory(memory),
-                .seq_lens = self.seq_lens.onMemory(memory),
-                .query_start_len = self.query_start_len.onMemory(memory),
-            };
-        }
-
-        pub fn toMemory(self: Parameters, memory: zml.platform.Memory.Kind) Parameters {
-            return .{
-                .opts = self.opts,
-                .block_table = self.block_table.toMemory(memory),
-                .seq_lens = self.seq_lens.toMemory(memory),
-                .query_start_len = self.query_start_len.toMemory(memory),
-            };
-        }
     };
 
     fn raggedPagedKernelCall(

--- a/zml/attention/triton_attention.zig
+++ b/zml/attention/triton_attention.zig
@@ -3,15 +3,12 @@ const std = @import("std");
 const stdx = @import("stdx");
 
 const zml = @import("../zml.zig");
+const triton = zml.kernel.triton;
 const AttentionOptions = @import("paged_attention.zig").AttentionOptions;
-
 const kernels = @import("triton_kernels/unified_attention.zig");
 const kernels_oneapi = @import("triton_kernels/unified_attention_oneapi.zig");
-const tri = zml.kernel.triton;
 
 const log = std.log.scoped(.@"zml/attention/triton");
-
-const toDType = tri.from;
 
 fn isOneapiTarget() bool {
     return zml.module.CompilationContext.current().platform.target == .oneapi;
@@ -317,9 +314,9 @@ pub const paged = struct {
         const config = select2dConfig(paged_attention_opts);
 
         const kernel_config: kernels.KernelUnifiedAttention2dPtr.Config = .{
-            .q_dtype = toDType(q.dtype()),
-            .kv_dtype = toDType(k_cache.dtype()),
-            .o_dtype = toDType(q.dtype()),
+            .q_dtype = .from(q.dtype()),
+            .kv_dtype = .from(k_cache.dtype()),
+            .o_dtype = .from(q.dtype()),
             .num_query_heads = @intCast(paged_attention_opts.num_heads),
             .num_queries_per_kv = @intCast(paged_attention_opts.numQueriesPerKv()),
             .block_size = @intCast(paged_attention_opts.block_size),
@@ -339,24 +336,16 @@ pub const paged = struct {
         };
         log.debug("pagedAttention2d config: {any}", .{kernel_config});
 
-        const dummy = zml.Tensor.constant(zml.DataType.i8.zero());
+        const dummy: zml.Tensor = .scalar(0, .i8);
         const block_table_strides = parameters.block_table.shape().computeElementStrides().constSlice();
-        const block_table_strides_ptr = zml.Tensor.constant(zml.DataType.i64.constant(block_table_strides[0]));
+
         const q_shape = q.shape().mergeAxes(.{ .h = .{ .hkv, .hg } });
         const q_strides = q_shape.computeElementStrides().constSlice();
-        const q_strides_0_ptr = zml.Tensor.constant(zml.DataType.i64.constant(q_strides[0]));
-        const q_strides_1_ptr = zml.Tensor.constant(zml.DataType.i64.constant(q_strides[1]));
         const k_strides = k_cache.shape().computeElementStrides().constSlice();
-        const k_strides_0_ptr = zml.Tensor.constant(zml.DataType.i64.constant(k_strides[0]));
-        const k_strides_1_ptr = zml.Tensor.constant(zml.DataType.i64.constant(k_strides[1]));
-        const k_strides_2_ptr = zml.Tensor.constant(zml.DataType.i64.constant(k_strides[2]));
         const v_strides = v_cache.shape().computeElementStrides().constSlice();
-        const v_strides_0_ptr = zml.Tensor.constant(zml.DataType.i64.constant(v_strides[0]));
-        const v_strides_1_ptr = zml.Tensor.constant(zml.DataType.i64.constant(v_strides[1]));
-        const v_strides_2_ptr = zml.Tensor.constant(zml.DataType.i64.constant(v_strides[2]));
-        const num_seqs_ptr = zml.Tensor.constant(zml.DataType.i32.constant(parameters.block_table.dim(0)));
+
         const scale: f32 = paged_attention_opts.scale orelse @floatCast(1.0 / @sqrt(@as(f64, @floatFromInt(q.dim(.hd)))));
-        const scale_ptr = zml.Tensor.constant(zml.DataType.f32.constant(scale));
+        const num_seqs = parameters.block_table.dim(0);
 
         const output = kernels.KernelUnifiedAttention2dPtr.Kernel.call(
             .{
@@ -368,32 +357,32 @@ pub const paged = struct {
                 .seq_lens_ptr = parameters.seq_lens,
                 .alibi_slopes_ptr = dummy,
                 .qq_bias_ptr = dummy,
-                .scale_ptr = scale_ptr,
+                .scale_ptr = .scalar(scale, .f32),
                 .k_scale_ptr = dummy,
                 .v_scale_ptr = dummy,
                 .out_scale_ptr = dummy,
                 .softcap_ptr = dummy,
-                .block_table_stride_ptr = block_table_strides_ptr,
-                .query_stride_0_ptr = q_strides_0_ptr,
-                .query_stride_1_ptr = q_strides_1_ptr,
-                .output_stride_0_ptr = q_strides_0_ptr,
-                .output_stride_1_ptr = q_strides_1_ptr,
+                .block_table_stride_ptr = .scalar(block_table_strides[0], .i64),
+                .query_stride_0_ptr = .scalar(q_strides[0], .i64),
+                .query_stride_1_ptr = .scalar(q_strides[1], .i64),
+                .output_stride_0_ptr = .scalar(q_strides[0], .i64),
+                .output_stride_1_ptr = .scalar(q_strides[1], .i64),
                 .qq_bias_stride_0_ptr = dummy,
-                .stride_k_cache_0_ptr = k_strides_0_ptr,
-                .stride_k_cache_1_ptr = k_strides_1_ptr,
-                .stride_k_cache_2_ptr = k_strides_2_ptr,
-                .stride_v_cache_0_ptr = v_strides_0_ptr,
-                .stride_v_cache_1_ptr = v_strides_1_ptr,
-                .stride_v_cache_2_ptr = v_strides_2_ptr,
+                .stride_k_cache_0_ptr = .scalar(k_strides[0], .i64),
+                .stride_k_cache_1_ptr = .scalar(k_strides[1], .i64),
+                .stride_k_cache_2_ptr = .scalar(k_strides[2], .i64),
+                .stride_v_cache_0_ptr = .scalar(v_strides[0], .i64),
+                .stride_v_cache_1_ptr = .scalar(v_strides[1], .i64),
+                .stride_v_cache_2_ptr = .scalar(v_strides[2], .i64),
                 .query_start_len_ptr = parameters.query_start_len,
-                .num_seqs_ptr = num_seqs_ptr,
+                .num_seqs_ptr = .scalar(num_seqs, .i32),
             },
             .{ .output = q.shape() },
             .{
                 .cfg = kernel_config,
                 .grid = .{ @intCast(paged_attention_opts.num_kv_heads), @intCast(config.total_q_blocks), 1 },
-                .num_stages = @intCast(config.num_stages),
-                .num_warps = @intCast(config.num_warps),
+                .num_stages = config.num_stages,
+                .num_warps = config.num_warps,
             },
         );
         return output.output;
@@ -404,8 +393,8 @@ pub const paged = struct {
 
         const head_size_padded: i64 = @intCast(std.math.ceilPowerOfTwoAssert(usize, paged_attention_opts.head_dim));
         const attn_kernel_config: kernels.KernelUnifiedAttention3dPtr.Config = .{
-            .q_dtype = toDType(q.dtype()),
-            .kv_dtype = toDType(k_cache.dtype()),
+            .q_dtype = .from(q.dtype()),
+            .kv_dtype = .from(k_cache.dtype()),
             .num_query_heads = @intCast(paged_attention_opts.num_heads),
             .num_queries_per_kv = @intCast(paged_attention_opts.numQueriesPerKv()),
             .block_size = @intCast(paged_attention_opts.block_size),
@@ -426,7 +415,7 @@ pub const paged = struct {
         log.debug("pagedAttention3d attention config: {any}", .{attn_kernel_config});
 
         const reduce_kernel_config: kernels.ReduceSegmentsPtr.Config = .{
-            .o_dtype = toDType(q.dtype()),
+            .o_dtype = .from(q.dtype()),
             .num_query_heads = @intCast(paged_attention_opts.num_heads),
             .tile_size = @intCast(config.reduce.tile_size),
             .head_size = @intCast(paged_attention_opts.head_dim),
@@ -437,26 +426,22 @@ pub const paged = struct {
         };
         log.debug("pagedAttention3d reduce config: {any}", .{reduce_kernel_config});
 
-        const dummy = zml.Tensor.constant(zml.DataType.i8.zero());
+        const dummy: zml.Tensor = .scalar(0, .i8);
         const block_table_strides = parameters.block_table.shape().computeElementStrides().constSlice();
-        const block_table_strides_ptr = zml.Tensor.constant(zml.DataType.i64.constant(block_table_strides[0]));
+
         const q_shape = q.shape().mergeAxes(.{ .h = .{ .hkv, .hg } });
         const q_strides = q_shape.computeElementStrides().constSlice();
-        const q_strides_0_ptr = zml.Tensor.constant(zml.DataType.i64.constant(q_strides[0]));
-        const q_strides_1_ptr = zml.Tensor.constant(zml.DataType.i64.constant(q_strides[1]));
         const k_strides = k_cache.shape().computeElementStrides().constSlice();
-        const k_strides_0_ptr = zml.Tensor.constant(zml.DataType.i64.constant(k_strides[0]));
-        const k_strides_1_ptr = zml.Tensor.constant(zml.DataType.i64.constant(k_strides[1]));
-        const k_strides_2_ptr = zml.Tensor.constant(zml.DataType.i64.constant(k_strides[2]));
         const v_strides = v_cache.shape().computeElementStrides().constSlice();
-        const v_strides_0_ptr = zml.Tensor.constant(zml.DataType.i64.constant(v_strides[0]));
-        const v_strides_1_ptr = zml.Tensor.constant(zml.DataType.i64.constant(v_strides[1]));
-        const v_strides_2_ptr = zml.Tensor.constant(zml.DataType.i64.constant(v_strides[2]));
-        const num_seqs_ptr = zml.Tensor.constant(zml.DataType.i32.constant(parameters.block_table.dim(0)));
-        const scale: f32 = paged_attention_opts.scale orelse @floatCast(1.0 / @sqrt(@as(f64, @floatFromInt(q.dim(.hd)))));
-        const scale_ptr = zml.Tensor.constant(zml.DataType.f32.constant(scale));
 
-        const attn_grid: [3]i32 = .{ @intCast(config.attention.total_q_blocks), @intCast(paged_attention_opts.num_kv_heads), @intCast(config.attention.num_segments_per_seq) };
+        const scale: f32 = paged_attention_opts.scale orelse @floatCast(1.0 / @sqrt(@as(f64, @floatFromInt(q.dim(.hd)))));
+        const num_seqs = parameters.block_table.dim(0);
+
+        const attn_grid: [3]i32 = .{
+            @intCast(config.attention.total_q_blocks),
+            @intCast(paged_attention_opts.num_kv_heads),
+            @intCast(config.attention.num_segments_per_seq),
+        };
         const attn_output = kernels.KernelUnifiedAttention3dPtr.Kernel.call(
             .{
                 .query_ptr = q,
@@ -467,22 +452,22 @@ pub const paged = struct {
                 .seq_lens_ptr = parameters.seq_lens,
                 .alibi_slopes_ptr = dummy,
                 .qq_bias_ptr = dummy,
-                .scale_ptr = scale_ptr,
+                .scale_ptr = .scalar(scale, .f32),
                 .k_scale_ptr = dummy,
                 .v_scale_ptr = dummy,
                 .softcap_ptr = dummy,
-                .block_table_stride_ptr = block_table_strides_ptr,
-                .query_stride_0_ptr = q_strides_0_ptr,
-                .query_stride_1_ptr = q_strides_1_ptr,
+                .block_table_stride_ptr = .scalar(block_table_strides[0], .i64),
+                .query_stride_0_ptr = .scalar(q_strides[0], .i64),
+                .query_stride_1_ptr = .scalar(q_strides[1], .i64),
                 .qq_bias_stride_0_ptr = dummy,
-                .stride_k_cache_0_ptr = k_strides_0_ptr,
-                .stride_k_cache_1_ptr = k_strides_1_ptr,
-                .stride_k_cache_2_ptr = k_strides_2_ptr,
-                .stride_v_cache_0_ptr = v_strides_0_ptr,
-                .stride_v_cache_1_ptr = v_strides_1_ptr,
-                .stride_v_cache_2_ptr = v_strides_2_ptr,
+                .stride_k_cache_0_ptr = .scalar(k_strides[0], .i64),
+                .stride_k_cache_1_ptr = .scalar(k_strides[1], .i64),
+                .stride_k_cache_2_ptr = .scalar(k_strides[2], .i64),
+                .stride_v_cache_0_ptr = .scalar(v_strides[0], .i64),
+                .stride_v_cache_1_ptr = .scalar(v_strides[1], .i64),
+                .stride_v_cache_2_ptr = .scalar(v_strides[2], .i64),
                 .query_start_len_ptr = parameters.query_start_len,
-                .num_seqs_ptr = num_seqs_ptr,
+                .num_seqs_ptr = .scalar(num_seqs, .i32),
             },
             .{
                 .segm_output = zml.Shape.init(.{ paged_attention_opts.num_tokens, paged_attention_opts.num_heads, config.attention.num_segments_per_seq, std.math.ceilPowerOfTwoAssert(usize, paged_attention_opts.head_dim) }, .f32),
@@ -492,8 +477,8 @@ pub const paged = struct {
             .{
                 .cfg = attn_kernel_config,
                 .grid = attn_grid,
-                .num_stages = @intCast(config.attention.num_stages),
-                .num_warps = @intCast(config.attention.num_warps),
+                .num_stages = config.attention.num_stages,
+                .num_warps = config.attention.num_warps,
             },
         );
 
@@ -503,19 +488,23 @@ pub const paged = struct {
                 .segm_max_ptr = attn_output.segm_max,
                 .segm_expsum_ptr = attn_output.segm_expsum,
                 .seq_lens_ptr = parameters.seq_lens,
-                .num_seqs_ptr = num_seqs_ptr,
+                .num_seqs_ptr = .scalar(num_seqs, .i32),
                 .out_scale_inv_ptr = dummy,
-                .output_stride_0_ptr = q_strides_0_ptr,
-                .output_stride_1_ptr = q_strides_1_ptr,
-                .block_table_stride_ptr = block_table_strides_ptr,
+                .output_stride_0_ptr = .scalar(q_strides[0], .i64),
+                .output_stride_1_ptr = .scalar(q_strides[1], .i64),
+                .block_table_stride_ptr = .scalar(block_table_strides[0], .i64),
                 .query_start_len_ptr = parameters.query_start_len,
             },
             .{ .output = q.shape() },
             .{
                 .cfg = reduce_kernel_config,
-                .grid = .{ @intCast(paged_attention_opts.num_tokens), @intCast(paged_attention_opts.num_heads), 1 },
-                .num_stages = @intCast(config.reduce.num_stages),
-                .num_warps = @intCast(config.reduce.num_warps),
+                .grid = .{
+                    @intCast(paged_attention_opts.num_tokens),
+                    @intCast(paged_attention_opts.num_heads),
+                    1,
+                },
+                .num_stages = config.reduce.num_stages,
+                .num_warps = config.reduce.num_warps,
             },
         );
 
@@ -538,8 +527,8 @@ pub const paged = struct {
         const v_strides_c = v_cache_shape_c.computeElementStrides().constSlice();
 
         const attn_kernel_config: kernels_oneapi.KernelUnifiedAttention3dPtr.Config = .{
-            .q_dtype = toDType(q.dtype()),
-            .kv_dtype = toDType(k_cache.dtype()),
+            .q_dtype = .from(q.dtype()),
+            .kv_dtype = .from(k_cache.dtype()),
             .num_query_heads = @intCast(paged_attention_opts.num_heads),
             .num_queries_per_kv = @intCast(paged_attention_opts.numQueriesPerKv()),
             .block_size = @intCast(paged_attention_opts.block_size),
@@ -568,7 +557,7 @@ pub const paged = struct {
         log.debug("pagedAttention3dOneapi attention config: {any}", .{attn_kernel_config});
 
         const reduce_kernel_config: kernels.ReduceSegmentsPtr.Config = .{
-            .o_dtype = toDType(q.dtype()),
+            .o_dtype = .from(q.dtype()),
             .num_query_heads = @intCast(paged_attention_opts.num_heads),
             .tile_size = @intCast(config.reduce.tile_size),
             .head_size = @intCast(paged_attention_opts.head_dim),

--- a/zml/attention/triton_attention.zig
+++ b/zml/attention/triton_attention.zig
@@ -314,9 +314,9 @@ pub const paged = struct {
         const config = select2dConfig(paged_attention_opts);
 
         const kernel_config: kernels.KernelUnifiedAttention2dPtr.Config = .{
-            .q_dtype = .from(q.dtype()),
-            .kv_dtype = .from(k_cache.dtype()),
-            .o_dtype = .from(q.dtype()),
+            .q_dtype = triton.from(q.dtype()),
+            .kv_dtype = triton.from(k_cache.dtype()),
+            .o_dtype = triton.from(q.dtype()),
             .num_query_heads = @intCast(paged_attention_opts.num_heads),
             .num_queries_per_kv = @intCast(paged_attention_opts.numQueriesPerKv()),
             .block_size = @intCast(paged_attention_opts.block_size),
@@ -381,8 +381,8 @@ pub const paged = struct {
             .{
                 .cfg = kernel_config,
                 .grid = .{ @intCast(paged_attention_opts.num_kv_heads), @intCast(config.total_q_blocks), 1 },
-                .num_stages = config.num_stages,
-                .num_warps = config.num_warps,
+                .num_stages = @intCast(config.num_stages),
+                .num_warps = @intCast(config.num_warps),
             },
         );
         return output.output;
@@ -393,8 +393,8 @@ pub const paged = struct {
 
         const head_size_padded: i64 = @intCast(std.math.ceilPowerOfTwoAssert(usize, paged_attention_opts.head_dim));
         const attn_kernel_config: kernels.KernelUnifiedAttention3dPtr.Config = .{
-            .q_dtype = .from(q.dtype()),
-            .kv_dtype = .from(k_cache.dtype()),
+            .q_dtype = triton.from(q.dtype()),
+            .kv_dtype = triton.from(k_cache.dtype()),
             .num_query_heads = @intCast(paged_attention_opts.num_heads),
             .num_queries_per_kv = @intCast(paged_attention_opts.numQueriesPerKv()),
             .block_size = @intCast(paged_attention_opts.block_size),
@@ -415,7 +415,7 @@ pub const paged = struct {
         log.debug("pagedAttention3d attention config: {any}", .{attn_kernel_config});
 
         const reduce_kernel_config: kernels.ReduceSegmentsPtr.Config = .{
-            .o_dtype = .from(q.dtype()),
+            .o_dtype = triton.from(q.dtype()),
             .num_query_heads = @intCast(paged_attention_opts.num_heads),
             .tile_size = @intCast(config.reduce.tile_size),
             .head_size = @intCast(paged_attention_opts.head_dim),
@@ -477,8 +477,8 @@ pub const paged = struct {
             .{
                 .cfg = attn_kernel_config,
                 .grid = attn_grid,
-                .num_stages = config.attention.num_stages,
-                .num_warps = config.attention.num_warps,
+                .num_stages = @intCast(config.attention.num_stages),
+                .num_warps = @intCast(config.attention.num_warps),
             },
         );
 
@@ -503,8 +503,8 @@ pub const paged = struct {
                     @intCast(paged_attention_opts.num_heads),
                     1,
                 },
-                .num_stages = config.reduce.num_stages,
-                .num_warps = config.reduce.num_warps,
+                .num_stages = @intCast(config.reduce.num_stages),
+                .num_warps = @intCast(config.reduce.num_warps),
             },
         );
 
@@ -521,14 +521,12 @@ pub const paged = struct {
 
         const head_size_padded: i64 = @intCast(std.math.ceilPowerOfTwoAssert(usize, paged_attention_opts.head_dim));
 
-        const k_cache_shape_c = k_cache.shape();
-        const k_strides_c = k_cache_shape_c.computeElementStrides().constSlice();
-        const v_cache_shape_c = v_cache.shape();
-        const v_strides_c = v_cache_shape_c.computeElementStrides().constSlice();
+        const k_strides = k_cache.shape().computeElementStrides().constSlice();
+        const v_strides = v_cache.shape().computeElementStrides().constSlice();
 
         const attn_kernel_config: kernels_oneapi.KernelUnifiedAttention3dPtr.Config = .{
-            .q_dtype = .from(q.dtype()),
-            .kv_dtype = .from(k_cache.dtype()),
+            .q_dtype = triton.from(q.dtype()),
+            .kv_dtype = triton.from(k_cache.dtype()),
             .num_query_heads = @intCast(paged_attention_opts.num_heads),
             .num_queries_per_kv = @intCast(paged_attention_opts.numQueriesPerKv()),
             .block_size = @intCast(paged_attention_opts.block_size),
@@ -544,12 +542,12 @@ pub const paged = struct {
             .block_m = @intCast(config.attention.block_m),
             .num_segments_per_seq = @intCast(config.attention.num_segments_per_seq),
             .all_decode = paged_attention_opts.all_decode,
-            .stride_k_cache_0 = @intCast(k_strides_c[k_cache_shape_c.axis(.page)]),
-            .stride_k_cache_1 = @intCast(k_strides_c[k_cache_shape_c.axis(.k_chunk)]),
-            .stride_k_cache_2 = @intCast(k_strides_c[k_cache_shape_c.axis(.hkv)]),
-            .stride_v_cache_0 = @intCast(v_strides_c[v_cache_shape_c.axis(.page)]),
-            .stride_v_cache_1 = @intCast(v_strides_c[v_cache_shape_c.axis(.k_chunk)]),
-            .stride_v_cache_2 = @intCast(v_strides_c[v_cache_shape_c.axis(.hkv)]),
+            .stride_k_cache_0 = k_strides[k_cache.axis(.page)],
+            .stride_k_cache_1 = k_strides[k_cache.axis(.k_chunk)],
+            .stride_k_cache_2 = k_strides[k_cache.axis(.hkv)],
+            .stride_v_cache_0 = v_strides[v_cache.axis(.page)],
+            .stride_v_cache_1 = v_strides[v_cache.axis(.k_chunk)],
+            .stride_v_cache_2 = v_strides[v_cache.axis(.hkv)],
             // Intel: keep KV loads cached (.none); the streaming .cg hint lowers to
             // fully-uncached here and defeats the L2 prefetcher.
             .kv_cache_modifier = .none,
@@ -557,7 +555,7 @@ pub const paged = struct {
         log.debug("pagedAttention3dOneapi attention config: {any}", .{attn_kernel_config});
 
         const reduce_kernel_config: kernels.ReduceSegmentsPtr.Config = .{
-            .o_dtype = .from(q.dtype()),
+            .o_dtype = triton.from(q.dtype()),
             .num_query_heads = @intCast(paged_attention_opts.num_heads),
             .tile_size = @intCast(config.reduce.tile_size),
             .head_size = @intCast(paged_attention_opts.head_dim),
@@ -568,26 +566,14 @@ pub const paged = struct {
         };
         log.debug("pagedAttention3d reduce config: {any}", .{reduce_kernel_config});
 
-        const dummy = zml.Tensor.constant(zml.DataType.i8.zero());
+        const dummy: zml.Tensor = .scalar(0, .i8);
         const block_table_strides = parameters.block_table.shape().computeElementStrides().constSlice();
-        const block_table_strides_ptr = zml.Tensor.constant(zml.DataType.i64.constant(block_table_strides[0]));
+
         const q_shape = q.shape().mergeAxes(.{ .h = .{ .hkv, .hg } });
         const q_strides = q_shape.computeElementStrides().constSlice();
-        const q_strides_0_ptr = zml.Tensor.constant(zml.DataType.i64.constant(q_strides[0]));
-        const q_strides_1_ptr = zml.Tensor.constant(zml.DataType.i64.constant(q_strides[1]));
-        const k_cache_shape = k_cache.shape();
-        const k_strides = k_cache_shape.computeElementStrides().constSlice();
-        const k_strides_0_ptr = zml.Tensor.constant(zml.DataType.i64.constant(k_strides[k_cache_shape.axis(.page)]));
-        const k_strides_1_ptr = zml.Tensor.constant(zml.DataType.i64.constant(k_strides[k_cache_shape.axis(.k_chunk)]));
-        const k_strides_2_ptr = zml.Tensor.constant(zml.DataType.i64.constant(k_strides[k_cache_shape.axis(.hkv)]));
-        const v_cache_shape = v_cache.shape();
-        const v_strides = v_cache_shape.computeElementStrides().constSlice();
-        const v_strides_0_ptr = zml.Tensor.constant(zml.DataType.i64.constant(v_strides[v_cache_shape.axis(.page)]));
-        const v_strides_1_ptr = zml.Tensor.constant(zml.DataType.i64.constant(v_strides[v_cache_shape.axis(.k_chunk)]));
-        const v_strides_2_ptr = zml.Tensor.constant(zml.DataType.i64.constant(v_strides[v_cache_shape.axis(.hkv)]));
-        const num_seqs_ptr = zml.Tensor.constant(zml.DataType.i32.constant(parameters.block_table.dim(0)));
+
         const scale: f32 = paged_attention_opts.scale orelse @floatCast(1.0 / @sqrt(@as(f64, @floatFromInt(q.dim(.hd)))));
-        const scale_ptr = zml.Tensor.constant(zml.DataType.f32.constant(scale));
+        const num_seqs = parameters.block_table.dim(0);
 
         const attn_grid: [3]i32 = .{ @intCast(config.attention.total_q_blocks), @intCast(paged_attention_opts.num_kv_heads), @intCast(config.attention.num_segments_per_seq) };
         const attn_output = kernels_oneapi.KernelUnifiedAttention3dPtr.Kernel.call(
@@ -600,22 +586,22 @@ pub const paged = struct {
                 .seq_lens_ptr = parameters.seq_lens,
                 .alibi_slopes_ptr = dummy,
                 .qq_bias_ptr = dummy,
-                .scale_ptr = scale_ptr,
+                .scale_ptr = .scalar(scale, .f32),
                 .k_scale_ptr = dummy,
                 .v_scale_ptr = dummy,
                 .softcap_ptr = dummy,
-                .block_table_stride_ptr = block_table_strides_ptr,
-                .query_stride_0_ptr = q_strides_0_ptr,
-                .query_stride_1_ptr = q_strides_1_ptr,
+                .block_table_stride_ptr = .scalar(block_table_strides[0], .i64),
+                .query_stride_0_ptr = .scalar(q_strides[0], .i64),
+                .query_stride_1_ptr = .scalar(q_strides[1], .i64),
                 .qq_bias_stride_0_ptr = dummy,
-                .stride_k_cache_0_ptr = k_strides_0_ptr,
-                .stride_k_cache_1_ptr = k_strides_1_ptr,
-                .stride_k_cache_2_ptr = k_strides_2_ptr,
-                .stride_v_cache_0_ptr = v_strides_0_ptr,
-                .stride_v_cache_1_ptr = v_strides_1_ptr,
-                .stride_v_cache_2_ptr = v_strides_2_ptr,
+                .stride_k_cache_0_ptr = .scalar(k_strides[k_cache.axis(.page)], .i64),
+                .stride_k_cache_1_ptr = .scalar(k_strides[k_cache.axis(.k_chunk)], .i64),
+                .stride_k_cache_2_ptr = .scalar(k_strides[k_cache.axis(.hkv)], .i64),
+                .stride_v_cache_0_ptr = .scalar(v_strides[v_cache.axis(.page)], .i64),
+                .stride_v_cache_1_ptr = .scalar(v_strides[v_cache.axis(.k_chunk)], .i64),
+                .stride_v_cache_2_ptr = .scalar(v_strides[v_cache.axis(.hkv)], .i64),
                 .query_start_len_ptr = parameters.query_start_len,
-                .num_seqs_ptr = num_seqs_ptr,
+                .num_seqs_ptr = .scalar(num_seqs, .i32),
             },
             .{
                 .segm_output = zml.Shape.init(.{ paged_attention_opts.num_tokens, paged_attention_opts.num_heads, config.attention.num_segments_per_seq, std.math.ceilPowerOfTwoAssert(usize, paged_attention_opts.head_dim) }, .f32),
@@ -636,11 +622,11 @@ pub const paged = struct {
                 .segm_max_ptr = attn_output.segm_max,
                 .segm_expsum_ptr = attn_output.segm_expsum,
                 .seq_lens_ptr = parameters.seq_lens,
-                .num_seqs_ptr = num_seqs_ptr,
+                .num_seqs_ptr = .scalar(num_seqs, .i32),
                 .out_scale_inv_ptr = dummy,
-                .output_stride_0_ptr = q_strides_0_ptr,
-                .output_stride_1_ptr = q_strides_1_ptr,
-                .block_table_stride_ptr = block_table_strides_ptr,
+                .output_stride_0_ptr = .scalar(q_strides[0], .i64),
+                .output_stride_1_ptr = .scalar(q_strides[1], .i64),
+                .block_table_stride_ptr = .scalar(block_table_strides[0], .i64),
                 .query_start_len_ptr = parameters.query_start_len,
             },
             .{ .output = q.shape() },

--- a/zml/attention/triton_attention.zig
+++ b/zml/attention/triton_attention.zig
@@ -181,24 +181,6 @@ pub const paged = struct {
         pub fn options(self: Parameters) Options {
             return self.options_;
         }
-
-        pub fn onMemory(self: Parameters, memory: zml.platform.Memory.Kind) Parameters {
-            return .{
-                .options_ = self.options_,
-                .block_table = self.block_table.onMemory(memory),
-                .seq_lens = self.seq_lens.onMemory(memory),
-                .query_start_len = self.query_start_len.onMemory(memory),
-            };
-        }
-
-        pub fn toMemory(self: Parameters, memory: zml.platform.Memory.Kind) Parameters {
-            return .{
-                .options_ = self.options_,
-                .block_table = self.block_table.toMemory(memory),
-                .seq_lens = self.seq_lens.toMemory(memory),
-                .query_start_len = self.query_start_len.toMemory(memory),
-            };
-        }
     };
 
     pub const PagedAttentionOptions = struct {

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -8,6 +8,7 @@ const constants = @import("constants.zig");
 const DataType = @import("dtype.zig").DataType;
 const mem = @import("mem.zig");
 const Memory = @import("platform.zig").Memory;
+const meta = @import("meta.zig");
 const pjrtx = @import("pjrtx.zig");
 const Platform = @import("platform.zig").Platform;
 const Shape = @import("shape.zig").Shape;
@@ -74,6 +75,14 @@ pub const Buffer = struct {
         for (self._shards.constSlice()) |buffer| {
             buffer.deinit(self._platform.pjrt_api);
         }
+    }
+
+    pub fn deinitAll(T: type, buffers: *mem.Bufferized(T)) void {
+        meta.visitStruct(struct {
+            fn deinit(_: void, x: *Buffer) void {
+                x.deinit();
+            }
+        }.deinit, {}, buffers);
     }
 
     /// This Buffer shape.

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -78,7 +78,7 @@ pub const Buffer = struct {
     }
 
     pub fn deinitAll(T: type, buffers: *mem.Bufferized(T)) void {
-        meta.visitStruct(struct {
+        meta.visitFlatStruct(struct {
             fn deinit(_: void, x: *Buffer) void {
                 x.deinit();
             }

--- a/zml/meta.zig
+++ b/zml/meta.zig
@@ -445,12 +445,12 @@ pub fn VisitReturn(comptime cb: anytype) type {
 }
 
 const Visitor = struct {
-    pub const VisitorType = enum {
+    pub const Action = enum {
         callback,
         recurse,
     };
 
-    pub fn determineAction(comptime callback: anytype, comptime PtrTypeOfV: type) VisitorType {
+    pub fn determineAction(comptime callback: anytype, comptime PtrTypeOfV: type) Action {
         const ptr_info = switch (@typeInfo(PtrTypeOfV)) {
             .pointer => |info| info,
             else => stdx.debug.compileError("zml.meta.visit({any}) is expecting a pointer/slice input, but received: {any}", .{ @TypeOf(callback), PtrTypeOfV }),
@@ -603,6 +603,56 @@ test visit {
         }).cb, &context, &container);
 
         try std.testing.expectEqual(14, context.result);
+    }
+}
+
+/// Similar to `visit` but doesn't follow pointers or slices.
+/// This guarantees that the given type is a flat struct.
+///
+/// see: `zml.meta.visit`
+pub fn visitStruct(comptime callback: anytype, ctx: FnParam(callback, 0), v: anytype) VisitReturn(callback) {
+    const action = comptime Visitor.determineAction(callback, @TypeOf(v));
+
+    const PtrTypeOfV = @TypeOf(v);
+    const ptr_info_v = @typeInfo(PtrTypeOfV).pointer;
+    const ChildTypeV = ptr_info_v.child;
+
+    const can_error = stdx.meta.FnReturnErrorSet(callback) != null;
+
+    switch (action) {
+        .callback => {
+            return if (can_error) try callback(ctx, v) else callback(ctx, v);
+        },
+        .recurse => {
+            const TargetType, const mutating_cb = switch (@typeInfo(FnParam(callback, 1))) {
+                .pointer => |info| .{ info.child, !info.is_const },
+                else => stdx.debug.compileError("zml.meta.visitStruct({any}) is expecting a callback with a pointer as second argument but found {any}", .{ @TypeOf(callback), FnParam(callback, 1) }),
+            };
+
+            if (comptime !Contains(PtrTypeOfV, TargetType)) return;
+
+            if (@typeInfo(ChildTypeV) == .@"struct" and @hasDecl(ChildTypeV, "constSlice") and @hasDecl(ChildTypeV, "slice")) {
+                return visit(callback, ctx, if (mutating_cb) v.slice() else v.constSlice());
+            }
+
+            switch (ptr_info_v.size) {
+                .one => switch (@typeInfo(ChildTypeV)) {
+                    .@"struct" => |s| inline for (s.fields) |field| {
+                        if (field.is_comptime or comptime !Contains(field.type, TargetType)) continue;
+                        stdx.debug.assertComptime(@typeInfo(field.type) != .pointer, "zml.meta.visitStruct only handles flat struct, found pointer in {s}", .{@typeName(ChildTypeV)});
+
+                        if (can_error) try visit(callback, ctx, &@field(v, field.name)) else visit(callback, ctx, &@field(v, field.name));
+                    },
+                    .array => inline for (v) |*elem| if (can_error) try visit(callback, ctx, elem) else visit(callback, ctx, elem),
+                    .optional => if (v.* != null) if (can_error) try visit(callback, ctx, &v.*.?) else visit(callback, ctx, &v.*.?),
+                    .@"union" => switch (v.*) {
+                        inline else => |*v_field| if (can_error) try visit(callback, ctx, v_field) else visit(callback, ctx, v_field),
+                    },
+                    else => stdx.debug.compileError("zml.meta.visitStruct flat struct, found pointer in {s}", .{ChildTypeV}),
+                },
+                else => stdx.debug.compileError("zml.meta.visitStruct flat struct, found pointer in {s}", .{ChildTypeV}),
+            }
+        },
     }
 }
 

--- a/zml/meta.zig
+++ b/zml/meta.zig
@@ -478,10 +478,8 @@ pub fn visit(comptime callback: anytype, ctx: FnParam(callback, 0), v: anytype) 
 
     const can_error = stdx.meta.FnReturnErrorSet(callback) != null;
 
-    switch (action) {
-        .callback => {
-            return if (can_error) try callback(ctx, v) else callback(ctx, v);
-        },
+    return switch (action) {
+        .callback => callback(ctx, v),
         .recurse => {
             const TargetType, const mutating_cb = switch (@typeInfo(FnParam(callback, 1))) {
                 .pointer => |info| .{ info.child, !info.is_const },
@@ -504,12 +502,14 @@ pub fn visit(comptime callback: anytype, ctx: FnParam(callback, 0), v: anytype) 
                             if (can_error) try visit(callback, ctx, &@field(v, field.name)) else visit(callback, ctx, &@field(v, field.name));
                         }
                     },
-                    .array => inline for (v) |*elem| if (can_error) try visit(callback, ctx, elem) else visit(callback, ctx, elem),
-                    .optional => if (v.* != null) if (can_error) try visit(callback, ctx, &v.*.?) else visit(callback, ctx, &v.*.?),
-                    .@"union" => switch (v.*) {
-                        inline else => |*v_field| if (can_error) try visit(callback, ctx, v_field) else visit(callback, ctx, v_field),
+                    .array => for (v[0..]) |*elem| {
+                        if (can_error) try visit(callback, ctx, elem) else visit(callback, ctx, elem);
                     },
-                    .pointer => if (can_error) try visit(callback, ctx, v.*) else visit(callback, ctx, v.*),
+                    .optional => return if (v.*) |*opt| visit(callback, ctx, opt),
+                    .@"union" => return switch (v.*) {
+                        inline else => |*v_field| visit(callback, ctx, v_field),
+                    },
+                    .pointer => return visit(callback, ctx, v.*),
                     else => stdx.debug.compileError("zml.meta.visit({any}) doesn't support visiting pointer type {any}", .{ @TypeOf(callback), ChildTypeV }),
                 },
                 .slice => {
@@ -520,7 +520,7 @@ pub fn visit(comptime callback: anytype, ctx: FnParam(callback, 0), v: anytype) 
                 .many, .c => stdx.debug.compileError("zml.meta.visit({any}) doesn't support [*] style pointers got {any}", .{ @TypeOf(callback), ChildTypeV }),
             }
         },
-    }
+    };
 }
 
 test visit {
@@ -529,20 +529,26 @@ test visit {
     const NestedAttr = struct { nested: Attr };
     const NestedAttrOptional = struct { nested: ?Attr };
     const SimpleStruct = struct { prop: Attr };
-    const MultipleTypesStruct = struct { prop1: Attr, prop2: OtherAttr, prop3: ?Attr };
+    const MultipleTypesStruct = struct { prop1: Attr, prop2: OtherAttr, prop3: ?Attr, prop4: []Attr };
     const NestedTypesStruct = struct { prop1: Attr, prop2: OtherAttr, prop3: NestedAttr, prop4: NestedAttrOptional, prop5: stdx.BoundedArray(Attr, 8) };
 
-    const LocalContext = struct { result: usize };
+    const LocalContext = struct {
+        result: usize,
+
+        fn cb(ctx: *@This(), attr: *const Attr) void {
+            ctx.result += attr.data;
+        }
+
+        fn mutCb(ctx: *@This(), attr: *Attr) void {
+            ctx.result += attr.data;
+        }
+    };
 
     {
         var context: LocalContext = .{ .result = 0 };
         const container: SimpleStruct = .{ .prop = .{ .data = 1 } };
 
-        visit((struct {
-            fn cb(ctx: *LocalContext, attr: *const Attr) void {
-                ctx.result += attr.data;
-            }
-        }).cb, &context, &container);
+        visit(LocalContext.cb, &context, &container);
 
         try std.testing.expectEqual(1, context.result);
     }
@@ -550,37 +556,28 @@ test visit {
         var context: LocalContext = .{ .result = 0 };
         var container: SimpleStruct = .{ .prop = .{ .data = 1 } };
 
-        visit((struct {
-            fn cb(ctx: *LocalContext, attr: *Attr) void {
-                ctx.result += attr.data;
-            }
-        }).cb, &context, &container);
+        visit(LocalContext.mutCb, &context, &container);
 
         try std.testing.expectEqual(1, context.result);
     }
     {
         var context: LocalContext = .{ .result = 0 };
-        var container: MultipleTypesStruct = .{ .prop1 = .{ .data = 1 }, .prop2 = .{ .other = "hello" }, .prop3 = null };
+        var more_props: [3]Attr = .{ .{ .data = 4 }, .{ .data = 5 }, .{ .data = 6 } };
 
-        visit((struct {
-            fn cb(ctx: *LocalContext, attr: *Attr) void {
-                ctx.result += attr.data;
-            }
-        }).cb, &context, &container);
+        var container: MultipleTypesStruct = .{ .prop1 = .{ .data = 1 }, .prop2 = .{ .other = "hello" }, .prop3 = null, .prop4 = &more_props };
 
-        try std.testing.expectEqual(1, context.result);
+        visit(LocalContext.mutCb, &context, &container);
+
+        try std.testing.expectEqual(1 + 4 + 5 + 6, context.result);
     }
     {
         var context: LocalContext = .{ .result = 0 };
-        const container: MultipleTypesStruct = .{ .prop1 = .{ .data = 1 }, .prop2 = .{ .other = "hello" }, .prop3 = .{ .data = 2 } };
+        var more_props: [3]Attr = .{ .{ .data = 4 }, .{ .data = 5 }, .{ .data = 6 } };
+        const container: MultipleTypesStruct = .{ .prop1 = .{ .data = 1 }, .prop2 = .{ .other = "hello" }, .prop3 = .{ .data = 2 }, .prop4 = &more_props };
 
-        visit((struct {
-            fn cb(ctx: *LocalContext, attr: *const Attr) void {
-                ctx.result += attr.data;
-            }
-        }).cb, &context, &container);
+        visit(LocalContext.cb, &context, &container);
 
-        try std.testing.expectEqual(3, context.result);
+        try std.testing.expectEqual(1 + 2 + 4 + 5 + 6, context.result);
     }
     {
         var context: LocalContext = .{ .result = 0 };
@@ -596,11 +593,7 @@ test visit {
             .prop5 = prop5, // 4 will be counted twice.
         };
 
-        visit((struct {
-            fn cb(ctx: *LocalContext, attr: *const Attr) void {
-                ctx.result += attr.data;
-            }
-        }).cb, &context, &container);
+        visit(LocalContext.cb, &context, &container);
 
         try std.testing.expectEqual(14, context.result);
     }
@@ -610,52 +603,134 @@ test visit {
 /// This guarantees that the given type is a flat struct.
 ///
 /// see: `zml.meta.visit`
-pub fn visitStruct(comptime callback: anytype, ctx: FnParam(callback, 0), v: anytype) VisitReturn(callback) {
+pub fn visitFlatStruct(comptime callback: anytype, ctx: FnParam(callback, 0), v: anytype) VisitReturn(callback) {
     const action = comptime Visitor.determineAction(callback, @TypeOf(v));
+
+    const TargetType = switch (@typeInfo(FnParam(callback, 1))) {
+        .pointer => |info| info.child,
+        else => stdx.debug.compileError("zml.meta.visitStruct({any}) is expecting a callback with a pointer as second argument but found {any}", .{ @TypeOf(callback), FnParam(callback, 1) }),
+    };
 
     const PtrTypeOfV = @TypeOf(v);
     const ptr_info_v = @typeInfo(PtrTypeOfV).pointer;
     const ChildTypeV = ptr_info_v.child;
 
     const can_error = stdx.meta.FnReturnErrorSet(callback) != null;
+    const err_msg = "zml.meta.visitStruct only handles flat struct, found pointer in {}";
+    const err_args = .{ChildTypeV};
 
     switch (action) {
-        .callback => {
-            return if (can_error) try callback(ctx, v) else callback(ctx, v);
-        },
+        .callback => return callback(ctx, v),
+
         .recurse => {
-            const TargetType, const mutating_cb = switch (@typeInfo(FnParam(callback, 1))) {
-                .pointer => |info| .{ info.child, !info.is_const },
-                else => stdx.debug.compileError("zml.meta.visitStruct({any}) is expecting a callback with a pointer as second argument but found {any}", .{ @TypeOf(callback), FnParam(callback, 1) }),
-            };
+            if (comptime !Contains(ChildTypeV, TargetType)) return;
 
-            if (comptime !Contains(PtrTypeOfV, TargetType)) return;
-
+            // bounded array support (like visit)
             if (@typeInfo(ChildTypeV) == .@"struct" and @hasDecl(ChildTypeV, "constSlice") and @hasDecl(ChildTypeV, "slice")) {
-                return visit(callback, ctx, if (mutating_cb) v.slice() else v.constSlice());
+                return for (v.slice()) |*elem| {
+                    if (can_error)
+                        try visitFlatStruct(callback, ctx, elem)
+                    else
+                        visitFlatStruct(callback, ctx, elem);
+                };
             }
 
-            switch (ptr_info_v.size) {
+            return switch (ptr_info_v.size) {
                 .one => switch (@typeInfo(ChildTypeV)) {
                     .@"struct" => |s| inline for (s.fields) |field| {
                         if (field.is_comptime or comptime !Contains(field.type, TargetType)) continue;
-                        stdx.debug.assertComptime(@typeInfo(field.type) != .pointer, "zml.meta.visitStruct only handles flat struct, found pointer in {s}", .{@typeName(ChildTypeV)});
+                        stdx.debug.assertComptime(@typeInfo(field.type) != .pointer, err_msg, err_args);
 
-                        if (can_error) try visit(callback, ctx, &@field(v, field.name)) else visit(callback, ctx, &@field(v, field.name));
+                        if (can_error) try visitFlatStruct(callback, ctx, &@field(v, field.name)) else visitFlatStruct(callback, ctx, &@field(v, field.name));
                     },
-                    .array => inline for (v) |*elem| if (can_error) try visit(callback, ctx, elem) else visit(callback, ctx, elem),
-                    .optional => if (v.* != null) if (can_error) try visit(callback, ctx, &v.*.?) else visit(callback, ctx, &v.*.?),
+                    .array => for (v[0..]) |*elem| {
+                        if (can_error) try visitFlatStruct(callback, ctx, elem) else visitFlatStruct(callback, ctx, elem);
+                    },
+                    .optional => if (v.*) |*opt| visitFlatStruct(callback, ctx, opt),
                     .@"union" => switch (v.*) {
-                        inline else => |*v_field| if (can_error) try visit(callback, ctx, v_field) else visit(callback, ctx, v_field),
+                        inline else => |*v_field| visitFlatStruct(callback, ctx, v_field),
                     },
-                    else => stdx.debug.compileError("zml.meta.visitStruct flat struct, found pointer in {s}", .{ChildTypeV}),
+                    else => stdx.debug.compileError(err_msg, err_args),
                 },
-                else => stdx.debug.compileError("zml.meta.visitStruct flat struct, found pointer in {s}", .{ChildTypeV}),
-            }
+                else => stdx.debug.compileError(err_msg, err_args),
+            };
         },
     }
 }
 
+test visitFlatStruct {
+    const Attr = struct { data: usize };
+    const OtherAttr = struct { other: []const u8 };
+    const NestedAttr = struct { nested: Attr };
+    const NestedAttrOptional = struct { nested: ?Attr };
+    const SimpleStruct = struct { prop: Attr };
+    // Note: no slice anymore, no stdx.BoundedArray
+    const MultipleTypesStruct = struct { prop1: Attr, prop2: OtherAttr, prop3: ?Attr };
+    const NestedTypesStruct = struct { prop1: Attr, prop2: OtherAttr, prop3: NestedAttr, prop4: NestedAttrOptional, prop5: stdx.BoundedArray(Attr, 8) };
+
+    const LocalContext = struct {
+        result: usize,
+
+        fn cb(ctx: *@This(), attr: *const Attr) void {
+            ctx.result += attr.data;
+        }
+
+        fn mutCb(ctx: *@This(), attr: *Attr) void {
+            ctx.result += attr.data;
+        }
+    };
+
+    {
+        var context: LocalContext = .{ .result = 0 };
+        const container: SimpleStruct = .{ .prop = .{ .data = 1 } };
+
+        visitFlatStruct(LocalContext.cb, &context, &container);
+
+        try std.testing.expectEqual(1, context.result);
+    }
+    {
+        var context: LocalContext = .{ .result = 0 };
+        var container: SimpleStruct = .{ .prop = .{ .data = 1 } };
+
+        visitFlatStruct(LocalContext.mutCb, &context, &container);
+
+        try std.testing.expectEqual(1, context.result);
+    }
+    {
+        var context: LocalContext = .{ .result = 0 };
+        var container: MultipleTypesStruct = .{ .prop1 = .{ .data = 1 }, .prop2 = .{ .other = "hello" }, .prop3 = null };
+
+        visitFlatStruct(LocalContext.mutCb, &context, &container);
+
+        try std.testing.expectEqual(1, context.result);
+    }
+    {
+        var context: LocalContext = .{ .result = 0 };
+        const container: MultipleTypesStruct = .{ .prop1 = .{ .data = 1 }, .prop2 = .{ .other = "hello" }, .prop3 = .{ .data = 2 } };
+
+        visitFlatStruct(LocalContext.cb, &context, &container);
+
+        try std.testing.expectEqual(1 + 2, context.result);
+    }
+    {
+        var context: LocalContext = .{ .result = 0 };
+        const prop5: stdx.BoundedArray(Attr, 8) = .{
+            .buffer = @splat(.{ .data = 4 }),
+            .len = 2,
+        };
+        const container: NestedTypesStruct = .{
+            .prop1 = .{ .data = 1 },
+            .prop2 = .{ .other = "hello" },
+            .prop3 = .{ .nested = .{ .data = 2 } },
+            .prop4 = .{ .nested = .{ .data = 3 } },
+            .prop5 = prop5, // 4 will be counted twice.
+        };
+
+        visitFlatStruct(LocalContext.cb, &context, &container);
+
+        try std.testing.expectEqual(1 + 2 + 3 + 4 + 4, context.result);
+    }
+}
 pub fn count(T: type, value: anytype) u32 {
     var counter: u32 = 0;
     visit(struct {

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -170,6 +170,10 @@ pub const CompilationContext = struct {
         _current = null;
     }
 
+    pub fn isActive() ?*CompilationContext {
+        return _current;
+    }
+
     pub fn current() *CompilationContext {
         return _current.?;
     }

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -170,12 +170,12 @@ pub const CompilationContext = struct {
         _current = null;
     }
 
-    pub fn isActive() ?*CompilationContext {
-        return _current;
-    }
-
     pub fn current() *CompilationContext {
         return _current.?;
+    }
+
+    pub fn currentOrNull() ?*CompilationContext {
+        return _current;
     }
 
     pub fn currentScope(self: *CompilationContext) *Scope {

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -151,7 +151,14 @@ pub const Tensor = struct {
         const ctx = CompilationContext.current();
         const partitioned_shape = self._shape.withPartitioning(axes_);
 
-        const attr = ctx.partitioning.tensorShardingAttr(ctx.allocator, ctx.mlir_ctx, partitioned_shape, null) catch unreachable;
+        const attr = ctx.partitioning.tensorShardingAttr(ctx.allocator, ctx.mlir_ctx, partitioned_shape, null) catch |err| switch (err) {
+            error.NoSuitableSharding => std.debug.panic(
+                "{f}.withPartitioning({f}) failed to resolve because it's using unknown sharding. Pass more shardings to `zml.compile`. Known shardings: {f}",
+                .{ self, partitioned_shape, stdx.fmt.slice(ctx.partitioning.shardings) },
+            ),
+            error.OutOfMemory, error.WriteFailed => @panic("OOM"),
+            error.MissingDeviceInTile => @panic("TODO"),
+        };
 
         const op_result = switch (ctx.partitioning.partitioner) {
             .shardy => blk: {

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -198,6 +198,7 @@ pub const Tensor = struct {
         return _result(partitioned_shape, op_result);
     }
 
+    /// Copy the given tensor to the specified memory.
     pub fn toMemory(self: Tensor, kind: Memory.Kind) Tensor {
         const ctx = CompilationContext.current();
         switch (ctx.platform.target) {
@@ -233,6 +234,26 @@ pub const Tensor = struct {
         return res;
     }
 
+    /// Copy all the given tensor to the specified memory.
+    /// The input struct is copied on the stack, so it must be a simple flat struct without pointers.
+    pub fn toMemoryAll(flat_tensors: anytype, kind: Memory.Kind) @TypeOf(flat_tensors) {
+        const ctx = CompilationContext.current();
+        switch (ctx.platform.target) {
+            .cpu, .neuron, .metal => return flat_tensors,
+            .cuda, .rocm, .tpu, .oneapi => {},
+        }
+
+        var copy = flat_tensors;
+        meta.visitFlatStruct(struct {
+            fn onMemory(k: Memory.Kind, x: *Tensor) void {
+                x.* = x.toMemory(k);
+            }
+        }.onMemory, kind, &copy);
+        return copy;
+    }
+
+    /// Mark the given input tensor as being physically located on a specific memory.
+    /// Has no effect if the input tensor is not an executable input.
     pub fn onMemory(self: Tensor, kind: Memory.Kind) Tensor {
         const ctx = CompilationContext.current();
         switch (ctx.platform.target) {
@@ -247,6 +268,23 @@ pub const Tensor = struct {
         ctx.currentScope().id_to_input_memory_kind.put(ctx.currentScope().arena.allocator(), self.id, kind) catch unreachable;
 
         return self;
+    }
+
+    /// Mark all the given input tensors as being physically located on a specific memory
+    /// see `zml.Tensor.onMemory`
+    pub fn onMemoryAll(tensors: anytype, kind: Memory.Kind) void {
+        const ctx = CompilationContext.current();
+        switch (ctx.platform.target) {
+            // Only one memory kind on those platform
+            .cpu, .neuron, .metal => return,
+            .cuda, .rocm, .tpu, .oneapi => {},
+        }
+
+        meta.visit(struct {
+            fn onMemory(k: Memory.Kind, x: *const Tensor) void {
+                _ = x.onMemory(k);
+            }
+        }.onMemory, kind, &tensors);
     }
 
     /// Returns a Tensor with new tag names.

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -148,8 +148,13 @@ pub const Tensor = struct {
     }
 
     pub fn withPartitioning(self: Tensor, axes_: anytype) Tensor {
-        const ctx = CompilationContext.current();
         const partitioned_shape = self._shape.withPartitioning(axes_);
+
+        const ctx = CompilationContext.isActive() orelse {
+            var res = self;
+            res._shape = partitioned_shape;
+            return res;
+        };
 
         const attr = ctx.partitioning.tensorShardingAttr(ctx.allocator, ctx.mlir_ctx, partitioned_shape, null) catch |err| switch (err) {
             error.NoSuitableSharding => std.debug.panic(

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -150,7 +150,7 @@ pub const Tensor = struct {
     pub fn withPartitioning(self: Tensor, axes_: anytype) Tensor {
         const partitioned_shape = self._shape.withPartitioning(axes_);
 
-        const ctx = CompilationContext.isActive() orelse {
+        const ctx = CompilationContext.currentOrNull() orelse {
             var res = self;
             res._shape = partitioned_shape;
             return res;


### PR DESCRIPTION
Add unit test for paged attention, enforcing all our backends produce the same outputs.

To simplify memory management of many small buffer provided in a struct (like paged attention metadata buffers), I introduce `zml.Buffer.deinitAll` backed by `zml.meta.visitFlatStruct`. Contrary to og `zml.meta.visit` the `flatStruct` variant emit a  compile error if the input has a slice/ptr inside it. The idea is that since it enforces the struct to be a trivial, it means the struct won't require complex `deinit` and `zml.Buffer.deinitAll` is in fact everything you need to `deinit`. This avoid previous footgun of `zml.io.unloadAll`.

This led to more improvement with `zml.Tensor.toMemoryAll` and `zml.Tensor.onMemoryAll` that also leverage the new `zml.meta.visitFlatStruct`