### PR TITLE
zml: simplify memory allocation during compilation

### DIFF
--- a/zml/module.zig
+++ b/zml/module.zig
@@ -198,10 +198,13 @@ pub const CompilationContext = struct {
         return self.channel_id;
     }
 
-    pub fn abortOOM() noreturn {
-        const self = CompilationContext.current();
+    pub fn abortOOM(self: *CompilationContext) noreturn {
         std.debug.assert(self.oom_jmp_buf_active);
         c.longjmp(&self.oom_jmp_buf, 1);
+    }
+
+    pub fn alloc(self: *CompilationContext, T: type, n: usize) []T {
+        return self.arena.allocator().alloc(T, n) catch self.abortOOM();
     }
 };
 
@@ -320,7 +323,7 @@ test "compile aborts OOM with live scopes" {
             return ops.reduce(.{x}, .{Tensor.constant(x.dtype().zero())}, &.{0}, struct {
                 pub fn abort(args: ops.ReduceArgs) struct { Tensor } {
                     _ = args;
-                    CompilationContext.abortOOM();
+                    CompilationContext.current().abortOOM();
                 }
             }.abort, .{})[0];
         }

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -12,6 +12,7 @@ const Exe = @import("exe.zig").Exe;
 const Memory = @import("platform.zig").Memory;
 const meta = @import("meta.zig");
 const mlirx = @import("mlirx.zig");
+const ops = @import("ops.zig");
 const pjrtx = @import("pjrtx.zig");
 const Platform = @import("platform.zig").Platform;
 const tracer = @import("profiling/tracer.zig");
@@ -100,6 +101,9 @@ pub const CompilationContext = struct {
 
     channel_id: i64 = 0,
 
+    oom_jmp_buf: c.jmp_buf = undefined,
+    oom_jmp_buf_active: bool = false,
+
     threadlocal var _current: ?*CompilationContext = null;
 
     pub fn init(allocator: std.mem.Allocator, io: std.Io, platform: *const Platform, opts: CompilationOptions) CompilationContext {
@@ -149,6 +153,10 @@ pub const CompilationContext = struct {
     }
 
     pub fn deinit(self: *CompilationContext) void {
+        if (_current == self) _current = null;
+        for (self.scopes.slice()) |*scope| {
+            scope.deinit();
+        }
         self.mlir_pass_manager.deinit();
         self.module.deinit();
         self.mlir_ctx.deinit();
@@ -188,6 +196,12 @@ pub const CompilationContext = struct {
     pub fn nextChannelId(self: *CompilationContext) i64 {
         self.channel_id += 1;
         return self.channel_id;
+    }
+
+    pub fn abortOOM() noreturn {
+        const self = CompilationContext.current();
+        std.debug.assert(self.oom_jmp_buf_active);
+        c.longjmp(&self.oom_jmp_buf, 1);
     }
 };
 
@@ -232,14 +246,27 @@ pub fn compile(
     var span = tracer.Span.start(span_name);
     defer span.end();
 
-    var compilation_context: CompilationContext = .init(allocator, st_io.io(), platform, opts);
+    const compilation_context = try allocator.create(CompilationContext);
+    defer allocator.destroy(compilation_context);
+
+    compilation_context.* = .init(allocator, st_io.io(), platform, opts);
     defer compilation_context.deinit();
 
-    const result = emitMlir(&compilation_context, func, args) catch unreachable;
+    compilation_context.oom_jmp_buf_active = true;
+    defer compilation_context.oom_jmp_buf_active = false;
+
+    if (c.setjmp(&compilation_context.oom_jmp_buf) != 0) {
+        return error.OutOfMemory;
+    }
+
+    const result = emitMlir(compilation_context, func, args) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => unreachable,
+    };
     defer result.output_info.deinit(compilation_context.allocator);
     defer result.input_info.deinit(compilation_context.allocator);
 
-    try addPartitionerOperations(&compilation_context);
+    try addPartitionerOperations(compilation_context);
 
     _ = result.func.appendTo(compilation_context.module.body());
 
@@ -283,6 +310,32 @@ pub fn compile(
     errdefer exe.deinit();
 
     return exe;
+}
+
+test "compile aborts OOM with live scopes" {
+    const platform = @import("testing.zig").env();
+
+    const Local = struct {
+        pub fn oom(x: Tensor) Tensor {
+            return ops.reduce(.{x}, .{Tensor.constant(x.dtype().zero())}, &.{0}, struct {
+                pub fn abort(args: ops.ReduceArgs) struct { Tensor } {
+                    _ = args;
+                    CompilationContext.abortOOM();
+                }
+            }.abort, .{})[0];
+        }
+    };
+
+    const x: Tensor = .fromShape(Shape.init(.{2}, .f32));
+
+    try std.testing.expectError(error.OutOfMemory, compile(
+        std.testing.allocator,
+        std.testing.io,
+        Local.oom,
+        .{x},
+        platform,
+        .{},
+    ));
 }
 
 fn addPartitionerOperations(ctx: *CompilationContext) !void {

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -101,9 +101,6 @@ pub const CompilationContext = struct {
 
     channel_id: i64 = 0,
 
-    oom_jmp_buf: c.jmp_buf = undefined,
-    oom_jmp_buf_active: bool = false,
-
     threadlocal var _current: ?*CompilationContext = null;
 
     pub fn init(allocator: std.mem.Allocator, io: std.Io, platform: *const Platform, opts: CompilationOptions) CompilationContext {
@@ -199,8 +196,8 @@ pub const CompilationContext = struct {
     }
 
     pub fn abortOOM(self: *CompilationContext) noreturn {
-        std.debug.assert(self.oom_jmp_buf_active);
-        c.longjmp(&self.oom_jmp_buf, 1);
+        _ = self;
+        @panic("OOM");
     }
 
     pub fn alloc(self: *CompilationContext, T: type, n: usize) []T {
@@ -249,27 +246,17 @@ pub fn compile(
     var span = tracer.Span.start(span_name);
     defer span.end();
 
-    const compilation_context = try allocator.create(CompilationContext);
-    defer allocator.destroy(compilation_context);
-
-    compilation_context.* = .init(allocator, st_io.io(), platform, opts);
+    var compilation_context: CompilationContext = .init(allocator, st_io.io(), platform, opts);
     defer compilation_context.deinit();
 
-    compilation_context.oom_jmp_buf_active = true;
-    defer compilation_context.oom_jmp_buf_active = false;
-
-    if (c.setjmp(&compilation_context.oom_jmp_buf) != 0) {
-        return error.OutOfMemory;
-    }
-
-    const result = emitMlir(compilation_context, func, args) catch |err| switch (err) {
+    const result = emitMlir(&compilation_context, func, args) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         else => unreachable,
     };
     defer result.output_info.deinit(compilation_context.allocator);
     defer result.input_info.deinit(compilation_context.allocator);
 
-    try addPartitionerOperations(compilation_context);
+    try addPartitionerOperations(&compilation_context);
 
     _ = result.func.appendTo(compilation_context.module.body());
 
@@ -313,32 +300,6 @@ pub fn compile(
     errdefer exe.deinit();
 
     return exe;
-}
-
-test "compile aborts OOM with live scopes" {
-    const platform = @import("testing.zig").env();
-
-    const Local = struct {
-        pub fn oom(x: Tensor) Tensor {
-            return ops.reduce(.{x}, .{Tensor.constant(x.dtype().zero())}, &.{0}, struct {
-                pub fn abort(args: ops.ReduceArgs) struct { Tensor } {
-                    _ = args;
-                    CompilationContext.current().abortOOM();
-                }
-            }.abort, .{})[0];
-        }
-    };
-
-    const x: Tensor = .fromShape(Shape.init(.{2}, .f32));
-
-    try std.testing.expectError(error.OutOfMemory, compile(
-        std.testing.allocator,
-        std.testing.io,
-        Local.oom,
-        .{x},
-        platform,
-        .{},
-    ));
 }
 
 fn addPartitionerOperations(ctx: *CompilationContext) !void {

--- a/zml/posix.h
+++ b/zml/posix.h
@@ -1,2 +1,3 @@
 #include <stdlib.h>
+#include <setjmp.h>
 #include <sys/mman.h>

--- a/zml/posix.h
+++ b/zml/posix.h
@@ -1,3 +1,2 @@
 #include <stdlib.h>
-#include <setjmp.h>
 #include <sys/mman.h>

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1893,7 +1893,8 @@ pub const Tensor = struct {
     /// Concatenates the input Tensors along the given axis.
     pub fn concatenate(tensors: []const Tensor, axis_: anytype) Tensor {
         if (tensors.len == 1) return tensors[0];
-        var buffer = CompilationContext.current().arena.allocator().alloc(*const mlir.Value, tensors.len) catch @panic("OOM");
+        const ctx = CompilationContext.current();
+        var buffer = ctx.arena.allocator().alloc(*const mlir.Value, tensors.len) catch CompilationContext.abortOOM();
         std.debug.assert(tensors.len <= buffer.len);
         std.debug.assert(tensors.len > 0);
         const a = tensors[0].axis(axis_);
@@ -1924,7 +1925,8 @@ pub const Tensor = struct {
             stdx.debug.assert(shape0.eqlWithTags(tensor._shape), "stack expects tensor shapes to match, got {f} and {f}", .{ shape0, tensor._shape });
         }
 
-        var reshaped = CompilationContext.current().arena.allocator().alloc(Tensor, tensors.len) catch @panic("OOM");
+        const ctx = CompilationContext.current();
+        var reshaped = ctx.arena.allocator().alloc(Tensor, tensors.len) catch CompilationContext.abortOOM();
         for (tensors, 0..) |tensor, i| {
             reshaped[i] = tensor.reshape(res_shape);
         }
@@ -3502,7 +3504,7 @@ pub const Tensor = struct {
 
         const allocator = CompilationContext.current().arena.allocator();
 
-        var chunks = std.ArrayList(Tensor).initCapacity(allocator, n_chunks + 1) catch @panic("OOM");
+        var chunks = std.ArrayList(Tensor).initCapacity(allocator, n_chunks + 1) catch CompilationContext.abortOOM();
         defer chunks.deinit(allocator);
 
         for (0..n_chunks) |i| {
@@ -3568,7 +3570,7 @@ pub const Tensor = struct {
 
         const allocator = CompilationContext.current().arena.allocator();
 
-        const res = allocator.alloc(Tensor, split_sizes.len) catch @panic("OOM");
+        const res = allocator.alloc(Tensor, split_sizes.len) catch CompilationContext.abortOOM();
 
         var start: i64 = 0;
         for (split_sizes, 0..) |n, i| {

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1894,7 +1894,7 @@ pub const Tensor = struct {
     pub fn concatenate(tensors: []const Tensor, axis_: anytype) Tensor {
         if (tensors.len == 1) return tensors[0];
         const ctx = CompilationContext.current();
-        var buffer = ctx.arena.allocator().alloc(*const mlir.Value, tensors.len) catch CompilationContext.abortOOM();
+        var buffer = ctx.alloc(*const mlir.Value, tensors.len);
         std.debug.assert(tensors.len <= buffer.len);
         std.debug.assert(tensors.len > 0);
         const a = tensors[0].axis(axis_);
@@ -1926,7 +1926,7 @@ pub const Tensor = struct {
         }
 
         const ctx = CompilationContext.current();
-        var reshaped = ctx.arena.allocator().alloc(Tensor, tensors.len) catch CompilationContext.abortOOM();
+        var reshaped = ctx.alloc(Tensor, tensors.len);
         for (tensors, 0..) |tensor, i| {
             reshaped[i] = tensor.reshape(res_shape);
         }
@@ -3495,29 +3495,21 @@ pub const Tensor = struct {
     pub fn chunkAllowTrailing(
         self: Tensor,
         axis_: i64,
-        n_chunks: comptime_int,
-    ) ![]Tensor {
+        n_chunks: usize,
+    ) []Tensor {
         const a = self.axis(axis_);
-        const d = self.dim(a);
-        const chunk_size: i64 = @divFloor(d, n_chunks);
+        const d: i64 = self.dim(a);
+        const chunk_size: i64 = @divFloor(d, @as(i64, @intCast(n_chunks)));
         const tail_chunk_size: i64 = @rem(d, chunk_size);
 
-        const allocator = CompilationContext.current().arena.allocator();
+        const len: usize = if (tail_chunk_size == 0) n_chunks else n_chunks + 1;
+        const chunks = CompilationContext.current().alloc(Tensor, len);
 
-        var chunks = std.ArrayList(Tensor).initCapacity(allocator, n_chunks + 1) catch CompilationContext.abortOOM();
-        defer chunks.deinit(allocator);
-
-        for (0..n_chunks) |i| {
+        for (0.., chunks) |i, *chunk| {
             const start: i64 = @as(i64, @intCast(i)) * chunk_size;
-            chunks.appendAssumeCapacity(
-                self.slice1d(a, .{ .start = start, .end = start + chunk_size }),
-            );
+            chunk.* = self.slice1d(a, .{ .start = start, .end = @min(start + chunk_size, d) });
         }
-        if (tail_chunk_size != 0) {
-            const start: i64 = n_chunks * chunk_size;
-            chunks.appendAssumeCapacity(self.slice1d(a, .{ .start = start }));
-        }
-        return chunks.toOwnedSlice(allocator);
+        return chunks;
     }
 
     test chunkAllowTrailing {
@@ -3542,8 +3534,8 @@ pub const Tensor = struct {
             .{ .{ 12, 2 }, 0, 3, .{ 4, 2 }, .{} },
         }) |testcase| {
             const x_shape, const ax, const n_chunks, const res, const trailing = testcase;
-            const x = Tensor.constant(.{ .f16 = 0 }).broad(Shape.init(x_shape, .f16));
-            const chunks = try x.chunkAllowTrailing(x.axis(ax), n_chunks);
+            const x = Tensor.zeroes(.init(x_shape, .f16));
+            const chunks = x.chunkAllowTrailing(x.axis(ax), n_chunks);
 
             const res_shape = Shape.init(res, .f16);
             for (chunks[0..n_chunks]) |chk| {
@@ -3568,9 +3560,7 @@ pub const Tensor = struct {
         for (split_sizes) |n| split_sum += n;
         stdx.debug.assert(split_sum == d, "split expects sum of 'split_sizes' values and axis dimension to be equal, got {} and {}", .{ split_sum, d });
 
-        const allocator = CompilationContext.current().arena.allocator();
-
-        const res = allocator.alloc(Tensor, split_sizes.len) catch CompilationContext.abortOOM();
+        const res = CompilationContext.current().alloc(Tensor, split_sizes.len);
 
         var start: i64 = 0;
         for (split_sizes, 0..) |n, i| {


### PR DESCRIPTION
My original proposition was to use setjmp/longjmp to properly recover from OOM during compilation.

We haven't reach an agreement on wether it's a good idea or not, so I removed that part,
and kept the part that simplify memory allocation when compiling.