### PR TITLE
zml: start of quantization support

### DIFF
--- a/mlir/dialects/stablehlo/stablehlo.zig
+++ b/mlir/dialects/stablehlo/stablehlo.zig
@@ -107,6 +107,34 @@ pub fn clamp(ctx: *mlir.Context, min: *const mlir.Value, value: *const mlir.Valu
     });
 }
 
+pub const CompositeOpts = struct {
+    name: []const u8,
+    decomposition: []const u8,
+    composite_attributes: []const mlir.NamedAttribute = &.{},
+    version: i32 = 0,
+};
+
+pub fn composite(
+    ctx: *mlir.Context,
+    inputs: []const *const mlir.Value,
+    result_types: []const *const mlir.Type,
+    opts: CompositeOpts,
+    location: *const mlir.Location,
+) *mlir.Operation {
+    return mlir.Operation.make(ctx, "stablehlo.composite", .{
+        .operands = .{ .flat = inputs },
+        .results = .{ .flat = result_types },
+        .attributes = &.{
+            .named(ctx, "name", .string(ctx, opts.name)),
+            .named(ctx, "decomposition", .flatSymbolRef(ctx, opts.decomposition)),
+            .named(ctx, "composite_attributes", .dict(ctx, opts.composite_attributes)),
+            .named(ctx, "version", .int(ctx, .i32, opts.version)),
+        },
+        .verify = false,
+        .location = location,
+    });
+}
+
 pub const DotPrecision = union(enum) {
     fast,
     high,

--- a/mlir/dialects/vector.zig
+++ b/mlir/dialects/vector.zig
@@ -140,14 +140,6 @@ pub const StridedSliceArgs = struct {
     strides: []const i64,
 };
 
-/// extract/insert_strided_slice need offsets/sizes/strides as an ArrayAttr of IntegerAttr, not a DenseArrayAttr
-fn intArrayAttribute(ctx: *mlir.Context, comptime T: type, values: []const T) *const mlir.Attribute {
-    const it: mlir.IntegerTypes = comptime @field(mlir.IntegerTypes, @typeName(T));
-    var buf: stdx.BoundedArray(*const mlir.Attribute, mlir.ShapedType.MAX_RANK) = .empty;
-    for (values) |v| buf.appendAssumeCapacity(.int(ctx, it, v));
-    return .array(ctx, buf.constSlice());
-}
-
 pub fn extract_strided_slice(
     ctx: *mlir.Context,
     src: *const mlir.Value,
@@ -159,9 +151,9 @@ pub fn extract_strided_slice(
         .operands = .{ .flat = &.{src} },
         .results = .{ .flat = &.{result_type} },
         .attributes = &.{
-            .named(ctx, "offsets", intArrayAttribute(ctx, i64, args.offsets)),
-            .named(ctx, "sizes", intArrayAttribute(ctx, i64, args.sizes)),
-            .named(ctx, "strides", intArrayAttribute(ctx, i64, args.strides)),
+            .named(ctx, "offsets", .intArray(ctx, i64, args.offsets)),
+            .named(ctx, "sizes", .intArray(ctx, i64, args.sizes)),
+            .named(ctx, "strides", .intArray(ctx, i64, args.strides)),
         },
         .location = location,
     });
@@ -179,8 +171,8 @@ pub fn insert_strided_slice(
         .operands = .{ .flat = &.{ src, dest } },
         .results = .{ .flat = &.{dest.type_()} },
         .attributes = &.{
-            .named(ctx, "offsets", intArrayAttribute(ctx, i64, offsets)),
-            .named(ctx, "strides", intArrayAttribute(ctx, i64, strides)),
+            .named(ctx, "offsets", .intArray(ctx, i64, offsets)),
+            .named(ctx, "strides", .intArray(ctx, i64, strides)),
         },
         .location = location,
     });

--- a/mlir/mlir.zig
+++ b/mlir/mlir.zig
@@ -611,6 +611,13 @@ pub const Attribute = opaque {
         return @ptrCast(ArrayAttribute.init(ctx, attrs));
     }
 
+    pub fn intArray(ctx: *Context, comptime T: type, values: []const T) *const Attribute {
+        const it: IntegerTypes = comptime @field(IntegerTypes, @typeName(T));
+        var buf: stdx.BoundedArray(*const Attribute, ShapedType.MAX_RANK) = .empty;
+        for (values) |v| buf.appendAssumeCapacity(.int(ctx, it, v));
+        return .array(ctx, buf.constSlice());
+    }
+
     pub fn flatSymbolRef(ctx: *Context, symbol: []const u8) *const Attribute {
         return @ptrCast(FlatSymbolRefAttribute.init(ctx, symbol));
     }

--- a/platforms/cuda/cuda.bzl
+++ b/platforms/cuda/cuda.bzl
@@ -131,12 +131,21 @@ CUDA_PACKAGES = {
             ],
         ),
     ],
+    "cuda_tileiras": [
+        packages.filegroup(
+            name = "cuda_tileiras",
+            srcs = ["bin/tileiras"],
+        ),
+    ],
     "libnvvm": [
         packages.filegroup(
             name = "libnvvm",
             srcs = [
                 "nvvm/bin/cicc",
                 "nvvm/libdevice/libdevice.10.bc",
+                "nvvm/lib64/libnvvm.so",
+                "nvvm/lib64/libnvvm.so.4",
+                "nvvm/lib64/libnvvm.so.4.0.0",
             ],
         ),
     ],
@@ -242,7 +251,6 @@ def _read_redist_json(mctx, url, sha256):
         sha256 = sha256,
     )
     return json.decode(mctx.read(fname))
-
 
 def _cuda_impl(mctx):
     loaded_packages = packages.read(mctx, [

--- a/platforms/cuda/libpjrt_cuda.BUILD.bazel
+++ b/platforms/cuda/libpjrt_cuda.BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
-load("@zml//bazel:patchelf.bzl", "patchelf")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@zml//bazel:patchelf.bzl", "patchelf")
 load("@zml//platforms/cuda:cuda.bzl", "CUDA_COMPAT_FILES")
 
 patchelf(
@@ -23,42 +23,46 @@ copy_to_directory(
         "@zml//platforms/cuda:zmlxcuda",
     ] + select({
         "@llvm//platforms/config:linux_x86_64": [
+            "@cuda_compat_linux_x86_64//:cuda_compat",
             "@cuda_cudart_linux_x86_64//:cuda_cudart",
             "@cuda_cupti_linux_x86_64//:cuda_cupti",
-            "@cuda_compat_linux_x86_64//:cuda_compat",
             "@cuda_nvcc_linux_x86_64//:cuda_nvcc",
-            "@libnvvm_linux_x86_64//:libnvvm",
             "@cuda_nvrtc_linux_x86_64//:cuda_nvrtc",
             "@cuda_nvtx_linux_x86_64//:cuda_nvtx",
+            "@cuda_tileiras_linux_x86_64//:cuda_tileiras",
             "@cudnn_linux_x86_64//:cudnn",
-            "@libnvshmem_linux_x86_64//:libnvshmem",
             "@libcublas_linux_x86_64//:libcublas",
             "@libcufft_linux_x86_64//:libcufft",
             "@libcusolver_linux_x86_64//:libcusolver",
             "@libcusparse_linux_x86_64//:libcusparse",
             "@libnvjitlink_linux_x86_64//:libnvjitlink",
+            "@libnvshmem_linux_x86_64//:libnvshmem",
+            "@libnvvm_linux_x86_64//:libnvvm",
             "@nccl_linux_amd64//:nccl",
             "@zlib1g_linux_amd64//:zlib1g",
         ],
         "@llvm//platforms/config:linux_aarch64": [
+            "@cuda_compat_linux_sbsa//:cuda_compat",
             "@cuda_cudart_linux_sbsa//:cuda_cudart",
             "@cuda_cupti_linux_sbsa//:cuda_cupti",
-            "@cuda_compat_linux_sbsa//:cuda_compat",
             "@cuda_nvcc_linux_sbsa//:cuda_nvcc",
-            "@libnvvm_linux_sbsa//:libnvvm",
             "@cuda_nvrtc_linux_sbsa//:cuda_nvrtc",
             "@cuda_nvtx_linux_sbsa//:cuda_nvtx",
+            "@cuda_tileiras_linux_sbsa//:cuda_tileiras",
             "@cudnn_linux_sbsa//:cudnn",
-            "@libnvshmem_linux_sbsa//:libnvshmem",
             "@libcublas_linux_sbsa//:libcublas",
             "@libcufft_linux_sbsa//:libcufft",
             "@libcusolver_linux_sbsa//:libcusolver",
             "@libcusparse_linux_sbsa//:libcusparse",
             "@libnvjitlink_linux_sbsa//:libnvjitlink",
+            "@libnvshmem_linux_sbsa//:libnvshmem",
+            "@libnvvm_linux_sbsa//:libnvvm",
             "@nccl_linux_arm64//:nccl",
             "@zlib1g_linux_arm64//:zlib1g",
         ],
     }),
+    add_directory_to_runfiles = False,
+    include_external_repositories = ["**"],
     replace_prefixes = {
         "compat": "lib/compat",
         "nvidia/nccl/lib": "lib",
@@ -72,21 +76,11 @@ copy_to_directory(
         "{}.patchelf".format(file): "lib/compat"
         for file in CUDA_COMPAT_FILES
     },
-    add_directory_to_runfiles = False,
-    include_external_repositories = ["**"],
 )
 
 cc_library(
     name = "libpjrt_cuda",
     data = [":sandbox"],
-    deps = select({
-        "@llvm//platforms/config:linux_x86_64": [
-            "@cuda_cudart_linux_x86_64//:cuda",
-        ],
-        "@llvm//platforms/config:linux_aarch64": [
-            "@cuda_cudart_linux_sbsa//:cuda",
-        ],
-    }),
     linkopts = [
         # Defer function call resolution until the function is called
         # (lazy loading) rather than at load time.
@@ -98,4 +92,12 @@ cc_library(
         "-Wl,-z,lazy",
     ],
     visibility = ["@zml//platforms/cuda:__subpackages__"],
+    deps = select({
+        "@llvm//platforms/config:linux_x86_64": [
+            "@cuda_cudart_linux_x86_64//:cuda",
+        ],
+        "@llvm//platforms/config:linux_aarch64": [
+            "@cuda_cudart_linux_sbsa//:cuda",
+        ],
+    }),
 )

--- a/zml/io.zig
+++ b/zml/io.zig
@@ -373,7 +373,8 @@ pub const Loader = struct {
         };
 
         if (sources.len != 1) {
-            std.debug.panic("Expected loaded tensor to have only 1 source, got {}", .{sources.len});
+            log.debug("Skipping fused tensor with {} sources; expected to be loaded via loadExecute", .{sources.len});
+            return;
         }
 
         self.loadSingleInner(io, sources[0], tensor.shape(), buffer, shardings, opts) catch |e| {

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -101,6 +101,8 @@ pub const CompilationContext = struct {
 
     channel_id: i64 = 0,
 
+    composite_id: i64 = 0,
+
     threadlocal var _current: ?*CompilationContext = null;
 
     pub fn init(allocator: std.mem.Allocator, io: std.Io, platform: *const Platform, opts: CompilationOptions) CompilationContext {
@@ -197,6 +199,11 @@ pub const CompilationContext = struct {
     pub fn nextChannelId(self: *CompilationContext) i64 {
         self.channel_id += 1;
         return self.channel_id;
+    }
+
+    pub fn nextCompositeId(self: *CompilationContext) i64 {
+        self.composite_id += 1;
+        return self.composite_id;
     }
 
     pub fn abortOOM(self: *CompilationContext) noreturn {

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -214,6 +214,10 @@ pub const CompilationContext = struct {
     pub fn alloc(self: *CompilationContext, T: type, n: usize) []T {
         return self.arena.allocator().alloc(T, n) catch self.abortOOM();
     }
+
+    pub fn allocPrint(self: *CompilationContext, comptime fmt: []const u8, args: anytype) []u8 {
+        return std.fmt.allocPrint(self.arena.allocator(), fmt, args) catch self.abortOOM();
+    }
 };
 
 pub fn Compiler(comptime func: anytype) type {

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -17,6 +17,9 @@ pub const Linear = struct {
     weight: Tensor,
     bias: ?Tensor = null,
     tag: Shape.Tag,
+    scales: ?Tensor = null,
+    global_scale: ?Tensor = null,
+    input_global_scale: ?Tensor = null,
 
     pub fn init(weight: Tensor, bias: ?Tensor, tag: anytype) Linear {
         return .{
@@ -26,12 +29,53 @@ pub const Linear = struct {
         };
     }
 
-    pub fn forward(self: Linear, x: Tensor) Tensor {
-        var y = x.dot(self.weight, self.tag);
+    pub fn unloadBuffers(self: *zml.Bufferized(Linear)) void {
+        self.weight.deinit();
+        if (self.bias) |*bias| bias.deinit();
+        if (self.scales) |*scales| scales.deinit();
+        if (self.global_scale) |*gs| gs.deinit();
+        if (self.input_global_scale) |*igs| igs.deinit();
+    }
 
+    pub fn forward(self: Linear, x: Tensor) Tensor {
+        const y = self.forwardWeight(x);
         return if (self.bias) |bias| y.add(bias.broad(y.shape())) else y;
     }
+
+    fn forwardWeight(self: Linear, x: Tensor) Tensor {
+        const scales = self.scales orelse return x.dot(self.weight, self.tag);
+
+        const weight = if (self.weight.dtype() == .u8)
+            ops.unpackNvfp4(self.weight.withTags(.{ .dout, .kw }), self.tag)
+        else
+            self.weight;
+
+        const scalar_f32 = zml.Shape.init(.{}, .f32);
+        const igs: ?Tensor = if (self.input_global_scale) |g| g.convert(.f32).reshape(scalar_f32) else null;
+        const wgs: ?Tensor = if (self.global_scale) |g| g.convert(.f32).reshape(scalar_f32) else null;
+
+        const platform = zml.module.CompilationContext.current().platform;
+        if (weight.dtype() == .f4e2m1 and platform.target == .cuda) {
+            const q_packed, const q_scale = ops.quantizeNvfp4(x.convert(.bf16), igs, self.tag);
+            const q = ops.unpackNvfp4(q_packed, self.tag);
+            const acc = ops.scaledDot(q, weight, q_scale, scales, self.tag);
+            return applyGlobalScale(acc, igs, wgs).convert(x.dtype());
+        }
+
+        const acc = ops.scaledDot(x.convert(.bf16), weight, null, scales, self.tag);
+        return applyGlobalScale(acc, null, wgs).convert(x.dtype());
+    }
 };
+
+fn applyGlobalScale(acc: Tensor, igs: ?Tensor, wgs: ?Tensor) Tensor {
+    const combined: ?Tensor = if (igs) |i|
+        (if (wgs) |w| i.mul(w) else i)
+    else
+        wgs;
+    const alpha = combined orelse return acc;
+    const f32_acc = acc.convert(.f32);
+    return f32_acc.div(alpha.broad(f32_acc.shape())).convert(acc.dtype());
+}
 
 pub const TokenEmbedding = struct {
     weight: Tensor,

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -55,7 +55,7 @@ pub const Linear = struct {
         const wgs: ?Tensor = if (self.global_scale) |g| g.convert(.f32).reshape(scalar_f32) else null;
 
         const platform = zml.module.CompilationContext.current().platform;
-        if (weight.dtype() == .f4e2m1 and platform.target == .cuda) {
+        if (weight.dtype() == .f4e2m1 and supportsNvfp4ActivationQuant(platform)) {
             const q_packed, const q_scale = ops.quantizeNvfp4(x.convert(.bf16), igs, self.tag);
             const q = ops.unpackNvfp4(q_packed, self.tag);
             const acc = ops.scaledDot(q, weight, q_scale, scales, self.tag);
@@ -66,6 +66,18 @@ pub const Linear = struct {
         return applyGlobalScale(acc, null, wgs).convert(x.dtype());
     }
 };
+
+fn supportsNvfp4ActivationQuant(platform: *const zml.Platform) bool {
+    if (platform.target != .cuda) {
+        return false;
+    }
+
+    const device = platform.pjrt_client.devices(platform.pjrt_api)[0];
+    const capability = zml.platform.cuda.tryGetComputeCapabilities(platform, device) orelse return false;
+    const major = std.fmt.parseInt(u8, std.mem.sliceTo(capability, '.'), 10) catch return false;
+
+    return major >= 10;
+}
 
 fn applyGlobalScale(acc: Tensor, igs: ?Tensor, wgs: ?Tensor) Tensor {
     const combined: ?Tensor = if (igs) |i|

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -56,8 +56,7 @@ pub const Linear = struct {
         const platform = zml.module.CompilationContext.current().platform;
         if (weight.dtype() == .f4e2m1 and supportsNvfp4ActivationQuant(platform)) {
             const q = ops.quantizeNvfp4(x.convert(.bf16), igs, self.tag);
-            const values = ops.unpackNvfp4(q.packed_values, self.tag);
-            const acc = ops.scaledDot(values, weight, q.scales, scales, self.tag);
+            const acc = ops.scaledDot(q.values, weight, q.scales, scales, self.tag);
             return applyGlobalScale(acc, igs, wgs).convert(x.dtype());
         }
 

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -50,15 +50,14 @@ pub const Linear = struct {
         else
             self.weight;
 
-        const scalar_f32 = zml.Shape.init(.{}, .f32);
-        const igs: ?Tensor = if (self.input_global_scale) |g| g.convert(.f32).reshape(scalar_f32) else null;
-        const wgs: ?Tensor = if (self.global_scale) |g| g.convert(.f32).reshape(scalar_f32) else null;
+        const igs: ?Tensor = if (self.input_global_scale) |g| g.convert(.f32).asScalar() else null;
+        const wgs: ?Tensor = if (self.global_scale) |g| g.convert(.f32).asScalar() else null;
 
         const platform = zml.module.CompilationContext.current().platform;
         if (weight.dtype() == .f4e2m1 and supportsNvfp4ActivationQuant(platform)) {
-            const q_packed, const q_scale = ops.quantizeNvfp4(x.convert(.bf16), igs, self.tag);
-            const q = ops.unpackNvfp4(q_packed, self.tag);
-            const acc = ops.scaledDot(q, weight, q_scale, scales, self.tag);
+            const q = ops.quantizeNvfp4(x.convert(.bf16), igs, self.tag);
+            const values = ops.unpackNvfp4(q.packed_values, self.tag);
+            const acc = ops.scaledDot(values, weight, q.scales, scales, self.tag);
             return applyGlobalScale(acc, igs, wgs).convert(x.dtype());
         }
 

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -128,20 +128,7 @@ pub fn scaledDot(
     rhs_scale: Tensor,
     args: anytype,
 ) Tensor {
-    stdx.debug.assert(lhs.shape().hasTag(args) != null, "scaledDot expects lhs to have {any} tag, got {f}", .{ args, lhs.shape() });
-    stdx.debug.assert(rhs.shape().hasTag(args) != null, "scaledDot expects rhs to have {any} tag, got {f}", .{ args, rhs.shape() });
-
-    const lhs_contracting_dim: i8 = @intCast(lhs.shape().hasTag(args).?);
-    const rhs_contracting_dim: i8 = @intCast(rhs.shape().hasTag(args).?);
-
-    var batching_axes: stdx.BoundedArray([2]i8, constants.MAX_RANK) = .empty;
-    for (0..lhs.rank()) |lhs_tag_index| {
-        const lhs_tag = lhs.shape().tag(lhs_tag_index);
-        if (lhs_tag == Shape.toTag(args)) continue;
-        if (rhs.shape().hasTag(lhs_tag)) |rhs_tag_index| {
-            batching_axes.appendAssumeCapacity(.{ @intCast(lhs_tag_index), @intCast(rhs_tag_index) });
-        }
-    }
+    const dot_axes = lhs.dotAxes(rhs, args);
 
     const Axes = stdx.BoundedArray(i64, constants.MAX_RANK);
 
@@ -152,7 +139,7 @@ pub fn scaledDot(
     var res_shape: Shape = .{ ._dtype = result_dtype };
     var lhs_batching_axes: Axes = .empty;
     var rhs_batching_axes: Axes = .empty;
-    for (batching_axes.constSlice()) |b_axes| {
+    for (dot_axes.batching.constSlice()) |b_axes| {
         const l, const r = b_axes;
         stdx.debug.assert(lhs._shape.dim(l) == rhs._shape.dim(r), "scaledDot expects batching dimensions to be equal, got {} and {} in {f} and {f}", .{ l, r, lhs, rhs });
         var t = lhs._shape.tag(l);
@@ -162,11 +149,14 @@ pub fn scaledDot(
         rhs_batching_axes.appendAssumeCapacity(rhs._shape.axis(r));
     }
 
-    stdx.debug.assert(lhs._shape.dim(lhs_contracting_dim) == rhs._shape.dim(rhs_contracting_dim), "scaledDot expects contracting dimensions to be equal, got {} and {} in {f} and {f}", .{ lhs_contracting_dim, rhs_contracting_dim, lhs, rhs });
     var lhs_contracting_axes: Axes = .empty;
     var rhs_contracting_axes: Axes = .empty;
-    lhs_contracting_axes.appendAssumeCapacity(lhs._shape.axis(lhs_contracting_dim));
-    rhs_contracting_axes.appendAssumeCapacity(rhs._shape.axis(rhs_contracting_dim));
+    for (dot_axes.contracting.constSlice()) |c_axes| {
+        const l, const r = c_axes;
+        stdx.debug.assert(lhs._shape.dim(l) == rhs._shape.dim(r), "scaledDot expects contracting dimensions to be equal, got {} and {} in {f} and {f}", .{ l, r, lhs, rhs });
+        lhs_contracting_axes.appendAssumeCapacity(lhs._shape.axis(l));
+        rhs_contracting_axes.appendAssumeCapacity(rhs._shape.axis(r));
+    }
 
     for (0..lhs.rank()) |l| {
         if (std.mem.indexOfScalar(i64, lhs_contracting_axes.constSlice(), @intCast(l))) |_| {

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -1,8 +1,10 @@
 //! Common layer definition and functions for Neural Networks (NN)
 const std = @import("std");
 
+const mlir = @import("mlir");
 const stdx = @import("stdx");
 
+const constants = @import("constants.zig");
 const DataType = @import("dtype.zig").DataType;
 const meta = @import("meta.zig");
 const ops = @import("ops.zig");
@@ -30,11 +32,7 @@ pub const Linear = struct {
     }
 
     pub fn unloadBuffers(self: *zml.Bufferized(Linear)) void {
-        self.weight.deinit();
-        if (self.bias) |*bias| bias.deinit();
-        if (self.scales) |*scales| scales.deinit();
-        if (self.global_scale) |*gs| gs.deinit();
-        if (self.input_global_scale) |*igs| igs.deinit();
+        zml.Buffer.deinitAll(Linear, self);
     }
 
     pub fn forward(self: Linear, x: Tensor) Tensor {
@@ -46,7 +44,7 @@ pub const Linear = struct {
         const scales = self.scales orelse return x.dot(self.weight, self.tag);
 
         const weight = if (self.weight.dtype() == .u8)
-            ops.unpackNvfp4(self.weight.withTags(.{ .dout, .kw }), self.tag)
+            unpackNvfp4(self.weight.withTags(.{ .dout, .kw }), self.tag)
         else
             self.weight;
 
@@ -55,15 +53,165 @@ pub const Linear = struct {
 
         const platform = zml.module.CompilationContext.current().platform;
         if (weight.dtype() == .f4e2m1 and supportsNvfp4ActivationQuant(platform)) {
-            const q = ops.quantizeNvfp4(x.convert(.bf16), igs, self.tag);
-            const acc = ops.scaledDot(q.values, weight, q.scales, scales, self.tag);
+            const q = quantizeNvfp4(x.convert(.bf16), igs, self.tag);
+            const acc = scaledDot(q.values, weight, q.scales, scales, self.tag);
             return applyGlobalScale(acc, igs, wgs).convert(x.dtype());
         }
 
-        const acc = ops.scaledDot(x.convert(.bf16), weight, null, scales, self.tag);
+        const acc = scaledDot(x.convert(.bf16), weight, null, scales, self.tag);
         return applyGlobalScale(acc, null, wgs).convert(x.dtype());
     }
 };
+
+pub fn unpackNvfp4(w: Tensor, k_tag: anytype) Tensor {
+    stdx.debug.assert(w.dtype() == .u8, "unpackNvfp4 expects packed u8 weights, got {}", .{w.dtype()});
+    return w.bitCast(.f4e2m1)
+        .merge(.{ .kb = .{ .kw, .bitcast } })
+        .renameTag(.kb, Shape.toTag(k_tag));
+}
+
+pub fn quantizeNvfp4(x: Tensor, input_global_scale: ?Tensor, axis: anytype) struct {
+    values: Tensor,
+    scales: Tensor,
+} {
+    const block_size = 16;
+    const value_max = 6.0;
+    const scale_min_normal = 0x1p-6;
+    const scale_max = DataType.f8e4m3fn.maxValue().as(f32);
+
+    stdx.debug.assert(x.shape().hasTag(axis) != null, "quantizeNvfp4 expects x to have {any} tag, got {f}", .{ axis, x.shape() });
+    stdx.debug.assert(@rem(x.dim(axis), block_size) == 0, "quantizeNvfp4 expects {any} to be a multiple of {}, got {f}", .{ axis, block_size, x.shape() });
+
+    const dt = x.dtype();
+    const scaled = if (input_global_scale) |igs|
+        x.mul(igs.convert(dt).broad(x.shape()))
+    else
+        x;
+    const grouped = scaled.splitAxis(axis, .{ .sc = -1, .blk = block_size });
+    const amax = grouped.abs().max(.blk);
+
+    const scales = amax.scale(1.0 / value_max)
+        .clamp(.scalar(scale_min_normal, dt), .scalar(scale_max, dt))
+        .convert(.f8e4m3fn);
+
+    const divisor = scales.convert(dt)
+        .maximum(.scalar(scale_min_normal, dt))
+        .broad(grouped.shape());
+
+    const values = grouped.div(divisor)
+        .convert(.f4e2m1)
+        .reshape(x.shape().withDtype(.f4e2m1));
+
+    return .{
+        .values = values,
+        .scales = scales.squeeze(.blk),
+    };
+}
+
+pub fn scaledDot(
+    lhs: Tensor,
+    rhs: Tensor,
+    lhs_scale: ?Tensor,
+    rhs_scale: Tensor,
+    args: anytype,
+) Tensor {
+    stdx.debug.assert(lhs.shape().hasTag(args) != null, "scaledDot expects lhs to have {any} tag, got {f}", .{ args, lhs.shape() });
+    stdx.debug.assert(rhs.shape().hasTag(args) != null, "scaledDot expects rhs to have {any} tag, got {f}", .{ args, rhs.shape() });
+
+    const lhs_contracting_dim: i8 = @intCast(lhs.shape().hasTag(args).?);
+    const rhs_contracting_dim: i8 = @intCast(rhs.shape().hasTag(args).?);
+
+    var batching_axes: stdx.BoundedArray([2]i8, constants.MAX_RANK) = .empty;
+    for (0..lhs.rank()) |lhs_tag_index| {
+        const lhs_tag = lhs.shape().tag(lhs_tag_index);
+        if (lhs_tag == Shape.toTag(args)) continue;
+        if (rhs.shape().hasTag(lhs_tag)) |rhs_tag_index| {
+            batching_axes.appendAssumeCapacity(.{ @intCast(lhs_tag_index), @intCast(rhs_tag_index) });
+        }
+    }
+
+    const Axes = stdx.BoundedArray(i64, constants.MAX_RANK);
+
+    const result_dtype: DataType = switch (lhs.dtype()) {
+        .f4e2m1, .f8e4m3, .f8e4m3fn, .f8e5m2, .f8e4m3b11fnuz, .f8e4m3fnuz, .f8e5m2fnuz => .bf16,
+        else => lhs.dtype(),
+    };
+    var res_shape: Shape = .{ ._dtype = result_dtype };
+    var lhs_batching_axes: Axes = .empty;
+    var rhs_batching_axes: Axes = .empty;
+    for (batching_axes.constSlice()) |b_axes| {
+        const l, const r = b_axes;
+        stdx.debug.assert(lhs._shape.dim(l) == rhs._shape.dim(r), "scaledDot expects batching dimensions to be equal, got {} and {} in {f} and {f}", .{ l, r, lhs, rhs });
+        var t = lhs._shape.tag(l);
+        if (t == Shape.TagUnknown) t = rhs._shape.tag(r);
+        res_shape = res_shape.appendDim(lhs._shape.dim(l), t);
+        lhs_batching_axes.appendAssumeCapacity(lhs._shape.axis(l));
+        rhs_batching_axes.appendAssumeCapacity(rhs._shape.axis(r));
+    }
+
+    stdx.debug.assert(lhs._shape.dim(lhs_contracting_dim) == rhs._shape.dim(rhs_contracting_dim), "scaledDot expects contracting dimensions to be equal, got {} and {} in {f} and {f}", .{ lhs_contracting_dim, rhs_contracting_dim, lhs, rhs });
+    var lhs_contracting_axes: Axes = .empty;
+    var rhs_contracting_axes: Axes = .empty;
+    lhs_contracting_axes.appendAssumeCapacity(lhs._shape.axis(lhs_contracting_dim));
+    rhs_contracting_axes.appendAssumeCapacity(rhs._shape.axis(rhs_contracting_dim));
+
+    for (0..lhs.rank()) |l| {
+        if (std.mem.indexOfScalar(i64, lhs_contracting_axes.constSlice(), @intCast(l))) |_| {
+            continue;
+        }
+        if (std.mem.indexOfScalar(i64, lhs_batching_axes.constSlice(), @intCast(l))) |_| {
+            continue;
+        }
+        res_shape = res_shape.appendDim(lhs._shape.dim(l), lhs._shape.tag(l));
+    }
+    for (0..rhs.rank()) |r| {
+        if (std.mem.indexOfScalar(i64, rhs_contracting_axes.constSlice(), @intCast(r))) |_| {
+            continue;
+        }
+        if (std.mem.indexOfScalar(i64, rhs_batching_axes.constSlice(), @intCast(r))) |_| {
+            continue;
+        }
+        res_shape = res_shape.appendDim(rhs._shape.dim(r), rhs._shape.tag(r));
+    }
+
+    const lhs_scale_operand = lhs_scale orelse blk: {
+        var lhs_scale_shape = lhs.shape().withDtype(.bf16);
+        for (0..lhs.rank()) |i| {
+            lhs_scale_shape = lhs_scale_shape.setDim(i, 1);
+        }
+        break :blk Tensor.constantTensor(lhs_scale_shape, DataType.bf16.one().asBytes());
+    };
+
+    const mlir_ctx = zml.module.CompilationContext.current().mlir_ctx;
+    const dnums = mlir.Attribute.array(mlir_ctx, &.{
+        .array(mlir_ctx, &.{
+            .intArray(mlir_ctx, i64, lhs_contracting_axes.constSlice()),
+            .intArray(mlir_ctx, i64, rhs_contracting_axes.constSlice()),
+        }),
+        .array(mlir_ctx, &.{
+            .intArray(mlir_ctx, i64, lhs_batching_axes.constSlice()),
+            .intArray(mlir_ctx, i64, rhs_batching_axes.constSlice()),
+        }),
+    });
+
+    const operands: []const Tensor = &.{ lhs, rhs, lhs_scale_operand, rhs_scale };
+
+    const outs = ops.composite("xla.scaled_dot", operands, &.{res_shape}, scaledDotReference, res_shape, .{
+        .composite_attributes = &.{.named(mlir_ctx, "dimension_numbers", dnums)},
+    });
+
+    return outs[0];
+}
+
+fn scaledDotReference(in: []const Tensor, out_shape: Shape) Tensor {
+    return ops.customCall(
+        "zml$scaled_dot_unmatched",
+        .{ in[0], in[1], in[2], in[3] },
+        out_shape,
+        {},
+        .{ .has_side_effect = false },
+    );
+}
 
 fn supportsNvfp4ActivationQuant(platform: *const zml.Platform) bool {
     if (platform.target != .cuda) {

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -108,6 +108,19 @@ pub fn quantizeNvfp4(x: Tensor, input_global_scale: ?Tensor, axis: anytype) stru
     };
 }
 
+/// Scaled matrix multiply (`xla.scaled_dot`): `acc = (lhs * lhs_scale) @ (rhs * rhs_scale)`.
+///
+/// - **NVFP4**: values `.f4e2m1`, scales `.f8e4m3fn`, block 16 (weight-only bf16 lhs ok)
+/// - **MXFP4**: values `.f4e2m1`, scales `.f8e8m0fnu`, block 32
+/// - **MXFP8**: values `.f8e4m3fn` / `.f8e5m2`, scales `.f8e8m0fnu`, block 32
+/// - TODO: INT4/8 and FP8 with block 128 and per tensor
+///
+/// Backends:
+/// 1. TileIR if CUDA sm>=10 and same lhs/rhs dtype
+/// 2. Triton otherwise
+/// 3. Unsupported combos fall back to dequant + Dot
+///
+/// CPU has no specialized path.
 pub fn scaledDot(
     lhs: Tensor,
     rhs: Tensor,

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -1601,18 +1601,18 @@ pub fn composite(
         result_types[i] = mlirx.Type.rankedTensor(mlir_ctx, s);
     }
 
-    const op = mlir.Operation.make(mlir_ctx, "stablehlo.composite", .{
-        .operands = .{ .flat = operand_values },
-        .results = .{ .flat = result_types },
-        .attributes = &.{
-            .named(mlir_ctx, "name", .string(mlir_ctx, name)),
-            .named(mlir_ctx, "decomposition", .flatSymbolRef(mlir_ctx, decomp_name)),
-            .named(mlir_ctx, "composite_attributes", .dict(mlir_ctx, opts.composite_attributes)),
-            .named(mlir_ctx, "version", .int(mlir_ctx, .i32, opts.version)),
+    const op = dialects.stablehlo.composite(
+        mlir_ctx,
+        operand_values,
+        result_types,
+        .{
+            .name = name,
+            .decomposition = decomp_name,
+            .composite_attributes = opts.composite_attributes,
+            .version = opts.version,
         },
-        .verify = false,
-        .location = .unknown(mlir_ctx),
-    }).appendTo(ctx.currentScope().block);
+        .unknown(mlir_ctx),
+    ).appendTo(ctx.currentScope().block);
 
     const out_tensors = allocator.alloc(Tensor, outputs.len) catch @panic("OOM");
     for (outputs, 0..) |s, i| {
@@ -1764,7 +1764,6 @@ fn scaledDotReference(in: []const Tensor, out_shape: Shape) Tensor {
         .{ .has_side_effect = false },
     );
 }
-
 
 pub fn customCall(target_name: [:0]const u8, inputs: anytype, outputs: anytype, metadata: anytype, opts: CustomCallOptions) CustomCallResultTypeFromOutputSpec(@TypeOf(outputs)) {
     // Transform generic inputs to flat slice.

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -1528,6 +1528,244 @@ pub fn customCallOutputOperandAliases(
     return &output_operand_aliases;
 }
 
+pub const CompositeOpts = struct {
+    version: i32 = 0,
+    composite_attributes: []const mlir.NamedAttribute = &.{},
+};
+
+pub fn composite(
+    name: [:0]const u8,
+    inputs: []const Tensor,
+    outputs: []const Shape,
+    comptime decomposition: anytype,
+    context: anytype,
+    opts: CompositeOpts,
+) []Tensor {
+    const ctx = CompilationContext.current();
+    const mlir_ctx = ctx.mlir_ctx;
+    const allocator = ctx.arena.allocator();
+
+    const decomp_name = std.fmt.allocPrint(allocator, "{s}.impl_{d}", .{ name, ctx.nextCompositeId() }) catch @panic("OOM");
+
+    {
+        const block_types = allocator.alloc(*const mlir.Type, inputs.len) catch @panic("OOM");
+        const block_locs = allocator.alloc(*const mlir.Location, inputs.len) catch @panic("OOM");
+
+        for (inputs, 0..) |t, i| {
+            block_types[i] = mlirx.Type.rankedTensor(mlir_ctx, t.shape());
+            block_locs[i] = mlir.Location.unknown(mlir_ctx);
+        }
+
+        const block = mlir.Block.init(block_types, block_locs);
+
+        ctx.pushBlock(block);
+        {
+            const arg_tensors = allocator.alloc(Tensor, inputs.len) catch @panic("OOM");
+            for (inputs, 0..) |t, i| {
+                arg_tensors[i] = Tensor._result(t.shape(), block.argument(i));
+            }
+
+            var result = @call(.auto, decomposition, .{ arg_tensors, context });
+            const rtensors = allocator.alloc(Tensor, outputs.len) catch @panic("OOM");
+            meta.collectBuf((struct {
+                pub fn func(t: Tensor) Tensor {
+                    return t;
+                }
+            }).func, {}, &result, rtensors);
+
+            const rvals = allocator.alloc(*const mlir.Value, outputs.len) catch @panic("OOM");
+            for (rtensors, 0..) |t, i| {
+                rvals[i] = t.value();
+            }
+
+            _ = dialects.func.returns(mlir_ctx, rvals, .unknown(mlir_ctx)).appendTo(block);
+        }
+        ctx.popBlock();
+
+        _ = dialects.func.func(mlir_ctx, .{
+            .name = decomp_name,
+            .block = block,
+            .location = .unknown(mlir_ctx),
+            .visibility = .private,
+            .verify = false,
+        }).appendTo(ctx.module.body());
+    }
+
+    const operand_values = allocator.alloc(*const mlir.Value, inputs.len) catch @panic("OOM");
+    for (inputs, 0..) |t, i| {
+        operand_values[i] = t.value();
+    }
+
+    const result_types = allocator.alloc(*const mlir.Type, outputs.len) catch @panic("OOM");
+    for (outputs, 0..) |s, i| {
+        result_types[i] = mlirx.Type.rankedTensor(mlir_ctx, s);
+    }
+
+    const op = mlir.Operation.make(mlir_ctx, "stablehlo.composite", .{
+        .operands = .{ .flat = operand_values },
+        .results = .{ .flat = result_types },
+        .attributes = &.{
+            .named(mlir_ctx, "name", .string(mlir_ctx, name)),
+            .named(mlir_ctx, "decomposition", .flatSymbolRef(mlir_ctx, decomp_name)),
+            .named(mlir_ctx, "composite_attributes", .dict(mlir_ctx, opts.composite_attributes)),
+            .named(mlir_ctx, "version", .int(mlir_ctx, .i32, opts.version)),
+        },
+        .verify = false,
+        .location = .unknown(mlir_ctx),
+    }).appendTo(ctx.currentScope().block);
+
+    const out_tensors = allocator.alloc(Tensor, outputs.len) catch @panic("OOM");
+    for (outputs, 0..) |s, i| {
+        out_tensors[i] = Tensor._result(s, op.result(i));
+    }
+
+    return out_tensors;
+}
+
+pub fn unpackNvfp4(w: Tensor, k_tag: anytype) Tensor {
+    stdx.debug.assert(w.dtype() == .u8, "unpackNvfp4 expects packed u8 weights, got {}", .{w.dtype()});
+    return w.bitCast(.f4e2m1)
+        .merge(.{ .kb = .{ .kw, .bitcast } })
+        .renameTag(.kb, Shape.toTag(k_tag));
+}
+
+pub fn quantizeNvfp4(x: Tensor, input_global_scale: ?Tensor, args: anytype) struct { Tensor, Tensor } {
+    stdx.debug.assert(x.shape().hasTag(args) != null, "quantizeNvfp4 expects x to have {any} tag, got {f}", .{ args, x.shape() });
+    stdx.debug.assert(@rem(x.dim(args), 16) == 0, "quantizeNvfp4 expects {any} to be a multiple of 16, got {f}", .{ args, x.shape() });
+
+    const dt = x.dtype();
+    const scaled = if (input_global_scale) |igs|
+        x.mul(igs.convert(dt).broad(x.shape()))
+    else
+        x;
+    const grouped = scaled.splitAxis(args, .{ .sc = -1, .blk = 16 });
+    const amax = grouped.abs().max(.blk);
+
+    const kMinE4m3 = 0.015625;
+    const kMaxE4m3 = 448.0;
+    const scale = amax.scale(1.0 / 6.0)
+        .clamp(Tensor.scalar(kMinE4m3, dt), Tensor.scalar(kMaxE4m3, dt))
+        .convert(.f8e4m3fn);
+
+    const kMinE4m3Normal = 0.015625;
+    const divisor = scale.convert(dt)
+        .maximum(Tensor.scalar(kMinE4m3Normal, dt).broad(scale.shape().withDtype(dt)))
+        .broad(grouped.shape());
+
+    const quantized = grouped.div(divisor).convert(.f4e2m1);
+    const packed_u8 = quantized
+        .reshape(x.shape().withDtype(.f4e2m1))
+        .splitAxis(args, .{ .kw = -1, .bitcast = 2 })
+        .bitCast(.u8);
+    return .{ packed_u8, scale.squeeze(.blk) };
+}
+
+pub fn scaledDot(
+    lhs: Tensor,
+    rhs: Tensor,
+    lhs_scale: ?Tensor,
+    rhs_scale: Tensor,
+    args: anytype,
+) Tensor {
+    stdx.debug.assert(lhs.shape().hasTag(args) != null, "scaledDot expects lhs to have {any} tag, got {f}", .{ args, lhs.shape() });
+    stdx.debug.assert(rhs.shape().hasTag(args) != null, "scaledDot expects rhs to have {any} tag, got {f}", .{ args, rhs.shape() });
+
+    const lhs_contracting_dim: i8 = @intCast(lhs.shape().hasTag(args).?);
+    const rhs_contracting_dim: i8 = @intCast(rhs.shape().hasTag(args).?);
+
+    var batching_axes: stdx.BoundedArray([2]i8, constants.MAX_RANK) = .empty;
+    for (0..lhs.rank()) |lhs_tag_index| {
+        const lhs_tag = lhs.shape().tag(lhs_tag_index);
+        if (lhs_tag == Shape.toTag(args)) continue;
+        if (rhs.shape().hasTag(lhs_tag)) |rhs_tag_index| {
+            batching_axes.appendAssumeCapacity(.{ @intCast(lhs_tag_index), @intCast(rhs_tag_index) });
+        }
+    }
+
+    const Axes = stdx.BoundedArray(i64, constants.MAX_RANK);
+
+    const result_dtype: DataType = switch (lhs.dtype()) {
+        .f4e2m1, .f8e4m3, .f8e4m3fn, .f8e5m2, .f8e4m3b11fnuz, .f8e4m3fnuz, .f8e5m2fnuz => .bf16,
+        else => lhs.dtype(),
+    };
+    var res_shape: Shape = .{ ._dtype = result_dtype };
+    var lhs_batching_axes: Axes = .empty;
+    var rhs_batching_axes: Axes = .empty;
+    for (batching_axes.constSlice()) |b_axes| {
+        const l, const r = b_axes;
+        stdx.debug.assert(lhs._shape.dim(l) == rhs._shape.dim(r), "scaledDot expects batching dimensions to be equal, got {} and {} in {f} and {f}", .{ l, r, lhs, rhs });
+        var t = lhs._shape.tag(l);
+        if (t == Shape.TagUnknown) t = rhs._shape.tag(r);
+        res_shape = res_shape.appendDim(lhs._shape.dim(l), t);
+        lhs_batching_axes.appendAssumeCapacity(lhs._shape.axis(l));
+        rhs_batching_axes.appendAssumeCapacity(rhs._shape.axis(r));
+    }
+
+    stdx.debug.assert(lhs._shape.dim(lhs_contracting_dim) == rhs._shape.dim(rhs_contracting_dim), "scaledDot expects contracting dimensions to be equal, got {} and {} in {f} and {f}", .{ lhs_contracting_dim, rhs_contracting_dim, lhs, rhs });
+    var lhs_contracting_axes: Axes = .empty;
+    var rhs_contracting_axes: Axes = .empty;
+    lhs_contracting_axes.appendAssumeCapacity(lhs._shape.axis(lhs_contracting_dim));
+    rhs_contracting_axes.appendAssumeCapacity(rhs._shape.axis(rhs_contracting_dim));
+
+    for (0..lhs.rank()) |l| {
+        if (std.mem.indexOfScalar(i64, lhs_contracting_axes.constSlice(), @intCast(l))) |_| {
+            continue;
+        }
+        if (std.mem.indexOfScalar(i64, lhs_batching_axes.constSlice(), @intCast(l))) |_| {
+            continue;
+        }
+        res_shape = res_shape.appendDim(lhs._shape.dim(l), lhs._shape.tag(l));
+    }
+    for (0..rhs.rank()) |r| {
+        if (std.mem.indexOfScalar(i64, rhs_contracting_axes.constSlice(), @intCast(r))) |_| {
+            continue;
+        }
+        if (std.mem.indexOfScalar(i64, rhs_batching_axes.constSlice(), @intCast(r))) |_| {
+            continue;
+        }
+        res_shape = res_shape.appendDim(rhs._shape.dim(r), rhs._shape.tag(r));
+    }
+
+    const lhs_scale_operand = lhs_scale orelse blk: {
+        var lhs_scale_shape = lhs.shape().withDtype(.bf16);
+        for (0..lhs.rank()) |i| {
+            lhs_scale_shape = lhs_scale_shape.setDim(i, 1);
+        }
+        break :blk Tensor.constantTensor(lhs_scale_shape, DataType.bf16.one().asBytes());
+    };
+
+    const mlir_ctx = CompilationContext.current().mlir_ctx;
+    const dnums = mlir.Attribute.array(mlir_ctx, &.{
+        .array(mlir_ctx, &.{
+            .intArray(mlir_ctx, i64, lhs_contracting_axes.constSlice()),
+            .intArray(mlir_ctx, i64, rhs_contracting_axes.constSlice()),
+        }),
+        .array(mlir_ctx, &.{
+            .intArray(mlir_ctx, i64, lhs_batching_axes.constSlice()),
+            .intArray(mlir_ctx, i64, rhs_batching_axes.constSlice()),
+        }),
+    });
+
+    const operands: []const Tensor = &.{ lhs, rhs, lhs_scale_operand, rhs_scale };
+
+    const outs = composite("xla.scaled_dot", operands, &.{res_shape}, scaledDotReference, res_shape, .{
+        .composite_attributes = &.{.named(mlir_ctx, "dimension_numbers", dnums)},
+    });
+
+    return outs[0];
+}
+
+fn scaledDotReference(in: []const Tensor, out_shape: Shape) Tensor {
+    return customCall(
+        "zml$scaled_dot_unmatched",
+        .{ in[0], in[1], in[2], in[3] },
+        out_shape,
+        {},
+        .{ .has_side_effect = false },
+    );
+}
+
+
 pub fn customCall(target_name: [:0]const u8, inputs: anytype, outputs: anytype, metadata: anytype, opts: CustomCallOptions) CustomCallResultTypeFromOutputSpec(@TypeOf(outputs)) {
     // Transform generic inputs to flat slice.
     const inputs_: []const Tensor = switch (@typeInfo(@TypeOf(inputs))) {

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -1629,35 +1629,48 @@ pub fn unpackNvfp4(w: Tensor, k_tag: anytype) Tensor {
         .renameTag(.kb, Shape.toTag(k_tag));
 }
 
-pub fn quantizeNvfp4(x: Tensor, input_global_scale: ?Tensor, args: anytype) struct { Tensor, Tensor } {
+pub fn quantizeNvfp4(x: Tensor, input_global_scale: ?Tensor, args: anytype) struct {
+    packed_values: Tensor,
+    scales: Tensor,
+} {
+    const block_size = 16;
+    const values_per_byte = 2;
+    const value_max = 6.0;
+    const scale_min_normal = 0x1p-6;
+    const scale_max = DataType.f8e4m3fn.maxValue().as(f32);
+
     stdx.debug.assert(x.shape().hasTag(args) != null, "quantizeNvfp4 expects x to have {any} tag, got {f}", .{ args, x.shape() });
-    stdx.debug.assert(@rem(x.dim(args), 16) == 0, "quantizeNvfp4 expects {any} to be a multiple of 16, got {f}", .{ args, x.shape() });
+    stdx.debug.assert(@rem(x.dim(args), block_size) == 0, "quantizeNvfp4 expects {any} to be a multiple of {}, got {f}", .{ args, block_size, x.shape() });
 
     const dt = x.dtype();
     const scaled = if (input_global_scale) |igs|
         x.mul(igs.convert(dt).broad(x.shape()))
     else
         x;
-    const grouped = scaled.splitAxis(args, .{ .sc = -1, .blk = 16 });
+    const grouped = scaled.splitAxis(args, .{ .sc = -1, .blk = block_size });
     const amax = grouped.abs().max(.blk);
 
-    const kMinE4m3 = 0.015625;
-    const kMaxE4m3 = 448.0;
-    const scale = amax.scale(1.0 / 6.0)
-        .clamp(Tensor.scalar(kMinE4m3, dt), Tensor.scalar(kMaxE4m3, dt))
+    const scales = amax.scale(1.0 / value_max)
+        .clamp(
+            Tensor.scalar(scale_min_normal, dt),
+            Tensor.scalar(scale_max, dt),
+        )
         .convert(.f8e4m3fn);
 
-    const kMinE4m3Normal = 0.015625;
-    const divisor = scale.convert(dt)
-        .maximum(Tensor.scalar(kMinE4m3Normal, dt).broad(scale.shape().withDtype(dt)))
+    const divisor = scales.convert(dt)
+        .maximum(Tensor.scalar(scale_min_normal, dt).broad(scales.shape().withDtype(dt)))
         .broad(grouped.shape());
 
-    const quantized = grouped.div(divisor).convert(.f4e2m1);
-    const packed_u8 = quantized
-        .reshape(x.shape().withDtype(.f4e2m1))
-        .splitAxis(args, .{ .kw = -1, .bitcast = 2 })
-        .bitCast(.u8);
-    return .{ packed_u8, scale.squeeze(.blk) };
+    const values = grouped.div(divisor)
+        .convert(.f4e2m1)
+        .reshape(x.shape().withDtype(.f4e2m1));
+
+    return .{
+        .packed_values = values
+            .splitAxis(args, .{ .kw = -1, .bitcast = values_per_byte })
+            .bitCast(.u8),
+        .scales = scales.squeeze(.blk),
+    };
 }
 
 pub fn scaledDot(

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -1630,11 +1630,10 @@ pub fn unpackNvfp4(w: Tensor, k_tag: anytype) Tensor {
 }
 
 pub fn quantizeNvfp4(x: Tensor, input_global_scale: ?Tensor, args: anytype) struct {
-    packed_values: Tensor,
+    values: Tensor,
     scales: Tensor,
 } {
     const block_size = 16;
-    const values_per_byte = 2;
     const value_max = 6.0;
     const scale_min_normal = 0x1p-6;
     const scale_max = DataType.f8e4m3fn.maxValue().as(f32);
@@ -1666,9 +1665,7 @@ pub fn quantizeNvfp4(x: Tensor, input_global_scale: ?Tensor, args: anytype) stru
         .reshape(x.shape().withDtype(.f4e2m1));
 
     return .{
-        .packed_values = values
-            .splitAxis(args, .{ .kw = -1, .bitcast = values_per_byte })
-            .bitCast(.u8),
+        .values = values,
         .scales = scales.squeeze(.blk),
     };
 }

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -1543,13 +1543,12 @@ pub fn composite(
 ) []Tensor {
     const ctx = CompilationContext.current();
     const mlir_ctx = ctx.mlir_ctx;
-    const allocator = ctx.arena.allocator();
 
-    const decomp_name = std.fmt.allocPrint(allocator, "{s}.impl_{d}", .{ name, ctx.nextCompositeId() }) catch @panic("OOM");
+    const decomp_name = ctx.allocPrint("{s}.impl_{d}", .{ name, ctx.nextCompositeId() });
 
     {
-        const block_types = allocator.alloc(*const mlir.Type, inputs.len) catch @panic("OOM");
-        const block_locs = allocator.alloc(*const mlir.Location, inputs.len) catch @panic("OOM");
+        const block_types = ctx.alloc(*const mlir.Type, inputs.len);
+        const block_locs = ctx.alloc(*const mlir.Location, inputs.len);
 
         for (inputs, 0..) |t, i| {
             block_types[i] = mlirx.Type.rankedTensor(mlir_ctx, t.shape());
@@ -1560,20 +1559,20 @@ pub fn composite(
 
         ctx.pushBlock(block);
         {
-            const arg_tensors = allocator.alloc(Tensor, inputs.len) catch @panic("OOM");
+            const arg_tensors = ctx.alloc(Tensor, inputs.len);
             for (inputs, 0..) |t, i| {
                 arg_tensors[i] = Tensor._result(t.shape(), block.argument(i));
             }
 
             var result = @call(.auto, decomposition, .{ arg_tensors, context });
-            const rtensors = allocator.alloc(Tensor, outputs.len) catch @panic("OOM");
+            const rtensors = ctx.alloc(Tensor, outputs.len);
             meta.collectBuf((struct {
                 pub fn func(t: Tensor) Tensor {
                     return t;
                 }
             }).func, {}, &result, rtensors);
 
-            const rvals = allocator.alloc(*const mlir.Value, outputs.len) catch @panic("OOM");
+            const rvals = ctx.alloc(*const mlir.Value, outputs.len);
             for (rtensors, 0..) |t, i| {
                 rvals[i] = t.value();
             }
@@ -1591,12 +1590,12 @@ pub fn composite(
         }).appendTo(ctx.module.body());
     }
 
-    const operand_values = allocator.alloc(*const mlir.Value, inputs.len) catch @panic("OOM");
+    const operand_values = ctx.alloc(*const mlir.Value, inputs.len);
     for (inputs, 0..) |t, i| {
         operand_values[i] = t.value();
     }
 
-    const result_types = allocator.alloc(*const mlir.Type, outputs.len) catch @panic("OOM");
+    const result_types = ctx.alloc(*const mlir.Type, outputs.len);
     for (outputs, 0..) |s, i| {
         result_types[i] = mlirx.Type.rankedTensor(mlir_ctx, s);
     }
@@ -1614,165 +1613,12 @@ pub fn composite(
         .unknown(mlir_ctx),
     ).appendTo(ctx.currentScope().block);
 
-    const out_tensors = allocator.alloc(Tensor, outputs.len) catch @panic("OOM");
+    const out_tensors = ctx.alloc(Tensor, outputs.len);
     for (outputs, 0..) |s, i| {
         out_tensors[i] = Tensor._result(s, op.result(i));
     }
 
     return out_tensors;
-}
-
-pub fn unpackNvfp4(w: Tensor, k_tag: anytype) Tensor {
-    stdx.debug.assert(w.dtype() == .u8, "unpackNvfp4 expects packed u8 weights, got {}", .{w.dtype()});
-    return w.bitCast(.f4e2m1)
-        .merge(.{ .kb = .{ .kw, .bitcast } })
-        .renameTag(.kb, Shape.toTag(k_tag));
-}
-
-pub fn quantizeNvfp4(x: Tensor, input_global_scale: ?Tensor, args: anytype) struct {
-    values: Tensor,
-    scales: Tensor,
-} {
-    const block_size = 16;
-    const value_max = 6.0;
-    const scale_min_normal = 0x1p-6;
-    const scale_max = DataType.f8e4m3fn.maxValue().as(f32);
-
-    stdx.debug.assert(x.shape().hasTag(args) != null, "quantizeNvfp4 expects x to have {any} tag, got {f}", .{ args, x.shape() });
-    stdx.debug.assert(@rem(x.dim(args), block_size) == 0, "quantizeNvfp4 expects {any} to be a multiple of {}, got {f}", .{ args, block_size, x.shape() });
-
-    const dt = x.dtype();
-    const scaled = if (input_global_scale) |igs|
-        x.mul(igs.convert(dt).broad(x.shape()))
-    else
-        x;
-    const grouped = scaled.splitAxis(args, .{ .sc = -1, .blk = block_size });
-    const amax = grouped.abs().max(.blk);
-
-    const scales = amax.scale(1.0 / value_max)
-        .clamp(
-            Tensor.scalar(scale_min_normal, dt),
-            Tensor.scalar(scale_max, dt),
-        )
-        .convert(.f8e4m3fn);
-
-    const divisor = scales.convert(dt)
-        .maximum(Tensor.scalar(scale_min_normal, dt).broad(scales.shape().withDtype(dt)))
-        .broad(grouped.shape());
-
-    const values = grouped.div(divisor)
-        .convert(.f4e2m1)
-        .reshape(x.shape().withDtype(.f4e2m1));
-
-    return .{
-        .values = values,
-        .scales = scales.squeeze(.blk),
-    };
-}
-
-pub fn scaledDot(
-    lhs: Tensor,
-    rhs: Tensor,
-    lhs_scale: ?Tensor,
-    rhs_scale: Tensor,
-    args: anytype,
-) Tensor {
-    stdx.debug.assert(lhs.shape().hasTag(args) != null, "scaledDot expects lhs to have {any} tag, got {f}", .{ args, lhs.shape() });
-    stdx.debug.assert(rhs.shape().hasTag(args) != null, "scaledDot expects rhs to have {any} tag, got {f}", .{ args, rhs.shape() });
-
-    const lhs_contracting_dim: i8 = @intCast(lhs.shape().hasTag(args).?);
-    const rhs_contracting_dim: i8 = @intCast(rhs.shape().hasTag(args).?);
-
-    var batching_axes: stdx.BoundedArray([2]i8, constants.MAX_RANK) = .empty;
-    for (0..lhs.rank()) |lhs_tag_index| {
-        const lhs_tag = lhs.shape().tag(lhs_tag_index);
-        if (lhs_tag == Shape.toTag(args)) continue;
-        if (rhs.shape().hasTag(lhs_tag)) |rhs_tag_index| {
-            batching_axes.appendAssumeCapacity(.{ @intCast(lhs_tag_index), @intCast(rhs_tag_index) });
-        }
-    }
-
-    const Axes = stdx.BoundedArray(i64, constants.MAX_RANK);
-
-    const result_dtype: DataType = switch (lhs.dtype()) {
-        .f4e2m1, .f8e4m3, .f8e4m3fn, .f8e5m2, .f8e4m3b11fnuz, .f8e4m3fnuz, .f8e5m2fnuz => .bf16,
-        else => lhs.dtype(),
-    };
-    var res_shape: Shape = .{ ._dtype = result_dtype };
-    var lhs_batching_axes: Axes = .empty;
-    var rhs_batching_axes: Axes = .empty;
-    for (batching_axes.constSlice()) |b_axes| {
-        const l, const r = b_axes;
-        stdx.debug.assert(lhs._shape.dim(l) == rhs._shape.dim(r), "scaledDot expects batching dimensions to be equal, got {} and {} in {f} and {f}", .{ l, r, lhs, rhs });
-        var t = lhs._shape.tag(l);
-        if (t == Shape.TagUnknown) t = rhs._shape.tag(r);
-        res_shape = res_shape.appendDim(lhs._shape.dim(l), t);
-        lhs_batching_axes.appendAssumeCapacity(lhs._shape.axis(l));
-        rhs_batching_axes.appendAssumeCapacity(rhs._shape.axis(r));
-    }
-
-    stdx.debug.assert(lhs._shape.dim(lhs_contracting_dim) == rhs._shape.dim(rhs_contracting_dim), "scaledDot expects contracting dimensions to be equal, got {} and {} in {f} and {f}", .{ lhs_contracting_dim, rhs_contracting_dim, lhs, rhs });
-    var lhs_contracting_axes: Axes = .empty;
-    var rhs_contracting_axes: Axes = .empty;
-    lhs_contracting_axes.appendAssumeCapacity(lhs._shape.axis(lhs_contracting_dim));
-    rhs_contracting_axes.appendAssumeCapacity(rhs._shape.axis(rhs_contracting_dim));
-
-    for (0..lhs.rank()) |l| {
-        if (std.mem.indexOfScalar(i64, lhs_contracting_axes.constSlice(), @intCast(l))) |_| {
-            continue;
-        }
-        if (std.mem.indexOfScalar(i64, lhs_batching_axes.constSlice(), @intCast(l))) |_| {
-            continue;
-        }
-        res_shape = res_shape.appendDim(lhs._shape.dim(l), lhs._shape.tag(l));
-    }
-    for (0..rhs.rank()) |r| {
-        if (std.mem.indexOfScalar(i64, rhs_contracting_axes.constSlice(), @intCast(r))) |_| {
-            continue;
-        }
-        if (std.mem.indexOfScalar(i64, rhs_batching_axes.constSlice(), @intCast(r))) |_| {
-            continue;
-        }
-        res_shape = res_shape.appendDim(rhs._shape.dim(r), rhs._shape.tag(r));
-    }
-
-    const lhs_scale_operand = lhs_scale orelse blk: {
-        var lhs_scale_shape = lhs.shape().withDtype(.bf16);
-        for (0..lhs.rank()) |i| {
-            lhs_scale_shape = lhs_scale_shape.setDim(i, 1);
-        }
-        break :blk Tensor.constantTensor(lhs_scale_shape, DataType.bf16.one().asBytes());
-    };
-
-    const mlir_ctx = CompilationContext.current().mlir_ctx;
-    const dnums = mlir.Attribute.array(mlir_ctx, &.{
-        .array(mlir_ctx, &.{
-            .intArray(mlir_ctx, i64, lhs_contracting_axes.constSlice()),
-            .intArray(mlir_ctx, i64, rhs_contracting_axes.constSlice()),
-        }),
-        .array(mlir_ctx, &.{
-            .intArray(mlir_ctx, i64, lhs_batching_axes.constSlice()),
-            .intArray(mlir_ctx, i64, rhs_batching_axes.constSlice()),
-        }),
-    });
-
-    const operands: []const Tensor = &.{ lhs, rhs, lhs_scale_operand, rhs_scale };
-
-    const outs = composite("xla.scaled_dot", operands, &.{res_shape}, scaledDotReference, res_shape, .{
-        .composite_attributes = &.{.named(mlir_ctx, "dimension_numbers", dnums)},
-    });
-
-    return outs[0];
-}
-
-fn scaledDotReference(in: []const Tensor, out_shape: Shape) Tensor {
-    return customCall(
-        "zml$scaled_dot_unmatched",
-        .{ in[0], in[1], in[2], in[3] },
-        out_shape,
-        {},
-        .{ .has_side_effect = false },
-    );
 }
 
 pub fn customCall(target_name: [:0]const u8, inputs: anytype, outputs: anytype, metadata: anytype, opts: CustomCallOptions) CustomCallResultTypeFromOutputSpec(@TypeOf(outputs)) {

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1283,21 +1283,52 @@ pub const Tensor = struct {
     /// Axes with the same tag on both sides, and which aren't contracting,
     /// are considered "batching axes".
     pub fn dot(lhs: Tensor, rhs: Tensor, args: anytype) Tensor {
-        stdx.debug.assert(lhs.shape().hasTag(args) != null, "Expected lhs to have {any} tag, got {f}", .{ args, lhs.shape() });
-        stdx.debug.assert(rhs.shape().hasTag(args) != null, "Expected rhs to have {any} tag, got {f}", .{ args, rhs.shape() });
+        const dot_axes = lhs.dotAxes(rhs, args);
+        return lhs.dotGeneral(rhs, dot_axes.contracting.constSlice(), dot_axes.batching.constSlice());
+    }
 
-        const lhs_contracting_dim: i8 = @intCast(lhs.shape().hasTag(args).?);
-        const rhs_contracting_dim: i8 = @intCast(rhs.shape().hasTag(args).?);
+    pub const DotAxes = struct {
+        contracting: stdx.BoundedArray([2]i8, constants.MAX_RANK),
+        batching: stdx.BoundedArray([2]i8, constants.MAX_RANK),
+    };
+
+    /// Returns contracting and batching axis pairs inferred from one or more tags.
+    pub fn dotAxes(lhs: Tensor, rhs: Tensor, tags: anytype) DotAxes {
+        const T = @TypeOf(tags);
+        if (comptime T == Shape.Tag or T == @EnumLiteral()) {
+            return lhs.dotAxes(rhs, .{tags});
+        }
+
+        const lhs_contracting_axes, _ = lhs.shape().parseAxes(tags);
+        const rhs_contracting_axes, _ = rhs.shape().parseAxes(tags);
+        var contracting_axes: stdx.BoundedArray([2]i8, constants.MAX_RANK) = .empty;
+        for (lhs_contracting_axes.constSlice(), rhs_contracting_axes.constSlice()) |l, r| {
+            contracting_axes.appendAssumeCapacity(.{ @intCast(l), @intCast(r) });
+        }
 
         var batching_axes: stdx.BoundedArray([2]i8, constants.MAX_RANK) = .empty;
         for (0..lhs.rank()) |lhs_tag_index| {
+            if (std.mem.indexOfScalar(u3, lhs_contracting_axes.constSlice(), @intCast(lhs_tag_index)) != null) {
+                continue;
+            }
+
             const lhs_tag = lhs.shape().tag(lhs_tag_index);
-            if (lhs_tag == Shape.toTag(args)) continue;
             if (rhs.shape().hasTag(lhs_tag)) |rhs_tag_index| {
                 batching_axes.appendAssumeCapacity(.{ @intCast(lhs_tag_index), @intCast(rhs_tag_index) });
             }
         }
-        return lhs.dotGeneral(rhs, &.{.{ lhs_contracting_dim, rhs_contracting_dim }}, batching_axes.slice());
+
+        return .{ .contracting = contracting_axes, .batching = batching_axes };
+    }
+
+    test dotAxes {
+        const lhs: Tensor = .init(.{ .a = 20, .b = 21, .c = 22 }, .f32);
+        const rhs: Tensor = .init(.{ .c = 22, .b = 21, .d = 23, .a = 20 }, .f32);
+
+        const dot_axes = lhs.dotAxes(rhs, .{ .c, .a });
+
+        try std.testing.expectEqualSlices([2]i8, &.{ .{ 2, 0 }, .{ 0, 3 } }, dot_axes.contracting.constSlice());
+        try std.testing.expectEqualSlices([2]i8, &.{.{ 1, 1 }}, dot_axes.batching.constSlice());
     }
 
     test dot {


### PR DESCRIPTION
Add MLIR composites, `scaledDot`, and a Linear path for NVFP4 weights (unpack, optional activation quant on Blackwell, global scales). Skip fused multi-source tensors in the generic loader so pack/`loadExecute` can fill them (may be used later for fused QKV etc).