### PR TITLE
kernels/mosaic_tpu: add log1p builder operation

### DIFF
--- a/kernels/mosaic_tpu/builder.zig
+++ b/kernels/mosaic_tpu/builder.zig
@@ -1380,6 +1380,9 @@ pub const Builder = struct {
     pub fn log(self: *Builder, x: Value) Value {
         return self.emit(math.log(self.ctx, x.inner, self.loc()));
     }
+    pub fn log1p(self: *Builder, x: Value) Value {
+        return self.emit(math.log1p(self.ctx, x.inner, self.loc()));
+    }
     pub fn log2(self: *Builder, x: Value) Value {
         return self.emit(math.log2(self.ctx, x.inner, self.loc()));
     }


### PR DESCRIPTION
Add `Builder.log1p` to Mosaic TPU kernel DSL

The MLIR math dialect already exposes `math.log1p`. 
This change makes it available through the Mosaic TPU builder alongside the already existing operations. 

--> This avoids kernels constructind `math.log1p` operations manually and makes the operation reusable for future DSL kernel translations. 

A companion DSL-harness changes replaces existing manual `math.log1p` construction with `Builder.log1p`.  