### PR TITLE
zml.ops: refactor while loop API

### DIFF
--- a/stdx/fmt.zig
+++ b/stdx/fmt.zig
@@ -63,7 +63,13 @@ pub fn formatBool(value: bool, spec: std.fmt.Number, writer: *std.Io.Writer) !vo
 pub fn formatAny(value: anytype, spec: std.fmt.Number, writer: *std.Io.Writer) !void {
     var buf: [48]u8 = undefined;
     const T = @TypeOf(value);
-    const fmt = if (@hasDecl(T, "formatNumber")) "{d}" else "{f}";
+    const fmt = switch (@typeInfo(T)) {
+        .@"struct", .@"union", .@"enum", .@"opaque" => if (@hasDecl(T, "formatNumber"))
+            "{d}"
+        else
+            "{f}",
+        else => "{f}",
+    };
 
     const s = std.fmt.bufPrint(&buf, fmt, .{value}) catch blk: {
         buf[45..].* = "...".*;

--- a/zml/meta.zig
+++ b/zml/meta.zig
@@ -748,6 +748,31 @@ pub fn collectBuf(func: anytype, func_ctx: _CollectCtx(func), obj: anytype, out:
     std.debug.assert(context.idx == context.out.len);
 }
 
+/// Finds all X in the given object, and write their pointers into an arraylist.
+pub fn collectPtrs(
+    T: type,
+    allocator: std.mem.Allocator,
+    obj: anytype,
+) std.mem.Allocator.Error![]*const T {
+    const CollectPtrCtx = struct {
+        allocator: std.mem.Allocator,
+        out: std.ArrayList(*const T) = .empty,
+        oom: bool = false,
+
+        fn cb(ctx: *@This(), val: *const T) void {
+            if (ctx.oom) return;
+            ctx.out.append(ctx.allocator, val) catch {
+                ctx.oom = true;
+            };
+        }
+    };
+    var context = CollectPtrCtx{ .allocator = allocator };
+    visit(CollectPtrCtx.cb, &context, obj);
+    if (context.oom) return error.OutOfMemory;
+
+    return context.out.toOwnedSlice(allocator);
+}
+
 fn _CollectCtx(func: anytype) type {
     const params = @typeInfo(@TypeOf(func)).@"fn".params;
     if (params.len == 1) return void;

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -1356,80 +1356,92 @@ pub fn sdpa(q_: Tensor, k_: Tensor, v_: Tensor, opts: SdpaOpts) Tensor {
 }
 
 pub const GatedDeltaNet = struct {
+    /// Query tensor .{ .s, .h, .k }.
+    queries: Tensor,
+    /// Key tensor .{ .s, .h, .k }.
+    keys: Tensor,
+    /// Value tensor .{ .s, .h, .v }.
+    values: Tensor,
+    /// Forget gate .{ .s, .h }.
+    alphas: Tensor,
+    /// Delta gate .{ .s, .h }.
+    betas: Tensor,
+
     pub const State = struct {
         /// Per-head recurrent state with shape .{ .h, .v, .k }.
         s: Tensor,
+        /// Sequence of outputs with shape .{ .s, .h, .v }.
+        outputs: Tensor,
+
+        /// Current step, scalar
+        step: Tensor,
     };
 
-    pub const StepInputs = struct {
-        /// Query tensor with shape .{ .h, .k }.
-        q: Tensor,
-        /// Key tensor with shape .{ .h, .k }.
-        k: Tensor,
-        /// Value tensor with shape .{ .h, .v }.
-        v: Tensor,
-        /// Forget gate with shape .{ .h }.
-        alpha: Tensor,
-        /// Delta gate with shape .{ .h }.
-        beta: Tensor,
-    };
-
-    pub const StepOutput = struct {
-        state: State,
-        output: Tensor,
+    pub const Input = struct {
+        s: Tensor,
     };
 
     pub const Output = struct {
+        /// Per-head recurrent state with shape .{ .h, .v, .k }.
+        state: Input,
         /// Sequence of outputs with shape .{ .s, .h, .v }.
         outputs: Tensor,
-        state: State,
     };
+
+    pub fn cond(gdn: GatedDeltaNet, state: State) Tensor {
+        return state.step.cmp(.LT, .scalar(gdn.queries.dim(.s), .i32));
+    }
+
+    /// Single-step recurrent update for Gated Delta Net.
+    pub fn body(gdn: GatedDeltaNet, state: State) State {
+        // q, k: .{ .h, .k }
+        const q = sliceStep(gdn.queries, state.step);
+        const k = sliceStep(gdn.keys, state.step);
+        //  v: .{ .h, .v }
+        const v = sliceStep(gdn.values, state.step);
+        // alpha, beta: .{ .h }
+        const alpha = sliceStep(gdn.alphas, state.step);
+        const beta = sliceStep(gdn.betas, state.step);
+
+        const hvk = state.s.shape();
+        const hv = hvk.drop(.k);
+
+        const v_hat = state.s.dot(k, .k).mul(alpha.broad(hv));
+        const delta = v.sub(v_hat).mul(beta.broad(hv));
+        const delta_k = delta.broad(hvk).mul(k.broad(hvk));
+        const s_new = state.s.mul(alpha.broad(hvk)).add(delta_k);
+        const y = s_new.dot(q, .k);
+
+        return .{
+            .s = s_new,
+            .outputs = state.outputs.dynamicUpdateSlice(.{ .s = state.step }, y),
+            .step = state.step.addConstant(1),
+        };
+    }
 
     fn sliceStep(input: Tensor, step_: Tensor) Tensor {
         return input.dynamicSlice(.{ .s = Tensor.DynSlice{ .start = step_, .len = 1 } }).squeeze(.s);
     }
 
-    fn validateStep(state: State, inputs: StepInputs) void {
+    fn validateInitialState(gdn: GatedDeltaNet, state: State) void {
         const err_template = "GatedDeltaNet.step(state: {f}, q: {f}, k: {f}, v: {f}, alpha: {f}, beta: {f}) is invalid ! ";
-        const err_args = .{ state.s, inputs.q, inputs.k, inputs.v, inputs.alpha, inputs.beta };
+        const err_args = .{ state.s, gdn.queries, gdn.keys, gdn.values, gdn.alphas, gdn.betas };
 
         stdx.debug.assert(state.s.shape().hasTags(.{ .h, .v, .k }), err_template ++ "state.s is missing tags {{.h, .v, .k}}", err_args);
-        stdx.debug.assert(inputs.q.shape().hasTags(.{ .h, .k }), err_template ++ "q is missing tags {{.h, .k}}", err_args);
-        stdx.debug.assert(inputs.k.shape().hasTags(.{ .h, .k }), err_template ++ "k is missing tags {{.h, .k}}", err_args);
-        stdx.debug.assert(inputs.v.shape().hasTags(.{ .h, .v }), err_template ++ "v is missing tags {{.h, .v}}", err_args);
-        stdx.debug.assert(inputs.alpha.shape().hasTags(.{.h}), err_template ++ "alpha is missing tag {{.h}}", err_args);
-        stdx.debug.assert(inputs.beta.shape().hasTags(.{.h}), err_template ++ "beta is missing tag {{.h}}", err_args);
+        stdx.debug.assert(gdn.queries.shape().hasTags(.{ .s, .h, .k }), err_template ++ "q is missing tags {{.h, .k}}", err_args);
+        stdx.debug.assert(gdn.keys.shape().hasTags(.{ .s, .h, .k }), err_template ++ "k is missing tags {{.h, .k}}", err_args);
+        stdx.debug.assert(gdn.values.shape().hasTags(.{ .s, .h, .v }), err_template ++ "v is missing tags {{.h, .v}}", err_args);
+        stdx.debug.assert(gdn.alphas.shape().hasTags(.{ .s, .h }), err_template ++ "alphas is missing tag {{.h}}", err_args);
+        stdx.debug.assert(gdn.betas.shape().hasTags(.{ .s, .h }), err_template ++ "betas is missing tag {{.h}}", err_args);
 
-        _ = collectDims(.{.h}, &.{ state.s, inputs.q, inputs.k, inputs.v, inputs.alpha, inputs.beta }, .strict) catch {
+        _ = collectDims(.{.h}, &.{ state.s, gdn.queries, gdn.keys, gdn.values, gdn.alphas, gdn.betas }, .strict) catch {
             stdx.debug.panic(err_template ++ "head dimensions are inconsistent.", err_args);
         };
-        _ = collectDims(.{.k}, &.{ state.s, inputs.q, inputs.k }, .strict) catch {
+        _ = collectDims(.{.k}, &.{ state.s, gdn.queries, gdn.keys }, .strict) catch {
             stdx.debug.panic(err_template ++ "key dimensions are inconsistent.", err_args);
         };
-        _ = collectDims(.{.v}, &.{ state.s, inputs.v }, .strict) catch {
+        _ = collectDims(.{.v}, &.{ state.s, gdn.values }, .strict) catch {
             stdx.debug.panic(err_template ++ "value dimensions are inconsistent.", err_args);
-        };
-    }
-
-    /// Single-step recurrent update for Gated Delta Net.
-    ///
-    /// Shapes:
-    /// - `state.s`: .{ .h, .v, .k }
-    /// - `inputs.q`, `inputs.k`: .{ .h, .k }
-    /// - `inputs.v`: .{ .h, .v }
-    /// - `inputs.alpha`, `inputs.beta`: .{ .h }
-    pub fn step(state: State, inputs: StepInputs) StepOutput {
-        validateStep(state, inputs);
-
-        const v_hat = state.s.dot(inputs.k, .k).mul(inputs.alpha.insertAxes(.last, .{.v}));
-        const delta = inputs.v.sub(v_hat).mul(inputs.beta.insertAxes(.last, .{.v}));
-        const delta_k = delta.insertAxes(.last, .{.k}).broad(state.s.shape()).mul(inputs.k.insertAxes(.k, .{.v}).broad(state.s.shape()));
-        const s_new = state.s.mul(inputs.alpha.insertAxes(.last, .{ .v, .k })).add(delta_k);
-        const y = s_new.dot(inputs.q, .k);
-
-        return .{
-            .state = .{ .s = s_new },
-            .output = y,
         };
     }
 
@@ -1446,83 +1458,26 @@ pub const GatedDeltaNet = struct {
         values: Tensor,
         alphas: Tensor,
         betas: Tensor,
-        initial_state: State,
+        initial_state: Input,
     ) Output {
-        const err_template = "GatedDeltaNet.forward(queries: {f}, keys: {f}, values: {f}, alphas: {f}, betas: {f}, state: {f}) is invalid ! ";
-        const err_args = .{ queries, keys, values, alphas, betas, initial_state.s };
-
-        stdx.debug.assert(queries.shape().hasTags(.{ .s, .h, .k }), err_template ++ "queries is missing tags {{.s, .h, .k}}", err_args);
-        stdx.debug.assert(keys.shape().hasTags(.{ .s, .h, .k }), err_template ++ "keys is missing tags {{.s, .h, .k}}", err_args);
-        stdx.debug.assert(values.shape().hasTags(.{ .s, .h, .v }), err_template ++ "values is missing tags {{.s, .h, .v}}", err_args);
-        stdx.debug.assert(alphas.shape().hasTags(.{ .s, .h }), err_template ++ "alphas is missing tags {{.s, .h}}", err_args);
-        stdx.debug.assert(betas.shape().hasTags(.{ .s, .h }), err_template ++ "betas is missing tags {{.s, .h}}", err_args);
-        stdx.debug.assert(initial_state.s.shape().hasTags(.{ .h, .v, .k }), err_template ++ "initial_state.s is missing tags {{.h, .v, .k}}", err_args);
-
-        _ = collectDims(.{ .s, .h }, &.{ queries, keys, values, alphas, betas }, .strict) catch {
-            stdx.debug.panic(err_template ++ "sequence/head dimensions are inconsistent.", err_args);
-        };
-        _ = collectDims(.{.k}, &.{ queries, keys, initial_state.s }, .strict) catch {
-            stdx.debug.panic(err_template ++ "key dimensions are inconsistent.", err_args);
-        };
-        _ = collectDims(.{.v}, &.{ values, initial_state.s }, .strict) catch {
-            stdx.debug.panic(err_template ++ "value dimensions are inconsistent.", err_args);
-        };
-
-        const WhileContext = struct {
-            queries: Tensor,
-            keys: Tensor,
-            values: Tensor,
-            alphas: Tensor,
-            betas: Tensor,
-            seq_len: Tensor,
-        };
-        const while_context: WhileContext = .{
+        const gdn: GatedDeltaNet = .{
             .queries = queries,
             .keys = keys,
             .values = values,
             .alphas = alphas,
             .betas = betas,
-            .seq_len = Tensor.scalar(queries.dim(.s), .i32),
         };
-
-        const Local = struct {
-            fn cond(step_: Tensor, _: Tensor, _: Tensor, ctx: WhileContext) Tensor {
-                return step_.cmp(.LT, ctx.seq_len);
-            }
-
-            fn body(step_: Tensor, s_prev: Tensor, outputs_prev: Tensor, ctx: WhileContext) [3]Tensor {
-                const step_out = step(
-                    .{ .s = s_prev },
-                    .{
-                        .q = sliceStep(ctx.queries, step_),
-                        .k = sliceStep(ctx.keys, step_),
-                        .v = sliceStep(ctx.values, step_),
-                        .alpha = sliceStep(ctx.alphas, step_),
-                        .beta = sliceStep(ctx.betas, step_),
-                    },
-                );
-                const outputs_new = outputs_prev.dynamicUpdateSlice(.{ .s = step_ }, step_out.output);
-
-                return .{
-                    step_.add(Tensor.scalar(1, .i32)),
-                    step_out.state.s,
-                    outputs_new,
-                };
-            }
+        const state: GatedDeltaNet.State = .{
+            .step = .scalar(0, .i32),
+            .s = initial_state.s,
+            .outputs = .zeroes(values.shape()),
         };
-
-        const step0 = Tensor.scalar(0, .i32);
-        const outputs0 = Tensor.zeroes(values.shape());
-        const loop_state = ops.@"while"(
-            .{ step0, initial_state.s, outputs0 },
-            Local.cond,
-            Local.body,
-            .{while_context},
-        );
+        validateInitialState(gdn, state);
+        const final_state = ops.@"while"(GatedDeltaNet, gdn, state);
 
         return .{
-            .outputs = loop_state[2],
-            .state = .{ .s = loop_state[1] },
+            .outputs = final_state.outputs,
+            .state = .{ .s = final_state.s },
         };
     }
 };
@@ -1541,7 +1496,7 @@ test "gated delta net" {
         std.testing.allocator,
         std.testing.io,
         GatedDeltaNet.forward,
-        .{ queries, keys, values, alphas, betas, GatedDeltaNet.State{ .s = initial_s } },
+        .{ queries, keys, values, alphas, betas, .{ .s = initial_s } },
         platform,
         .{},
     );

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 const dialects = @import("mlir/dialects");
 const mlir = @import("mlir");
@@ -460,123 +461,126 @@ pub fn sort(inputs: anytype, axis_: i64, comptime func: anytype, context: anytyp
     return result;
 }
 
-pub fn @"while"(operands: anytype, comptime cond: anytype, comptime body: anytype, context: anytype) stdx.meta.FnReturn(body) {
-    stdx.debug.assertComptime(stdx.meta.isTupleOf(@TypeOf(operands), Tensor), "zml.ops.while expects a tuple of Tensor operands, got {}", .{@TypeOf(operands)});
-    stdx.debug.assertComptime(stdx.meta.isTuple(@TypeOf(context)), "zml.ops.while expects tuple context like .{{ ... }}, got {}", .{@TypeOf(context)});
+/// Implement a while loop.
+/// The given While struct contains all the parameters that are fixed through the while.
+/// It must have:
+/// * a State struct definition that captures all the loop state that will change on each iteration
+/// * a `cond(While, State) Tensor` function returning a scalar boolean tensor
+/// * a `body(While, State) State` function that preserves the state shapes.
+pub fn @"while"(
+    While: type,
+    context: While,
+    initial_state: While.State,
+) While.State {
+    const comp = CompilationContext.current();
 
-    var arena = std.heap.ArenaAllocator.init(CompilationContext.current().allocator);
+    var arena = std.heap.ArenaAllocator.init(comp.allocator);
     defer arena.deinit();
+    const allocator = arena.allocator();
 
-    const mlir_ctx = CompilationContext.current().mlir_ctx;
+    const mlir_ctx = comp.mlir_ctx;
     const location = mlir.Location.unknown(mlir_ctx);
 
-    var captured_context: @TypeOf(context) = undefined;
+    // Force to materialize tensor.value() before we push a new scope.
+    var captured_context: While = undefined;
     meta.mapAlloc(struct {
         fn capture(_: void, tensor: Tensor) Tensor {
             return Tensor._result(tensor.shape(), tensor.value());
         }
-    }.capture, arena.allocator(), {}, context, &captured_context) catch unreachable;
+    }.capture, allocator, {}, context, &captured_context) catch unreachable;
 
-    var block_types: [operands.len]*const mlir.Type = undefined;
-    var block_locs: [operands.len]*const mlir.Location = @splat(location);
-    var operand_values: [operands.len]*const mlir.Value = undefined;
-    var operand_shapes: [operands.len]Shape = undefined;
+    const flat_operands: []*const Tensor = meta.collectPtrs(Tensor, allocator, &initial_state) catch @panic("OOM");
 
-    inline for (0..operands.len) |i| {
-        operand_shapes[i] = operands[i].shape();
-        block_types[i] = mlirx.Type.rankedTensor(mlir_ctx, operand_shapes[i]);
-        operand_values[i] = operands[i].value();
+    const OperandInfo = struct {
+        type: *const mlir.Type,
+        location: *const mlir.Location,
+        value: *const mlir.Value,
+    };
+
+    var operands_info = std.MultiArrayList(OperandInfo).initCapacity(allocator, flat_operands.len) catch @panic("OOM");
+
+    for (flat_operands) |input| {
+        operands_info.appendAssumeCapacity(.{
+            .type = mlirx.Type.rankedTensor(mlir_ctx, input._shape),
+            .location = location,
+            .value = input.value(),
+        });
     }
 
     const cond_block = b: {
-        var cond_args: @TypeOf(operands) = undefined;
-        inline for (0..operands.len) |i| {
-            cond_args[i] = .fromShape(operand_shapes[i]);
-        }
-
-        const block = mlir.Block.init(&block_types, &block_locs);
+        const block = mlir.Block.init(operands_info.items(.type), operands_info.items(.location));
         errdefer block.deinit();
 
-        CompilationContext.current().pushBlock(block);
-        defer CompilationContext.current().popBlock();
+        comp.pushBlock(block);
+        defer comp.popBlock();
 
-        const scope = CompilationContext.current().currentScope();
-        inline for (0..operands.len) |i| {
-            scope.id_to_argument.put(scope.arena.allocator(), cond_args[i].id, i) catch unreachable;
+        // Interpret initial_state as the block argument
+        const scope = comp.currentScope();
+        scope.id_to_argument.ensureUnusedCapacity(scope.arena.allocator(), flat_operands.len) catch @panic("OOM");
+        for (0.., flat_operands) |i, input| {
+            scope.id_to_argument.putAssumeCapacity(input.id, i);
         }
 
-        const cond_result = @call(.auto, cond, cond_args ++ captured_context);
-        stdx.debug.assert(meta.count(Tensor, &cond_result) == 1, "zml.ops.while expects cond to return exactly one Tensor, got {}", .{@TypeOf(cond_result)});
+        const cond: Tensor = captured_context.cond(initial_state);
+        stdx.debug.assert(cond.rank() == 0 and cond.dtype() == .bool, "zml.ops.while expects cond to return a scalar bool Tensor, got {f}", .{cond});
 
-        const cond_tensor = meta.first(Tensor, cond_result);
-        stdx.debug.assert(cond_tensor.rank() == 0 and cond_tensor.dtype() == .bool, "zml.ops.while expects cond to return a scalar bool Tensor, got {f}", .{cond_tensor});
-
-        _ = dialects.stablehlo.return_(mlir_ctx, cond_tensor.value(), location).appendTo(block);
+        _ = dialects.stablehlo.return_(mlir_ctx, cond.value(), location).appendTo(block);
         break :b block;
     };
 
     const body_block, var result = b: {
-        var body_args: @TypeOf(operands) = undefined;
-        inline for (0..operands.len) |i| {
-            body_args[i] = .fromShape(operand_shapes[i]);
-        }
-
-        const block = mlir.Block.init(&block_types, &block_locs);
+        const block = mlir.Block.init(operands_info.items(.type), operands_info.items(.location));
         errdefer block.deinit();
 
-        CompilationContext.current().pushBlock(block);
-        defer CompilationContext.current().popBlock();
+        comp.pushBlock(block);
+        defer comp.popBlock();
 
-        const scope = CompilationContext.current().currentScope();
-        inline for (0..operands.len) |i| {
-            scope.id_to_argument.put(scope.arena.allocator(), body_args[i].id, i) catch unreachable;
+        // Interpret operands as the block argument
+        const scope = comp.currentScope();
+        scope.id_to_argument.ensureUnusedCapacity(scope.arena.allocator(), flat_operands.len) catch @panic("OOM");
+        for (0.., flat_operands) |i, input| {
+            scope.id_to_argument.putAssumeCapacity(input.id, i);
         }
 
-        const result = @call(.auto, body, body_args ++ captured_context);
-        stdx.debug.assert(meta.count(Tensor, &result) == operands.len, "zml.ops.while expects body to return {d} Tensor values, got {}", .{ operands.len, @TypeOf(result) });
+        const result: While.State = captured_context.body(initial_state);
 
-        var result_tensors: [operands.len]Tensor = undefined;
-        meta.collectBuf(struct {
-            fn cb(tensor: Tensor) Tensor {
-                return tensor;
+        if (builtin.mode == .Debug) {
+            const result_tensors = meta.collectPtrs(Tensor, allocator, &result) catch @panic("OOM");
+            stdx.debug.assert(flat_operands.len == result_tensors.len, "zml.ops.while({s}) expects body to return {d} Tensor values, got {d} values in ", .{ @typeName(While), flat_operands.len, result_tensors.len });
+            for (0.., flat_operands, result_tensors) |i, in, out| {
+                stdx.debug.assert(in.shape().eql(out.shape()), "zml.ops.while({s}) expects body to preserve loop state shape, got {f} for operand {d} but expected {f}", .{ @typeName(While), in, i, out });
             }
-        }.cb, {}, &result, &result_tensors);
-
-        var result_values: [operands.len]*const mlir.Value = undefined;
-        inline for (0..operands.len) |i| {
-            stdx.debug.assert(result_tensors[i].shape().eql(operand_shapes[i]), "zml.ops.while expects body to preserve loop state shape, got {f} for operand {d} but expected {f}", .{ result_tensors[i], i, operands[i] });
-            result_values[i] = result_tensors[i].value();
         }
 
-        _ = dialects.stablehlo.returns(mlir_ctx, &result_values, location).appendTo(block);
+        const result_values = meta.collectAlloc(Tensor.value, {}, allocator, &result) catch @panic("OOM");
+        _ = dialects.stablehlo.returns(mlir_ctx, result_values, location).appendTo(block);
         break :b .{ block, result };
     };
 
     const op = dialects.stablehlo.while_(
         mlir_ctx,
-        &operand_values,
-        &block_types,
+        operands_info.items(.value),
+        operands_info.items(.type),
         cond_block,
         body_block,
         location,
-    ).appendTo(CompilationContext.current().currentScope().block);
+    ).appendTo(comp.currentScope().block);
 
-    const n_operands = operands.len;
     const AssignResultCtx = struct {
         op_: *mlir.Operation,
-        shapes: [n_operands]Shape,
+        og_tensors: []*const Tensor,
         idx: usize = 0,
+
+        fn assign(ctx: *@This(), tensor: *Tensor) void {
+            tensor.* = Tensor._result(ctx.og_tensors[ctx.idx].shape(), ctx.op_.result(ctx.idx));
+            ctx.idx += 1;
+        }
     };
     var assign_result_ctx: AssignResultCtx = .{
         .op_ = op,
-        .shapes = operand_shapes,
+        .og_tensors = flat_operands,
     };
-    meta.visit(struct {
-        fn cb(ctx: *AssignResultCtx, tensor: *Tensor) void {
-            tensor.* = Tensor._result(ctx.shapes[ctx.idx], ctx.op_.result(ctx.idx));
-            ctx.idx += 1;
-        }
-    }.cb, &assign_result_ctx, &result);
+    meta.visit(AssignResultCtx.assign, &assign_result_ctx, &result);
 
     return result;
 }
@@ -587,32 +591,42 @@ test @"while" {
     const zml = @import("zml.zig");
     const platform = zml.testing.env();
 
-    const initial_i: zml.Tensor = .init(.{}, .i64);
-    const initial_sum: zml.Tensor = .init(.{}, .i64);
+    const While = struct {
+        // While struct can contain tensor and non-tensor fields.
+        limit: i64,
+        step: Tensor,
 
-    const Local = struct {
-        fn cond(i: Tensor, sum: Tensor) Tensor {
-            _ = sum;
-            return i.cmp(.LT, Tensor.scalar(10, .i64));
+        pub const State = struct {
+            i: zml.Tensor,
+            sum: zml.Tensor,
+        };
+
+        pub fn cond(self: @This(), state: State) Tensor {
+            return state.i.cmp(.LT, Tensor.scalar(self.limit, .i64));
         }
 
-        fn body(i: Tensor, sum: Tensor) [2]Tensor {
-            const one = Tensor.scalar(1, .i64);
+        pub fn body(self: @This(), state: State) State {
             return .{
-                i.add(one),
-                sum.add(one),
+                .i = state.i.add(self.step),
+                .sum = state.sum.add(self.step),
             };
         }
 
-        fn forward(i: Tensor, sum: Tensor) [2]Tensor {
-            return zml.ops.@"while"(.{ i, sum }, cond, body, .{});
+        fn forward(i: Tensor, sum: Tensor) State {
+            return zml.ops.@"while"(
+                @This(),
+                .{ .limit = 10, .step = .scalar(1, .i64) },
+                .{ .i = i, .sum = sum },
+            );
         }
     };
 
+    const initial_i: zml.Tensor = .init(.{}, .i64);
+    const initial_sum: zml.Tensor = .init(.{}, .i64);
     var exe = try zml.module.compile(
         std.testing.allocator,
         std.testing.io,
-        Local.forward,
+        While.forward,
         .{ initial_i, initial_sum },
         platform,
         .{},
@@ -624,13 +638,13 @@ test @"while" {
     var sum_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, initial_sum.shape(), .replicated, std.mem.sliceAsBytes(&[1]i64{0}));
     defer sum_buffer.deinit();
 
-    var results = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Local.forward, .{ i_buffer, sum_buffer });
-    defer results[0].deinit();
-    defer results[1].deinit();
+    var results = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, While.forward, .{ i_buffer, sum_buffer });
+    defer results.i.deinit();
+    defer results.sum.deinit();
 
-    var cpu_i = try results[0].toSliceAlloc(std.testing.allocator, std.testing.io);
+    var cpu_i = try results.i.toSliceAlloc(std.testing.allocator, std.testing.io);
     defer cpu_i.free(std.testing.allocator);
-    var cpu_sum = try results[1].toSliceAlloc(std.testing.allocator, std.testing.io);
+    var cpu_sum = try results.sum.toSliceAlloc(std.testing.allocator, std.testing.io);
     defer cpu_sum.free(std.testing.allocator);
 
     try std.testing.expectEqual(@as(i64, 10), cpu_i.items(i64)[0]);

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -4158,6 +4158,10 @@ pub const Tensor = struct {
         return _result(on_true._shape, op.result(0));
     }
 
+    pub fn mask(x: Tensor, pred: Tensor, mask_value: anytype) Tensor {
+        return pred.broad(x.shape()).select(x, .scalar(mask_value, x.dtype()));
+    }
+
     /// Returns a Tensor containing the element-wise not logical operation of the input Tensor.
     pub fn not(self: Tensor) Tensor {
         const op = dialects.stablehlo.not(mlirCtx(), self.value(), .unknown(mlirCtx())).appendTo(currentBlock());


### PR DESCRIPTION
removes `anytype` from `zml.ops.while`, helping with type checking and simplifying a bit the logic.
A `While` struct needs 
* a State struct definition that captures all the loop state that will change on each iteration
* a `cond(While, State) Tensor` function returning a scalar boolean tensor
* a `body(While, State) State` function that preserves the state shapes.

example:

```
const While = struct {
    // While struct can contain tensor and non-tensor fields.
    limit: i64,
    step: Tensor,

    pub const State = struct {
        i: zml.Tensor,
        sum: zml.Tensor,
    };

    pub fn cond(self: @This(), state: State) Tensor {
        return state.i.cmp(.LT, Tensor.scalar(self.limit, .i64));
    }

    pub fn body(self: @This(), state: State) State {
        return .{
            .i = state.i.add(self.step),
            .sum = state.sum.add(self.step),
        };
    }

    fn forward(i: Tensor, sum: Tensor) State {
        return zml.ops.@"while"(
            @This(),
            .{ .limit = 10, .step = .scalar(1, .i64) },
            .{ .i = i, .sum = sum },
        );
    }
};
```

The code is a bit more verbose for simple example, but for GatedDeltaNet it's equivalent, and I have also used it for paged attention.