### PR TITLE
zml/attention: stablehlo paged attention

### DIFF
--- a/mlir/mlir.zig
+++ b/mlir/mlir.zig
@@ -1294,11 +1294,11 @@ pub const Operation = opaque {
             state.addAttributes(attrs);
         }
         if (args.blocks) |blocks| {
-            const body_region = Region.init();
             for (blocks) |block_| {
+                const body_region = Region.init();
                 body_region.appendOwnedBlock(block_);
+                state.addOwnedRegions(&.{body_region});
             }
-            state.addOwnedRegions(&.{body_region});
         }
         const new_op = try Operation.init(&state);
         errdefer new_op.deinit();

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -598,7 +598,7 @@ const AttentionLoop = struct {
                 page_size: u32,
 
                 /// Prefill version: num_slots == page_size, we multiply a full page of queries with a page of keys.
-                pub fn ifTrue(if_ctx: IfPrefill) State {
+                pub fn onTrue(if_ctx: IfPrefill) State {
                     const while_body = if_ctx.while_body;
                     const state = if_ctx.state;
                     const page_size = if_ctx.page_size;
@@ -619,7 +619,7 @@ const AttentionLoop = struct {
                 }
 
                 /// Decode version: num_slots == 1, we multiply one query with a page of keys.
-                pub fn ifFalse(if_ctx: IfPrefill) State {
+                pub fn onFalse(if_ctx: IfPrefill) State {
                     const while_body = if_ctx.while_body;
                     const state = if_ctx.state;
                     const page_size = if_ctx.page_size;

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -22,7 +22,7 @@ pub const Backend = enum {
     triton,
     mosaic_tpu,
     metal,
-    // vanilla,
+    stablehlo,
 
     pub fn auto(platform: *const zml.Platform) Backend {
         return switch (platform.target) {
@@ -31,14 +31,14 @@ pub const Backend = enum {
             .oneapi => .triton,
             .tpu => .mosaic_tpu,
             .metal => .metal,
-            // .cpu => .vanilla
-            .cpu, .neuron => stdx.debug.panic("Paged attention is not supported on {s} yet", .{@tagName(platform.target)}),
+            .cpu => .stablehlo,
+            .neuron => stdx.debug.panic("Paged attention is not supported on {s} yet", .{@tagName(platform.target)}),
         };
     }
 
     pub fn isAvailable(backend: Backend, platform: *const zml.Platform) bool {
         return switch (backend) {
-            // .vanilla => true,
+            .stablehlo => true,
             .triton => platform.target != .cpu,
             .metal => platform.target == .metal,
             .mosaic_tpu => platform.target == .tpu,
@@ -59,6 +59,7 @@ pub const Options = union(Backend) {
     triton: triton.paged.Options,
     mosaic_tpu: tpu.mosaic_tpu.Options,
     metal: metal.paged.Options,
+    stablehlo: triton.paged.Options,
 
     const Args = struct {
         backend: Backend,
@@ -143,7 +144,7 @@ pub const Options = union(Backend) {
                     .head_dim = args.head_dim,
                 },
             },
-            inline .triton, .metal => |t| @unionInit(Options, @tagName(t), .{
+            inline .triton, .metal, .stablehlo => |t| @unionInit(Options, @tagName(t), .{
                 .batch_size = args.batch_size,
                 .max_num_pages = args.max_num_pages,
                 .max_seqlen_q = args.max_seqlen_q,
@@ -171,6 +172,7 @@ pub const Parameters = union(Backend) {
     triton: triton.paged.Parameters,
     mosaic_tpu: tpu.mosaic_tpu.Parameters,
     metal: metal.paged.Parameters,
+    stablehlo: triton.paged.Parameters,
 
     pub fn init(options_: Options) Parameters {
         return switch (options_) {
@@ -225,7 +227,7 @@ pub const KvCache = union(enum) {
 
         var kv: KvCache = switch (self) {
             .split => |split| switch (backend) {
-                .cuda_fa2, .cuda_fa3, .triton, .mosaic_tpu, .metal => .{ .split = .{
+                .cuda_fa2, .cuda_fa3, .triton, .mosaic_tpu, .metal, .stablehlo => .{ .split = .{
                     .k = split.k.scatterSlices(
                         .{ .page = page_index, .k_chunk = offset },
                         new_k,
@@ -250,6 +252,19 @@ pub const KvCache = union(enum) {
         const offset = slot_mapping.remainder(.scalar(page_size, slot_mapping.dtype()));
         return .{ page_index, offset };
     }
+
+    pub fn getPage(
+        self: KvCache,
+        page_index: zml.Tensor,
+    ) [2]zml.Tensor {
+        return switch (self) {
+            .split => |split| .{
+                split.k.dynamicSlice1d(split.k.axis(.page), .{ .start = page_index, .len = 1 }).squeeze(.page),
+                split.v.dynamicSlice1d(split.k.axis(.page), .{ .start = page_index, .len = 1 }).squeeze(.page),
+            },
+            .dense => @panic("TODO"),
+        };
+    }
 };
 
 pub fn pagedAttention(parameters: Parameters, q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, kv_cache: KvCache, opts: AttentionOptions) zml.Tensor {
@@ -273,6 +288,7 @@ pub fn pagedAttention(parameters: Parameters, q: zml.Tensor, k: zml.Tensor, v: z
             .split => |split| metal.paged.pagedAttention(metal_parameters, q, split.k, split.v, opts),
             .dense => std.debug.panic("fused KV pages are only supported with the mosaic_tpu backend", .{}),
         },
+        .stablehlo => |params| stablehlo_pagedAttention(params, q, kv_cache, opts),
     };
 }
 
@@ -328,13 +344,13 @@ test pagedAttention {
     const dt: zml.DataType = .bf16;
     const partition = .{ .hkv = .model };
     const tensors: struct { q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, kv_cache: KvCache } = .{
-        .q = .withPartitioning(.init(.{ .b = query_token_count, .hkv = 2, .hg = 4, .hd = 32 }, dt), partition),
-        .k = .withPartitioning(.init(.{ .b = query_token_count, .hkv = 2, .hd = 32 }, dt), partition),
-        .v = .withPartitioning(.init(.{ .b = query_token_count, .hkv = 2, .hd = 32 }, dt), partition),
+        .q = .withPartitioning(.init(.{ .b = query_token_count, .hkv = 4, .hg = 4, .hd = 32 }, dt), partition),
+        .k = .withPartitioning(.init(.{ .b = query_token_count, .hkv = 4, .hd = 32 }, dt), partition),
+        .v = .withPartitioning(.init(.{ .b = query_token_count, .hkv = 4, .hd = 32 }, dt), partition),
         .kv_cache = .{
             .split = .{
-                .k = .withPartitioning(.init(.{ .page = num_pages, .k_chunk = page_size, .hkv = 2, .hd = 32 }, dt), partition),
-                .v = .withPartitioning(.init(.{ .page = num_pages, .k_chunk = page_size, .hkv = 2, .hd = 32 }, dt), partition),
+                .k = .withPartitioning(.init(.{ .page = num_pages, .k_chunk = page_size, .hkv = 4, .hd = 32 }, dt), partition),
+                .v = .withPartitioning(.init(.{ .page = num_pages, .k_chunk = page_size, .hkv = 4, .hd = 32 }, dt), partition),
             },
         },
     };
@@ -469,7 +485,7 @@ test pagedAttention {
                 } } };
             },
             .triton => triton_parameters_d,
-            inline .metal, .mosaic_tpu => |_, t| @unionInit(zml.Bufferized(Parameters), @tagName(t), .{
+            inline .metal, .mosaic_tpu, .stablehlo => |_, t| @unionInit(zml.Bufferized(Parameters), @tagName(t), .{
                 .block_table = triton_parameters_d.triton.block_table,
                 .seq_lens = triton_parameters_d.triton.seq_lens,
                 .query_start_len = triton_parameters_d.triton.query_start_len,
@@ -503,8 +519,8 @@ test pagedAttention {
                 std.log.err("test pagedAttention failed on backend {0t}\n--> reference ({1t}): {2d:32.3}\n--> pagedAttention({0t}): {3d:32.3}", .{
                     backend,
                     reference_backend,
-                    reference.subSlice(1, 0, 1).subSlice(2, 0, 1),
-                    output_h.subSlice(1, 0, 1).subSlice(2, 0, 1),
+                    reference.subSlice(1, 0, 1).squeeze(1).subSlice(1, 0, 1).squeeze(1),
+                    output_h.subSlice(1, 0, 1).squeeze(1).subSlice(1, 0, 1).squeeze(1),
                 });
             },
             else => |e| return e,
@@ -512,4 +528,248 @@ test pagedAttention {
     }
 
     if (num_failed > 0) return error.TestUnexpectedResult;
+}
+
+fn stablehlo_pagedAttention(
+    parameters: triton.paged.Parameters,
+    q: zml.Tensor,
+    kv_cache: KvCache,
+    opts: AttentionOptions,
+) zml.Tensor {
+    const page_size = kv_cache.split.k.dim(.k_chunk);
+
+    const final_state = zml.ops.@"while"(
+        AttentionLoop,
+        .{ .q = q, .kv_cache = kv_cache, .parameters = parameters, .opts = opts },
+        .{
+            // i32 to match triton conventions
+            .slot_id = .scalar(0, .i32),
+            .seq_id = .scalar(0, .i32),
+            .q_page_idx = .scalar(0, .i32),
+            .k_page_idx = .scalar(0, .i32),
+            // Note: we do all partial softmax in f32
+            .partial_softmax_prefill = .zeroes(q.shape().setDim(.b, page_size).withDtype(.f32)),
+            .partial_softmax_decode = .zeroes(q.shape().setDim(.b, 1).withDtype(.f32)),
+            .out = .zeroes(q.shape()),
+        },
+    );
+
+    return final_state.out;
+}
+
+const AttentionLoop = struct {
+    q: zml.Tensor,
+    kv_cache: KvCache,
+    parameters: triton.paged.Parameters,
+    opts: AttentionOptions,
+
+    const While = @This();
+
+    pub const State = struct {
+        slot_id: zml.Tensor,
+        seq_id: zml.Tensor,
+        q_page_idx: zml.Tensor,
+        k_page_idx: zml.Tensor,
+        partial_softmax_prefill: PartialSoftmax,
+        partial_softmax_decode: PartialSoftmax,
+        out: zml.Tensor,
+    };
+
+    pub fn cond(self: While, state: State) zml.Tensor {
+        const has_more_sequences = state.seq_id.cmp(.LT, .scalar(self.parameters.seq_lens.count(), .i32));
+        const query_start = self.parameters.query_start_len.dynamicSlice1d(0, .{ .start = state.seq_id, .len = 1 });
+        const query_end = self.parameters.query_start_len.dynamicSlice1d(0, .{ .start = state.seq_id.addConstant(1), .len = 1 });
+        const has_queries = query_start.cmp(.LT, query_end).asScalar();
+        return has_more_sequences.logical(.AND, has_queries);
+    }
+
+    pub fn body(self: While, state_: State) State {
+        const query_start = self.parameters.query_start_len.dynamicSlice1d(0, .{ .start = state_.seq_id, .len = 1 });
+        const query_end = self.parameters.query_start_len.dynamicSlice1d(0, .{ .start = state_.seq_id.addConstant(1), .len = 1 });
+        const seq_num_queries_: zml.Tensor = .asScalar(.sub(query_end, query_start));
+        const page_size_: u32 = @intCast(self.kv_cache.split.k.dim(.k_chunk));
+
+        return zml.ops.@"if"(
+            struct {
+                const IfPrefill = @This();
+                while_body: While,
+                state: State,
+                seq_num_queries: zml.Tensor,
+                page_size: u32,
+
+                /// Prefill version: num_slots == page_size, we multiply a full page of queries with a page of keys.
+                pub fn ifTrue(if_ctx: IfPrefill) State {
+                    const while_body = if_ctx.while_body;
+                    const state = if_ctx.state;
+                    const page_size = if_ctx.page_size;
+                    const num_slots: u32 = page_size;
+
+                    // seq_lens includes the current queries; subtracting their count gives the context length.
+                    const seq_len = while_body.parameters.seq_lens.dynamicSlice1d(0, .{ .start = state.seq_id, .len = 1 }).asScalar();
+                    const q_offset = seq_len.sub(if_ctx.seq_num_queries).add(state.q_page_idx.scale(page_size));
+                    const next_k_offset = state.k_page_idx.addConstant(1).scale(page_size);
+
+                    // The current K page is processed in this iteration. Continue if the next page contains
+                    // any key visible to the current query chunk, whose exclusive end is q_offset + num_slots.
+                    const query_has_more_keys: zml.Tensor = .cmp(next_k_offset, .LT, q_offset.addConstant(num_slots));
+                    const sequence_has_more_queries: zml.Tensor = .cmp(state.q_page_idx.addConstant(1).scale(num_slots), .LT, if_ctx.seq_num_queries);
+
+                    const partial_softmax = while_body.attentionOnePage(state, q_offset, num_slots, page_size);
+                    return updateState(state, num_slots, query_has_more_keys, sequence_has_more_queries, partial_softmax);
+                }
+
+                /// Decode version: num_slots == 1, we multiply one query with a page of keys.
+                pub fn ifFalse(if_ctx: IfPrefill) State {
+                    const while_body = if_ctx.while_body;
+                    const state = if_ctx.state;
+                    const page_size = if_ctx.page_size;
+                    const num_slots: u32 = 1;
+
+                    // A decode query is the final token in seq_len, so its zero-based offset is seq_len - 1.
+                    const seq_len = while_body.parameters.seq_lens.dynamicSlice1d(0, .{ .start = state.seq_id, .len = 1 }).asScalar();
+                    const q_offset = seq_len.sub(if_ctx.seq_num_queries);
+                    const next_k_offset = state.k_page_idx.addConstant(1).scale(page_size);
+
+                    const query_has_more_keys: zml.Tensor = .cmp(next_k_offset, .LT, q_offset.addConstant(num_slots));
+                    const sequence_has_more_queries: zml.Tensor = .scalar(false, .bool);
+
+                    const partial_softmax = while_body.attentionOnePage(state, q_offset, num_slots, page_size);
+                    return updateState(state, num_slots, query_has_more_keys, sequence_has_more_queries, partial_softmax);
+                }
+            },
+            .{
+                .while_body = self,
+                .state = state_,
+                .seq_num_queries = seq_num_queries_,
+                .page_size = page_size_,
+            },
+            .cmp(seq_num_queries_, .GT, .scalar(1, .i32)),
+        );
+    }
+
+    pub fn attentionOnePage(self: While, state: State, q_offset: zml.Tensor, q_chunk: u32, page_size: u32) PartialSoftmax {
+        const k_offset = state.k_page_idx.scale(page_size);
+        const active_q = self.q.dynamicSlice1d(self.q.axis(.b), .{ .start = state.slot_id, .len = q_chunk });
+
+        const active_k_page_id = self.parameters.block_table.dynamicSlice(.{
+            .b = zml.Tensor.DynSlice{ .start = state.seq_id, .len = 1 },
+            .p = zml.Tensor.DynSlice{ .start = state.k_page_idx, .len = 1 },
+        }).asScalar();
+        const active_k, const active_v = self.kv_cache.getPage(active_k_page_id);
+
+        const dtype = self.q.dtype();
+        const attn_mask: zml.Tensor = attn_mask: {
+            const mask_shape: zml.Shape = .init(.{ .b = q_chunk, .k_chunk = page_size }, dtype);
+
+            const q_idx = zml.Tensor.iota(mask_shape, .b).add(q_offset);
+            const k_idx = zml.Tensor.iota(mask_shape, .k_chunk).add(k_offset);
+
+            const mask = zml.Tensor.cmp(k_idx, .LE, q_idx);
+            const minus_inf = zml.Tensor.constant(dtype.minValue());
+            break :attn_mask .select(mask, .scalar(0, dtype), minus_inf);
+        };
+
+        const scale: f32 = self.opts.scale orelse @floatCast(1.0 / @sqrt(@as(f64, @floatFromInt(active_q.dim(.hd)))));
+        var attn_weights = active_q.dot(active_k, .hd).scale(scale);
+        attn_weights = attn_weights.add(attn_mask.broad(attn_weights.shape()));
+
+        const og_softmax = if (q_chunk == 1) state.partial_softmax_decode else state.partial_softmax_prefill;
+        // Note: we compute q * k using q and k dtype, but the partial softmax is in f32.
+        const precise_dt = og_softmax.values.dtype();
+        var partial = partialSoftmax(attn_weights.convert(precise_dt), .k_chunk);
+        partial.values = partial.values.dot(active_v.convert(precise_dt), .k_chunk).transpose(og_softmax.values.shape());
+        partial.max_value = partial.max_value.transpose(og_softmax.max_value.shape());
+        partial.exp_sum = partial.exp_sum.transpose(og_softmax.exp_sum.shape());
+
+        return og_softmax.merge(partial);
+    }
+
+    pub fn updateState(state: State, num_slots: u32, query_has_more_keys: zml.Tensor, sequence_has_more_queries: zml.Tensor, softmax: PartialSoftmax) State {
+        return zml.ops.if2(
+            query_has_more_keys,
+            // If the query has more pages: update partial softmax with attention on current page, delay updating output.
+            State{
+                .slot_id = state.slot_id,
+                .seq_id = state.seq_id,
+                .q_page_idx = state.q_page_idx,
+                .k_page_idx = state.k_page_idx.addConstant(1),
+                .partial_softmax_prefill = if (num_slots == 1) state.partial_softmax_prefill else softmax,
+                .partial_softmax_decode = if (num_slots == 1) softmax else state.partial_softmax_decode,
+                .out = state.out,
+            },
+            // Query has no more pages, we commit softmax to output and increment slot
+            State{
+                .k_page_idx = .scalar(0, .i32),
+                .partial_softmax_prefill = if (num_slots == 1) state.partial_softmax_prefill else .reset(softmax),
+                .partial_softmax_decode = if (num_slots == 1) .reset(softmax) else state.partial_softmax_decode,
+                .out = state.out.dynamicUpdateSlice(.{ .b = state.slot_id }, softmax.finalize().convert(state.out.dtype())),
+                .slot_id = state.slot_id.addConstant(num_slots),
+                // If the sequence has more query chunks: increment q_page_idx, otherwise start over at 0.
+                .q_page_idx = .select(sequence_has_more_queries, state.q_page_idx.addConstant(1), .scalar(0, .i32)),
+                // If the sequence has more query chunks: keep seq_id, otherwise increment seq_id.
+                .seq_id = .select(sequence_has_more_queries, state.seq_id, state.seq_id.addConstant(1)),
+            },
+        );
+    }
+};
+
+pub const PartialSoftmax = struct {
+    values: zml.Tensor,
+    exp_sum: zml.Tensor,
+    max_value: zml.Tensor,
+
+    pub fn zeroes(q_shape: zml.Shape) PartialSoftmax {
+        return .{
+            .values = .zeroes(q_shape),
+            .exp_sum = .zeroes(q_shape.drop(.hd)),
+            .max_value = .broad(.constant(q_shape.dtype().minValue()), q_shape.drop(.hd)),
+        };
+    }
+
+    pub fn reset(self: PartialSoftmax) PartialSoftmax {
+        return .zeroes(self.values.shape());
+    }
+
+    pub fn merge(self: PartialSoftmax, other: PartialSoftmax) PartialSoftmax {
+        // Rescale self and other using the new global_max.
+        const global_max = self.max_value.maximum(other.max_value.convert(self.max_value.dtype()));
+        const new_self = self.rescale(global_max);
+        const new_other = other.rescale(global_max);
+
+        // Now that self and other are using the same scale, we can just add them:
+        return .{
+            .max_value = global_max,
+            .values = new_self.values.add(new_other.values),
+            .exp_sum = new_self.exp_sum.add(new_other.exp_sum),
+        };
+    }
+
+    /// Update max_value and rescale attn and exp_sum accordingly.
+    pub fn rescale(self: PartialSoftmax, max_value: zml.Tensor) PartialSoftmax {
+        const max_diff_exp: zml.Tensor = .exp(self.max_value.sub(max_value));
+        const sum_dtype = self.exp_sum.dtype();
+        return .{
+            .max_value = max_value,
+            .values = self.values.mul(max_diff_exp.broad(self.values.shape())),
+            .exp_sum = self.exp_sum.mul(max_diff_exp.convert(sum_dtype)),
+        };
+    }
+
+    /// Divides the intermediary results by the exp_sum to get the proper attention values.
+    pub fn finalize(self: PartialSoftmax) zml.Tensor {
+        return self.values.div(self.exp_sum.broad(self.values.shape()).convert(self.values.dtype()));
+    }
+};
+
+/// Compute softmax over a chunk.
+/// Returns intermediary results to allow aggregating later.
+pub fn partialSoftmax(self: zml.Tensor, axis: anytype) PartialSoftmax {
+    const a = self.axis(axis);
+    const max_val = self.max(a).squeeze(a).maximum(.scalar(-1e16, self.dtype()));
+    const out = self.sub(max_val.broad(self.shape())).exp();
+    return .{
+        .values = out,
+        .exp_sum = out.convert(.f32).sum(a).squeeze(a),
+        .max_value = max_val,
+    };
 }

--- a/zml/floats.zig
+++ b/zml/floats.zig
@@ -29,16 +29,15 @@ fn FloatConversionHelpers(Float: type) type {
 
             const vf32: Float32 = @bitCast(f);
             const exponent: i16 = @as(i16, vf32.exponent) - exp_off;
-            const overflow = exponent > std.math.maxInt(@FieldType(Float, "exponent"));
+            const overflow = std.math.isInf(f) or exponent > std.math.maxInt(@FieldType(Float, "exponent"));
             if (overflow) {
                 @branchHint(.unlikely);
                 return if (@hasDecl(Float, "inf"))
                     if (vf32.sign == 0) Float.inf else Float.minus_inf
                 else if (@hasDecl(Float, "nan"))
                     Float.nan
-                else b: {
-                    break :b if (vf32.sign == 0) Float.max else Float.min;
-                };
+                else
+                    std.debug.panic("{} doesn't have infinite representations", .{Float});
             }
 
             return if (exponent <= 0)
@@ -271,10 +270,8 @@ test "Float8E4" {
     }) |Float8T| {
         try testCustomFloat(Float8T, test_case_e4);
         try std.testing.expectEqual(0.0, Float8T.fromF32(1.0 / 2048.0).toF32());
-        if (@hasDecl(Float8T, "inf")) {
-            try std.testing.expectEqual(Float8T.inf, Float8T.fromF32(128.0));
-            try std.testing.expectEqual(Float8T.inf.neg(), Float8T.fromF32(-128.0));
-        }
+
+        if (@hasDecl(Float8T, "inf")) @compileError("Float8E4 don't have ±∞ representations");
     }
 }
 

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -1289,9 +1289,7 @@ pub fn causalAttnMask(
     }
 
     if (dtype.isFloat()) {
-        const zeros = Tensor.constant(dtype.zero()).broad(mask.shape());
-        const minus_inf = Tensor.constant(dtype.minValue()).broad(mask.shape());
-        mask = Tensor.select(mask, zeros, minus_inf);
+        mask = Tensor.select(mask, .scalar(0, dtype), .scalar(-std.math.inf(f32), dtype));
     } else {
         mask = mask.convert(dtype);
     }

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -651,6 +651,134 @@ test @"while" {
     try std.testing.expectEqual(@as(i64, 9), cpu_sum.items(i64)[0]);
 }
 
+pub fn @"if"(
+    BlkCtx: type,
+    _blkctx: BlkCtx,
+    pred: Tensor,
+) stdx.meta.FnReturn(BlkCtx.ifTrue) {
+    stdx.debug.assertComptime(
+        stdx.meta.FnReturn(BlkCtx.ifTrue) == stdx.meta.FnReturn(BlkCtx.ifFalse),
+        "zml.ops.if expects same return types for ifTrue and ifFalse, got {s} and {s}",
+        .{ @typeName(stdx.meta.FnReturn(BlkCtx.ifTrue)), @typeName(stdx.meta.FnReturn(BlkCtx.ifFalse)) },
+    );
+
+    stdx.debug.assert(pred.dtype() == .bool and pred.count() == 1, "zml.ops.if expects the condition to have exactly one element of dtype .bool, got {f}", .{pred});
+
+    var arena = std.heap.ArenaAllocator.init(CompilationContext.current().allocator);
+    defer arena.deinit();
+
+    const allocator = arena.allocator();
+    var blkctx: BlkCtx = undefined;
+
+    // Explicitly capture values from the parent block.
+    meta.mapAlloc(struct {
+        fn capture(_: void, tensor: Tensor) Tensor {
+            return Tensor._result(tensor.shape(), tensor.value());
+        }
+    }.capture, arena.allocator(), {}, _blkctx, &blkctx) catch unreachable;
+
+    const mlir_ctx = CompilationContext.current().mlir_ctx;
+    const loc: *const mlir.Location = .unknown(mlir_ctx);
+
+    const true_branch, const true_branch_block = b: {
+        const block = mlir.Block.init(&.{}, &.{});
+        errdefer block.deinit();
+
+        CompilationContext.current().pushBlock(block);
+        defer CompilationContext.current().popBlock();
+
+        const result = blkctx.ifTrue();
+        const result_values = meta.collectAlloc(Tensor.value, {}, allocator, &result) catch @panic("OOM");
+        defer allocator.free(result_values);
+        _ = dialects.stablehlo.returns(mlir_ctx, result_values, loc).appendTo(block);
+        break :b .{ result, block };
+    };
+
+    const false_branch, const false_branch_block = b: {
+        const block = mlir.Block.init(&.{}, &.{});
+        errdefer block.deinit();
+
+        CompilationContext.current().pushBlock(block);
+        defer CompilationContext.current().popBlock();
+
+        const result = blkctx.ifFalse();
+        const result_values = meta.collectAlloc(Tensor.value, {}, allocator, &result) catch @panic("OOM");
+        defer allocator.free(result_values);
+        _ = dialects.stablehlo.returns(mlir_ctx, result_values, loc).appendTo(block);
+        break :b .{ result, block };
+    };
+    // TODO check that false branch values matches right branch
+    _ = false_branch;
+
+    const op = mlir.Operation.make(mlir_ctx, "stablehlo.if", .{
+        .operands = .{ .flat = &.{pred.asScalar().value()} },
+        .result_type_inference = true,
+        .blocks = &.{ true_branch_block, false_branch_block },
+        // We can't verify right away, cause the weights captured by the if haven't been added yet.
+        .verify = false,
+        .location = loc,
+    });
+    _ = op.appendTo(CompilationContext.current().currentScope().block);
+
+    return fromMlirOperationWithTags(op, true_branch);
+}
+
+test "if" {
+    const zml = @import("zml.zig");
+    const platform = zml.testing.env();
+    const allocator = std.testing.allocator;
+
+    const IfMod = struct {
+        a: Tensor,
+        b: Tensor,
+
+        pub fn _fwd(pred: Tensor, a: Tensor, b: Tensor) Tensor {
+            return @"if"(@This(), .{ .a = a, .b = b }, pred.convert(.bool));
+        }
+
+        pub fn ifTrue(ctx: @This()) Tensor {
+            return ctx.a.dotGeneral(ctx.b, &.{.{ 1, 0 }}, &.{});
+        }
+
+        pub fn ifFalse(ctx: @This()) Tensor {
+            return ctx.b.dotGeneral(ctx.a, &.{.{ 1, 0 }}, &.{});
+        }
+    };
+
+    {
+        const pred: Tensor = .init(.{}, .i32);
+        const a: Tensor = .init(.{ 4, 4 }, .f32);
+        const b: Tensor = .init(.{ 4, 4 }, .f32);
+        const mod = try platform.compileFn(allocator, std.testing.io, IfMod._fwd, .{ pred, a, b }, .{});
+        defer mod.deinit();
+    }
+}
+
+/// Create a Tensor struct similar to base, keeping base tags,
+/// but using mlir value and dims from the mlir operation.
+fn fromMlirOperationWithTags(op: *const mlir.Operation, base: anytype) @TypeOf(base) {
+    const LocalContext = struct {
+        index: usize,
+        op: *const mlir.Operation,
+    };
+    var context = LocalContext{ .index = 0, .op = op };
+    var res = base;
+    meta.visit((struct {
+        fn cb(inner_ctx: *LocalContext, tensor: *Tensor) void {
+            var new = Tensor.fromMlirValue(inner_ctx.op.result(inner_ctx.index));
+            stdx.debug.internalAssert(new.rank() == tensor.rank(), "expected operand result to have rank {} but got {f}", .{ tensor.rank(), new });
+            // copy tags and sharding info over
+            // some ops can change dims eg reduceWindow, so we trust mlir here.
+            new._shape._tags = tensor._shape._tags;
+            new._shape._partitioning = tensor._shape._partitioning;
+            tensor.* = new;
+            inner_ctx.index += 1;
+        }
+    }).cb, &context, &res);
+    std.debug.assert(context.index == op.numResults());
+    return res;
+}
+
 pub const TritonOps = struct {
     debug: bool = false,
     name: [:0]const u8,

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -651,15 +651,24 @@ test @"while" {
     try std.testing.expectEqual(@as(i64, 9), cpu_sum.items(i64)[0]);
 }
 
+/// Implement if/else branches.
+/// The given If struct contains all the parameters that can be referenced in the if/else branches.
+///
+/// It must have:
+/// * an `onTrue(If) T` function returning some tensors
+/// * an `onFalse(If) T` function returning similar shaped tensors
+///
+/// If some expression in `onTrue` or `onFalse` has side effects (like printing),
+/// stablehlo guarantees they will only be evaluated in its branch.
 pub fn @"if"(
-    BlkCtx: type,
-    _blkctx: BlkCtx,
+    If: type,
+    if_captures: If,
     pred: Tensor,
-) stdx.meta.FnReturn(BlkCtx.ifTrue) {
+) stdx.meta.FnReturn(If.onTrue) {
     stdx.debug.assertComptime(
-        stdx.meta.FnReturn(BlkCtx.ifTrue) == stdx.meta.FnReturn(BlkCtx.ifFalse),
-        "zml.ops.if expects same return types for ifTrue and ifFalse, got {s} and {s}",
-        .{ @typeName(stdx.meta.FnReturn(BlkCtx.ifTrue)), @typeName(stdx.meta.FnReturn(BlkCtx.ifFalse)) },
+        stdx.meta.FnReturn(If.onTrue) == stdx.meta.FnReturn(If.onFalse),
+        "zml.ops.if expects same return types for onTrue and onFalse, got {s} and {s}",
+        .{ @typeName(stdx.meta.FnReturn(If.onTrue)), @typeName(stdx.meta.FnReturn(If.onFalse)) },
     );
 
     stdx.debug.assert(pred.dtype() == .bool and pred.count() == 1, "zml.ops.if expects the condition to have exactly one element of dtype .bool, got {f}", .{pred});
@@ -668,14 +677,14 @@ pub fn @"if"(
     defer arena.deinit();
 
     const allocator = arena.allocator();
-    var blkctx: BlkCtx = undefined;
+    var blkctx: If = undefined;
 
     // Explicitly capture values from the parent block.
     meta.mapAlloc(struct {
         fn capture(_: void, tensor: Tensor) Tensor {
             return Tensor._result(tensor.shape(), tensor.value());
         }
-    }.capture, arena.allocator(), {}, _blkctx, &blkctx) catch unreachable;
+    }.capture, arena.allocator(), {}, if_captures, &blkctx) catch unreachable;
 
     const mlir_ctx = CompilationContext.current().mlir_ctx;
     const loc: *const mlir.Location = .unknown(mlir_ctx);
@@ -687,7 +696,7 @@ pub fn @"if"(
         CompilationContext.current().pushBlock(block);
         defer CompilationContext.current().popBlock();
 
-        const result = blkctx.ifTrue();
+        const result = blkctx.onTrue();
         const result_values = meta.collectAlloc(Tensor.value, {}, allocator, &result) catch @panic("OOM");
         defer allocator.free(result_values);
         _ = dialects.stablehlo.returns(mlir_ctx, result_values, loc).appendTo(block);
@@ -701,7 +710,7 @@ pub fn @"if"(
         CompilationContext.current().pushBlock(block);
         defer CompilationContext.current().popBlock();
 
-        const result = blkctx.ifFalse();
+        const result = blkctx.onFalse();
         const result_values = meta.collectAlloc(Tensor.value, {}, allocator, &result) catch @panic("OOM");
         defer allocator.free(result_values);
         _ = dialects.stablehlo.returns(mlir_ctx, result_values, loc).appendTo(block);
@@ -736,11 +745,11 @@ test "if" {
             return @"if"(@This(), .{ .a = a, .b = b }, pred.convert(.bool));
         }
 
-        pub fn ifTrue(ctx: @This()) Tensor {
+        pub fn onTrue(ctx: @This()) Tensor {
             return ctx.a.dotGeneral(ctx.b, &.{.{ 1, 0 }}, &.{});
         }
 
-        pub fn ifFalse(ctx: @This()) Tensor {
+        pub fn onFalse(ctx: @This()) Tensor {
             return ctx.b.dotGeneral(ctx.a, &.{.{ 1, 0 }}, &.{});
         }
     };
@@ -754,13 +763,13 @@ test "if" {
     }
 }
 
-/// Simpler variant of `if` that assumes code-motion is supported by the backend.
+/// Simpler variant of `zml.ops.if` that assumes code-motion is supported by the backend.
 /// The two branches are evaluated before the condition, then the condition chose which branches to keep.
 pub fn if2(
     pred: Tensor,
-    if_true: anytype,
-    if_false: @TypeOf(if_true),
-) @TypeOf(if_true) {
+    on_true: anytype,
+    on_false: @TypeOf(on_true),
+) @TypeOf(on_true) {
     stdx.debug.assert(pred.dtype() == .bool and pred.count() == 1, "zml.ops.if expects the condition to have exactly one element of dtype .bool, got {f}", .{pred});
 
     var arena = std.heap.ArenaAllocator.init(CompilationContext.current().allocator);
@@ -771,7 +780,7 @@ pub fn if2(
     const mlir_ctx = CompilationContext.current().mlir_ctx;
     const loc: *const mlir.Location = .unknown(mlir_ctx);
 
-    const true_values = meta.collectAlloc(Tensor.value, {}, allocator, &if_true) catch @panic("OOM");
+    const true_values = meta.collectAlloc(Tensor.value, {}, allocator, &on_true) catch @panic("OOM");
     defer allocator.free(true_values);
     const true_branch_block = b: {
         const block = mlir.Block.init(&.{}, &.{});
@@ -783,7 +792,7 @@ pub fn if2(
         break :b block;
     };
 
-    const false_values = meta.collectAlloc(Tensor.value, {}, allocator, &if_false) catch @panic("OOM");
+    const false_values = meta.collectAlloc(Tensor.value, {}, allocator, &on_false) catch @panic("OOM");
     defer allocator.free(false_values);
     const false_branch_block = b: {
         const block = mlir.Block.init(&.{}, &.{});
@@ -805,7 +814,7 @@ pub fn if2(
     });
     _ = op.appendTo(CompilationContext.current().currentScope().block);
 
-    return fromMlirOperationWithTags(op, if_true);
+    return fromMlirOperationWithTags(op, on_true);
 }
 
 test if2 {

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -754,6 +754,84 @@ test "if" {
     }
 }
 
+/// Simpler variant of `if` that assumes code-motion is supported by the backend.
+/// The two branches are evaluated before the condition, then the condition chose which branches to keep.
+pub fn if2(
+    pred: Tensor,
+    if_true: anytype,
+    if_false: @TypeOf(if_true),
+) @TypeOf(if_true) {
+    stdx.debug.assert(pred.dtype() == .bool and pred.count() == 1, "zml.ops.if expects the condition to have exactly one element of dtype .bool, got {f}", .{pred});
+
+    var arena = std.heap.ArenaAllocator.init(CompilationContext.current().allocator);
+    defer arena.deinit();
+
+    const allocator = arena.allocator();
+
+    const mlir_ctx = CompilationContext.current().mlir_ctx;
+    const loc: *const mlir.Location = .unknown(mlir_ctx);
+
+    const true_values = meta.collectAlloc(Tensor.value, {}, allocator, &if_true) catch @panic("OOM");
+    defer allocator.free(true_values);
+    const true_branch_block = b: {
+        const block = mlir.Block.init(&.{}, &.{});
+        errdefer block.deinit();
+
+        CompilationContext.current().pushBlock(block);
+        defer CompilationContext.current().popBlock();
+        _ = dialects.stablehlo.returns(mlir_ctx, true_values, loc).appendTo(block);
+        break :b block;
+    };
+
+    const false_values = meta.collectAlloc(Tensor.value, {}, allocator, &if_false) catch @panic("OOM");
+    defer allocator.free(false_values);
+    const false_branch_block = b: {
+        const block = mlir.Block.init(&.{}, &.{});
+        errdefer block.deinit();
+
+        CompilationContext.current().pushBlock(block);
+        defer CompilationContext.current().popBlock();
+
+        _ = dialects.stablehlo.returns(mlir_ctx, false_values, loc).appendTo(block);
+        break :b block;
+    };
+
+    const op = mlir.Operation.make(mlir_ctx, "stablehlo.if", .{
+        .operands = .{ .flat = &.{pred.asScalar().value()} },
+        .result_type_inference = true,
+        .blocks = &.{ true_branch_block, false_branch_block },
+        .location = loc,
+        .verify = false,
+    });
+    _ = op.appendTo(CompilationContext.current().currentScope().block);
+
+    return fromMlirOperationWithTags(op, if_true);
+}
+
+test if2 {
+    const zml = @import("zml.zig");
+    const platform = zml.testing.env();
+    const allocator = std.testing.allocator;
+
+    const IfMod = struct {
+        pub fn _fwd(pred: Tensor, a: Tensor, b: Tensor) Tensor {
+            return if2(
+                pred.convert(.bool),
+                a.dotGeneral(b, &.{.{ 1, 0 }}, &.{}),
+                b.dotGeneral(a, &.{.{ 1, 0 }}, &.{}),
+            );
+        }
+    };
+
+    {
+        const pred: Tensor = .init(.{}, .i32);
+        const a: Tensor = .init(.{ 4, 4 }, .f32);
+        const b: Tensor = .init(.{ 4, 4 }, .f32);
+        const mod = try platform.compileFn(allocator, std.testing.io, IfMod._fwd, .{ pred, a, b }, .{});
+        defer mod.deinit();
+    }
+}
+
 /// Create a Tensor struct similar to base, keeping base tags,
 /// but using mlir value and dims from the mlir operation.
 fn fromMlirOperationWithTags(op: *const mlir.Operation, base: anytype) @TypeOf(base) {

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -836,7 +836,7 @@ fn printCallbackInner(call_frame: *pjrt.ffi.CallFrame) !?*pjrt.ffi.Error {
     const slice: zml.Slice = .init(shape, host_visible_data[0..shape.byteSize()]);
     const name = call_frame.attrs.getByName(.string, "name").?.slice();
 
-    std.debug.print("{s} {f} [device={d}]: {d}\n", .{ name, slice.shape, device_ordinal, slice });
+    std.debug.print("{s} [device={d}]: {d}\n", .{ name, device_ordinal, slice });
 
     return null;
 }

--- a/zml/slice.zig
+++ b/zml/slice.zig
@@ -125,7 +125,7 @@ pub const Slice = struct {
         return res;
     }
 
-    fn dropAxis(slice: Slice, axis_: anytype) Slice {
+    pub fn squeeze(slice: Slice, axis_: anytype) Slice {
         const axis = slice.shape.axis(axis_);
         var res = slice;
         res.shape = slice.shape.drop(axis);
@@ -354,7 +354,7 @@ pub const Slice = struct {
         const outer_span_bytes = total_bytes / outer_len;
 
         for (0..outer_len) |i| {
-            const destination_outer = destination.subSlice(0, @intCast(i), 1).dropAxis(0);
+            const destination_outer = destination.subSlice(0, @intCast(i), 1).squeeze(0);
             const source_outer_start = i * outer_span_bytes;
             const source_outer_end = source_outer_start + outer_span_bytes;
             destination_outer.copy(source[source_outer_start..source_outer_end]);

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -4438,11 +4438,14 @@ pub const Tensor = struct {
     /// Only for debug purpose, it inserts device to host synchronization
     /// so it will slow down the program execution.
     pub fn print(input: Tensor, name: []const u8) void {
-        switch (CompilationContext.current().platform.target) {
+        const ctx = CompilationContext.current();
+        const full_name = std.fmt.allocPrint(ctx.arena.allocator(), "{s}: {f}", .{ name, input.shape() }) catch @panic("OOM");
+        defer ctx.arena.allocator().free(full_name);
+        switch (ctx.platform.target) {
             .cpu, .cuda, .rocm, .tpu, .metal => {
-                ops.manualComputation(input, {}, .{ .name = name }, (struct {
-                    fn body(ctx_: anytype, _: std.mem.Allocator, sharded_input: Tensor, _: void) void {
-                        ops.customCall("zml$print", sharded_input, {}, .{ .name = ctx_.name }, .{ .has_side_effect = true });
+                ops.manualComputation(input, {}, full_name, (struct {
+                    fn body(_full_name: []const u8, _: std.mem.Allocator, sharded_input: Tensor, _: void) void {
+                        ops.customCall("zml$print", sharded_input, {}, .{ .name = _full_name }, .{ .has_side_effect = true });
                     }
                 }).body);
             },


### PR DESCRIPTION
Implement paged_attention in pure stablehlo.

introduces `zml.ops.if` and `zml.ops.if2`
The first one is similar to `zml.ops.while` and requires a full struct with two functions. it's a bit heavy to use, but it follows the stablehlo API, and if one of the branch has side effects it will correctly evaluate the side effect only in that branch.

`zml.ops.if2` is a simpler version that doesn't require to create intermediary struct, but as a consequence, if you have side effect they will always evaluate, and it relies on the compiler to correctly avoid duplicated compute by moving relevant compute inside the branches.

(open to feedback  about if/if2)


