### PR TITLE
zml/exe: TypedExe

### DIFF
--- a/examples/llm/chat.zig
+++ b/examples/llm/chat.zig
@@ -34,24 +34,26 @@ pub const Chat = struct {
         io: std.Io,
         platform: *const zml.Platform,
         tokenizer: zml.tokenizer.Tokenizer,
-        compiled_model: *const models.CompiledModel,
+        compiled_model: *models.CompiledModel,
         model_buffers: *models.Buffers,
     ) !Chat {
-        var session = try compiled_model.newSession(
+        var tokens: std.ArrayList(u32) = try .initCapacity(allocator, compiled_model.seqlen);
+        errdefer tokens.deinit(allocator);
+
+        const session = try compiled_model.newSession(
             allocator,
             io,
             platform,
             model_buffers,
             tokenizer,
         );
-        errdefer session.deinit();
 
         return .{
             .allocator = allocator,
             .io = io,
             .platform = platform,
             .session = session,
-            .tokens = try .initCapacity(allocator, session.maxTokens()),
+            .tokens = tokens,
         };
     }
 

--- a/examples/llm/main.zig
+++ b/examples/llm/main.zig
@@ -147,8 +147,8 @@ pub fn main(init: std.process.Init) !void {
     try printZmlLogo(io, init.environ_map);
 
     const interactive = args.prompt == null;
-    const prompt = if (args.prompt) |prompt| b: {
-        break :b try allocator.dupe(u8, prompt);
+    const prompt = if (args.prompt) |prompt_arg| b: {
+        break :b try allocator.dupe(u8, prompt_arg);
     } else b: {
         chat.initHistory();
         const line = c.linenoise(chat.prompt_prefix) orelse return;

--- a/examples/llm/models.zig
+++ b/examples/llm/models.zig
@@ -110,7 +110,7 @@ pub const CompiledModel = struct {
     }
 
     pub fn newSession(
-        self: *const CompiledModel,
+        self: *CompiledModel,
         allocator: std.mem.Allocator,
         io: std.Io,
         platform: *const zml.Platform,

--- a/examples/llm/models/lfm2/inference.zig
+++ b/examples/llm/models/lfm2/inference.zig
@@ -8,6 +8,7 @@ const Phase = common.Phase;
 const model = @import("model.zig");
 
 const log = std.log.scoped(.lfm);
+
 pub const CompilationParameters = struct {
     hidden_dim: usize,
     batch_dim: usize,
@@ -52,10 +53,7 @@ pub const CompilationParameters = struct {
 pub const CompilationOptions = CompilationParameters;
 
 pub const Args = struct {
-    allocator: std.mem.Allocator,
     io: std.Io,
-    platform: *const zml.Platform,
-    model_buffers: *model.Buffers,
     tokens_buf: *zml.Buffer,
     tokens_pos_buf: *zml.Buffer,
     actual_seq_len_buf: *zml.Buffer,
@@ -79,10 +77,13 @@ pub const CompiledModel = struct {
         opts: CompilationParameters,
         progress: *std.Progress.Node,
     ) !CompiledModel {
+        const prefill = try compileKernel(allocator, io, platform, mdl, opts, opts.seqlen, .prefill, progress);
+        errdefer prefill.deinit();
+        const decode = try compileKernel(allocator, io, platform, mdl, opts, 1, .decode, progress);
         return .{
             .loaded_model = loaded_model,
-            .prefill = try KernelExe.init(allocator, io, platform, mdl, opts, opts.seqlen, .prefill, progress),
-            .decode = try KernelExe.init(allocator, io, platform, mdl, opts, 1, .decode, progress),
+            .prefill = prefill,
+            .decode = decode,
             .params = opts,
         };
     }
@@ -95,323 +96,227 @@ pub const CompiledModel = struct {
 
 pub const Inference = CompiledModel;
 
+pub const EmbedExe = zml.TypedExe(model.TokenEmbedding.forward);
+pub const LayerExe = zml.TypedExe(model.DecoderLayer.forward);
+pub const SampleExe = zml.TypedExe(model.LmHead.forward);
+
 pub const KernelExe = struct {
-    composed: ComposedKernelExe,
+    embed: EmbedExe,
+    conv: LayerExe,
+    self_attn: LayerExe,
+    sample: SampleExe,
 
-    pub fn init(
-        allocator: std.mem.Allocator,
-        io: std.Io,
-        platform: *zml.Platform,
-        mdl: model.Model,
-        opts: CompilationOptions,
-        seqlen: u32,
-        phase: Phase,
-        progress: *std.Progress.Node,
-    ) !KernelExe {
-        return .{
-            .composed = try ComposedKernelExe.init(allocator, io, platform, mdl, opts, seqlen, phase, progress),
-        };
-    }
-
-    pub fn deinit(self: KernelExe) void {
-        self.composed.deinit();
-    }
-
-    pub fn run(self: *const KernelExe, args: Args) !void {
-        try self.composed.run(args);
+    pub fn deinit(self: *const KernelExe) void {
+        self.embed.deinit();
+        self.conv.deinit();
+        self.self_attn.deinit();
+        self.sample.deinit();
     }
 };
 
-pub const ComposedKernelExe = struct {
-    embed_tokens: zml.Exe,
-    conv_layer: zml.Exe,
-    attn_layer: zml.Exe,
-    lm_head: zml.Exe,
+pub const KernelRunner = struct {
+    embed: EmbedExe.Runner(.{.embedding}),
+    layers: []LayerExe.Runner(.{.layer}),
+    sample: SampleExe.Runner(.{ .lm_head, .embed_tokens }),
 
-    fn init(
-        allocator: std.mem.Allocator,
-        io: std.Io,
-        platform: *zml.Platform,
-        mdl: model.Model,
-        opts: CompilationOptions,
-        seqlen: u32,
-        phase: Phase,
-        progress: *std.Progress.Node,
-    ) !ComposedKernelExe {
-        const embed_tokens = try ComposedKernelExe.compileEmbedTokens(allocator, io, platform, mdl.embed_tokens, opts, seqlen, phase, progress);
-        errdefer embed_tokens.deinit();
+    pub fn init(allocator: std.mem.Allocator, exe: *const KernelExe, buffers: *const model.Buffers) !KernelRunner {
+        var embed = try EmbedExe.Runner(.{.embedding}).init(&exe.embed, allocator, .{ .embedding = buffers.embed_tokens });
+        errdefer embed.deinit(allocator);
 
-        const conv_layer = try ComposedKernelExe.compileConvLayer(allocator, io, platform, mdl, opts, seqlen, phase, progress);
-        errdefer conv_layer.deinit();
-
-        const attn_layer = try ComposedKernelExe.compileAttnLayer(allocator, io, platform, mdl, opts, seqlen, phase, progress);
-        errdefer attn_layer.deinit();
-
-        const lm_head = try ComposedKernelExe.compileLmHead(allocator, io, platform, mdl, opts, seqlen, phase, progress);
-        errdefer lm_head.deinit();
-
-        return .{
-            .embed_tokens = embed_tokens,
-            .conv_layer = conv_layer,
-            .attn_layer = attn_layer,
-            .lm_head = lm_head,
-        };
-    }
-
-    fn deinit(self: ComposedKernelExe) void {
-        self.embed_tokens.deinit();
-        self.conv_layer.deinit();
-        self.attn_layer.deinit();
-        self.lm_head.deinit();
-    }
-
-    pub fn run(self: *const ComposedKernelExe, args: Args) !void {
-        var hidden_buf: zml.Buffer = b: {
-            var exe_args = try self.embed_tokens.args(args.allocator);
-            defer exe_args.deinit(args.allocator);
-
-            var results = try self.embed_tokens.results(args.allocator);
-            defer results.deinit(args.allocator);
-
-            exe_args.set(.{ args.model_buffers.embed_tokens, args.tokens_buf });
-            self.embed_tokens.call(exe_args, &results);
-            break :b results.get(zml.Buffer);
-        };
-        defer hidden_buf.deinit();
-
-        var conv_cache_index_buf: zml.Buffer = try .scalar(args.io, args.platform, 0, .u32);
-        defer conv_cache_index_buf.deinit();
-        var kv_cache_index_buf: zml.Buffer = try .scalar(args.io, args.platform, 0, .u32);
-        defer kv_cache_index_buf.deinit();
-
-        for (args.model_buffers.layers) |layer_bufs| {
-            const exe = switch (layer_bufs.operator) {
-                .conv => &self.conv_layer,
-                .self_attn => &self.attn_layer,
+        const layers = try allocator.alloc(LayerExe.Runner(.{.layer}), buffers.layers.len);
+        errdefer allocator.free(layers);
+        var initialized_layers: usize = 0;
+        errdefer for (layers[0..initialized_layers]) |*layer| layer.deinit(allocator);
+        for (layers, buffers.layers) |*layer, layer_buffers| {
+            const layer_exe: *const LayerExe = switch (layer_buffers.operator) {
+                .conv => &exe.conv,
+                .self_attn => &exe.self_attn,
             };
-
-            var exe_args = try exe.args(args.allocator);
-            defer exe_args.deinit(args.allocator);
-            var results = try exe.results(args.allocator);
-            defer results.deinit(args.allocator);
-
-            exe_args.set(.{
-                layer_bufs,
-                &hidden_buf,
-                args.tokens_pos_buf,
-                args.actual_seq_len_buf,
-                args.cache_buffers,
-                &conv_cache_index_buf,
-                &kv_cache_index_buf,
-                args.attention_metadata_buffers,
-            });
-            ComposedKernelExe.runLayer(exe, &exe_args, &results, args.cache_buffers, &hidden_buf, &conv_cache_index_buf, &kv_cache_index_buf);
+            layer.* = try LayerExe.Runner(.{.layer}).init(layer_exe, allocator, .{ .layer = layer_buffers });
+            initialized_layers += 1;
         }
 
-        var exe_args = try self.lm_head.args(args.allocator);
-        defer exe_args.deinit(args.allocator);
-        var results = try self.lm_head.results(args.allocator);
-        defer results.deinit(args.allocator);
-
-        exe_args.set(.{ args.model_buffers.lm_head, hidden_buf, args.model_buffers.embed_tokens, args.tokens_buf, args.rng_buf });
-        self.runLmHead(&exe_args, &results, args.tokens_buf, args.rng_buf);
-    }
-
-    fn runLayer(
-        exe: *const zml.Exe,
-        exe_args: *zml.exe.Exe.Arguments,
-        results: *zml.exe.Exe.Results,
-        cache_buffers: *zml.Bufferized(model.Cache),
-        hidden_buf: *zml.Buffer,
-        conv_cache_index_buf: *zml.Buffer,
-        kv_cache_index_buf: *zml.Buffer,
-    ) void {
-        exe.call(exe_args.*, results);
-
-        var new_hidden, var new_cache, var new_conv_cache_index, var new_kv_cache_index = results.get(struct {
-            zml.Buffer,
-            zml.Bufferized(model.Cache),
-            zml.Buffer,
-            zml.Buffer,
+        var sample = try SampleExe.Runner(.{ .lm_head, .embed_tokens }).init(&exe.sample, allocator, .{
+            .lm_head = buffers.lm_head,
+            .embed_tokens = buffers.embed_tokens,
         });
-        ComposedKernelExe.replaceBuffer(hidden_buf, &new_hidden);
-        ComposedKernelExe.replaceCacheBuffers(cache_buffers, &new_cache);
-        ComposedKernelExe.replaceBuffer(conv_cache_index_buf, &new_conv_cache_index);
-        ComposedKernelExe.replaceBuffer(kv_cache_index_buf, &new_kv_cache_index);
+        errdefer sample.deinit(allocator);
+
+        return .{ .embed = embed, .layers = layers, .sample = sample };
     }
 
-    fn runLmHead(
-        self: *const ComposedKernelExe,
-        exe_args: *zml.exe.Exe.Arguments,
-        results: *zml.exe.Exe.Results,
-        tokens_buf: *zml.Buffer,
-        rng_buf: *zml.Bufferized(zml.Tensor.Rng),
-    ) void {
-        self.lm_head.call(exe_args.*, results);
-
-        var new_tokens, var new_rng = results.get(struct {
-            zml.Buffer,
-            zml.Bufferized(zml.Tensor.Rng),
-        });
-        ComposedKernelExe.replaceBuffer(tokens_buf, &new_tokens);
-        ComposedKernelExe.replaceBuffer(&rng_buf._state, &new_rng._state);
-    }
-
-    fn replaceCacheBuffers(dst: *zml.Bufferized(model.Cache), src: *zml.Bufferized(model.Cache)) void {
-        ComposedKernelExe.replaceBuffer(&dst.conv.state, &src.conv.state);
-        ComposedKernelExe.replaceBuffer(&dst.kv.k, &src.kv.k);
-        ComposedKernelExe.replaceBuffer(&dst.kv.v, &src.kv.v);
-    }
-
-    fn replaceBuffer(dst: *zml.Buffer, src: *zml.Buffer) void {
-        if (!ComposedKernelExe.sameBufferHandle(dst.*, src.*)) {
-            dst.deinit();
-        }
-        dst.* = src.*;
-    }
-
-    fn sameBufferHandle(a: zml.Buffer, b: zml.Buffer) bool {
-        if (a._shards.len != b._shards.len) return false;
-        for (a._shards.constSlice(), b._shards.constSlice()) |a_shard, b_shard| {
-            if (a_shard != b_shard) return false;
-        }
-        return true;
-    }
-
-    fn compileEmbedTokens(
-        allocator: std.mem.Allocator,
-        io: std.Io,
-        platform: *zml.Platform,
-        embed_tokens: model.TokenEmbedding,
-        opts: CompilationOptions,
-        seqlen: u32,
-        phase: Phase,
-        progress: *std.Progress.Node,
-    ) !zml.Exe {
-        progress.increaseEstimatedTotalItems(1);
-        var node = progress.start(phase.startMessage("embed_tokens"), 1);
-        defer node.end();
-
-        const from: std.Io.Timestamp = .now(io, .awake);
-        defer phase.logCompileDone(log, "embed_tokens", io, from);
-
-        const tokens: zml.Tensor = .init(.{ .batch = opts.batch_dim, .seq = seqlen }, .u32);
-
-        return platform.compile(allocator, io, embed_tokens, .forward, .{tokens}, .{
-            .shardings = &opts.shardings.all(),
-            .program_name = phase.programName("lfm2", "embed_tokens"),
-        });
-    }
-
-    fn compileConvLayer(
-        allocator: std.mem.Allocator,
-        io: std.Io,
-        platform: *zml.Platform,
-        mdl: model.Model,
-        opts: CompilationOptions,
-        seqlen: u32,
-        phase: Phase,
-        progress: *std.Progress.Node,
-    ) !zml.Exe {
-        progress.increaseEstimatedTotalItems(1);
-        var node = progress.start(phase.startMessage("conv layer"), 1);
-        defer node.end();
-
-        const from: std.Io.Timestamp = .now(io, .awake);
-        defer phase.logCompileDone(log, "conv layer", io, from);
-
-        const conv_layer = for (mdl.layers) |layer| {
-            if (layer.operator == .conv) break layer;
-        } else unreachable;
-
-        const hidden: zml.Tensor = .init(.{ .batch = opts.batch_dim, .seq = seqlen, .d = opts.hidden_dim }, mdl.embed_tokens.weight.dtype());
-        const token_position_offset: zml.Tensor = .init(.{ .batch = opts.batch_dim }, .u32);
-        const actual_seq_len: zml.Tensor = .init(.{}, .u32);
-        const conv_cache_index: zml.Tensor = .init(.{}, .u32);
-        const kv_cache_index: zml.Tensor = .init(.{}, .u32);
-
-        return platform.compile(allocator, io, conv_layer, .forward, .{
-            hidden,
-            token_position_offset,
-            actual_seq_len,
-            opts.cache,
-            conv_cache_index,
-            kv_cache_index,
-            opts.attention_metadata,
-            opts.attention_parameters,
-            model.ConvParameters{ .is_prefill = phase.isPrefill() },
-        }, .{
-            .shardings = &opts.shardings.all(),
-            .program_name = phase.programName("lfm2", "conv_layer"),
-        });
-    }
-
-    fn compileAttnLayer(
-        allocator: std.mem.Allocator,
-        io: std.Io,
-        platform: *zml.Platform,
-        mdl: model.Model,
-        opts: CompilationOptions,
-        seqlen: u32,
-        phase: Phase,
-        progress: *std.Progress.Node,
-    ) !zml.Exe {
-        progress.increaseEstimatedTotalItems(1);
-        var node = progress.start(phase.startMessage("attn layer"), 1);
-        defer node.end();
-
-        const from: std.Io.Timestamp = .now(io, .awake);
-        defer phase.logCompileDone(log, "attn layer", io, from);
-
-        const attn_layer = for (mdl.layers) |layer| {
-            if (layer.operator == .self_attn) break layer;
-        } else unreachable;
-
-        const hidden: zml.Tensor = .init(.{ .batch = opts.batch_dim, .seq = seqlen, .d = opts.hidden_dim }, mdl.embed_tokens.weight.dtype());
-        const token_position_offset: zml.Tensor = .init(.{ .batch = opts.batch_dim }, .u32);
-        const actual_seq_len: zml.Tensor = .init(.{}, .u32);
-        const conv_cache_index: zml.Tensor = .init(.{}, .u32);
-        const kv_cache_index: zml.Tensor = .init(.{}, .u32);
-
-        return platform.compile(allocator, io, attn_layer, .forward, .{
-            hidden,
-            token_position_offset,
-            actual_seq_len,
-            opts.cache,
-            conv_cache_index,
-            kv_cache_index,
-            opts.attention_metadata,
-            opts.attention_parameters,
-            model.ConvParameters{ .is_prefill = phase.isPrefill() },
-        }, .{
-            .shardings = &opts.shardings.all(),
-            .program_name = phase.programName("lfm2", "attn_layer"),
-        });
-    }
-
-    fn compileLmHead(
-        allocator: std.mem.Allocator,
-        io: std.Io,
-        platform: *zml.Platform,
-        mdl: model.Model,
-        opts: CompilationOptions,
-        seqlen: u32,
-        phase: Phase,
-        progress: *std.Progress.Node,
-    ) !zml.Exe {
-        progress.increaseEstimatedTotalItems(1);
-        var node = progress.start(phase.startMessage("lm_head"), 1);
-        defer node.end();
-
-        const from: std.Io.Timestamp = .now(io, .awake);
-        defer phase.logCompileDone(log, "lm_head", io, from);
-
-        const hidden: zml.Tensor = .init(.{ .batch = opts.batch_dim, .seq = seqlen, .d = opts.hidden_dim }, mdl.embed_tokens.weight.dtype());
-        const tokens: zml.Tensor = .init(.{ .batch = opts.batch_dim, .seq = seqlen }, .u32);
-
-        return platform.compile(allocator, io, mdl.lm_head, .forward, .{ hidden, mdl.embed_tokens, tokens, opts.rng }, .{
-            .shardings = &opts.shardings.all(),
-            .program_name = phase.programName("lfm2", "lm_head"),
-        });
+    pub fn deinit(self: *KernelRunner, allocator: std.mem.Allocator) void {
+        self.embed.deinit(allocator);
+        for (self.layers) |*layer| layer.deinit(allocator);
+        allocator.free(self.layers);
+        self.sample.deinit(allocator);
     }
 };
+
+pub fn run(
+    runner: *KernelRunner,
+    args: Args,
+    conv_cache_index_buffer: *zml.Buffer,
+    kv_cache_index_buffer: *zml.Buffer,
+) void {
+    var hidden_buffer: zml.Buffer = undefined;
+    runner.embed.run(args.io, .{
+        .inputs = .{
+            .tokens = args.tokens_buf.*,
+        },
+        .outputs = .{ .hidden = &hidden_buffer },
+    });
+    defer hidden_buffer.deinit();
+
+    for (runner.layers) |*layer| {
+        layer.run(args.io, .{
+            .inputs = .{
+                .hidden = hidden_buffer,
+                .tokens_position_offset = args.tokens_pos_buf.*,
+                .actual_seq_len = args.actual_seq_len_buf.*,
+                .cache = args.cache_buffers.*,
+                .conv_cache_index = conv_cache_index_buffer.*,
+                .kv_cache_index = kv_cache_index_buffer.*,
+                .attention_metadata = args.attention_metadata_buffers,
+            },
+            .outputs = .{
+                .hidden = &hidden_buffer,
+                .cache = args.cache_buffers,
+                .conv_cache_index = conv_cache_index_buffer,
+                .kv_cache_index = kv_cache_index_buffer,
+            },
+        });
+    }
+
+    runner.sample.run(args.io, .{
+        .inputs = .{
+            .hidden = hidden_buffer,
+            .tokens = args.tokens_buf.*,
+            .rng = args.rng_buf.*,
+        },
+        .outputs = .{
+            .tokens = args.tokens_buf,
+            .rng = args.rng_buf,
+        },
+    });
+}
+
+fn compileKernel(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    platform: *zml.Platform,
+    mdl: model.Model,
+    opts: CompilationOptions,
+    seqlen: u32,
+    phase: Phase,
+    progress: *std.Progress.Node,
+) !KernelExe {
+    const embed = try compileEmbed(allocator, io, platform, mdl.embed_tokens, opts, seqlen, phase, progress);
+    errdefer embed.deinit();
+    const conv_layer = try compileLayer(allocator, io, platform, mdl, opts, seqlen, .conv, phase, progress);
+    errdefer conv_layer.deinit();
+    const attn_layer = try compileLayer(allocator, io, platform, mdl, opts, seqlen, .full_attention, phase, progress);
+    errdefer attn_layer.deinit();
+    const sample = try compileSample(allocator, io, platform, mdl, opts, seqlen, phase, progress);
+    errdefer sample.deinit();
+    return .{ .embed = embed, .conv = conv_layer, .self_attn = attn_layer, .sample = sample };
+}
+
+fn compileEmbed(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    platform: *zml.Platform,
+    embed_tokens: model.TokenEmbedding,
+    opts: CompilationOptions,
+    seqlen: u32,
+    phase: Phase,
+    progress: *std.Progress.Node,
+) !EmbedExe {
+    progress.increaseEstimatedTotalItems(1);
+    var node = progress.start(phase.startMessage("embed_tokens"), 1);
+    defer node.end();
+    const from: std.Io.Timestamp = .now(io, .awake);
+    defer phase.logCompileDone(log, "embed_tokens", io, from);
+
+    return EmbedExe.compile(allocator, io, platform, .{
+        .shardings = &opts.shardings.all(),
+        .program_name = phase.programName("lfm2", "embed_tokens"),
+    }, .{.{
+        .embedding = embed_tokens,
+        .tokens = zml.Tensor.init(.{ .batch = opts.batch_dim, .seq = seqlen }, .u32),
+    }});
+}
+
+fn compileLayer(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    platform: *zml.Platform,
+    mdl: model.Model,
+    opts: CompilationOptions,
+    seqlen: u32,
+    comptime kind: model.OperatorKind,
+    phase: Phase,
+    progress: *std.Progress.Node,
+) !LayerExe {
+    const label = switch (kind) {
+        .conv => "conv layer",
+        .full_attention => "attn layer",
+    };
+    progress.increaseEstimatedTotalItems(1);
+    var node = progress.start(phase.startMessage(label), 1);
+    defer node.end();
+    const from: std.Io.Timestamp = .now(io, .awake);
+    defer phase.logCompileDone(log, label, io, from);
+
+    const layer = for (mdl.layers) |candidate| {
+        const candidate_kind: model.OperatorKind = switch (candidate.operator) {
+            .conv => .conv,
+            .self_attn => .full_attention,
+        };
+        if (candidate_kind == kind) break candidate;
+    } else unreachable;
+
+    return LayerExe.compile(allocator, io, platform, .{
+        .shardings = &opts.shardings.all(),
+        .program_name = phase.programName("lfm2", if (kind == .conv) "conv_layer" else "attn_layer"),
+    }, .{.{
+        .layer = layer,
+        .hidden = zml.Tensor.init(.{ .batch = opts.batch_dim, .seq = seqlen, .d = opts.hidden_dim }, mdl.embed_tokens.weight.dtype()),
+        .tokens_position_offset = zml.Tensor.init(.{ .batch = opts.batch_dim }, .u32),
+        .actual_seq_len = zml.Tensor.init(.{}, .u32),
+        .cache = opts.cache,
+        .conv_cache_index = zml.Tensor.init(.{}, .u32),
+        .kv_cache_index = zml.Tensor.init(.{}, .u32),
+        .attention_metadata = opts.attention_metadata,
+        .attention_parameters = opts.attention_parameters,
+        .conv_parameters = .{ .is_prefill = phase.isPrefill() },
+    }});
+}
+
+fn compileSample(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    platform: *zml.Platform,
+    mdl: model.Model,
+    opts: CompilationOptions,
+    seqlen: u32,
+    phase: Phase,
+    progress: *std.Progress.Node,
+) !SampleExe {
+    progress.increaseEstimatedTotalItems(1);
+    var node = progress.start(phase.startMessage("lm_head"), 1);
+    defer node.end();
+    const from: std.Io.Timestamp = .now(io, .awake);
+    defer phase.logCompileDone(log, "lm_head", io, from);
+
+    return SampleExe.compile(allocator, io, platform, .{
+        .shardings = &opts.shardings.all(),
+        .program_name = phase.programName("lfm2", "lm_head"),
+    }, .{.{
+        .lm_head = mdl.lm_head,
+        .embed_tokens = mdl.embed_tokens,
+        .hidden = zml.Tensor.init(.{ .batch = opts.batch_dim, .seq = seqlen, .d = opts.hidden_dim }, mdl.embed_tokens.weight.dtype()),
+        .tokens = zml.Tensor.init(.{ .batch = opts.batch_dim, .seq = seqlen }, .u32),
+        .rng = opts.rng,
+    }});
+}

--- a/examples/llm/models/lfm2/model.zig
+++ b/examples/llm/models/lfm2/model.zig
@@ -222,7 +222,10 @@ pub const Model = struct {
     ) struct { zml.Tensor, Cache, zml.Tensor.Rng } {
         stdx.debug.assert(tokens.shape().hasTags(.{ .batch, .seq }), "Tokens should have tags {{.batch, .seq}}, got {f}", .{tokens.shape()});
 
-        const embeds = self.embed_tokens.forward(tokens);
+        const embeds = TokenEmbedding.forward(.{
+            .embedding = self.embed_tokens,
+            .tokens = tokens,
+        }).hidden;
 
         var hidden = embeds;
         var cache = cache_;
@@ -230,20 +233,31 @@ pub const Model = struct {
         var conv_cache_index = zml.Tensor.scalar(@as(u32, 0), .u32);
         var kv_cache_index = zml.Tensor.scalar(@as(u32, 0), .u32);
         for (self.layers) |layer| {
-            hidden, cache, conv_cache_index, kv_cache_index = layer.forward(
-                hidden,
-                tokens_position_offset,
-                actual_seq_len,
-                cache,
-                conv_cache_index,
-                kv_cache_index,
-                attention_metadata,
-                attention_parameters,
-                conv_parameters,
-            );
+            const result = DecoderLayer.forward(.{
+                .layer = layer,
+                .hidden = hidden,
+                .tokens_position_offset = tokens_position_offset,
+                .actual_seq_len = actual_seq_len,
+                .cache = cache,
+                .conv_cache_index = conv_cache_index,
+                .kv_cache_index = kv_cache_index,
+                .attention_metadata = attention_metadata,
+                .attention_parameters = attention_parameters,
+                .conv_parameters = conv_parameters,
+            });
+            hidden = result.hidden;
+            cache = result.cache;
+            conv_cache_index = result.conv_cache_index;
+            kv_cache_index = result.kv_cache_index;
         }
-        const new_tokens, const new_rng = self.lm_head.forward(hidden, self.embed_tokens, tokens, rng);
-        return .{ new_tokens, cache.reuseBuffer(cache_), new_rng };
+        const result = LmHead.forward(.{
+            .lm_head = self.lm_head,
+            .embed_tokens = self.embed_tokens,
+            .hidden = hidden,
+            .tokens = tokens,
+            .rng = rng,
+        });
+        return .{ result.tokens, cache.reuseBuffer(cache_), result.rng };
     }
 
     pub fn deinit(self: Model, allocator: std.mem.Allocator) void {
@@ -254,14 +268,23 @@ pub const Model = struct {
 pub const TokenEmbedding = struct {
     weight: zml.Tensor,
 
+    pub const Input = struct {
+        embedding: TokenEmbedding,
+        tokens: zml.Tensor,
+    };
+
+    pub const Output = struct {
+        hidden: zml.Tensor,
+    };
+
     pub fn init(store: zml.io.TensorStore.View) TokenEmbedding {
         return .{ .weight = store.createTensor("weight", .{ .voc, .d }, .{ .voc = .replicated, .d = .model }) };
     }
 
-    pub fn forward(self: TokenEmbedding, tokens: zml.Tensor) zml.Tensor {
-        stdx.debug.assert(tokens.dtype().isInteger(), "TokenEmbedding expects an integer input, received: {f}", .{tokens});
-        stdx.debug.assert(self.weight.rank() == 2, "TokenEmbedding expects it's weight zml.Tensor to be a 2D matrix, got {f}", .{self.weight});
-        return self.weight.gather(.{ .voc = tokens }, .{});
+    pub fn forward(input: Input) Output {
+        stdx.debug.assert(input.tokens.dtype().isInteger(), "TokenEmbedding expects an integer input, received: {f}", .{input.tokens});
+        stdx.debug.assert(input.embedding.weight.rank() == 2, "TokenEmbedding expects it's weight zml.Tensor to be a 2D matrix, got {f}", .{input.embedding.weight});
+        return .{ .hidden = input.embedding.weight.gather(.{ .voc = input.tokens }, .{}) };
     }
 
     pub fn unembed(self: TokenEmbedding, embeds: zml.Tensor) zml.Tensor {
@@ -274,6 +297,19 @@ pub const LmHead = struct {
     embedding_norm: RmsNorm,
     sampling_strategy: zml.nn.SamplingStrategy,
 
+    pub const Input = struct {
+        lm_head: LmHead,
+        embed_tokens: TokenEmbedding,
+        hidden: zml.Tensor,
+        tokens: zml.Tensor,
+        rng: zml.Tensor.Rng,
+    };
+
+    pub const Output = struct {
+        tokens: zml.Tensor,
+        rng: zml.Tensor.Rng,
+    };
+
     pub fn init(store: zml.io.TensorStore.View, config: Config, sampling_strategy: zml.nn.SamplingStrategy) LmHead {
         return .{
             .embedding_norm = RmsNorm.init(store.withPrefix("embedding_norm"), config.norm_eps, .d),
@@ -281,10 +317,11 @@ pub const LmHead = struct {
         };
     }
 
-    pub fn forward(self: LmHead, hidden: zml.Tensor, embed_tokens: TokenEmbedding, tokens: zml.Tensor, rng: zml.Tensor.Rng) struct { zml.Tensor, zml.Tensor.Rng } {
-        const logits = embed_tokens.unembed(self.embedding_norm.forward(hidden));
-        const new_tokens, const new_rng = zml.nn.sampleTokens(logits, self.sampling_strategy, rng);
-        return .{ new_tokens.convert(tokens.dtype()).reuseBuffer(tokens), new_rng };
+    pub fn forward(input: Input) Output {
+        const self = input.lm_head;
+        const logits = input.embed_tokens.unembed(self.embedding_norm.forward(input.hidden));
+        const new_tokens, const new_rng = zml.nn.sampleTokens(logits, self.sampling_strategy, input.rng);
+        return .{ .tokens = new_tokens.convert(input.tokens.dtype()).reuseBuffer(input.tokens), .rng = new_rng };
     }
 
     pub fn unloadBuffers(self: *zml.Bufferized(LmHead)) void {
@@ -300,6 +337,26 @@ pub const DecoderLayer = struct {
     operator_norm: RmsNorm,
     ffn_norm: RmsNorm,
     feed_forward: Mlp,
+
+    pub const Input = struct {
+        layer: DecoderLayer,
+        hidden: zml.Tensor,
+        tokens_position_offset: zml.Tensor,
+        actual_seq_len: zml.Tensor,
+        cache: Cache,
+        conv_cache_index: zml.Tensor,
+        kv_cache_index: zml.Tensor,
+        attention_metadata: zml.attention.Metadata,
+        attention_parameters: zml.attention.Parameters,
+        conv_parameters: ConvParameters,
+    };
+
+    pub const Output = struct {
+        hidden: zml.Tensor,
+        cache: Cache,
+        conv_cache_index: zml.Tensor,
+        kv_cache_index: zml.Tensor,
+    };
 
     pub fn parseOperatorKind(layer_type: []const u8) OperatorKind {
         return std.meta.stringToEnum(OperatorKind, layer_type) orelse {
@@ -325,30 +382,20 @@ pub const DecoderLayer = struct {
         };
     }
 
-    pub fn forward(
-        self: DecoderLayer,
-        input: zml.Tensor,
-        tokens_position_offset: zml.Tensor,
-        actual_seq_len: zml.Tensor,
-        cache_: Cache,
-        conv_cache_index_: zml.Tensor,
-        kv_cache_index_: zml.Tensor,
-        attention_metadata: zml.attention.Metadata,
-        attention_parameters: zml.attention.Parameters,
-        conv_parameters: ConvParameters,
-    ) struct { zml.Tensor, Cache, zml.Tensor, zml.Tensor } {
-        var cache = cache_;
-        var conv_cache_index = conv_cache_index_;
-        var kv_cache_index = kv_cache_index_;
+    pub fn forward(input: Input) Output {
+        const self = input.layer;
+        var cache = input.cache;
+        var conv_cache_index = input.conv_cache_index;
+        var kv_cache_index = input.kv_cache_index;
         const residual = switch (self.operator) {
             .conv => |operator| b: {
                 const residual, const updated_conv_cache = operator.forward(
-                    self.operator_norm.forward(input),
-                    tokens_position_offset,
-                    actual_seq_len,
+                    self.operator_norm.forward(input.hidden),
+                    input.tokens_position_offset,
+                    input.actual_seq_len,
                     cache.conv,
                     conv_cache_index,
-                    conv_parameters,
+                    input.conv_parameters,
                 );
                 cache.conv = updated_conv_cache;
                 conv_cache_index = conv_cache_index.add(zml.Tensor.scalar(@as(u32, 1), .u32));
@@ -356,12 +403,12 @@ pub const DecoderLayer = struct {
             },
             .self_attn => |operator| b: {
                 const residual, const updated_kv_cache = operator.forward(
-                    self.operator_norm.forward(input),
-                    tokens_position_offset,
+                    self.operator_norm.forward(input.hidden),
+                    input.tokens_position_offset,
                     cache.kv,
                     kv_cache_index,
-                    attention_metadata,
-                    attention_parameters,
+                    input.attention_metadata,
+                    input.attention_parameters,
                 );
                 cache.kv = updated_kv_cache;
                 kv_cache_index = kv_cache_index.add(zml.Tensor.scalar(@as(u32, 1), .u32));
@@ -369,13 +416,13 @@ pub const DecoderLayer = struct {
             },
         };
 
-        const x = input.add(residual);
+        const x = input.hidden.add(residual);
 
         return .{
-            x.add(self.feed_forward.forward(self.ffn_norm.forward(x))).reuseBuffer(input),
-            cache.reuseBuffer(cache_),
-            conv_cache_index.reuseBuffer(conv_cache_index_),
-            kv_cache_index.reuseBuffer(kv_cache_index_),
+            .hidden = x.add(self.feed_forward.forward(self.ffn_norm.forward(x))).reuseBuffer(input.hidden),
+            .cache = cache.reuseBuffer(input.cache),
+            .conv_cache_index = conv_cache_index.reuseBuffer(input.conv_cache_index),
+            .kv_cache_index = kv_cache_index.reuseBuffer(input.kv_cache_index),
         };
     }
 

--- a/examples/llm/models/lfm2/session.zig
+++ b/examples/llm/models/lfm2/session.zig
@@ -9,8 +9,9 @@ pub const Session = struct {
     allocator: std.mem.Allocator,
     io: std.Io,
     platform: *const zml.Platform,
-    model_buffers: *model.Buffers,
-    compiled_model: *const inference.CompiledModel,
+    compiled_model: *inference.CompiledModel,
+    prefill: inference.KernelRunner,
+    decode: inference.KernelRunner,
     config: *const model.Config,
     seqlen: u32,
     cache_buffers: zml.Bufferized(model.Cache),
@@ -25,28 +26,42 @@ pub const Session = struct {
         io: std.Io,
         platform: *const zml.Platform,
         tokenizer: zml.tokenizer.Tokenizer,
-        compiled_model: *const inference.CompiledModel,
+        compiled_model: *inference.CompiledModel,
         model_buffers: *model.Buffers,
     ) !Session {
         const seed: u128 = @intCast(std.Io.Clock.now(.real, io).toNanoseconds());
+        var cache_buffers = try compiled_model.params.cache.initBuffers(allocator, io, platform, compiled_model.params.shardings.model);
+        errdefer model.Cache.unloadBuffers(&cache_buffers);
+        var rng_buf = try zml.Tensor.Rng.initBuffer(io, platform, .replicated, seed);
+        errdefer zml.Tensor.Rng.deinitBuffer(&rng_buf);
+        const generated_token_slice = try zml.Slice.alloc(allocator, zml.Shape.init(.{ .batch = 1, .seq = 1 }, .u32));
+        errdefer generated_token_slice.free(allocator);
+
+        var prefill = try inference.KernelRunner.init(allocator, &compiled_model.prefill, model_buffers);
+        errdefer prefill.deinit(allocator);
+        const decode = try inference.KernelRunner.init(allocator, &compiled_model.decode, model_buffers);
+
         return .{
             .allocator = allocator,
             .io = io,
             .platform = platform,
-            .model_buffers = model_buffers,
             .compiled_model = compiled_model,
+            .prefill = prefill,
+            .decode = decode,
             .tokenizer = tokenizer,
             .config = &compiled_model.loaded_model.parsed_config.value,
             .seqlen = compiled_model.params.seqlen,
-            .cache_buffers = try compiled_model.params.cache.initBuffers(allocator, io, platform, compiled_model.params.shardings.model),
-            .rng_buf = try zml.Tensor.Rng.initBuffer(io, platform, .replicated, seed),
-            .generated_token_slice = try .alloc(allocator, zml.Shape.init(.{ .batch = 1, .seq = 1 }, .u32)),
+            .cache_buffers = cache_buffers,
+            .rng_buf = rng_buf,
+            .generated_token_slice = generated_token_slice,
             .think_start = tokenizer.tokenId("<think>") orelse unreachable,
             .think_end = tokenizer.tokenId("</think>") orelse unreachable,
         };
     }
 
     pub fn deinit(self: *Session) void {
+        self.prefill.deinit(self.allocator);
+        self.decode.deinit(self.allocator);
         model.Cache.unloadBuffers(&self.cache_buffers);
         zml.Tensor.Rng.deinitBuffer(&self.rng_buf);
         self.generated_token_slice.free(self.allocator);
@@ -123,18 +138,20 @@ pub const Session = struct {
         };
         defer zml.attention.Metadata.deinitBuffer(&attention_metadata_buffers);
 
-        try self.compiled_model.prefill.run(.{
-            .allocator = self.allocator,
+        var conv_cache_index_buffer: zml.Buffer = try .scalar(self.io, self.platform, 0, .u32);
+        defer conv_cache_index_buffer.deinit();
+        var kv_cache_index_buffer: zml.Buffer = try .scalar(self.io, self.platform, 0, .u32);
+        defer kv_cache_index_buffer.deinit();
+
+        inference.run(&self.prefill, .{
             .io = self.io,
-            .platform = self.platform,
-            .model_buffers = self.model_buffers,
             .tokens_buf = &tokens_buf,
             .tokens_pos_buf = &tokens_pos_buf,
             .actual_seq_len_buf = &actual_seq_len_buf,
             .rng_buf = &self.rng_buf,
             .cache_buffers = &self.cache_buffers,
             .attention_metadata_buffers = attention_metadata_buffers,
-        });
+        }, &conv_cache_index_buffer, &kv_cache_index_buffer);
 
         try tokens_buf.toSlice(self.io, tokens_slice);
         self.generated_token_slice.items(u32)[0] = tokens_slice.items(u32)[all_tokens.len - 1];
@@ -180,18 +197,20 @@ pub const Session = struct {
             var token_pos_buffer: zml.Buffer = try .fromSlice(self.io, self.platform, token_pos_slice, .replicated);
             defer token_pos_buffer.deinit();
 
-            try self.compiled_model.decode.run(.{
-                .allocator = self.allocator,
+            var conv_cache_index_buffer: zml.Buffer = try .scalar(self.io, self.platform, 0, .u32);
+            defer conv_cache_index_buffer.deinit();
+            var kv_cache_index_buffer: zml.Buffer = try .scalar(self.io, self.platform, 0, .u32);
+            defer kv_cache_index_buffer.deinit();
+
+            inference.run(&self.decode, .{
                 .io = self.io,
-                .platform = self.platform,
-                .model_buffers = self.model_buffers,
                 .tokens_buf = &current_token_buffer,
                 .tokens_pos_buf = &token_pos_buffer,
                 .actual_seq_len_buf = &actual_seq_len_buf,
                 .rng_buf = &self.rng_buf,
                 .cache_buffers = &self.cache_buffers,
                 .attention_metadata_buffers = attention_metadata_buffers,
-            });
+            }, &conv_cache_index_buffer, &kv_cache_index_buffer);
 
             try current_token_buffer.toSlice(self.io, self.generated_token_slice);
         }

--- a/examples/llm/models/lfm2_tests.zig
+++ b/examples/llm/models/lfm2_tests.zig
@@ -155,7 +155,10 @@ const TestContext = struct {
         var out_buffer_expected = try loadBufferFromStore(self.allocator, self.io, self.platform, self.activations_store, out_key, self.sharding);
         defer out_buffer_expected.deinit();
 
-        const exe = try self.platform.compileFn(self.allocator, self.io, @TypeOf(layer).forward, .{ layer, in_tensor }, .{ .shardings = &.{self.sharding} });
+        const exe = if (comptime @TypeOf(layer) == model.TokenEmbedding)
+            try self.platform.compileFn(self.allocator, self.io, model.TokenEmbedding.forward, .{.{ .embedding = layer, .tokens = in_tensor }}, .{ .shardings = &.{self.sharding} })
+        else
+            try self.platform.compileFn(self.allocator, self.io, @TypeOf(layer).forward, .{ layer, in_tensor }, .{ .shardings = &.{self.sharding} });
         defer exe.deinit();
 
         var args = try exe.args(self.allocator);

--- a/examples/llm/models/llama/inference.zig
+++ b/examples/llm/models/llama/inference.zig
@@ -67,10 +67,7 @@ pub const CompilationParameters = struct {
 pub const CompilationOptions = CompilationParameters;
 
 pub const Args = struct {
-    allocator: std.mem.Allocator,
     io: std.Io,
-    platform: *const zml.Platform,
-    model_buffers: *model.Buffers,
     tokens_buf: *zml.Buffer,
     token_index_buf: *zml.Buffer,
     kv_cache_buffers: *zml.Bufferized(model.KvCache),
@@ -93,10 +90,14 @@ pub const CompiledModel = struct {
         parameters: CompilationParameters,
         progress: *std.Progress.Node,
     ) !CompiledModel {
+        const prefill = try compileKernel(allocator, io, platform, llama_model, parameters, @intCast(parameters.prefill_tokens.dim(.s)), parameters.prefill_attention_parameters, .prefill, progress);
+        errdefer prefill.deinit();
+        const decode = try compileKernel(allocator, io, platform, llama_model, parameters, @intCast(parameters.decode_tokens.dim(.s)), parameters.decode_attention_parameters, .decode, progress);
+
         return .{
             .loaded_model = loaded_model,
-            .prefill = try KernelExe.init(allocator, io, platform, llama_model, parameters, @intCast(parameters.prefill_tokens.dim(.s)), parameters.prefill_attention_parameters, .prefill, progress),
-            .decode = try KernelExe.init(allocator, io, platform, llama_model, parameters, @intCast(parameters.decode_tokens.dim(.s)), parameters.decode_attention_parameters, .decode, progress),
+            .prefill = prefill,
+            .decode = decode,
             .params = parameters,
         };
     }
@@ -109,489 +110,227 @@ pub const CompiledModel = struct {
 
 pub const Inference = CompiledModel;
 
+pub const EmbedExe = zml.TypedExe(model.EmbedTokens.forward);
+pub const LayerExe = zml.TypedExe(model.TransformerLayer.forward);
+pub const SampleExe = zml.TypedExe(model.LmHead.forward);
+
 pub const KernelExe = struct {
-    composed: ComposedKernelExe,
+    embed: EmbedExe,
+    layer: LayerExe,
+    sample: SampleExe,
 
-    pub const Runner = struct {
-        exe: *const ComposedKernelExe,
-        embed_args: zml.exe.Exe.Arguments,
-        embed_results: zml.exe.Exe.Results,
-        layers: Layers,
-        lm_head_args: zml.exe.Exe.Arguments,
-        lm_head_results: zml.exe.Exe.Results,
-
-        const Layers = struct {
-            args: []zml.exe.Exe.Arguments,
-            results: []zml.exe.Exe.Results,
-            kv_cache_indices: []zml.Buffer,
-
-            fn init(
-                allocator: std.mem.Allocator,
-                io: std.Io,
-                platform: *const zml.Platform,
-                exe: *const ComposedKernelExe,
-                model_buffers: *model.Buffers,
-            ) !Layers {
-                const args = try allocator.alloc(zml.exe.Exe.Arguments, model_buffers.model.layers.len);
-                errdefer allocator.free(args);
-
-                const results = try allocator.alloc(zml.exe.Exe.Results, model_buffers.model.layers.len);
-                errdefer allocator.free(results);
-
-                const kv_cache_indices = try allocator.alloc(zml.Buffer, model_buffers.model.layers.len);
-                errdefer allocator.free(kv_cache_indices);
-
-                var initialized_args: usize = 0;
-                errdefer {
-                    for (args[0..initialized_args]) |*exe_args| {
-                        exe_args.deinit(allocator);
-                    }
-                }
-
-                var initialized_results: usize = 0;
-                errdefer {
-                    for (results[0..initialized_results]) |*exe_results| {
-                        exe_results.deinit(allocator);
-                    }
-                }
-
-                var initialized_kv_cache_indices: usize = 0;
-                errdefer {
-                    for (kv_cache_indices[0..initialized_kv_cache_indices]) |*kv_cache_index| {
-                        kv_cache_index.deinit();
-                    }
-                }
-
-                for (model_buffers.model.layers, 0..) |layer_bufs, i| {
-                    args[i] = try exe.layer.args(allocator);
-                    initialized_args = i + 1;
-                    args[i].bake(layer_bufs);
-
-                    results[i] = try exe.layer.results(allocator);
-                    initialized_results = i + 1;
-
-                    kv_cache_indices[i] = try zml.Buffer.scalar(io, platform, i, .u32);
-                    initialized_kv_cache_indices = i + 1;
-                }
-
-                return .{ .args = args, .results = results, .kv_cache_indices = kv_cache_indices };
-            }
-
-            fn deinit(self: *Layers, allocator: std.mem.Allocator) void {
-                for (self.args) |*exe_args| {
-                    exe_args.deinit(allocator);
-                }
-                allocator.free(self.args);
-
-                for (self.results) |*exe_results| {
-                    exe_results.deinit(allocator);
-                }
-                allocator.free(self.results);
-
-                for (self.kv_cache_indices) |*kv_cache_index| {
-                    kv_cache_index.deinit();
-                }
-                allocator.free(self.kv_cache_indices);
-            }
-        };
-
-        pub fn init(
-            allocator: std.mem.Allocator,
-            io: std.Io,
-            platform: *const zml.Platform,
-            exe: *const ComposedKernelExe,
-            model_buffers: *model.Buffers,
-        ) !Runner {
-            var embed_args = try exe.embed_tokens.args(allocator);
-            errdefer embed_args.deinit(allocator);
-
-            embed_args.bake(ComposedKernelExe.embedTokensBuffers(model_buffers));
-
-            var embed_results = try exe.embed_tokens.results(allocator);
-            errdefer embed_results.deinit(allocator);
-
-            var layers = try Layers.init(allocator, io, platform, exe, model_buffers);
-            errdefer layers.deinit(allocator);
-
-            var lm_head_args = try exe.lm_head.args(allocator);
-            errdefer lm_head_args.deinit(allocator);
-
-            lm_head_args.bake(ComposedKernelExe.lmHeadBuffers(model_buffers));
-
-            var lm_head_results = try exe.lm_head.results(allocator);
-            errdefer lm_head_results.deinit(allocator);
-
-            return .{
-                .exe = exe,
-                .embed_args = embed_args,
-                .embed_results = embed_results,
-                .layers = layers,
-                .lm_head_args = lm_head_args,
-                .lm_head_results = lm_head_results,
-            };
-        }
-
-        pub fn deinit(self: *Runner, allocator: std.mem.Allocator) void {
-            self.embed_args.deinit(allocator);
-            self.embed_results.deinit(allocator);
-            self.layers.deinit(allocator);
-            self.lm_head_args.deinit(allocator);
-            self.lm_head_results.deinit(allocator);
-        }
-
-        pub fn run(self: *Runner, args: Args) !void {
-            var hidden_buf: zml.Buffer = b: {
-                self.embed_args.set(.{args.tokens_buf});
-                self.exe.embed_tokens.call(self.embed_args, &self.embed_results);
-
-                break :b self.embed_results.get(zml.Buffer);
-            };
-            defer hidden_buf.deinit();
-
-            for (self.layers.args, self.layers.results, self.layers.kv_cache_indices) |*exe_args, *results, *kv_cache_index_buf| {
-                self.exe.runLayer(exe_args, results, args, &hidden_buf, kv_cache_index_buf);
-            }
-
-            self.exe.runLmHead(&self.lm_head_args, &self.lm_head_results, args, &hidden_buf);
-        }
-    };
-
-    pub fn init(
-        allocator: std.mem.Allocator,
-        io: std.Io,
-        platform: *const zml.Platform,
-        llama_model: model.Model,
-        parameters: CompilationOptions,
-        seqlen: usize,
-        attention_parameters: zml.attention.Parameters,
-        phase: Phase,
-        progress: *std.Progress.Node,
-    ) !KernelExe {
-        return .{
-            .composed = try ComposedKernelExe.init(allocator, io, platform, llama_model, parameters, seqlen, attention_parameters, phase, progress),
-        };
-    }
-
-    pub fn deinit(self: KernelExe) void {
-        self.composed.deinit();
-    }
-
-    pub fn run(self: *const KernelExe, args: Args) !void {
-        try self.composed.run(args);
-    }
-
-    pub fn initRunner(
-        self: *const KernelExe,
-        allocator: std.mem.Allocator,
-        io: std.Io,
-        platform: *const zml.Platform,
-        model_buffers: *model.Buffers,
-    ) !Runner {
-        return .init(allocator, io, platform, &self.composed, model_buffers);
-    }
-};
-
-const ComposedKernelExe = struct {
-    embed_tokens: zml.Exe,
-    layer: zml.Exe,
-    lm_head: zml.Exe,
-
-    const EmbedTokens = struct {
-        embed_tokens: zml.nn.TokenEmbedding,
-
-        pub fn forward(self: EmbedTokens, tokens_: zml.Tensor) zml.Tensor {
-            const tokens = tokens_.withPartialTags(.{.s});
-            return self.embed_tokens.forward(tokens)
-                .withPartialTags(.{.d})
-                .withPartitioning(.{ .d = .replicated });
-        }
-    };
-
-    fn init(
-        allocator: std.mem.Allocator,
-        io: std.Io,
-        platform: *const zml.Platform,
-        llama_model: model.Model,
-        parameters: CompilationOptions,
-        seqlen: usize,
-        attention_parameters: zml.attention.Parameters,
-        phase: Phase,
-        progress: *std.Progress.Node,
-    ) !ComposedKernelExe {
-        const embed_tokens = try ComposedKernelExe.compileEmbedTokens(allocator, io, platform, llama_model.model.embed_tokens, parameters, seqlen, phase, progress);
-        errdefer embed_tokens.deinit();
-
-        const layer = try ComposedKernelExe.compileLayer(allocator, io, platform, llama_model, parameters, seqlen, attention_parameters, phase, progress);
-        errdefer layer.deinit();
-
-        const lm_head = try ComposedKernelExe.compileLmHead(allocator, io, platform, llama_model, parameters, seqlen, phase, progress);
-        errdefer lm_head.deinit();
-
-        return .{
-            .embed_tokens = embed_tokens,
-            .layer = layer,
-            .lm_head = lm_head,
-        };
-    }
-
-    fn deinit(self: ComposedKernelExe) void {
-        self.embed_tokens.deinit();
+    pub fn deinit(self: *const KernelExe) void {
+        self.embed.deinit();
         self.layer.deinit();
-        self.lm_head.deinit();
-    }
-
-    fn run(self: *const ComposedKernelExe, args: Args) !void {
-        var hidden_buf: zml.Buffer = b: {
-            var exe_args = try self.embed_tokens.args(args.allocator);
-            defer exe_args.deinit(args.allocator);
-
-            var results = try self.embed_tokens.results(args.allocator);
-            defer results.deinit(args.allocator);
-
-            exe_args.bake(ComposedKernelExe.embedTokensBuffers(args.model_buffers));
-            exe_args.set(.{args.tokens_buf});
-
-            self.embed_tokens.call(exe_args, &results);
-
-            break :b results.get(zml.Buffer);
-        };
-        defer hidden_buf.deinit();
-
-        for (args.model_buffers.model.layers, 0..) |layer_bufs, i| {
-            var exe_args = try self.layer.args(args.allocator);
-            defer exe_args.deinit(args.allocator);
-
-            var results = try self.layer.results(args.allocator);
-            defer results.deinit(args.allocator);
-
-            var kv_cache_index_buf: zml.Buffer = try .scalar(args.io, args.platform, i, .u32);
-            defer kv_cache_index_buf.deinit();
-
-            exe_args.bake(layer_bufs);
-
-            self.runLayer(&exe_args, &results, args, &hidden_buf, &kv_cache_index_buf);
-        }
-
-        {
-            var exe_args = try self.lm_head.args(args.allocator);
-            defer exe_args.deinit(args.allocator);
-
-            var results = try self.lm_head.results(args.allocator);
-            defer results.deinit(args.allocator);
-
-            exe_args.bake(ComposedKernelExe.lmHeadBuffers(args.model_buffers));
-
-            self.runLmHead(&exe_args, &results, args, &hidden_buf);
-        }
-    }
-
-    fn runLayer(
-        self: *const ComposedKernelExe,
-        exe_args: *zml.exe.Exe.Arguments,
-        results: *zml.exe.Exe.Results,
-        args: Args,
-        hidden_buf: *zml.Buffer,
-        kv_cache_index_buf: *zml.Buffer,
-    ) void {
-        exe_args.set(.{
-            hidden_buf,
-            args.token_index_buf,
-            args.kv_cache_buffers,
-            kv_cache_index_buf,
-            args.attention_metadata_buffers,
-        });
-
-        self.layer.call(exe_args.*, results);
-
-        var new_hidden, var new_kv_cache = results.get(struct {
-            zml.Buffer,
-            zml.Bufferized(model.KvCache),
-        });
-
-        ComposedKernelExe.replaceBuffer(hidden_buf, &new_hidden);
-        ComposedKernelExe.replaceKvCacheBuffers(args.kv_cache_buffers, &new_kv_cache);
-    }
-
-    fn runLmHead(
-        self: *const ComposedKernelExe,
-        exe_args: *zml.exe.Exe.Arguments,
-        results: *zml.exe.Exe.Results,
-        args: Args,
-        hidden_buf: *zml.Buffer,
-    ) void {
-        exe_args.set(.{ hidden_buf, args.tokens_buf, args.rng_buffers });
-        self.lm_head.call(exe_args.*, results);
-
-        var new_tokens, var new_rng = results.get(struct {
-            zml.Buffer,
-            zml.Bufferized(zml.Tensor.Rng),
-        });
-
-        ComposedKernelExe.replaceBuffer(args.tokens_buf, &new_tokens);
-        ComposedKernelExe.replaceBuffer(&args.rng_buffers._state, &new_rng._state);
-    }
-
-    fn embedTokensBuffers(model_buffers: *const model.Buffers) zml.Bufferized(EmbedTokens) {
-        return .{
-            .embed_tokens = model_buffers.model.embed_tokens,
-        };
-    }
-
-    fn lmHeadBuffers(model_buffers: *const model.Buffers) zml.Bufferized(model.LmHead) {
-        return .{
-            .lm_head = model_buffers.lm_head,
-            .embed_tokens = model_buffers.model.embed_tokens,
-            .norm = model_buffers.model.norm,
-        };
-    }
-
-    fn replaceKvCacheBuffers(dst: *zml.Bufferized(model.KvCache), src: *zml.Bufferized(model.KvCache)) void {
-        ComposedKernelExe.replaceBuffer(&dst.k, &src.k);
-        ComposedKernelExe.replaceBuffer(&dst.v, &src.v);
-    }
-
-    fn replaceBuffer(dst: *zml.Buffer, src: *zml.Buffer) void {
-        if (!ComposedKernelExe.sameBufferHandle(dst.*, src.*)) {
-            dst.deinit();
-        }
-
-        dst.* = src.*;
-    }
-
-    fn sameBufferHandle(a: zml.Buffer, b: zml.Buffer) bool {
-        if (a._shards.len != b._shards.len) return false;
-
-        for (a._shards.constSlice(), b._shards.constSlice()) |a_shard, b_shard| {
-            if (a_shard != b_shard) return false;
-        }
-
-        return true;
-    }
-
-    fn compileEmbedTokens(
-        allocator: std.mem.Allocator,
-        io: std.Io,
-        platform: *const zml.Platform,
-        embed_tokens: zml.nn.TokenEmbedding,
-        parameters: CompilationOptions,
-        seqlen: usize,
-        phase: Phase,
-        progress: *std.Progress.Node,
-    ) !zml.Exe {
-        progress.increaseEstimatedTotalItems(1);
-        var node = progress.start(phase.startMessage("embed_tokens"), 1);
-        defer node.end();
-
-        const from: std.Io.Timestamp = .now(io, .awake);
-        defer phase.logCompileDone(log, "embed_tokens", io, from);
-
-        const tokens: zml.Tensor = .init(.{ .s = seqlen }, .u32);
-
-        return platform.compile(allocator, io, EmbedTokens{ .embed_tokens = embed_tokens }, .forward, .{tokens}, .{
-            .shardings = &parameters.shardings.all(),
-            .program_name = phase.programName("llama", "embed_tokens"),
-        });
-    }
-
-    fn compileLayer(
-        allocator: std.mem.Allocator,
-        io: std.Io,
-        platform: *const zml.Platform,
-        llama_model: model.Model,
-        parameters: CompilationOptions,
-        seqlen: usize,
-        attention_parameters: zml.attention.Parameters,
-        phase: Phase,
-        progress: *std.Progress.Node,
-    ) !zml.Exe {
-        const Layer = struct {
-            layer: model.TransformerLayer,
-
-            pub fn forward(
-                self: @This(),
-                hidden: zml.Tensor,
-                token_index: zml.Tensor,
-                kv_cache: model.KvCache,
-                kv_cache_index: zml.Tensor,
-                attention_metadata: zml.attention.Metadata,
-                attention_parameters_: zml.attention.Parameters,
-            ) struct { zml.Tensor, model.KvCache } {
-                const new_hidden, const new_kv_cache, _ = self.layer.forward(
-                    hidden,
-                    token_index,
-                    kv_cache,
-                    kv_cache_index,
-                    attention_metadata,
-                    attention_parameters_,
-                );
-
-                return .{ new_hidden, new_kv_cache };
-            }
-        };
-
-        progress.increaseEstimatedTotalItems(1);
-
-        var node = progress.start(phase.startMessage("transformer layer"), 1);
-        defer node.end();
-
-        const from: std.Io.Timestamp = .now(io, .awake);
-        defer phase.logCompileDone(log, "transformer layer", io, from);
-
-        const hidden: zml.Tensor = .fromShape(zml.Shape.init(
-            .{ .s = seqlen, .d = llama_model.config.hidden_size },
-            llama_model.model.embed_tokens.weight.dtype(),
-        ).withPartitioning(.{ .d = .replicated }));
-
-        const kv_cache_index: zml.Tensor = .init(.{}, .u32);
-
-        return platform.compile(
-            allocator,
-            io,
-            Layer{ .layer = llama_model.model.layers[0] },
-            .forward,
-            .{
-                hidden,
-                parameters.token_index,
-                parameters.kv_cache,
-                kv_cache_index,
-                parameters.attention_metadata,
-                attention_parameters,
-            },
-            .{
-                .shardings = &parameters.shardings.all(),
-                .program_name = phase.programName("llama", "layer"),
-            },
-        );
-    }
-
-    fn compileLmHead(
-        allocator: std.mem.Allocator,
-        io: std.Io,
-        platform: *const zml.Platform,
-        llama_model: model.Model,
-        parameters: CompilationOptions,
-        seqlen: usize,
-        phase: Phase,
-        progress: *std.Progress.Node,
-    ) !zml.Exe {
-        progress.increaseEstimatedTotalItems(1);
-
-        var node = progress.start(phase.startMessage("lm_head"), 1);
-        defer node.end();
-
-        const from: std.Io.Timestamp = .now(io, .awake);
-        defer phase.logCompileDone(log, "lm_head", io, from);
-
-        const hidden: zml.Tensor = .fromShape(zml.Shape.init(
-            .{ .s = seqlen, .d = llama_model.config.hidden_size },
-            llama_model.model.embed_tokens.weight.dtype(),
-        ).withPartitioning(.{ .d = .replicated }));
-
-        const tokens: zml.Tensor = .init(.{ .s = seqlen }, .u32);
-
-        return platform.compile(allocator, io, model.LmHead.init(llama_model), .forward, .{ hidden, tokens, parameters.rng }, .{
-            .shardings = &parameters.shardings.all(),
-            .program_name = phase.programName("llama", "lm_head"),
-        });
+        self.sample.deinit();
     }
 };
+
+pub const KernelRunner = struct {
+    embed: EmbedExe.Runner(.{.embedding}),
+    layers: []LayerExe.Runner(.{.layer}),
+    sample: SampleExe.Runner(.{.lm_head}),
+
+    pub fn init(allocator: std.mem.Allocator, exe: *const KernelExe, buffers: *const model.Buffers) !KernelRunner {
+        var embed = try EmbedExe.Runner(.{.embedding}).init(&exe.embed, allocator, .{
+            .embedding = .{ .embed_tokens = buffers.model.embed_tokens },
+        });
+        errdefer embed.deinit(allocator);
+
+        const layers = try allocator.alloc(LayerExe.Runner(.{.layer}), buffers.model.layers.len);
+        errdefer allocator.free(layers);
+        var initialized_layers: usize = 0;
+        errdefer for (layers[0..initialized_layers]) |*layer| layer.deinit(allocator);
+        for (layers, buffers.model.layers) |*layer, layer_buffers| {
+            layer.* = try LayerExe.Runner(.{.layer}).init(&exe.layer, allocator, .{ .layer = layer_buffers });
+            initialized_layers += 1;
+        }
+
+        var sample = try SampleExe.Runner(.{.lm_head}).init(&exe.sample, allocator, .{
+            .lm_head = .{
+                .lm_head = buffers.lm_head,
+                .embed_tokens = buffers.model.embed_tokens,
+                .norm = buffers.model.norm,
+            },
+        });
+        errdefer sample.deinit(allocator);
+
+        return .{ .embed = embed, .layers = layers, .sample = sample };
+    }
+
+    pub fn deinit(self: *KernelRunner, allocator: std.mem.Allocator) void {
+        self.embed.deinit(allocator);
+        for (self.layers) |*layer| layer.deinit(allocator);
+        allocator.free(self.layers);
+        self.sample.deinit(allocator);
+    }
+};
+
+pub fn run(runner: *KernelRunner, args: Args, kv_cache_index_buffers: []const zml.Buffer) void {
+    var hidden_buffer: zml.Buffer = undefined;
+    runner.embed.run(args.io, .{
+        .inputs = .{
+            .tokens = args.tokens_buf.*,
+        },
+        .outputs = .{ .hidden = &hidden_buffer },
+    });
+    defer hidden_buffer.deinit();
+
+    for (runner.layers, kv_cache_index_buffers) |*layer, kv_cache_index_buffer| {
+        layer.run(args.io, .{
+            .inputs = .{
+                .hidden = hidden_buffer,
+                .token_index = args.token_index_buf.*,
+                .kv_cache = args.kv_cache_buffers.*,
+                .kv_cache_index = kv_cache_index_buffer,
+                .attention_metadata = args.attention_metadata_buffers.*,
+            },
+            .outputs = .{
+                .hidden = &hidden_buffer,
+                .kv_cache = args.kv_cache_buffers,
+            },
+        });
+    }
+
+    runner.sample.run(args.io, .{
+        .inputs = .{
+            .hidden = hidden_buffer,
+            .tokens = args.tokens_buf.*,
+            .rng = args.rng_buffers.*,
+        },
+        .outputs = .{
+            .tokens = args.tokens_buf,
+            .rng = args.rng_buffers,
+        },
+    });
+}
+
+fn compileKernel(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    platform: *const zml.Platform,
+    llama_model: model.Model,
+    parameters: CompilationOptions,
+    seqlen: usize,
+    attention_parameters: zml.attention.Parameters,
+    phase: Phase,
+    progress: *std.Progress.Node,
+) !KernelExe {
+    const embed = try compileEmbed(allocator, io, platform, llama_model.model.embed_tokens, parameters, seqlen, phase, progress);
+    errdefer embed.deinit();
+    const layer = try compileLayer(allocator, io, platform, llama_model, parameters, seqlen, attention_parameters, phase, progress);
+    errdefer layer.deinit();
+    const sample = try compileSample(allocator, io, platform, llama_model, parameters, seqlen, phase, progress);
+    errdefer sample.deinit();
+    return .{ .embed = embed, .layer = layer, .sample = sample };
+}
+
+fn compileEmbed(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    platform: *const zml.Platform,
+    embed_tokens: zml.nn.TokenEmbedding,
+    parameters: CompilationOptions,
+    seqlen: usize,
+    phase: Phase,
+    progress: *std.Progress.Node,
+) !EmbedExe {
+    progress.increaseEstimatedTotalItems(1);
+    var node = progress.start(phase.startMessage("embed_tokens"), 1);
+    defer node.end();
+
+    const from: std.Io.Timestamp = .now(io, .awake);
+    defer phase.logCompileDone(log, "embed_tokens", io, from);
+
+    const tokens: zml.Tensor = .init(.{ .s = seqlen }, .u32);
+
+    return EmbedExe.compile(allocator, io, platform, .{
+        .shardings = &parameters.shardings.all(),
+        .program_name = phase.programName("llama", "embed_tokens"),
+    }, .{.{
+        .embedding = .{ .embed_tokens = embed_tokens },
+        .tokens = tokens,
+    }});
+}
+
+fn compileLayer(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    platform: *const zml.Platform,
+    llama_model: model.Model,
+    parameters: CompilationOptions,
+    seqlen: usize,
+    attention_parameters: zml.attention.Parameters,
+    phase: Phase,
+    progress: *std.Progress.Node,
+) !LayerExe {
+    progress.increaseEstimatedTotalItems(1);
+
+    var node = progress.start(phase.startMessage("transformer layer"), 1);
+    defer node.end();
+
+    const from: std.Io.Timestamp = .now(io, .awake);
+    defer phase.logCompileDone(log, "transformer layer", io, from);
+
+    const hidden: zml.Tensor = .fromShape(zml.Shape.init(
+        .{ .s = seqlen, .d = llama_model.config.hidden_size },
+        llama_model.model.embed_tokens.weight.dtype(),
+    ).withPartitioning(.{ .d = .replicated }));
+
+    const kv_cache_index: zml.Tensor = .init(.{}, .u32);
+
+    return LayerExe.compile(
+        allocator,
+        io,
+        platform,
+        .{
+            .shardings = &parameters.shardings.all(),
+            .program_name = phase.programName("llama", "layer"),
+        },
+        .{.{
+            .layer = llama_model.model.layers[0],
+            .hidden = hidden,
+            .token_index = parameters.token_index,
+            .kv_cache = parameters.kv_cache,
+            .kv_cache_index = kv_cache_index,
+            .attention_metadata = parameters.attention_metadata,
+            .attention_parameters = attention_parameters,
+        }},
+    );
+}
+
+fn compileSample(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    platform: *const zml.Platform,
+    llama_model: model.Model,
+    parameters: CompilationOptions,
+    seqlen: usize,
+    phase: Phase,
+    progress: *std.Progress.Node,
+) !SampleExe {
+    progress.increaseEstimatedTotalItems(1);
+
+    var node = progress.start(phase.startMessage("lm_head"), 1);
+    defer node.end();
+
+    const from: std.Io.Timestamp = .now(io, .awake);
+    defer phase.logCompileDone(log, "lm_head", io, from);
+
+    const hidden: zml.Tensor = .fromShape(zml.Shape.init(
+        .{ .s = seqlen, .d = llama_model.config.hidden_size },
+        llama_model.model.embed_tokens.weight.dtype(),
+    ).withPartitioning(.{ .d = .replicated }));
+
+    const tokens: zml.Tensor = .init(.{ .s = seqlen }, .u32);
+
+    return SampleExe.compile(allocator, io, platform, .{
+        .shardings = &parameters.shardings.all(),
+        .program_name = phase.programName("llama", "lm_head"),
+    }, .{.{
+        .lm_head = model.LmHead.init(llama_model),
+        .hidden = hidden,
+        .tokens = tokens,
+        .rng = parameters.rng,
+    }});
+}

--- a/examples/llm/models/llama/model.zig
+++ b/examples/llm/models/llama/model.zig
@@ -221,9 +221,14 @@ pub const Model = struct {
             attention_parameters,
         );
 
-        const new_tokens, const new_rng = self.lmHead().forward(out, tokens, rng);
+        const sample = LmHead.forward(.{
+            .lm_head = self.lmHead(),
+            .hidden = out,
+            .tokens = tokens,
+            .rng = rng,
+        });
 
-        return .{ new_tokens, updated_kv_cache, new_rng };
+        return .{ sample.tokens, updated_kv_cache, sample.rng };
     }
 };
 
@@ -283,17 +288,41 @@ const Llama = struct {
         var kv_cache_index = zml.Tensor.scalar(0, .u32);
 
         for (self.layers) |layer| {
-            hidden, updated_kv_cache, kv_cache_index = layer.forward(
-                hidden,
-                token_index,
-                updated_kv_cache,
-                kv_cache_index,
-                attention_metadata,
-                attention_parameters,
-            );
+            const result = TransformerLayer.forward(.{
+                .layer = layer,
+                .hidden = hidden,
+                .token_index = token_index,
+                .kv_cache = updated_kv_cache,
+                .kv_cache_index = kv_cache_index,
+                .attention_metadata = attention_metadata,
+                .attention_parameters = attention_parameters,
+            });
+            hidden = result.hidden;
+            updated_kv_cache = result.kv_cache;
+            kv_cache_index = kv_cache_index.add(zml.Tensor.scalar(@as(u32, 1), .u32));
         }
 
         return .{ self.norm.forward(hidden), updated_kv_cache.reuseBuffer(kv_cache) };
+    }
+};
+
+pub const EmbedTokens = struct {
+    embed_tokens: zml.nn.TokenEmbedding,
+
+    pub const Input = struct {
+        embedding: EmbedTokens,
+        tokens: zml.Tensor,
+    };
+
+    pub const Output = struct {
+        hidden: zml.Tensor,
+    };
+
+    pub fn forward(input: Input) Output {
+        const tokens = input.tokens.withPartialTags(.{.s});
+        return .{ .hidden = input.embedding.embed_tokens.forward(tokens)
+            .withPartialTags(.{.d})
+            .withPartitioning(.{ .d = .replicated }) };
     }
 };
 
@@ -312,9 +341,22 @@ pub const LmHead = struct {
         };
     }
 
-    pub fn forward(self: LmHead, hidden_: zml.Tensor, tokens_: zml.Tensor, rng: zml.Tensor.Rng) struct { zml.Tensor, zml.Tensor.Rng } {
-        const tokens = tokens_.withPartialTags(.{.s});
-        const hidden = self.norm.forward(hidden_.withPartialTags(.{ .s, .d }));
+    pub const Input = struct {
+        lm_head: LmHead,
+        hidden: zml.Tensor,
+        tokens: zml.Tensor,
+        rng: zml.Tensor.Rng,
+    };
+
+    pub const Output = struct {
+        tokens: zml.Tensor,
+        rng: zml.Tensor.Rng,
+    };
+
+    pub fn forward(input: Input) Output {
+        const self = input.lm_head;
+        const tokens = input.tokens.withPartialTags(.{.s});
+        const hidden = self.norm.forward(input.hidden.withPartialTags(.{ .s, .d }));
 
         var logits = blk: {
             if (self.lm_head) |lm_head| {
@@ -327,8 +369,8 @@ pub const LmHead = struct {
         if (logits.shape().hasTag(.voc) == null)
             logits = logits.rename(.{ .d = .voc });
 
-        const next_tokens, const new_rng = zml.nn.sampleTokens(logits, self.gen_opts, rng);
-        return .{ next_tokens.convert(tokens.dtype()).reuseBuffer(tokens), new_rng };
+        const next_tokens, const new_rng = zml.nn.sampleTokens(logits, self.gen_opts, input.rng);
+        return .{ .tokens = next_tokens.convert(tokens.dtype()).reuseBuffer(tokens), .rng = new_rng };
     }
 };
 
@@ -354,15 +396,24 @@ pub const TransformerLayer = struct {
         Mlp.unloadBuffers(&self.mlp);
     }
 
-    pub fn forward(
-        self: TransformerLayer,
-        x0: zml.Tensor,
+    pub const Input = struct {
+        layer: TransformerLayer,
+        hidden: zml.Tensor,
         token_index: zml.Tensor,
         kv_cache: KvCache,
         kv_cache_index: zml.Tensor,
         attention_metadata: zml.attention.Metadata,
         attention_parameters: zml.attention.Parameters,
-    ) struct { zml.Tensor, KvCache, zml.Tensor } {
+    };
+
+    pub const Output = struct {
+        hidden: zml.Tensor,
+        kv_cache: KvCache,
+    };
+
+    pub fn forward(input: Input) Output {
+        const self = input.layer;
+        const x0 = input.hidden;
         // Self Attention
         //log.debug("TransformerLayer({f}) -> {f}", .{ x0, self.input_layernorm.forward(x0) });
         stdx.debug.assert(x0.rank() >= 2 and x0.shape().hasTags(.{ .s, .d }), "TransformerLayer expected input shape: {{..., .s, .d}}, received: {f}", .{x0});
@@ -372,13 +423,12 @@ pub const TransformerLayer = struct {
         const x0_normalized = self.input_layernorm.forward(x0_replicated);
         const delta0, const updated_kv_cache = self.self_attn.forward(
             x0_normalized,
-            token_index,
-            kv_cache,
-            kv_cache_index,
-            attention_metadata,
-            attention_parameters,
+            input.token_index,
+            input.kv_cache,
+            input.kv_cache_index,
+            input.attention_metadata,
+            input.attention_parameters,
         );
-        const updated_kv_cache_index = kv_cache_index.add(zml.Tensor.scalar(@as(u32, 1), .u32));
 
         // Fully Connected
         const x1 = x0_replicated.add(delta0).withPartitioning(.{ .d = .replicated });
@@ -389,7 +439,7 @@ pub const TransformerLayer = struct {
             .add(x1)
             .withPartitioning(.{ .d = .replicated });
 
-        return .{ x2.reuseBuffer(x0), updated_kv_cache, updated_kv_cache_index.reuseBuffer(kv_cache_index) };
+        return .{ .hidden = x2.reuseBuffer(x0), .kv_cache = updated_kv_cache };
     }
 };
 

--- a/examples/llm/models/llama/session.zig
+++ b/examples/llm/models/llama/session.zig
@@ -9,11 +9,12 @@ pub const Session = struct {
     allocator: std.mem.Allocator,
     io: std.Io,
     platform: *const zml.Platform,
-    model_buffers: *model.Buffers,
-    compiled_model: *const inference.CompiledModel,
-    decode_runner: inference.KernelExe.Runner,
+    compiled_model: *inference.CompiledModel,
+    prefill: inference.KernelRunner,
+    decode: inference.KernelRunner,
     kv_cache_buffers: zml.Bufferized(model.KvCache),
     token_index_buffers: []zml.Buffer,
+    kv_cache_index_buffers: []zml.Buffer,
     rng_buffers: zml.Bufferized(zml.Tensor.Rng),
     tokenizer: zml.tokenizer.Tokenizer,
     config: *const model.Config,
@@ -26,7 +27,7 @@ pub const Session = struct {
         io: std.Io,
         platform: *const zml.Platform,
         tokenizer: zml.tokenizer.Tokenizer,
-        compiled_model: *const inference.CompiledModel,
+        compiled_model: *inference.CompiledModel,
         model_buffers: *model.Buffers,
     ) !Session {
         const shardings = &compiled_model.params.shardings;
@@ -52,18 +53,29 @@ pub const Session = struct {
         var rng_buffers = try zml.Tensor.Rng.initBuffer(io, platform, .replicated, seed);
         errdefer zml.Tensor.Rng.deinitBuffer(&rng_buffers);
 
-        var decode_runner = try compiled_model.decode.initRunner(allocator, io, platform, model_buffers);
-        errdefer decode_runner.deinit(allocator);
+        const kv_cache_index_buffers = try allocator.alloc(zml.Buffer, model_buffers.model.layers.len);
+        errdefer allocator.free(kv_cache_index_buffers);
+        var initialized_kv_cache_index_buffers: usize = 0;
+        errdefer for (kv_cache_index_buffers[0..initialized_kv_cache_index_buffers]) |*buffer| buffer.deinit();
+        for (kv_cache_index_buffers, 0..) |*buffer, i| {
+            buffer.* = try .scalar(io, platform, i, .u32);
+            initialized_kv_cache_index_buffers = i + 1;
+        }
+
+        var prefill = try inference.KernelRunner.init(allocator, &compiled_model.prefill, model_buffers);
+        errdefer prefill.deinit(allocator);
+        const decode = try inference.KernelRunner.init(allocator, &compiled_model.decode, model_buffers);
 
         return .{
             .allocator = allocator,
             .io = io,
             .platform = platform,
-            .model_buffers = model_buffers,
             .compiled_model = compiled_model,
-            .decode_runner = decode_runner,
+            .prefill = prefill,
+            .decode = decode,
             .kv_cache_buffers = kv_cache_buffers,
             .token_index_buffers = token_index_buffers,
+            .kv_cache_index_buffers = kv_cache_index_buffers,
             .rng_buffers = rng_buffers,
             .tokenizer = tokenizer,
             .config = &compiled_model.loaded_model.parsed_config.value,
@@ -73,12 +85,15 @@ pub const Session = struct {
     }
 
     pub fn deinit(self: *Session) void {
-        self.decode_runner.deinit(self.allocator);
+        self.prefill.deinit(self.allocator);
+        self.decode.deinit(self.allocator);
         model.KvCache.deinitBuffer(&self.kv_cache_buffers);
         for (self.token_index_buffers) |*token_index_buffer| {
             token_index_buffer.deinit();
         }
         self.allocator.free(self.token_index_buffers);
+        for (self.kv_cache_index_buffers) |*buffer| buffer.deinit();
+        self.allocator.free(self.kv_cache_index_buffers);
         zml.Tensor.Rng.deinitBuffer(&self.rng_buffers);
     }
 
@@ -151,17 +166,14 @@ pub const Session = struct {
         };
         defer zml.attention.Metadata.deinitBuffer(&attention_metadata_buffers);
 
-        try self.compiled_model.prefill.run(.{
-            .allocator = self.allocator,
+        inference.run(&self.prefill, .{
             .io = self.io,
-            .platform = self.platform,
-            .model_buffers = self.model_buffers,
             .tokens_buf = &prefill_tokens_buffer,
             .token_index_buf = &self.token_index_buffers[0],
             .kv_cache_buffers = &self.kv_cache_buffers,
             .rng_buffers = &self.rng_buffers,
             .attention_metadata_buffers = &attention_metadata_buffers,
-        });
+        }, self.kv_cache_index_buffers);
         try prefill_tokens_buffer.toSlice(self.io, prefill_tokens_slice);
 
         self.last_generated_token = prefill_tokens_slice.items(u32)[all_tokens.len - 1];
@@ -198,17 +210,14 @@ pub const Session = struct {
             try all_tokens.append(self.allocator, last_token_id);
             if (all_tokens.items.len >= self.seqlen) break :generation;
 
-            try self.decode_runner.run(.{
-                .allocator = self.allocator,
+            inference.run(&self.decode, .{
                 .io = self.io,
-                .platform = self.platform,
-                .model_buffers = self.model_buffers,
                 .tokens_buf = &current_token_buffer,
                 .token_index_buf = &self.token_index_buffers[all_tokens.items.len],
                 .kv_cache_buffers = &self.kv_cache_buffers,
                 .rng_buffers = &self.rng_buffers,
                 .attention_metadata_buffers = &attention_metadata_buffers,
-            });
+            }, self.kv_cache_index_buffers);
             last_token_id = try current_token_buffer.getValue(u32, self.io);
         }
 

--- a/examples/llm/models/qwen3_5/inference.zig
+++ b/examples/llm/models/qwen3_5/inference.zig
@@ -34,10 +34,7 @@ pub const CompilationParameters = struct {
 pub const CompilationOptions = CompilationParameters;
 
 pub const Args = struct {
-    allocator: std.mem.Allocator,
     io: std.Io,
-    platform: *const zml.Platform,
-    model_buffers: *model.Buffers,
     tokens_buf: *zml.Buffer,
     token_index_buf: *zml.Buffer,
     kv_cache_buffers: *zml.Bufferized(model.KvCache),
@@ -59,28 +56,13 @@ pub const CompiledModel = struct {
         parameters: CompilationParameters,
         progress: *std.Progress.Node,
     ) !CompiledModel {
+        const prefill = try compileKernel(allocator, io, platform, qwen_model, parameters, @intCast(parameters.prefill_tokens.dim(.s)), .prefill, progress);
+        errdefer prefill.deinit();
+        const decode = try compileKernel(allocator, io, platform, qwen_model, parameters, @intCast(parameters.decode_tokens.dim(.s)), .decode, progress);
         return .{
             .loaded_model = loaded_model,
-            .prefill = try .init(
-                allocator,
-                io,
-                platform,
-                qwen_model,
-                parameters,
-                @intCast(parameters.prefill_tokens.dim(.s)),
-                .prefill,
-                progress,
-            ),
-            .decode = try .init(
-                allocator,
-                io,
-                platform,
-                qwen_model,
-                parameters,
-                @intCast(parameters.decode_tokens.dim(.s)),
-                .decode,
-                progress,
-            ),
+            .prefill = prefill,
+            .decode = decode,
             .params = parameters,
         };
     }
@@ -93,628 +75,243 @@ pub const CompiledModel = struct {
 
 pub const Inference = CompiledModel;
 
+pub const EmbedExe = zml.TypedExe(model.EmbedTokens.forward);
+pub const FullAttentionExe = zml.TypedExe(model.TransformerLayer.forwardSelfAttn);
+pub const LinearAttentionExe = zml.TypedExe(model.TransformerLayer.forwardLinearAttn);
+pub const SampleExe = zml.TypedExe(model.Sampler.sampleTokens);
+
 pub const KernelExe = struct {
-    composed: ComposedKernelExe,
+    embed: EmbedExe,
+    full_attention: FullAttentionExe,
+    linear_attention: LinearAttentionExe,
+    sample: SampleExe,
 
-    pub const Runner = struct {
-        exe: *const ComposedKernelExe,
-        embed_args: zml.exe.Exe.Arguments,
-        embed_results: zml.exe.Exe.Results,
-        layers: Layers,
-        sampler_args: zml.exe.Exe.Arguments,
-        sampler_results: zml.exe.Exe.Results,
-
-        const Layers = struct {
-            args: []zml.exe.Exe.Arguments,
-            results: []zml.exe.Exe.Results,
-            layer_indices: []zml.Buffer,
-            layer_types: []const model.LayerType,
-
-            fn init(
-                allocator: std.mem.Allocator,
-                io: std.Io,
-                platform: *const zml.Platform,
-                exe: *const ComposedKernelExe,
-                model_buffers: *model.Buffers,
-            ) !Layers {
-                const args = try allocator.alloc(zml.exe.Exe.Arguments, model_buffers.text_model.layers.len);
-                errdefer allocator.free(args);
-
-                const results = try allocator.alloc(zml.exe.Exe.Results, model_buffers.text_model.layers.len);
-                errdefer allocator.free(results);
-
-                const layer_indices = try allocator.alloc(zml.Buffer, model_buffers.text_model.layers.len);
-                errdefer allocator.free(layer_indices);
-
-                var initialized_args: usize = 0;
-                errdefer {
-                    for (args[0..initialized_args]) |*exe_args| {
-                        exe_args.deinit(allocator);
-                    }
-                }
-
-                var initialized_results: usize = 0;
-                errdefer {
-                    for (results[0..initialized_results]) |*exe_results| {
-                        exe_results.deinit(allocator);
-                    }
-                }
-
-                var initialized_layer_indices: usize = 0;
-                errdefer {
-                    for (layer_indices[0..initialized_layer_indices]) |*layer_index| {
-                        layer_index.deinit();
-                    }
-                }
-
-                var self_attn_layer_index: usize = 0;
-                var linear_attn_layer_index: usize = 0;
-                for (model_buffers.text_model.layers, exe.layer_types, 0..) |layer_bufs, layer_type, i| {
-                    args[i] = try switch (layer_type) {
-                        .full_attention => (exe.full_attention_layer orelse unreachable).args(allocator),
-                        .linear_attention => (exe.linear_attention_layer orelse unreachable).args(allocator),
-                    };
-                    initialized_args = i + 1;
-                    args[i].bake(layer_bufs);
-
-                    results[i] = try switch (layer_type) {
-                        .full_attention => (exe.full_attention_layer orelse unreachable).results(allocator),
-                        .linear_attention => (exe.linear_attention_layer orelse unreachable).results(allocator),
-                    };
-                    initialized_results = i + 1;
-
-                    layer_indices[i] = try switch (layer_type) {
-                        .full_attention => b: {
-                            defer self_attn_layer_index += 1;
-                            break :b zml.Buffer.scalar(io, platform, @as(u32, @intCast(self_attn_layer_index)), .u32);
-                        },
-                        .linear_attention => b: {
-                            defer linear_attn_layer_index += 1;
-                            break :b zml.Buffer.scalar(io, platform, @as(u32, @intCast(linear_attn_layer_index)), .u32);
-                        },
-                    };
-                    initialized_layer_indices = i + 1;
-                }
-
-                return .{
-                    .args = args,
-                    .results = results,
-                    .layer_indices = layer_indices,
-                    .layer_types = exe.layer_types,
-                };
-            }
-
-            fn deinit(self: *Layers, allocator: std.mem.Allocator) void {
-                for (self.args) |*exe_args| {
-                    exe_args.deinit(allocator);
-                }
-                allocator.free(self.args);
-
-                for (self.results) |*exe_results| {
-                    exe_results.deinit(allocator);
-                }
-                allocator.free(self.results);
-
-                for (self.layer_indices) |*layer_index| {
-                    layer_index.deinit();
-                }
-                allocator.free(self.layer_indices);
-            }
-        };
-
-        pub fn init(
-            allocator: std.mem.Allocator,
-            io: std.Io,
-            platform: *const zml.Platform,
-            exe: *const ComposedKernelExe,
-            model_buffers: *model.Buffers,
-        ) !Runner {
-            var embed_args = try exe.embed_tokens.args(allocator);
-            errdefer embed_args.deinit(allocator);
-            embed_args.bake(ComposedKernelExe.embedTokensBuffers(model_buffers));
-
-            var embed_results = try exe.embed_tokens.results(allocator);
-            errdefer embed_results.deinit(allocator);
-
-            var layers = try Layers.init(allocator, io, platform, exe, model_buffers);
-            errdefer layers.deinit(allocator);
-
-            var sampler_args = try exe.sampler.args(allocator);
-            errdefer sampler_args.deinit(allocator);
-            sampler_args.bake(ComposedKernelExe.samplerBuffers(model_buffers));
-
-            var sampler_results = try exe.sampler.results(allocator);
-            errdefer sampler_results.deinit(allocator);
-
-            return .{
-                .exe = exe,
-                .embed_args = embed_args,
-                .embed_results = embed_results,
-                .layers = layers,
-                .sampler_args = sampler_args,
-                .sampler_results = sampler_results,
-            };
-        }
-
-        pub fn deinit(self: *Runner, allocator: std.mem.Allocator) void {
-            self.embed_args.deinit(allocator);
-            self.embed_results.deinit(allocator);
-            self.layers.deinit(allocator);
-            self.sampler_args.deinit(allocator);
-            self.sampler_results.deinit(allocator);
-        }
-
-        pub fn run(self: *Runner, args: Args) !void {
-            var hidden_buf: zml.Buffer = b: {
-                self.embed_args.set(.{args.tokens_buf});
-                self.exe.embed_tokens.call(self.embed_args, &self.embed_results);
-
-                break :b self.embed_results.get(zml.Buffer);
-            };
-            defer hidden_buf.deinit();
-
-            for (
-                self.layers.args,
-                self.layers.results,
-                self.layers.layer_indices,
-                self.layers.layer_types,
-            ) |*exe_args, *results, *layer_index_buf, layer_type| {
-                self.exe.runLayer(exe_args, results, layer_type, args, &hidden_buf, layer_index_buf);
-            }
-
-            self.exe.runSampler(&self.sampler_args, &self.sampler_results, args, &hidden_buf);
-        }
-    };
-
-    pub fn init(
-        allocator: std.mem.Allocator,
-        io: std.Io,
-        platform: *const zml.Platform,
-        qwen_model: model.Model,
-        parameters: CompilationOptions,
-        seqlen: usize,
-        phase: Phase,
-        progress: *std.Progress.Node,
-    ) !KernelExe {
-        return .{
-            .composed = try .init(allocator, io, platform, qwen_model, parameters, seqlen, phase, progress),
-        };
-    }
-
-    pub fn deinit(self: KernelExe) void {
-        self.composed.deinit();
-    }
-
-    pub fn run(self: *const KernelExe, args: Args) !void {
-        try self.composed.run(args);
-    }
-
-    pub fn initRunner(
-        self: *const KernelExe,
-        allocator: std.mem.Allocator,
-        io: std.Io,
-        platform: *const zml.Platform,
-        model_buffers: *model.Buffers,
-    ) !Runner {
-        return .init(allocator, io, platform, &self.composed, model_buffers);
+    pub fn deinit(self: *const KernelExe) void {
+        self.embed.deinit();
+        self.full_attention.deinit();
+        self.linear_attention.deinit();
+        self.sample.deinit();
     }
 };
 
-const ComposedKernelExe = struct {
-    embed_tokens: zml.Exe,
-    full_attention_layer: ?zml.Exe,
-    linear_attention_layer: ?zml.Exe,
-    sampler: zml.Exe,
-    layer_types: []const model.LayerType,
-    phase: Phase,
+pub const LayerRunner = union(enum) {
+    full_attention: FullAttentionExe.Runner(.{.layer}),
+    linear_attention: LinearAttentionExe.Runner(.{.layer}),
 
-    const EmbedTokens = struct {
-        embed_tokens: zml.nn.TokenEmbedding,
-
-        pub fn forward(self: EmbedTokens, tokens_: zml.Tensor) zml.Tensor {
-            const tokens = tokens_.withPartialTags(.{.s});
-            return self.embed_tokens.forward(tokens)
-                .withPartialTags(.{.d})
-                .withPartitioning(.{ .d = .replicated });
-        }
-    };
-
-    fn init(
-        allocator: std.mem.Allocator,
-        io: std.Io,
-        platform: *const zml.Platform,
-        qwen_model: model.Model,
-        parameters: CompilationOptions,
-        seqlen: usize,
-        phase: Phase,
-        progress: *std.Progress.Node,
-    ) !ComposedKernelExe {
-        const embed_tokens = try ComposedKernelExe.compileEmbedTokens(allocator, io, platform, qwen_model.text_model.embed_tokens, parameters, seqlen, phase, progress);
-        errdefer embed_tokens.deinit();
-
-        const full_attention_layer: ?zml.Exe = b: {
-            const index = ComposedKernelExe.findFirstLayerIndex(qwen_model.config.text_config.layer_types, .full_attention) orelse break :b null;
-            break :b try ComposedKernelExe.compileFullAttentionLayer(allocator, io, platform, qwen_model, parameters, seqlen, index, phase, progress);
-        };
-        errdefer if (full_attention_layer) |exe| exe.deinit();
-
-        const linear_attention_layer: ?zml.Exe = b: {
-            const index = ComposedKernelExe.findFirstLayerIndex(qwen_model.config.text_config.layer_types, .linear_attention) orelse break :b null;
-            break :b try ComposedKernelExe.compileLinearAttentionLayer(allocator, io, platform, qwen_model, parameters, seqlen, index, phase, progress);
-        };
-        errdefer if (linear_attention_layer) |exe| exe.deinit();
-
-        const sampler = try ComposedKernelExe.compileSampler(allocator, io, platform, qwen_model, parameters, seqlen, phase, progress);
-        errdefer sampler.deinit();
-
-        return .{
-            .embed_tokens = embed_tokens,
-            .full_attention_layer = full_attention_layer,
-            .linear_attention_layer = linear_attention_layer,
-            .sampler = sampler,
-            .layer_types = qwen_model.config.text_config.layer_types,
-            .phase = phase,
-        };
-    }
-
-    fn deinit(self: ComposedKernelExe) void {
-        self.embed_tokens.deinit();
-        if (self.full_attention_layer) |exe| exe.deinit();
-        if (self.linear_attention_layer) |exe| exe.deinit();
-        self.sampler.deinit();
-    }
-
-    fn run(self: *const ComposedKernelExe, args: Args) !void {
-        var hidden_buf: zml.Buffer = b: {
-            var exe_args = try self.embed_tokens.args(args.allocator);
-            defer exe_args.deinit(args.allocator);
-
-            var results = try self.embed_tokens.results(args.allocator);
-            defer results.deinit(args.allocator);
-
-            exe_args.bake(ComposedKernelExe.embedTokensBuffers(args.model_buffers));
-            exe_args.set(.{args.tokens_buf});
-
-            self.embed_tokens.call(exe_args, &results);
-
-            break :b results.get(zml.Buffer);
-        };
-        defer hidden_buf.deinit();
-
-        var self_attn_layer_index: usize = 0;
-        var linear_attn_layer_index: usize = 0;
-        for (args.model_buffers.text_model.layers, self.layer_types) |layer_bufs, layer_type| {
-            var exe_args = try switch (layer_type) {
-                .full_attention => (self.full_attention_layer orelse unreachable).args(args.allocator),
-                .linear_attention => (self.linear_attention_layer orelse unreachable).args(args.allocator),
-            };
-            defer exe_args.deinit(args.allocator);
-            exe_args.bake(layer_bufs);
-
-            var results = try switch (layer_type) {
-                .full_attention => (self.full_attention_layer orelse unreachable).results(args.allocator),
-                .linear_attention => (self.linear_attention_layer orelse unreachable).results(args.allocator),
-            };
-            defer results.deinit(args.allocator);
-
-            var layer_index_buf: zml.Buffer = try switch (layer_type) {
-                .full_attention => b: {
-                    defer self_attn_layer_index += 1;
-                    break :b zml.Buffer.scalar(args.io, args.platform, @as(u32, @intCast(self_attn_layer_index)), .u32);
-                },
-                .linear_attention => b: {
-                    defer linear_attn_layer_index += 1;
-                    break :b zml.Buffer.scalar(args.io, args.platform, @as(u32, @intCast(linear_attn_layer_index)), .u32);
-                },
-            };
-            defer layer_index_buf.deinit();
-
-            self.runLayer(&exe_args, &results, layer_type, args, &hidden_buf, &layer_index_buf);
-        }
-
-        {
-            var exe_args = try self.sampler.args(args.allocator);
-            defer exe_args.deinit(args.allocator);
-
-            var results = try self.sampler.results(args.allocator);
-            defer results.deinit(args.allocator);
-
-            exe_args.bake(ComposedKernelExe.samplerBuffers(args.model_buffers));
-
-            self.runSampler(&exe_args, &results, args, &hidden_buf);
+    pub fn deinit(self: *LayerRunner, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            inline else => |*runner| runner.deinit(allocator),
         }
     }
+};
 
-    fn runLayer(
-        self: *const ComposedKernelExe,
-        exe_args: *zml.exe.Exe.Arguments,
-        results: *zml.exe.Exe.Results,
-        layer_type: model.LayerType,
-        args: Args,
-        hidden_buf: *zml.Buffer,
-        layer_index_buf: *zml.Buffer,
-    ) void {
-        switch (layer_type) {
-            .full_attention => {
-                const layer_cache: zml.Bufferized(model.KvCache.SelfAttnCache) = .{
+pub const KernelRunner = struct {
+    embed: EmbedExe.Runner(.{.embedding}),
+    layers: []LayerRunner,
+    sample: SampleExe.Runner(.{.sampler}),
+
+    pub fn init(allocator: std.mem.Allocator, exe: *const KernelExe, buffers: *const model.Buffers) !KernelRunner {
+        var embed = try EmbedExe.Runner(.{.embedding}).init(&exe.embed, allocator, .{
+            .embedding = .{ .embed_tokens = buffers.text_model.embed_tokens },
+        });
+        errdefer embed.deinit(allocator);
+
+        const layers = try allocator.alloc(LayerRunner, buffers.text_model.layers.len);
+        errdefer allocator.free(layers);
+        var initialized_layers: usize = 0;
+        errdefer for (layers[0..initialized_layers]) |*layer| layer.deinit(allocator);
+        for (layers, buffers.text_model.layers) |*layer, layer_buffers| {
+            layer.* = switch (layer_buffers.attn) {
+                .full_attention => .{ .full_attention = try FullAttentionExe.Runner(.{.layer}).init(
+                    &exe.full_attention,
+                    allocator,
+                    .{ .layer = layer_buffers },
+                ) },
+                .linear_attention => .{ .linear_attention = try LinearAttentionExe.Runner(.{.layer}).init(
+                    &exe.linear_attention,
+                    allocator,
+                    .{ .layer = layer_buffers },
+                ) },
+            };
+            initialized_layers += 1;
+        }
+
+        var sample = try SampleExe.Runner(.{.sampler}).init(&exe.sample, allocator, .{
+            .sampler = .{
+                .norm = buffers.text_model.norm,
+                .lm_head = buffers.lm_head,
+            },
+        });
+        errdefer sample.deinit(allocator);
+
+        return .{ .embed = embed, .layers = layers, .sample = sample };
+    }
+
+    pub fn deinit(self: *KernelRunner, allocator: std.mem.Allocator) void {
+        self.embed.deinit(allocator);
+        for (self.layers) |*layer| layer.deinit(allocator);
+        allocator.free(self.layers);
+        self.sample.deinit(allocator);
+    }
+};
+
+pub fn run(runner: *KernelRunner, args: Args, layer_index_buffers: []const zml.Buffer) void {
+    var hidden_buffer: zml.Buffer = undefined;
+    runner.embed.run(args.io, .{
+        .inputs = .{
+            .tokens = args.tokens_buf.*,
+        },
+        .outputs = .{ .hidden = &hidden_buffer },
+    });
+    defer hidden_buffer.deinit();
+
+    for (runner.layers, layer_index_buffers) |*layer_runner, layer_index_buffer| {
+        switch (layer_runner.*) {
+            .full_attention => |*layer| {
+                var layer_cache: zml.Bufferized(model.KvCache.SelfAttnCache) = .{
                     .k = args.kv_cache_buffers.self_attn.k,
                     .v = args.kv_cache_buffers.self_attn.v,
-                    .layer_index = layer_index_buf.*,
+                    .layer_index = layer_index_buffer,
                 };
-                exe_args.set(.{ hidden_buf, args.token_index_buf, layer_cache });
-                (self.full_attention_layer orelse unreachable).call(exe_args.*, results);
-
-                var new_hidden, var new_cache = results.get(struct {
-                    zml.Buffer,
-                    zml.Bufferized(model.KvCache.SelfAttnCache),
+                layer.run(args.io, .{
+                    .inputs = .{
+                        .hidden = hidden_buffer,
+                        .token_index = args.token_index_buf.*,
+                        .cache = layer_cache,
+                    },
+                    .outputs = .{ .hidden = &hidden_buffer, .cache = &layer_cache },
                 });
-                ComposedKernelExe.replaceBuffer(hidden_buf, &new_hidden);
-                ComposedKernelExe.replaceBuffer(&args.kv_cache_buffers.self_attn.k, &new_cache.k);
-                ComposedKernelExe.replaceBuffer(&args.kv_cache_buffers.self_attn.v, &new_cache.v);
-                ComposedKernelExe.releaseBuffer(layer_index_buf.*, &new_cache.layer_index);
+                args.kv_cache_buffers.self_attn.k = layer_cache.k;
+                args.kv_cache_buffers.self_attn.v = layer_cache.v;
             },
-            .linear_attention => {
-                const layer_cache: zml.Bufferized(model.KvCache.GatedDeltaNetCache) = .{
+            .linear_attention => |*layer| {
+                var layer_cache: zml.Bufferized(model.KvCache.GatedDeltaNetCache) = .{
                     .conv_state = args.kv_cache_buffers.gated_delta_net.conv_state,
                     .recurrent_state = args.kv_cache_buffers.gated_delta_net.recurrent_state,
-                    .layer_index = layer_index_buf.*,
+                    .layer_index = layer_index_buffer,
                 };
-                exe_args.set(.{ hidden_buf, args.token_index_buf, layer_cache });
-                (self.linear_attention_layer orelse unreachable).call(exe_args.*, results);
-
-                var new_hidden, var new_cache = results.get(struct {
-                    zml.Buffer,
-                    zml.Bufferized(model.KvCache.GatedDeltaNetCache),
+                layer.run(args.io, .{
+                    .inputs = .{
+                        .hidden = hidden_buffer,
+                        .token_index = args.token_index_buf.*,
+                        .cache = layer_cache,
+                    },
+                    .outputs = .{ .hidden = &hidden_buffer, .cache = &layer_cache },
                 });
-                ComposedKernelExe.replaceBuffer(hidden_buf, &new_hidden);
-                ComposedKernelExe.replaceBuffer(&args.kv_cache_buffers.gated_delta_net.conv_state, &new_cache.conv_state);
-                ComposedKernelExe.replaceBuffer(&args.kv_cache_buffers.gated_delta_net.recurrent_state, &new_cache.recurrent_state);
-                ComposedKernelExe.releaseBuffer(layer_index_buf.*, &new_cache.layer_index);
+                args.kv_cache_buffers.gated_delta_net.conv_state = layer_cache.conv_state;
+                args.kv_cache_buffers.gated_delta_net.recurrent_state = layer_cache.recurrent_state;
             },
         }
     }
 
-    fn runSampler(
-        self: *const ComposedKernelExe,
-        exe_args: *zml.exe.Exe.Arguments,
-        results: *zml.exe.Exe.Results,
-        args: Args,
-        hidden_buf: *zml.Buffer,
-    ) void {
-        switch (self.phase) {
-            .prefill => self.runPrefillSampler(exe_args, results, args, hidden_buf),
-            .decode => self.runDecodeSampler(exe_args, results, args, hidden_buf),
-        }
-    }
+    runner.sample.run(args.io, .{
+        .inputs = .{
+            .hidden = hidden_buffer,
+            .rng = args.rng_buffers.*,
+            .token_index = args.token_index_buf.*,
+        },
+        .outputs = .{
+            .tokens = args.tokens_buf,
+            .rng = args.rng_buffers,
+            .token_index = args.token_index_buf,
+        },
+    });
+}
 
-    fn runPrefillSampler(
-        self: *const ComposedKernelExe,
-        exe_args: *zml.exe.Exe.Arguments,
-        results: *zml.exe.Exe.Results,
-        args: Args,
-        hidden_buf: *zml.Buffer,
-    ) void {
-        exe_args.set(.{ hidden_buf, args.rng_buffers });
-        self.sampler.call(exe_args.*, results);
+fn compileKernel(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    platform: *const zml.Platform,
+    qwen_model: model.Model,
+    parameters: CompilationOptions,
+    seqlen: usize,
+    phase: Phase,
+    progress: *std.Progress.Node,
+) !KernelExe {
+    const full_index = findFirstLayerIndex(qwen_model.config.text_config.layer_types, .full_attention) orelse return error.MissingFullAttentionLayer;
+    const linear_index = findFirstLayerIndex(qwen_model.config.text_config.layer_types, .linear_attention) orelse return error.MissingLinearAttentionLayer;
 
-        var new_tokens, var new_rng = results.get(struct {
-            zml.Buffer,
-            zml.Bufferized(zml.Tensor.Rng),
-        });
+    const embed = try compileEmbed(allocator, io, platform, qwen_model, parameters, seqlen, phase, progress);
+    errdefer embed.deinit();
+    const full_attention = try compileFullAttention(allocator, io, platform, qwen_model, parameters, seqlen, full_index, phase, progress);
+    errdefer full_attention.deinit();
+    const linear_attention = try compileLinearAttention(allocator, io, platform, qwen_model, parameters, seqlen, linear_index, phase, progress);
+    errdefer linear_attention.deinit();
+    const sample = try compileSample(allocator, io, platform, qwen_model, parameters, seqlen, phase, progress);
+    errdefer sample.deinit();
+    return .{ .embed = embed, .full_attention = full_attention, .linear_attention = linear_attention, .sample = sample };
+}
 
-        ComposedKernelExe.replaceBuffer(args.tokens_buf, &new_tokens);
-        ComposedKernelExe.replaceBuffer(&args.rng_buffers._state, &new_rng._state);
-    }
+fn compileEmbed(allocator: std.mem.Allocator, io: std.Io, platform: *const zml.Platform, mdl: model.Model, parameters: CompilationOptions, seqlen: usize, phase: Phase, progress: *std.Progress.Node) !EmbedExe {
+    progress.increaseEstimatedTotalItems(1);
+    var node = progress.start(phase.startMessage("embed tokens"), 1);
+    defer node.end();
+    const from: std.Io.Timestamp = .now(io, .awake);
+    defer phase.logCompileDone(log, "embed tokens", io, from);
+    return EmbedExe.compile(allocator, io, platform, .{ .shardings = &parameters.shardings.all(), .program_name = phase.programName("qwen3_5", "embed_tokens") }, .{.{
+        .embedding = .{ .embed_tokens = mdl.text_model.embed_tokens },
+        .tokens = zml.Tensor.init(.{ .b = 1, .s = seqlen }, .u32),
+    }});
+}
 
-    fn runDecodeSampler(
-        self: *const ComposedKernelExe,
-        exe_args: *zml.exe.Exe.Arguments,
-        results: *zml.exe.Exe.Results,
-        args: Args,
-        hidden_buf: *zml.Buffer,
-    ) void {
-        exe_args.set(.{ hidden_buf, args.rng_buffers, args.token_index_buf });
-        self.sampler.call(exe_args.*, results);
-
-        var new_tokens, var new_rng, var new_token_index = results.get(struct {
-            zml.Buffer,
-            zml.Bufferized(zml.Tensor.Rng),
-            zml.Buffer,
-        });
-
-        ComposedKernelExe.replaceBuffer(args.tokens_buf, &new_tokens);
-        ComposedKernelExe.replaceBuffer(&args.rng_buffers._state, &new_rng._state);
-        ComposedKernelExe.replaceBuffer(args.token_index_buf, &new_token_index);
-    }
-
-    fn embedTokensBuffers(model_buffers: *const model.Buffers) zml.Bufferized(EmbedTokens) {
-        return .{
-            .embed_tokens = model_buffers.text_model.embed_tokens,
-        };
-    }
-
-    fn samplerBuffers(model_buffers: *const model.Buffers) zml.Bufferized(model.Sampler) {
-        return .{
-            .norm = model_buffers.text_model.norm,
-            .lm_head = model_buffers.lm_head,
-        };
-    }
-
-    fn replaceBuffer(dst: *zml.Buffer, src: *zml.Buffer) void {
-        if (!ComposedKernelExe.sameBufferHandle(dst.*, src.*)) {
-            dst.deinit();
-        }
-
-        dst.* = src.*;
-    }
-
-    fn releaseBuffer(expected: zml.Buffer, actual: *zml.Buffer) void {
-        if (!ComposedKernelExe.sameBufferHandle(expected, actual.*)) {
-            actual.deinit();
-        }
-    }
-
-    fn sameBufferHandle(a: zml.Buffer, b: zml.Buffer) bool {
-        if (a._shards.len != b._shards.len) return false;
-
-        for (a._shards.constSlice(), b._shards.constSlice()) |a_shard, b_shard| {
-            if (a_shard != b_shard) return false;
-        }
-
-        return true;
-    }
-
-    fn compileEmbedTokens(
-        allocator: std.mem.Allocator,
-        io: std.Io,
-        platform: *const zml.Platform,
-        embed_tokens: zml.nn.TokenEmbedding,
-        parameters: CompilationOptions,
-        seqlen: usize,
-        phase: Phase,
-        progress: *std.Progress.Node,
-    ) !zml.Exe {
-        progress.increaseEstimatedTotalItems(1);
-        var node = progress.start(phase.startMessage("embed tokens"), 1);
-        defer node.end();
-
-        const from: std.Io.Timestamp = .now(io, .awake);
-        defer phase.logCompileDone(log, "embed tokens", io, from);
-
-        const tokens: zml.Tensor = .init(.{ .b = 1, .s = seqlen }, .u32);
-
-        return platform.compile(allocator, io, EmbedTokens{ .embed_tokens = embed_tokens }, .forward, .{tokens}, .{
-            .shardings = &parameters.shardings.all(),
-            .program_name = phase.programName("qwen3_5", "embed_tokens"),
-        });
-    }
-
-    fn compileFullAttentionLayer(
-        allocator: std.mem.Allocator,
-        io: std.Io,
-        platform: *const zml.Platform,
-        qwen_model: model.Model,
-        parameters: CompilationOptions,
-        seqlen: usize,
-        layer_index: usize,
-        phase: Phase,
-        progress: *std.Progress.Node,
-    ) !zml.Exe {
-        progress.increaseEstimatedTotalItems(1);
-        var node = progress.start(phase.startMessage("full attention layer"), 1);
-        defer node.end();
-
-        const from: std.Io.Timestamp = .now(io, .awake);
-        defer phase.logCompileDone(log, "full attention layer", io, from);
-
-        const hidden_tensor = ComposedKernelExe.hidden(qwen_model, seqlen);
-        const self_attn_cache: model.KvCache.SelfAttnCache = .{
+fn compileFullAttention(allocator: std.mem.Allocator, io: std.Io, platform: *const zml.Platform, mdl: model.Model, parameters: CompilationOptions, seqlen: usize, layer_index: usize, phase: Phase, progress: *std.Progress.Node) !FullAttentionExe {
+    progress.increaseEstimatedTotalItems(1);
+    var node = progress.start(phase.startMessage("full attention layer"), 1);
+    defer node.end();
+    const from: std.Io.Timestamp = .now(io, .awake);
+    defer phase.logCompileDone(log, "full attention layer", io, from);
+    return FullAttentionExe.compile(allocator, io, platform, .{ .shardings = &parameters.shardings.all(), .program_name = phase.programName("qwen3_5", "full_attention_layer") }, .{.{
+        .layer = mdl.text_model.layers[layer_index],
+        .hidden = hiddenTensor(mdl, seqlen),
+        .token_index = parameters.token_index,
+        .cache = .{
             .k = parameters.kv_cache.self_attn.k,
             .v = parameters.kv_cache.self_attn.v,
             .layer_index = zml.Tensor.init(.{}, .u32),
-        };
+        },
+    }});
+}
 
-        return platform.compile(
-            allocator,
-            io,
-            qwen_model.text_model.layers[layer_index],
-            .forwardSelfAttn,
-            .{ hidden_tensor, parameters.token_index, self_attn_cache },
-            .{
-                .shardings = &parameters.shardings.all(),
-                .program_name = phase.programName("qwen3_5", "full_attention_layer"),
-            },
-        );
-    }
-
-    fn compileLinearAttentionLayer(
-        allocator: std.mem.Allocator,
-        io: std.Io,
-        platform: *const zml.Platform,
-        qwen_model: model.Model,
-        parameters: CompilationOptions,
-        seqlen: usize,
-        layer_index: usize,
-        phase: Phase,
-        progress: *std.Progress.Node,
-    ) !zml.Exe {
-        progress.increaseEstimatedTotalItems(1);
-        var node = progress.start(phase.startMessage("linear attention layer"), 1);
-        defer node.end();
-
-        const from: std.Io.Timestamp = .now(io, .awake);
-        defer phase.logCompileDone(log, "linear attention layer", io, from);
-
-        const hidden_tensor = ComposedKernelExe.hidden(qwen_model, seqlen);
-        const linear_attn_cache: model.KvCache.GatedDeltaNetCache = .{
+fn compileLinearAttention(allocator: std.mem.Allocator, io: std.Io, platform: *const zml.Platform, mdl: model.Model, parameters: CompilationOptions, seqlen: usize, layer_index: usize, phase: Phase, progress: *std.Progress.Node) !LinearAttentionExe {
+    progress.increaseEstimatedTotalItems(1);
+    var node = progress.start(phase.startMessage("linear attention layer"), 1);
+    defer node.end();
+    const from: std.Io.Timestamp = .now(io, .awake);
+    defer phase.logCompileDone(log, "linear attention layer", io, from);
+    return LinearAttentionExe.compile(allocator, io, platform, .{ .shardings = &parameters.shardings.all(), .program_name = phase.programName("qwen3_5", "linear_attention_layer") }, .{.{
+        .layer = mdl.text_model.layers[layer_index],
+        .hidden = hiddenTensor(mdl, seqlen),
+        .token_index = parameters.token_index,
+        .cache = .{
             .conv_state = parameters.kv_cache.gated_delta_net.conv_state,
             .recurrent_state = parameters.kv_cache.gated_delta_net.recurrent_state,
             .layer_index = zml.Tensor.init(.{}, .u32),
-        };
+        },
+    }});
+}
 
-        return platform.compile(
-            allocator,
-            io,
-            qwen_model.text_model.layers[layer_index],
-            .forwardLinearAttn,
-            .{ hidden_tensor, parameters.token_index, linear_attn_cache },
-            .{
-                .shardings = &parameters.shardings.all(),
-                .program_name = phase.programName("qwen3_5", "linear_attention_layer"),
-            },
-        );
-    }
+fn compileSample(allocator: std.mem.Allocator, io: std.Io, platform: *const zml.Platform, mdl: model.Model, parameters: CompilationOptions, seqlen: usize, phase: Phase, progress: *std.Progress.Node) !SampleExe {
+    progress.increaseEstimatedTotalItems(1);
+    var node = progress.start(phase.startMessage("sampler"), 1);
+    defer node.end();
+    const from: std.Io.Timestamp = .now(io, .awake);
+    defer phase.logCompileDone(log, "sampler", io, from);
+    return SampleExe.compile(allocator, io, platform, .{ .shardings = &parameters.shardings.all(), .program_name = phase.programName("qwen3_5", "sampler") }, .{.{
+        .sampler = mdl.sampler(),
+        .hidden = hiddenTensor(mdl, seqlen),
+        .rng = parameters.rng,
+        .token_index = parameters.token_index,
+    }});
+}
 
-    fn compileSampler(
-        allocator: std.mem.Allocator,
-        io: std.Io,
-        platform: *const zml.Platform,
-        qwen_model: model.Model,
-        parameters: CompilationOptions,
-        seqlen: usize,
-        phase: Phase,
-        progress: *std.Progress.Node,
-    ) !zml.Exe {
-        progress.increaseEstimatedTotalItems(1);
-        var node = progress.start(phase.startMessage("sampler"), 1);
-        defer node.end();
+fn hiddenTensor(mdl: model.Model, seqlen: usize) zml.Tensor {
+    return .fromShape(zml.Shape.init(
+        .{ .b = 1, .s = seqlen, .d = mdl.config.text_config.hidden_size },
+        mdl.text_model.embed_tokens.weight.dtype(),
+    ).withPartitioning(.{ .b = .replicated, .s = .replicated, .d = .replicated }));
+}
 
-        const from: std.Io.Timestamp = .now(io, .awake);
-        defer phase.logCompileDone(log, "sampler", io, from);
-
-        const token_index: ?zml.Tensor = switch (phase) {
-            .prefill => null,
-            .decode => parameters.token_index,
-        };
-
-        return platform.compile(
-            allocator,
-            io,
-            qwen_model.sampler(),
-            .sampleTokens,
-            .{ ComposedKernelExe.hidden(qwen_model, seqlen), parameters.rng, token_index },
-            .{
-                .shardings = &parameters.shardings.all(),
-                .program_name = phase.programName("qwen3_5", "sampler"),
-            },
-        );
-    }
-
-    fn hidden(qwen_model: model.Model, seqlen: usize) zml.Tensor {
-        return .fromShape(zml.Shape.init(
-            .{ .b = 1, .s = seqlen, .d = qwen_model.config.text_config.hidden_size },
-            qwen_model.text_model.embed_tokens.weight.dtype(),
-        ).withPartitioning(.{
-            .b = .replicated,
-            .s = .replicated,
-            .d = .replicated,
-        }));
-    }
-
-    fn findFirstLayerIndex(layer_types: []const model.LayerType, target: model.LayerType) ?usize {
-        for (layer_types, 0..) |layer_type, index| {
-            if (layer_type == target) return index;
-        }
-        return null;
-    }
-};
+fn findFirstLayerIndex(layer_types: []const model.LayerType, target: model.LayerType) ?usize {
+    for (layer_types, 0..) |layer_type, index| if (layer_type == target) return index;
+    return null;
+}

--- a/examples/llm/models/qwen3_5/model.zig
+++ b/examples/llm/models/qwen3_5/model.zig
@@ -220,8 +220,13 @@ pub const Model = struct {
     ) struct { zml.Tensor, KvCache, zml.Tensor.Rng } {
         const tokens = tokens_.withPartialTags(.{.s});
         const text_model_output, const updated_kv_cache = self.text_model.forward(tokens, token_index, kv_cache);
-        const new_tokens, const new_rng, _ = self.sampler().sampleTokens(text_model_output, rng, null);
-        return .{ new_tokens.convert(tokens.dtype()).reuseBuffer(tokens), updated_kv_cache, new_rng };
+        const result = Sampler.sampleTokens(.{
+            .sampler = self.sampler(),
+            .hidden = text_model_output,
+            .rng = rng,
+            .token_index = token_index,
+        });
+        return .{ result.tokens.convert(tokens.dtype()).reuseBuffer(tokens), updated_kv_cache, result.rng };
     }
 
     pub fn sampler(self: Model) Sampler {
@@ -238,19 +243,49 @@ pub const Sampler = struct {
     lm_head: zml.nn.Linear,
     gen_options: Model.GenOptions,
 
-    pub fn sampleTokens(
-        self: Sampler,
-        out: zml.Tensor,
+    pub const Input = struct {
+        sampler: Sampler,
+        hidden: zml.Tensor,
         rng: zml.Tensor.Rng,
-        token_index: ?zml.Tensor,
-    ) struct { zml.Tensor, zml.Tensor.Rng, ?zml.Tensor } {
-        const x = self.norm.forward(out);
+        token_index: zml.Tensor,
+    };
+
+    pub const Output = struct {
+        tokens: zml.Tensor,
+        rng: zml.Tensor.Rng,
+        token_index: zml.Tensor,
+    };
+
+    pub fn sampleTokens(input: Input) Output {
+        const self = input.sampler;
+        const x = self.norm.forward(input.hidden);
         const logits = self.lm_head.forward(x.withPartialTags(.{.d})).rename(.{ .dout = .voc });
-        const next_tokens, const new_rng = zml.nn.sampleTokens(logits, self.gen_options.sampling_strategy, rng);
-        if (token_index) |token_idx| {
-            return .{ next_tokens.convert(.u32), new_rng, token_idx.addConstant(1) };
-        }
-        return .{ next_tokens.convert(.u32), new_rng, null };
+        const next_tokens, const new_rng = zml.nn.sampleTokens(logits, self.gen_options.sampling_strategy, input.rng);
+        return .{
+            .tokens = next_tokens.convert(.u32),
+            .rng = new_rng,
+            .token_index = input.token_index.addConstant(1),
+        };
+    }
+};
+
+pub const EmbedTokens = struct {
+    embed_tokens: zml.nn.TokenEmbedding,
+
+    pub const Input = struct {
+        embedding: EmbedTokens,
+        tokens: zml.Tensor,
+    };
+
+    pub const Output = struct {
+        hidden: zml.Tensor,
+    };
+
+    pub fn forward(input: Input) Output {
+        const tokens = input.tokens.withPartialTags(.{.s});
+        return .{ .hidden = input.embedding.embed_tokens.forward(tokens)
+            .withPartialTags(.{.d})
+            .withPartitioning(.{ .d = .replicated }) };
     }
 };
 
@@ -297,7 +332,10 @@ pub const TextModel = struct {
         token_index: zml.Tensor,
         kv_cache: KvCache,
     ) struct { zml.Tensor, KvCache } {
-        var hidden_states = self.embed_tokens.weight.gather(.{ .voc = tokens }, .{});
+        var hidden_states = EmbedTokens.forward(.{
+            .embedding = .{ .embed_tokens = self.embed_tokens },
+            .tokens = tokens,
+        }).hidden;
 
         var updated_kv_cache = kv_cache;
         for (self.layers, 0..) |layer, i| {
@@ -318,6 +356,30 @@ pub const TransformerLayer = struct {
     attn: Attn,
     mlp: Mlp,
     post_attention_layernorm: RmsNorm,
+
+    pub const SelfAttnInput = struct {
+        layer: TransformerLayer,
+        hidden: zml.Tensor,
+        token_index: zml.Tensor,
+        cache: KvCache.SelfAttnCache,
+    };
+
+    pub const SelfAttnOutput = struct {
+        hidden: zml.Tensor,
+        cache: KvCache.SelfAttnCache,
+    };
+
+    pub const LinearAttnInput = struct {
+        layer: TransformerLayer,
+        hidden: zml.Tensor,
+        token_index: zml.Tensor,
+        cache: KvCache.GatedDeltaNetCache,
+    };
+
+    pub const LinearAttnOutput = struct {
+        hidden: zml.Tensor,
+        cache: KvCache.GatedDeltaNetCache,
+    };
 
     pub fn init(store: zml.io.TensorStore.View, config: Config, layer_index: usize) !TransformerLayer {
         const is_full_attention = config.text_config.layer_types[layer_index] == .full_attention;
@@ -383,12 +445,9 @@ pub const TransformerLayer = struct {
         return .{ mlp_output.add(x1).withPartitioning(.{ .d = .replicated }).reuseBuffer(x0), updated_kv_cache };
     }
 
-    pub fn forwardSelfAttn(
-        self: TransformerLayer,
-        x0: zml.Tensor,
-        token_index: zml.Tensor,
-        kv_cache: KvCache.SelfAttnCache,
-    ) struct { zml.Tensor, KvCache.SelfAttnCache } {
+    pub fn forwardSelfAttn(input: SelfAttnInput) SelfAttnOutput {
+        const self = input.layer;
+        const x0 = input.hidden;
         const x0_replicated = x0.withPartitioning(.{ .d = .replicated });
         const normalized_x0 = self.input_layernorm.forward(x0_replicated);
 
@@ -396,22 +455,22 @@ pub const TransformerLayer = struct {
             .full_attention => |self_attn| self_attn,
             .linear_attention => unreachable,
         };
-        const attention_output, const updated_kv_cache = self_attn.forward(normalized_x0, token_index, kv_cache);
+        const attention_output, const updated_kv_cache = self_attn.forward(normalized_x0, input.token_index, input.cache);
 
         const x1 = attention_output.add(x0_replicated).withPartitioning(.{ .d = .replicated });
         const normalized_hidden = self.post_attention_layernorm.forward(x1);
         const mlp_output = self.mlp.forward(normalized_hidden).withPartitioning(.{ .d = .replicated });
 
-        return .{ mlp_output.add(x1).withPartitioning(.{ .d = .replicated }).reuseBuffer(x0), updated_kv_cache };
+        return .{
+            .hidden = mlp_output.add(x1).withPartitioning(.{ .d = .replicated }).reuseBuffer(x0),
+            .cache = updated_kv_cache,
+        };
     }
 
-    pub fn forwardLinearAttn(
-        self: TransformerLayer,
-        x0: zml.Tensor,
-        token_index: zml.Tensor,
-        kv_cache: KvCache.GatedDeltaNetCache,
-    ) struct { zml.Tensor, KvCache.GatedDeltaNetCache } {
-        _ = token_index;
+    pub fn forwardLinearAttn(input: LinearAttnInput) LinearAttnOutput {
+        const self = input.layer;
+        const x0 = input.hidden;
+        _ = input.token_index;
         const x0_replicated = x0.withPartitioning(.{ .d = .replicated });
         const normalized_x0 = self.input_layernorm.forward(x0_replicated);
 
@@ -419,13 +478,16 @@ pub const TransformerLayer = struct {
             .linear_attention => |linear_attn| linear_attn,
             .full_attention => unreachable,
         };
-        const attention_output, const updated_kv_cache = linear_attn.forward(normalized_x0, kv_cache);
+        const attention_output, const updated_kv_cache = linear_attn.forward(normalized_x0, input.cache);
 
         const x1 = attention_output.add(x0_replicated).withPartitioning(.{ .d = .replicated });
         const normalized_hidden = self.post_attention_layernorm.forward(x1);
         const mlp_output = self.mlp.forward(normalized_hidden).withPartitioning(.{ .d = .replicated });
 
-        return .{ mlp_output.add(x1).withPartitioning(.{ .d = .replicated }).reuseBuffer(x0), updated_kv_cache };
+        return .{
+            .hidden = mlp_output.add(x1).withPartitioning(.{ .d = .replicated }).reuseBuffer(x0),
+            .cache = updated_kv_cache,
+        };
     }
 };
 

--- a/examples/llm/models/qwen3_5/session.zig
+++ b/examples/llm/models/qwen3_5/session.zig
@@ -9,9 +9,10 @@ pub const Session = struct {
     allocator: std.mem.Allocator,
     io: std.Io,
     platform: *const zml.Platform,
-    model_buffers: *model.Buffers,
-    compiled_model: *const inference.CompiledModel,
-    decode_runner: inference.KernelExe.Runner,
+    compiled_model: *inference.CompiledModel,
+    prefill: inference.KernelRunner,
+    decode: inference.KernelRunner,
+    layer_index_buffers: []zml.Buffer,
     kv_cache_buffers: zml.Bufferized(model.KvCache),
     rng_buffers: zml.Bufferized(zml.Tensor.Rng),
     tokenizer: zml.tokenizer.Tokenizer,
@@ -27,7 +28,7 @@ pub const Session = struct {
         io: std.Io,
         platform: *const zml.Platform,
         tokenizer: zml.tokenizer.Tokenizer,
-        compiled_model: *const inference.CompiledModel,
+        compiled_model: *inference.CompiledModel,
         model_buffers: *model.Buffers,
     ) !Session {
         var kv_cache_buffers = try compiled_model.params.kv_cache.initBuffer(io, platform, compiled_model.params.shardings.model);
@@ -37,25 +38,46 @@ pub const Session = struct {
         var rng_buffers = try zml.Tensor.Rng.initBuffer(io, platform, .replicated, seed);
         errdefer zml.Tensor.Rng.deinitBuffer(&rng_buffers);
 
-        var decode_runner = try compiled_model.decode.initRunner(
-            allocator,
-            io,
-            platform,
-            model_buffers,
-        );
-        errdefer decode_runner.deinit(allocator);
+        const layer_types = compiled_model.loaded_model.inner.config.text_config.layer_types;
+        const layer_index_buffers = try allocator.alloc(zml.Buffer, layer_types.len);
+        errdefer allocator.free(layer_index_buffers);
+        var initialized_layer_index_buffers: usize = 0;
+        errdefer for (layer_index_buffers[0..initialized_layer_index_buffers]) |*buffer| buffer.deinit();
+        var full_attention_index: u32 = 0;
+        var linear_attention_index: u32 = 0;
+        for (layer_index_buffers, layer_types) |*buffer, layer_type| {
+            buffer.* = try switch (layer_type) {
+                .full_attention => b: {
+                    defer full_attention_index += 1;
+                    break :b zml.Buffer.scalar(io, platform, full_attention_index, .u32);
+                },
+                .linear_attention => b: {
+                    defer linear_attention_index += 1;
+                    break :b zml.Buffer.scalar(io, platform, linear_attention_index, .u32);
+                },
+            };
+            initialized_layer_index_buffers += 1;
+        }
+
+        const generated_token_slice = try zml.Slice.alloc(allocator, zml.Shape.init(.{ .b = 1, .s = 1 }, .u32));
+        errdefer generated_token_slice.free(allocator);
+
+        var prefill = try inference.KernelRunner.init(allocator, &compiled_model.prefill, model_buffers);
+        errdefer prefill.deinit(allocator);
+        const decode = try inference.KernelRunner.init(allocator, &compiled_model.decode, model_buffers);
 
         return .{
             .allocator = allocator,
             .io = io,
             .platform = platform,
-            .model_buffers = model_buffers,
             .compiled_model = compiled_model,
-            .decode_runner = decode_runner,
+            .prefill = prefill,
+            .decode = decode,
+            .layer_index_buffers = layer_index_buffers,
             .kv_cache_buffers = kv_cache_buffers,
             .rng_buffers = rng_buffers,
             .tokenizer = tokenizer,
-            .generated_token_slice = try .alloc(allocator, zml.Shape.init(.{ .b = 1, .s = 1 }, .u32)),
+            .generated_token_slice = generated_token_slice,
             .seqlen = compiled_model.params.seqlen,
             .eos_token_id = compiled_model.loaded_model.inner.special_tokens.end_of_text_token_id,
             .special_tokens = compiled_model.loaded_model.inner.special_tokens,
@@ -65,7 +87,10 @@ pub const Session = struct {
     }
 
     pub fn deinit(self: *Session) void {
-        self.decode_runner.deinit(self.allocator);
+        self.prefill.deinit(self.allocator);
+        self.decode.deinit(self.allocator);
+        for (self.layer_index_buffers) |*buffer| buffer.deinit();
+        self.allocator.free(self.layer_index_buffers);
         model.KvCache.deinitBuffer(&self.kv_cache_buffers);
         zml.Tensor.Rng.deinitBuffer(&self.rng_buffers);
         self.generated_token_slice.free(self.allocator);
@@ -94,16 +119,13 @@ pub const Session = struct {
         var prefill_token_index_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, 0), .u32);
         defer prefill_token_index_buffer.deinit();
 
-        try self.compiled_model.prefill.run(.{
-            .allocator = self.allocator,
+        inference.run(&self.prefill, .{
             .io = self.io,
-            .platform = self.platform,
-            .model_buffers = self.model_buffers,
             .tokens_buf = &prefill_tokens_buffer,
             .token_index_buf = &prefill_token_index_buffer,
             .kv_cache_buffers = &self.kv_cache_buffers,
             .rng_buffers = &self.rng_buffers,
-        });
+        }, self.layer_index_buffers);
 
         try prefill_tokens_buffer.toSlice(self.io, prefill_tokens_slice);
         const generated_token = prefill_tokens_slice.items(u32)[all_tokens.len - 1];
@@ -141,16 +163,13 @@ pub const Session = struct {
             try all_tokens.append(self.allocator, token_id);
             if (all_tokens.items.len >= self.seqlen) break :generation;
 
-            try self.decode_runner.run(.{
-                .allocator = self.allocator,
+            inference.run(&self.decode, .{
                 .io = self.io,
-                .platform = self.platform,
-                .model_buffers = self.model_buffers,
                 .tokens_buf = &current_token_buffer,
                 .token_index_buf = &token_index_buffer,
                 .kv_cache_buffers = &self.kv_cache_buffers,
                 .rng_buffers = &self.rng_buffers,
-            });
+            }, self.layer_index_buffers);
 
             try current_token_buffer.toSlice(self.io, self.generated_token_slice);
         }

--- a/examples/llm/models/qwen3_5_moe/inference.zig
+++ b/examples/llm/models/qwen3_5_moe/inference.zig
@@ -7,17 +7,6 @@ const model = @import("model.zig");
 
 const log = std.log.scoped(.qwen3_5_moe);
 
-const CompileModelResult = struct {
-    prefill_embedding_exe: zml.Exe,
-    decode_embedding_exe: zml.Exe,
-    prefill_full_layer_exe: ?zml.Exe,
-    decode_full_layer_exe: ?zml.Exe,
-    prefill_linear_layer_exe: ?zml.Exe,
-    decode_linear_layer_exe: ?zml.Exe,
-    prefill_sampling_exe: zml.Exe,
-    decode_sampling_exe: zml.Exe,
-};
-
 pub const CompilationParameters = struct {
     kv_cache: model.KvCache,
     rng: zml.Tensor.Rng,
@@ -45,16 +34,26 @@ pub const CompilationParameters = struct {
 
 pub const CompilationOptions = CompilationParameters;
 
+pub const LayerIndexBuffer = union(enum) {
+    self_attn: zml.Buffer,
+    linear_attn: zml.Buffer,
+};
+
+pub const RunArgs = struct {
+    io: std.Io,
+    tokens_buffer: *zml.Buffer,
+    full_attention_token_index_buffer: *zml.Buffer,
+    linear_attention_token_index_buffer: *zml.Buffer,
+    kv_cache_buffers: *zml.Bufferized(model.KvCache),
+    moe_metadata_buffers: zml.Bufferized(zml.moe.Metadata),
+    rng_buffers: *zml.Bufferized(zml.Tensor.Rng),
+    layer_index_buffers: []const LayerIndexBuffer,
+};
+
 pub const CompiledModel = struct {
     loaded_model: *const model.LoadedModel,
-    prefill_embedding_exe: zml.Exe,
-    decode_embedding_exe: zml.Exe,
-    prefill_full_layer_exe: ?zml.Exe,
-    decode_full_layer_exe: ?zml.Exe,
-    prefill_linear_layer_exe: ?zml.Exe,
-    decode_linear_layer_exe: ?zml.Exe,
-    prefill_sampling_exe: zml.Exe,
-    decode_sampling_exe: zml.Exe,
+    prefill: KernelExe,
+    decode: KernelExe,
     params: CompilationParameters,
 
     pub fn init(
@@ -66,360 +65,300 @@ pub const CompiledModel = struct {
         parameters: CompilationParameters,
         progress: *std.Progress.Node,
     ) !CompiledModel {
-        const compile_result = try compileModel(allocator, io, platform, qwen_model, parameters, progress);
+        const prefill = try compileKernel(allocator, io, platform, qwen_model, parameters, parameters.seqlen, parameters.prefill_moe_metadata, "prefill", progress);
+        errdefer prefill.deinit();
+        const decode = try compileKernel(allocator, io, platform, qwen_model, parameters, 1, parameters.decode_moe_metadata, "decode", progress);
         return .{
             .loaded_model = loaded_model,
-            .prefill_embedding_exe = compile_result.prefill_embedding_exe,
-            .decode_embedding_exe = compile_result.decode_embedding_exe,
-            .prefill_full_layer_exe = compile_result.prefill_full_layer_exe,
-            .decode_full_layer_exe = compile_result.decode_full_layer_exe,
-            .prefill_linear_layer_exe = compile_result.prefill_linear_layer_exe,
-            .decode_linear_layer_exe = compile_result.decode_linear_layer_exe,
-            .prefill_sampling_exe = compile_result.prefill_sampling_exe,
-            .decode_sampling_exe = compile_result.decode_sampling_exe,
+            .prefill = prefill,
+            .decode = decode,
             .params = parameters,
         };
     }
 
     pub fn deinit(self: *CompiledModel) void {
-        self.prefill_embedding_exe.deinit();
-        self.decode_embedding_exe.deinit();
-        if (self.prefill_full_layer_exe) |exe| exe.deinit();
-        if (self.decode_full_layer_exe) |exe| exe.deinit();
-        if (self.prefill_linear_layer_exe) |exe| exe.deinit();
-        if (self.decode_linear_layer_exe) |exe| exe.deinit();
-        self.prefill_sampling_exe.deinit();
-        self.decode_sampling_exe.deinit();
+        self.prefill.deinit();
+        self.decode.deinit();
     }
 };
 
 pub const Inference = CompiledModel;
 
-fn compileSelfAttnLayerExe(
-    allocator: std.mem.Allocator,
-    io: std.Io,
-    platform: *const zml.Platform,
-    mdl: model.TransformerLayer,
-    hidden: zml.Tensor,
-    token_index: zml.Tensor,
-    cache: model.KvCache.SelfAttnCache,
-    config: model.Config,
-    moe_metadata: zml.moe.Metadata,
-    moe_parameters: zml.moe.Parameters,
-    shardings: []const zml.Sharding,
-    xla_dump_to: ?[]const u8,
-    progress: *std.Progress.Node,
-    label: []const u8,
-) !zml.Exe {
-    progress.increaseEstimatedTotalItems(1);
-    const compiling_label = try std.fmt.allocPrint(allocator, "Compiling {s}...", .{label});
-    defer allocator.free(compiling_label);
-    var node = progress.start(compiling_label, 1);
-    defer node.end();
+pub const EmbedExe = zml.TypedExe(model.EmbedTokens.forward);
+pub const FullAttentionExe = zml.TypedExe(model.TransformerLayer.forwardSelfAttn);
+pub const LinearAttentionExe = zml.TypedExe(model.TransformerLayer.forwardLinearAttn);
+pub const SampleExe = zml.TypedExe(model.Sampler.sampleTokens);
 
-    const now: std.Io.Timestamp = .now(io, .awake);
-    defer log.info("Compiled {s} [{f}]", .{ label, now.untilNow(io, .awake) });
+pub const KernelExe = struct {
+    embed: EmbedExe,
+    full_attention: FullAttentionExe,
+    linear_attention: LinearAttentionExe,
+    sample: SampleExe,
 
-    return platform.compile(allocator, io, mdl, .forwardSelfAttn, .{ hidden, token_index, cache, config, moe_metadata, moe_parameters }, .{
-        .shardings = shardings,
-        .xla_dump_to = xla_dump_to,
+    pub fn deinit(self: *const KernelExe) void {
+        self.embed.deinit();
+        self.full_attention.deinit();
+        self.linear_attention.deinit();
+        self.sample.deinit();
+    }
+};
+
+pub const LayerRunner = union(enum) {
+    full_attention: FullAttentionExe.Runner(.{.layer}),
+    linear_attention: LinearAttentionExe.Runner(.{.layer}),
+
+    pub fn deinit(self: *LayerRunner, allocator: std.mem.Allocator) void {
+        switch (self.*) {
+            inline else => |*runner| runner.deinit(allocator),
+        }
+    }
+};
+
+pub const KernelRunner = struct {
+    embed: EmbedExe.Runner(.{.embedding}),
+    layers: []LayerRunner,
+    sample: SampleExe.Runner(.{.sampler}),
+
+    pub fn init(allocator: std.mem.Allocator, exe: *const KernelExe, buffers: *const model.Buffers) !KernelRunner {
+        var embed = try EmbedExe.Runner(.{.embedding}).init(&exe.embed, allocator, .{
+            .embedding = buffers.text_model.embed_tokens,
+        });
+        errdefer embed.deinit(allocator);
+
+        const layers = try allocator.alloc(LayerRunner, buffers.text_model.layers.len);
+        errdefer allocator.free(layers);
+        var initialized_layers: usize = 0;
+        errdefer for (layers[0..initialized_layers]) |*layer| layer.deinit(allocator);
+        for (layers, buffers.text_model.layers) |*layer, layer_buffers| {
+            layer.* = switch (layer_buffers.attn) {
+                .self_attn => .{ .full_attention = try FullAttentionExe.Runner(.{.layer}).init(
+                    &exe.full_attention,
+                    allocator,
+                    .{ .layer = layer_buffers },
+                ) },
+                .linear_attn => .{ .linear_attention = try LinearAttentionExe.Runner(.{.layer}).init(
+                    &exe.linear_attention,
+                    allocator,
+                    .{ .layer = layer_buffers },
+                ) },
+            };
+            initialized_layers += 1;
+        }
+
+        var sample = try SampleExe.Runner(.{.sampler}).init(&exe.sample, allocator, .{
+            .sampler = .{
+                .norm = buffers.text_model.norm,
+                .lm_head = buffers.text_model.lm_head,
+            },
+        });
+        errdefer sample.deinit(allocator);
+
+        return .{ .embed = embed, .layers = layers, .sample = sample };
+    }
+
+    pub fn deinit(self: *KernelRunner, allocator: std.mem.Allocator) void {
+        self.embed.deinit(allocator);
+        for (self.layers) |*layer| layer.deinit(allocator);
+        allocator.free(self.layers);
+        self.sample.deinit(allocator);
+    }
+};
+
+pub fn run(runner: *KernelRunner, args: RunArgs) void {
+    var hidden_buffer: zml.Buffer = undefined;
+    runner.embed.run(args.io, .{
+        .inputs = .{
+            .tokens = args.tokens_buffer.*,
+        },
+        .outputs = .{ .hidden = &hidden_buffer },
+    });
+    defer hidden_buffer.deinit();
+
+    for (runner.layers, args.layer_index_buffers) |*layer_runner, layer_index_buffer| {
+        switch (layer_runner.*) {
+            .full_attention => |*layer| {
+                const index_buffer = switch (layer_index_buffer) {
+                    .self_attn => |buffer| buffer,
+                    .linear_attn => unreachable,
+                };
+                var layer_cache: zml.Bufferized(model.KvCache.SelfAttnCache) = .{
+                    .k = args.kv_cache_buffers.self_attn.k,
+                    .v = args.kv_cache_buffers.self_attn.v,
+                    .layer_index = index_buffer,
+                };
+                layer.run(args.io, .{
+                    .inputs = .{
+                        .hidden = hidden_buffer,
+                        .token_index = args.full_attention_token_index_buffer.*,
+                        .cache = layer_cache,
+                        .moe_metadata = args.moe_metadata_buffers,
+                    },
+                    .outputs = .{ .hidden = &hidden_buffer, .cache = &layer_cache },
+                });
+                args.kv_cache_buffers.self_attn.k = layer_cache.k;
+                args.kv_cache_buffers.self_attn.v = layer_cache.v;
+            },
+            .linear_attention => |*layer| {
+                const index_buffer = switch (layer_index_buffer) {
+                    .linear_attn => |buffer| buffer,
+                    .self_attn => unreachable,
+                };
+                var layer_cache: zml.Bufferized(model.KvCache.GatedDeltaNetCache) = .{
+                    .conv_state = args.kv_cache_buffers.gated_delta_net.conv_state,
+                    .recurrent_state = args.kv_cache_buffers.gated_delta_net.recurrent_state,
+                    .layer_index = index_buffer,
+                };
+                layer.run(args.io, .{
+                    .inputs = .{
+                        .hidden = hidden_buffer,
+                        .token_index = args.linear_attention_token_index_buffer.*,
+                        .cache = layer_cache,
+                        .moe_metadata = args.moe_metadata_buffers,
+                    },
+                    .outputs = .{ .hidden = &hidden_buffer, .cache = &layer_cache },
+                });
+                args.kv_cache_buffers.gated_delta_net.conv_state = layer_cache.conv_state;
+                args.kv_cache_buffers.gated_delta_net.recurrent_state = layer_cache.recurrent_state;
+            },
+        }
+    }
+
+    runner.sample.run(args.io, .{
+        .inputs = .{
+            .hidden = hidden_buffer,
+            .rng = args.rng_buffers.*,
+            .token_index = args.full_attention_token_index_buffer.*,
+        },
+        .outputs = .{
+            .tokens = args.tokens_buffer,
+            .rng = args.rng_buffers,
+            .token_index = args.full_attention_token_index_buffer,
+        },
     });
 }
 
-fn compileLinearAttnLayerExe(
+fn compileKernel(
     allocator: std.mem.Allocator,
     io: std.Io,
     platform: *const zml.Platform,
-    mdl: model.TransformerLayer,
-    hidden: zml.Tensor,
-    token_index: zml.Tensor,
-    cache: model.KvCache.GatedDeltaNetCache,
-    config: model.Config,
+    mdl: model.Model,
+    parameters: CompilationParameters,
+    seqlen: usize,
     moe_metadata: zml.moe.Metadata,
-    moe_parameters: zml.moe.Parameters,
-    shardings: []const zml.Sharding,
-    xla_dump_to: ?[]const u8,
+    phase: []const u8,
     progress: *std.Progress.Node,
-    label: []const u8,
-) !zml.Exe {
+) !KernelExe {
+    const full_index = findFirstLayerIndex(mdl.config.text_config.layer_types, .full_attention) orelse return error.MissingFullAttentionLayer;
+    const linear_index = findFirstLayerIndex(mdl.config.text_config.layer_types, .linear_attention) orelse return error.MissingLinearAttentionLayer;
+
+    var embed_future = try io.concurrent(compileEmbed, .{ allocator, io, platform, mdl, parameters, seqlen, phase, progress });
+    errdefer if (embed_future.cancel(io)) |exe| exe.deinit() else |_| {};
+    var full_attention_future = try io.concurrent(compileFullAttention, .{ allocator, io, platform, mdl, parameters, seqlen, full_index, moe_metadata, phase, progress });
+    errdefer if (full_attention_future.cancel(io)) |exe| exe.deinit() else |_| {};
+    var linear_attention_future = try io.concurrent(compileLinearAttention, .{ allocator, io, platform, mdl, parameters, seqlen, linear_index, moe_metadata, phase, progress });
+    errdefer if (linear_attention_future.cancel(io)) |exe| exe.deinit() else |_| {};
+    var sample_future = try io.concurrent(compileSample, .{ allocator, io, platform, mdl, parameters, seqlen, phase, progress });
+    errdefer if (sample_future.cancel(io)) |exe| exe.deinit() else |_| {};
+
+    const embed = try embed_future.await(io);
+    errdefer embed.deinit();
+    const full_attention = try full_attention_future.await(io);
+    errdefer full_attention.deinit();
+    const linear_attention = try linear_attention_future.await(io);
+    errdefer linear_attention.deinit();
+    const sample = try sample_future.await(io);
+    errdefer sample.deinit();
+
+    return .{
+        .embed = embed,
+        .full_attention = full_attention,
+        .linear_attention = linear_attention,
+        .sample = sample,
+    };
+}
+
+fn compileEmbed(allocator: std.mem.Allocator, io: std.Io, platform: *const zml.Platform, mdl: model.Model, parameters: CompilationParameters, seqlen: usize, phase: []const u8, progress: *std.Progress.Node) !EmbedExe {
+    return compileExe(allocator, io, platform, model.EmbedTokens.forward, .{.{
+        .embedding = mdl.text_model.embed_tokens,
+        .tokens = zml.Tensor.init(.{ .b = 1, .s = seqlen }, .u32),
+    }}, parameters, progress, phase, "embedding");
+}
+
+fn compileFullAttention(allocator: std.mem.Allocator, io: std.Io, platform: *const zml.Platform, mdl: model.Model, parameters: CompilationParameters, seqlen: usize, layer_index: usize, moe_metadata: zml.moe.Metadata, phase: []const u8, progress: *std.Progress.Node) !FullAttentionExe {
+    return compileExe(allocator, io, platform, model.TransformerLayer.forwardSelfAttn, .{.{
+        .layer = mdl.text_model.layers[layer_index],
+        .hidden = hiddenTensor(mdl, seqlen),
+        .token_index = zml.Tensor.init(.{}, .u32),
+        .cache = .{
+            .k = parameters.kv_cache.self_attn.k,
+            .v = parameters.kv_cache.self_attn.v,
+            .layer_index = zml.Tensor.init(.{}, .u32),
+        },
+        .config = mdl.config,
+        .moe_metadata = moe_metadata,
+        .moe_parameters = parameters.moe_parameters,
+    }}, parameters, progress, phase, "full-attention layer");
+}
+
+fn compileLinearAttention(allocator: std.mem.Allocator, io: std.Io, platform: *const zml.Platform, mdl: model.Model, parameters: CompilationParameters, seqlen: usize, layer_index: usize, moe_metadata: zml.moe.Metadata, phase: []const u8, progress: *std.Progress.Node) !LinearAttentionExe {
+    return compileExe(allocator, io, platform, model.TransformerLayer.forwardLinearAttn, .{.{
+        .layer = mdl.text_model.layers[layer_index],
+        .hidden = hiddenTensor(mdl, seqlen),
+        .token_index = zml.Tensor.init(.{}, .u32),
+        .cache = .{
+            .conv_state = parameters.kv_cache.gated_delta_net.conv_state,
+            .recurrent_state = parameters.kv_cache.gated_delta_net.recurrent_state,
+            .layer_index = zml.Tensor.init(.{}, .u32),
+        },
+        .config = mdl.config,
+        .moe_metadata = moe_metadata,
+        .moe_parameters = parameters.moe_parameters,
+    }}, parameters, progress, phase, "linear-attention layer");
+}
+
+fn compileSample(allocator: std.mem.Allocator, io: std.Io, platform: *const zml.Platform, mdl: model.Model, parameters: CompilationParameters, seqlen: usize, phase: []const u8, progress: *std.Progress.Node) !SampleExe {
+    return compileExe(allocator, io, platform, model.Sampler.sampleTokens, .{.{
+        .sampler = mdl.text_model.sampler(),
+        .hidden = hiddenTensor(mdl, seqlen),
+        .rng = parameters.rng,
+        .token_index = zml.Tensor.init(.{}, .u32),
+    }}, parameters, progress, phase, "sampling");
+}
+
+fn compileExe(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    platform: *const zml.Platform,
+    comptime function: anytype,
+    args: std.meta.ArgsTuple(@TypeOf(function)),
+    parameters: CompilationParameters,
+    progress: *std.Progress.Node,
+    phase: []const u8,
+    component: []const u8,
+) !zml.TypedExe(function) {
     progress.increaseEstimatedTotalItems(1);
-    const compiling_label = try std.fmt.allocPrint(allocator, "Compiling {s}...", .{label});
-    defer allocator.free(compiling_label);
-    var node = progress.start(compiling_label, 1);
+    const label = try std.fmt.allocPrint(allocator, "Compiling {s} {s}...", .{ phase, component });
+    defer allocator.free(label);
+    var node = progress.start(label, 1);
     defer node.end();
-
     const now: std.Io.Timestamp = .now(io, .awake);
-    defer log.info("Compiled {s} [{f}]", .{ label, now.untilNow(io, .awake) });
+    defer log.info("Compiled {s} {s} [{f}]", .{ phase, component, now.untilNow(io, .awake) });
+    return zml.TypedExe(function).compile(allocator, io, platform, .{
+        .shardings = &parameters.shardings.all(),
+        .xla_dump_to = parameters.xla_dump_to,
+    }, args);
+}
 
-    return platform.compile(allocator, io, mdl, .forwardLinearAttn, .{ hidden, token_index, cache, config, moe_metadata, moe_parameters }, .{
-        .shardings = shardings,
-        .xla_dump_to = xla_dump_to,
-    });
+fn hiddenTensor(mdl: model.Model, seqlen: usize) zml.Tensor {
+    return .fromShape(zml.Shape.init(
+        .{ .b = 1, .s = seqlen, .d = mdl.config.text_config.hidden_size },
+        mdl.text_model.embed_tokens.weight.dtype(),
+    ).withPartitioning(.{ .b = .replicated, .s = .replicated, .d = .replicated }));
 }
 
 fn findFirstLayerIndex(layer_types: []const model.LayerType, target: model.LayerType) ?usize {
-    for (layer_types, 0..) |layer_type, index| {
-        if (layer_type == target) return index;
-    }
+    for (layer_types, 0..) |layer_type, index| if (layer_type == target) return index;
     return null;
-}
-
-fn compileModel(
-    allocator: std.mem.Allocator,
-    io: std.Io,
-    platform: *const zml.Platform,
-    qwen35_model: model.Model,
-    parameters: CompilationParameters,
-    progress: *std.Progress.Node,
-) !CompileModelResult {
-    const now: std.Io.Timestamp = .now(io, .awake);
-    const all_shardings = parameters.shardings.all();
-    const prefill_len: usize = @intCast(parameters.seqlen);
-    defer log.info("Compiled model [{f}]", .{now.untilNow(io, .awake)});
-    log.info("Compiling model for platform {any} with prefill length {d}...", .{ platform.target, prefill_len });
-
-    const prefill_tokens = zml.Tensor.init(.{ .b = 1, .s = prefill_len }, .u32);
-    const decode_tokens = zml.Tensor.init(.{ .b = 1, .s = 1 }, .u32);
-    const hidden_dtype = qwen35_model.text_model.embed_tokens.weight.dtype();
-    const prefill_hidden: zml.Tensor = .fromShape(zml.Shape.init(
-        .{ .b = 1, .s = prefill_len, .d = qwen35_model.config.text_config.hidden_size },
-        hidden_dtype,
-    ).withPartitioning(.{
-        .b = .replicated,
-        .s = .replicated,
-        .d = .replicated,
-    }));
-    const decode_hidden: zml.Tensor = .fromShape(zml.Shape.init(
-        .{ .b = 1, .s = 1, .d = qwen35_model.config.text_config.hidden_size },
-        hidden_dtype,
-    ).withPartitioning(.{
-        .b = .replicated,
-        .s = .replicated,
-        .d = .replicated,
-    }));
-    const token_index = zml.Tensor.init(.{}, .u32);
-    const self_attn_cache: model.KvCache.SelfAttnCache = .{
-        .k = parameters.kv_cache.self_attn.k,
-        .v = parameters.kv_cache.self_attn.v,
-        .layer_index = zml.Tensor.init(.{}, .u32),
-    };
-    const linear_attn_cache: model.KvCache.GatedDeltaNetCache = .{
-        .conv_state = parameters.kv_cache.gated_delta_net.conv_state,
-        .recurrent_state = parameters.kv_cache.gated_delta_net.recurrent_state,
-        .layer_index = zml.Tensor.init(.{}, .u32),
-    };
-
-    var prefill_embedding_future = try io.concurrent(struct {
-        fn call(
-            allocator_: std.mem.Allocator,
-            io_: std.Io,
-            platform_: *const zml.Platform,
-            model_: zml.nn.TokenEmbedding,
-            prefill_tokens_: zml.Tensor,
-            shardings_: []const zml.Sharding,
-            progress_: *std.Progress.Node,
-        ) !zml.Exe {
-            progress_.increaseEstimatedTotalItems(1);
-            var node_ = progress_.start("Compiling prefill embedding...", 1);
-            defer node_.end();
-            const now_: std.Io.Timestamp = .now(io_, .awake);
-            defer log.info("Compiled prefill embedding [{f}]", .{now_.untilNow(io_, .awake)});
-            return platform_.compile(allocator_, io_, model_, .forward, .{prefill_tokens_}, .{ .shardings = shardings_ });
-        }
-    }.call, .{ allocator, io, platform, qwen35_model.text_model.embed_tokens, prefill_tokens, &all_shardings, progress });
-    errdefer if (prefill_embedding_future.cancel(io)) |v| {
-        v.deinit();
-    } else |_| {};
-
-    var decode_embedding_future = try io.concurrent(struct {
-        fn call(
-            allocator_: std.mem.Allocator,
-            io_: std.Io,
-            platform_: *const zml.Platform,
-            model_: zml.nn.TokenEmbedding,
-            decode_tokens_: zml.Tensor,
-            shardings_: []const zml.Sharding,
-            progress_: *std.Progress.Node,
-        ) !zml.Exe {
-            progress_.increaseEstimatedTotalItems(1);
-            var node_ = progress_.start("Compiling decode embedding...", 1);
-            defer node_.end();
-            const now_: std.Io.Timestamp = .now(io_, .awake);
-            defer log.info("Compiled decode embedding [{f}]", .{now_.untilNow(io_, .awake)});
-            return platform_.compile(allocator_, io_, model_, .forward, .{decode_tokens_}, .{ .shardings = shardings_ });
-        }
-    }.call, .{ allocator, io, platform, qwen35_model.text_model.embed_tokens, decode_tokens, &all_shardings, progress });
-    errdefer if (decode_embedding_future.cancel(io)) |v| {
-        v.deinit();
-    } else |_| {};
-
-    const prefill_embedding_exe = try prefill_embedding_future.await(io);
-    const decode_embedding_exe = try decode_embedding_future.await(io);
-
-    const full_layer_index = findFirstLayerIndex(qwen35_model.config.text_config.layer_types, .full_attention) orelse return error.MissingFullAttentionLayer;
-    const linear_layer_index = findFirstLayerIndex(qwen35_model.config.text_config.layer_types, .linear_attention) orelse return error.MissingLinearAttentionLayer;
-    const full_layer_model = qwen35_model.text_model.layers[full_layer_index];
-    const linear_layer_model = qwen35_model.text_model.layers[linear_layer_index];
-
-    var prefill_full_layer_future = try io.concurrent(struct {
-        fn call(
-            allocator_: std.mem.Allocator,
-            io_: std.Io,
-            platform_: *const zml.Platform,
-            layer_model_: model.TransformerLayer,
-            hidden_: zml.Tensor,
-            token_index_: zml.Tensor,
-            cache_: model.KvCache.SelfAttnCache,
-            config_: model.Config,
-            moe_metadata_: zml.moe.Metadata,
-            moe_parameters_: zml.moe.Parameters,
-            shardings_: []const zml.Sharding,
-            xla_dump_to_: ?[]const u8,
-            progress_: *std.Progress.Node,
-        ) !zml.Exe {
-            return compileSelfAttnLayerExe(allocator_, io_, platform_, layer_model_, hidden_, token_index_, cache_, config_, moe_metadata_, moe_parameters_, shardings_, xla_dump_to_, progress_, "prefill full-attention layer...");
-        }
-    }.call, .{ allocator, io, platform, full_layer_model, prefill_hidden, token_index, self_attn_cache, qwen35_model.config, parameters.prefill_moe_metadata, parameters.moe_parameters, &all_shardings, parameters.xla_dump_to, progress });
-    errdefer if (prefill_full_layer_future.cancel(io)) |v| v.deinit() else |_| {};
-
-    var decode_full_layer_future = try io.concurrent(struct {
-        fn call(
-            allocator_: std.mem.Allocator,
-            io_: std.Io,
-            platform_: *const zml.Platform,
-            layer_model_: model.TransformerLayer,
-            hidden_: zml.Tensor,
-            token_index_: zml.Tensor,
-            cache_: model.KvCache.SelfAttnCache,
-            config_: model.Config,
-            moe_metadata_: zml.moe.Metadata,
-            moe_parameters_: zml.moe.Parameters,
-            shardings_: []const zml.Sharding,
-            xla_dump_to_: ?[]const u8,
-            progress_: *std.Progress.Node,
-        ) !zml.Exe {
-            return compileSelfAttnLayerExe(allocator_, io_, platform_, layer_model_, hidden_, token_index_, cache_, config_, moe_metadata_, moe_parameters_, shardings_, xla_dump_to_, progress_, "decode full-attention layer...");
-        }
-    }.call, .{ allocator, io, platform, full_layer_model, decode_hidden, token_index, self_attn_cache, qwen35_model.config, parameters.decode_moe_metadata, parameters.moe_parameters, &all_shardings, parameters.xla_dump_to, progress });
-    errdefer if (decode_full_layer_future.cancel(io)) |v| v.deinit() else |_| {};
-
-    var prefill_full_layer_exe: ?zml.Exe = null;
-    errdefer if (prefill_full_layer_exe) |exe| exe.deinit();
-    var decode_full_layer_exe: ?zml.Exe = null;
-    errdefer if (decode_full_layer_exe) |exe| exe.deinit();
-    prefill_full_layer_exe = try prefill_full_layer_future.await(io);
-    decode_full_layer_exe = try decode_full_layer_future.await(io);
-
-    var prefill_linear_layer_future = try io.concurrent(struct {
-        fn call(
-            allocator_: std.mem.Allocator,
-            io_: std.Io,
-            platform_: *const zml.Platform,
-            layer_model_: model.TransformerLayer,
-            hidden_: zml.Tensor,
-            token_index_: zml.Tensor,
-            cache_: model.KvCache.GatedDeltaNetCache,
-            config_: model.Config,
-            moe_metadata_: zml.moe.Metadata,
-            moe_parameters_: zml.moe.Parameters,
-            shardings_: []const zml.Sharding,
-            xla_dump_to_: ?[]const u8,
-            progress_: *std.Progress.Node,
-        ) !zml.Exe {
-            return compileLinearAttnLayerExe(allocator_, io_, platform_, layer_model_, hidden_, token_index_, cache_, config_, moe_metadata_, moe_parameters_, shardings_, xla_dump_to_, progress_, "prefill linear-attention layer...");
-        }
-    }.call, .{ allocator, io, platform, linear_layer_model, prefill_hidden, token_index, linear_attn_cache, qwen35_model.config, parameters.prefill_moe_metadata, parameters.moe_parameters, &all_shardings, parameters.xla_dump_to, progress });
-    errdefer if (prefill_linear_layer_future.cancel(io)) |v| v.deinit() else |_| {};
-
-    var decode_linear_layer_future = try io.concurrent(struct {
-        fn call(
-            allocator_: std.mem.Allocator,
-            io_: std.Io,
-            platform_: *const zml.Platform,
-            layer_model_: model.TransformerLayer,
-            hidden_: zml.Tensor,
-            token_index_: zml.Tensor,
-            cache_: model.KvCache.GatedDeltaNetCache,
-            config_: model.Config,
-            moe_metadata_: zml.moe.Metadata,
-            moe_parameters_: zml.moe.Parameters,
-            shardings_: []const zml.Sharding,
-            xla_dump_to_: ?[]const u8,
-            progress_: *std.Progress.Node,
-        ) !zml.Exe {
-            return compileLinearAttnLayerExe(allocator_, io_, platform_, layer_model_, hidden_, token_index_, cache_, config_, moe_metadata_, moe_parameters_, shardings_, xla_dump_to_, progress_, "decode linear-attention layer...");
-        }
-    }.call, .{ allocator, io, platform, linear_layer_model, decode_hidden, token_index, linear_attn_cache, qwen35_model.config, parameters.decode_moe_metadata, parameters.moe_parameters, &all_shardings, parameters.xla_dump_to, progress });
-    errdefer if (decode_linear_layer_future.cancel(io)) |v| v.deinit() else |_| {};
-
-    var prefill_linear_layer_exe: ?zml.Exe = null;
-    errdefer if (prefill_linear_layer_exe) |exe| exe.deinit();
-    var decode_linear_layer_exe: ?zml.Exe = null;
-    errdefer if (decode_linear_layer_exe) |exe| exe.deinit();
-
-    prefill_linear_layer_exe = try prefill_linear_layer_future.await(io);
-    decode_linear_layer_exe = try decode_linear_layer_future.await(io);
-
-    var prefill_sampling_future = try io.concurrent(struct {
-        fn call(
-            allocator_: std.mem.Allocator,
-            io_: std.Io,
-            platform_: *const zml.Platform,
-            sampler_: model.Sampler,
-            prefill_hidden_: zml.Tensor,
-            rng_: zml.Tensor.Rng,
-            shardings_: []const zml.Sharding,
-            progress_: *std.Progress.Node,
-        ) !zml.Exe {
-            progress_.increaseEstimatedTotalItems(1);
-            var node_ = progress_.start("Compiling prefill sampling...", 1);
-            defer node_.end();
-            const now_: std.Io.Timestamp = .now(io_, .awake);
-            defer log.info("Compiled prefill sampling [{f}]", .{now_.untilNow(io_, .awake)});
-            return platform_.compile(allocator_, io_, sampler_, .sampleTokens, .{ prefill_hidden_, rng_, null }, .{ .shardings = shardings_ });
-        }
-    }.call, .{ allocator, io, platform, qwen35_model.text_model.sampler(), prefill_hidden, parameters.rng, &all_shardings, progress });
-    errdefer if (prefill_sampling_future.cancel(io)) |v| {
-        v.deinit();
-    } else |_| {};
-    const prefill_sampling_exe = try prefill_sampling_future.await(io);
-
-    var decode_sampling_future = try io.concurrent(struct {
-        fn call(
-            allocator_: std.mem.Allocator,
-            io_: std.Io,
-            platform_: *const zml.Platform,
-            sampler_: model.Sampler,
-            decode_hidden_: zml.Tensor,
-            rng_: zml.Tensor.Rng,
-            token_index_: zml.Tensor,
-            shardings_: []const zml.Sharding,
-            progress_: *std.Progress.Node,
-        ) !zml.Exe {
-            progress_.increaseEstimatedTotalItems(1);
-            var node_ = progress_.start("Compiling decode sampling...", 1);
-            defer node_.end();
-            const now_: std.Io.Timestamp = .now(io_, .awake);
-            defer log.info("Compiled decode sampling [{f}]", .{now_.untilNow(io_, .awake)});
-            return platform_.compile(allocator_, io_, sampler_, .sampleTokens, .{ decode_hidden_, rng_, token_index_ }, .{ .shardings = shardings_ });
-        }
-    }.call, .{ allocator, io, platform, qwen35_model.text_model.sampler(), decode_hidden, parameters.rng, token_index, &all_shardings, progress });
-    errdefer if (decode_sampling_future.cancel(io)) |v| {
-        v.deinit();
-    } else |_| {};
-
-    const decode_sampling_exe = try decode_sampling_future.await(io);
-
-    return .{
-        .prefill_embedding_exe = prefill_embedding_exe,
-        .decode_embedding_exe = decode_embedding_exe,
-        .prefill_full_layer_exe = prefill_full_layer_exe,
-        .decode_full_layer_exe = decode_full_layer_exe,
-        .prefill_linear_layer_exe = prefill_linear_layer_exe,
-        .decode_linear_layer_exe = decode_linear_layer_exe,
-        .prefill_sampling_exe = prefill_sampling_exe,
-        .decode_sampling_exe = decode_sampling_exe,
-    };
 }
 
 fn initMoeMetadata(qwen_model: model.Model, token_len: usize, batch_size: u32, backend: zml.moe.Backend) zml.moe.Metadata {

--- a/examples/llm/models/qwen3_5_moe/model.zig
+++ b/examples/llm/models/qwen3_5_moe/model.zig
@@ -249,19 +249,44 @@ pub const Sampler = struct {
     lm_head: zml.nn.Linear,
     gen_options: Model.GenOptions,
 
-    pub fn sampleTokens(
-        self: Sampler,
-        out: zml.Tensor,
+    pub const Input = struct {
+        sampler: Sampler,
+        hidden: zml.Tensor,
         rng: zml.Tensor.Rng,
-        token_index: ?zml.Tensor,
-    ) struct { zml.Tensor, zml.Tensor.Rng, ?zml.Tensor } {
-        const x = self.norm.forward(out);
+        token_index: zml.Tensor,
+    };
+
+    pub const Output = struct {
+        tokens: zml.Tensor,
+        rng: zml.Tensor.Rng,
+        token_index: zml.Tensor,
+    };
+
+    pub fn sampleTokens(input: Input) Output {
+        const self = input.sampler;
+        const x = self.norm.forward(input.hidden);
         const logits = self.lm_head.forward(x.withPartialTags(.{.d})).rename(.{ .dout = .voc });
-        const next_tokens, const new_rng = zml.nn.sampleTokens(logits, self.gen_options.sampling_strategy, rng);
-        if (token_index) |token_idx| {
-            return .{ next_tokens.convert(.u32), new_rng, token_idx.addConstant(1) };
-        }
-        return .{ next_tokens.convert(.u32), new_rng, null };
+        const next_tokens, const new_rng = zml.nn.sampleTokens(logits, self.gen_options.sampling_strategy, input.rng);
+        return .{
+            .tokens = next_tokens.convert(.u32),
+            .rng = new_rng,
+            .token_index = input.token_index.addConstant(1),
+        };
+    }
+};
+
+pub const EmbedTokens = struct {
+    pub const Input = struct {
+        embedding: zml.nn.TokenEmbedding,
+        tokens: zml.Tensor,
+    };
+
+    pub const Output = struct {
+        hidden: zml.Tensor,
+    };
+
+    pub fn forward(input: Input) Output {
+        return .{ .hidden = input.embedding.forward(input.tokens) };
     }
 };
 
@@ -332,24 +357,23 @@ pub const TextModel = struct {
         moe_metadata: zml.moe.Metadata,
         moe_parameters: zml.moe.Parameters,
     ) struct { zml.Tensor, KvCache, zml.Tensor.Rng } {
-        var hidden_states = self.embed_tokens.weight.gather(.{ .voc = tokens }, .{});
+        var hidden_states = EmbedTokens.forward(.{
+            .embedding = self.embed_tokens,
+            .tokens = tokens,
+        }).hidden;
 
         var updated_kv_cache = kv_cache;
         for (self.layers, 0..) |layer, i| {
             hidden_states, updated_kv_cache = layer.forward(hidden_states, token_index, updated_kv_cache.atLayer(i), config, moe_metadata, moe_parameters);
         }
 
-        const new_tokens, const new_rng = self.sampleTokens(hidden_states, rng);
-        return .{ new_tokens, updated_kv_cache.reuseBuffer(kv_cache), new_rng };
-    }
-
-    pub fn sampleTokens(
-        self: TextModel,
-        out: zml.Tensor,
-        rng: zml.Tensor.Rng,
-        token_index: ?zml.Tensor,
-    ) struct { zml.Tensor, zml.Tensor.Rng, ?zml.Tensor } {
-        return self.sampler().sampleTokens(out, rng, token_index);
+        const result = Sampler.sampleTokens(.{
+            .sampler = self.sampler(),
+            .hidden = hidden_states,
+            .rng = rng,
+            .token_index = token_index,
+        });
+        return .{ result.tokens, updated_kv_cache.reuseBuffer(kv_cache), result.rng };
     }
 };
 
@@ -363,6 +387,36 @@ pub const TransformerLayer = struct {
     attn: Attn,
     moe: Moe,
     post_attention_layernorm: RmsNorm,
+
+    pub const SelfAttnInput = struct {
+        layer: TransformerLayer,
+        hidden: zml.Tensor,
+        token_index: zml.Tensor,
+        cache: KvCache.SelfAttnCache,
+        config: Config,
+        moe_metadata: zml.moe.Metadata,
+        moe_parameters: zml.moe.Parameters,
+    };
+
+    pub const SelfAttnOutput = struct {
+        hidden: zml.Tensor,
+        cache: KvCache.SelfAttnCache,
+    };
+
+    pub const LinearAttnInput = struct {
+        layer: TransformerLayer,
+        hidden: zml.Tensor,
+        token_index: zml.Tensor,
+        cache: KvCache.GatedDeltaNetCache,
+        config: Config,
+        moe_metadata: zml.moe.Metadata,
+        moe_parameters: zml.moe.Parameters,
+    };
+
+    pub const LinearAttnOutput = struct {
+        hidden: zml.Tensor,
+        cache: KvCache.GatedDeltaNetCache,
+    };
 
     pub fn init(allocator: std.mem.Allocator, store: zml.io.TensorStore.View, config: Config, layer_index: usize) !TransformerLayer {
         const is_full_attention = config.text_config.layer_types[layer_index] == .full_attention;
@@ -391,16 +445,10 @@ pub const TransformerLayer = struct {
         RmsNorm.unloadBuffers(&self.post_attention_layernorm);
     }
 
-    pub fn forwardSelfAttn(
-        self: TransformerLayer,
-        x0: zml.Tensor,
-        token_index: zml.Tensor,
-        kv_cache: KvCache.SelfAttnCache,
-        config: Config,
-        moe_metadata: zml.moe.Metadata,
-        moe_parameters: zml.moe.Parameters,
-    ) struct { zml.Tensor, KvCache.SelfAttnCache } {
-        _ = config;
+    pub fn forwardSelfAttn(input: SelfAttnInput) SelfAttnOutput {
+        const self = input.layer;
+        const x0 = input.hidden;
+        _ = input.config;
         const x0_replicated = x0.withPartitioning(.{ .d = .replicated });
         const normalized_x0 = self.input_layernorm.forward(x0_replicated);
 
@@ -408,26 +456,23 @@ pub const TransformerLayer = struct {
             .self_attn => |self_attn| self_attn,
             .linear_attn => unreachable,
         };
-        const attention_output, const updated_kv_cache = self_attn.forward(normalized_x0, token_index, kv_cache);
+        const attention_output, const updated_kv_cache = self_attn.forward(normalized_x0, input.token_index, input.cache);
 
         const x1 = attention_output.add(x0_replicated).withPartitioning(.{ .d = .replicated });
         const normalized_hidden = self.post_attention_layernorm.forward(x1);
 
-        const moe_output = self.moe.forward(normalized_hidden, moe_metadata, moe_parameters);
+        const moe_output = self.moe.forward(normalized_hidden, input.moe_metadata, input.moe_parameters);
 
-        return .{ moe_output.add(x1).withPartitioning(.{ .d = .replicated }).reuseBuffer(x0), updated_kv_cache };
+        return .{
+            .hidden = moe_output.add(x1).withPartitioning(.{ .d = .replicated }).reuseBuffer(x0),
+            .cache = updated_kv_cache,
+        };
     }
 
-    pub fn forwardLinearAttn(
-        self: TransformerLayer,
-        x0: zml.Tensor,
-        token_index: zml.Tensor,
-        kv_cache: KvCache.GatedDeltaNetCache,
-        config: Config,
-        moe_metadata: zml.moe.Metadata,
-        moe_parameters: zml.moe.Parameters,
-    ) struct { zml.Tensor, KvCache.GatedDeltaNetCache } {
-        _ = config;
+    pub fn forwardLinearAttn(input: LinearAttnInput) LinearAttnOutput {
+        const self = input.layer;
+        const x0 = input.hidden;
+        _ = input.config;
         const x0_replicated = x0.withPartitioning(.{ .d = .replicated });
         const normalized_x0 = self.input_layernorm.forward(x0_replicated);
 
@@ -435,14 +480,17 @@ pub const TransformerLayer = struct {
             .linear_attn => |linear_attn| linear_attn,
             .self_attn => unreachable,
         };
-        const attention_output, const updated_kv_cache = linear_attn.forward(normalized_x0, kv_cache, token_index);
+        const attention_output, const updated_kv_cache = linear_attn.forward(normalized_x0, input.cache, input.token_index);
 
         const x1 = attention_output.add(x0_replicated).withPartitioning(.{ .d = .replicated });
         const normalized_hidden = self.post_attention_layernorm.forward(x1);
 
-        const moe_output = self.moe.forward(normalized_hidden, moe_metadata, moe_parameters);
+        const moe_output = self.moe.forward(normalized_hidden, input.moe_metadata, input.moe_parameters);
 
-        return .{ moe_output.add(x1).withPartitioning(.{ .d = .replicated }).reuseBuffer(x0), updated_kv_cache };
+        return .{
+            .hidden = moe_output.add(x1).withPartitioning(.{ .d = .replicated }).reuseBuffer(x0),
+            .cache = updated_kv_cache,
+        };
     }
 
     pub fn forward(

--- a/examples/llm/models/qwen3_5_moe/session.zig
+++ b/examples/llm/models/qwen3_5_moe/session.zig
@@ -5,26 +5,18 @@ const zml = @import("zml");
 const inference = @import("inference.zig");
 const model = @import("model.zig");
 
-const LayerIndexBuffer = union(enum) {
-    self_attn: zml.Buffer,
-    linear_attn: zml.Buffer,
-};
-
 pub const Session = struct {
     allocator: std.mem.Allocator,
     io: std.Io,
     platform: *const zml.Platform,
-    model_buffers: *model.Buffers,
-    compiled_model: *const inference.CompiledModel,
+    compiled_model: *inference.CompiledModel,
+    prefill: inference.KernelRunner,
+    decode: inference.KernelRunner,
     kv_cache_buffers: zml.Bufferized(model.KvCache),
     prefill_moe_metadata_buffers: zml.Bufferized(zml.moe.Metadata),
     decode_moe_metadata_buffers: zml.Bufferized(zml.moe.Metadata),
     rng_buffers: zml.Bufferized(zml.Tensor.Rng),
-    layer_index_buffers: []LayerIndexBuffer,
-    decode_token_index_buffer: zml.Buffer,
-    self_attn_layers_caches: []zml.Bufferized(model.KvCache.SelfAttnCache),
-    linear_attn_layers_caches: []zml.Bufferized(model.KvCache.GatedDeltaNetCache),
-    step_token_slice: zml.Slice,
+    layer_index_buffers: []inference.LayerIndexBuffer,
     generated_token_slice: zml.Slice,
     tokenizer: zml.tokenizer.Tokenizer,
     seqlen: u32,
@@ -38,7 +30,7 @@ pub const Session = struct {
         io: std.Io,
         platform: *const zml.Platform,
         tokenizer: zml.tokenizer.Tokenizer,
-        compiled_model: *const inference.CompiledModel,
+        compiled_model: *inference.CompiledModel,
         model_buffers: *model.Buffers,
     ) !Session {
         const shardings = compiled_model.params.shardings;
@@ -47,7 +39,6 @@ pub const Session = struct {
 
         var prefill_moe_metadata_buffers = try compiled_model.params.prefill_moe_metadata.initBuffer(io, platform);
         errdefer zml.moe.Metadata.deinitBuffer(&prefill_moe_metadata_buffers);
-
         var decode_moe_metadata_buffers = try compiled_model.params.decode_moe_metadata.initBuffer(io, platform);
         errdefer zml.moe.Metadata.deinitBuffer(&decode_moe_metadata_buffers);
 
@@ -56,90 +47,52 @@ pub const Session = struct {
         errdefer zml.Tensor.Rng.deinitBuffer(&rng_buffers);
 
         const layer_types = compiled_model.loaded_model.inner.config.text_config.layer_types;
-        var layer_index_buffers = try allocator.alloc(LayerIndexBuffer, compiled_model.loaded_model.inner.text_model.layers.len);
-        errdefer {
-            for (layer_index_buffers) |*layer_index_buffer| {
-                switch (layer_index_buffer.*) {
-                    .self_attn => |*buffer| buffer.deinit(),
-                    .linear_attn => |*buffer| buffer.deinit(),
-                }
+        const layer_index_buffers = try allocator.alloc(inference.LayerIndexBuffer, layer_types.len);
+        errdefer allocator.free(layer_index_buffers);
+        var initialized_layer_index_buffers: usize = 0;
+        errdefer for (layer_index_buffers[0..initialized_layer_index_buffers]) |*layer_index_buffer| {
+            switch (layer_index_buffer.*) {
+                .self_attn => |*buffer| buffer.deinit(),
+                .linear_attn => |*buffer| buffer.deinit(),
             }
-            allocator.free(layer_index_buffers);
+        };
+
+        var self_attn_layer_index: u32 = 0;
+        var linear_attn_layer_index: u32 = 0;
+        for (layer_types, layer_index_buffers) |layer_type, *layer_index_buffer| {
+            layer_index_buffer.* = switch (layer_type) {
+                .full_attention => b: {
+                    defer self_attn_layer_index += 1;
+                    break :b .{ .self_attn = try .scalar(io, platform, self_attn_layer_index, .u32) };
+                },
+                .linear_attention => b: {
+                    defer linear_attn_layer_index += 1;
+                    break :b .{ .linear_attn = try .scalar(io, platform, linear_attn_layer_index, .u32) };
+                },
+            };
+            initialized_layer_index_buffers += 1;
         }
 
-        var self_attn_layer_index: usize = 0;
-        var linear_attn_layer_index: usize = 0;
-        for (layer_types, 0..) |layer_type, layer_index| {
-            switch (layer_type) {
-                .full_attention => {
-                    const layer_index_buffer = try zml.Buffer.scalar(io, platform, @as(u32, @intCast(self_attn_layer_index)), .u32);
-                    layer_index_buffers[layer_index] = .{ .self_attn = layer_index_buffer };
-                    self_attn_layer_index += 1;
-                },
-                .linear_attention => {
-                    const layer_index_buffer = try zml.Buffer.scalar(io, platform, @as(u32, @intCast(linear_attn_layer_index)), .u32);
-                    layer_index_buffers[layer_index] = .{ .linear_attn = layer_index_buffer };
-                    linear_attn_layer_index += 1;
-                },
-            }
-        }
+        const generated_token_slice = try zml.Slice.alloc(allocator, zml.Shape.init(.{ .b = 1, .s = 1 }, .u32));
+        errdefer generated_token_slice.free(allocator);
 
-        var decode_token_index_buffer = try zml.Buffer.scalar(io, platform, @as(u32, 0), .u32);
-        errdefer decode_token_index_buffer.deinit();
-
-        var self_attn_layers_caches = try allocator.alloc(zml.Bufferized(model.KvCache.SelfAttnCache), self_attn_layer_index);
-        errdefer allocator.free(self_attn_layers_caches);
-
-        var linear_attn_layers_caches = try allocator.alloc(zml.Bufferized(model.KvCache.GatedDeltaNetCache), linear_attn_layer_index);
-        errdefer allocator.free(linear_attn_layers_caches);
-
-        var self_attn_cache_index: usize = 0;
-        var linear_attn_cache_index: usize = 0;
-        for (layer_types, 0..) |layer_type, layer_index| {
-            switch (layer_type) {
-                .full_attention => {
-                    const layer_index_buffer = switch (layer_index_buffers[layer_index]) {
-                        .self_attn => |buffer| buffer,
-                        .linear_attn => unreachable,
-                    };
-                    self_attn_layers_caches[self_attn_cache_index] = .{
-                        .k = kv_cache_buffers.self_attn.k,
-                        .v = kv_cache_buffers.self_attn.v,
-                        .layer_index = layer_index_buffer,
-                    };
-                    self_attn_cache_index += 1;
-                },
-                .linear_attention => {
-                    const layer_index_buffer = switch (layer_index_buffers[layer_index]) {
-                        .linear_attn => |buffer| buffer,
-                        .self_attn => unreachable,
-                    };
-                    linear_attn_layers_caches[linear_attn_cache_index] = .{
-                        .conv_state = kv_cache_buffers.gated_delta_net.conv_state,
-                        .recurrent_state = kv_cache_buffers.gated_delta_net.recurrent_state,
-                        .layer_index = layer_index_buffer,
-                    };
-                    linear_attn_cache_index += 1;
-                },
-            }
-        }
+        var prefill = try inference.KernelRunner.init(allocator, &compiled_model.prefill, model_buffers);
+        errdefer prefill.deinit(allocator);
+        const decode = try inference.KernelRunner.init(allocator, &compiled_model.decode, model_buffers);
 
         return .{
             .allocator = allocator,
             .io = io,
             .platform = platform,
-            .model_buffers = model_buffers,
             .compiled_model = compiled_model,
+            .prefill = prefill,
+            .decode = decode,
             .kv_cache_buffers = kv_cache_buffers,
             .prefill_moe_metadata_buffers = prefill_moe_metadata_buffers,
             .decode_moe_metadata_buffers = decode_moe_metadata_buffers,
             .rng_buffers = rng_buffers,
             .layer_index_buffers = layer_index_buffers,
-            .decode_token_index_buffer = decode_token_index_buffer,
-            .self_attn_layers_caches = self_attn_layers_caches,
-            .linear_attn_layers_caches = linear_attn_layers_caches,
-            .step_token_slice = try .alloc(allocator, zml.Shape.init(.{ .b = 1, .s = 1 }, .u32)),
-            .generated_token_slice = try .alloc(allocator, zml.Shape.init(.{ .b = 1, .s = 1 }, .u32)),
+            .generated_token_slice = generated_token_slice,
             .tokenizer = tokenizer,
             .seqlen = compiled_model.params.seqlen,
             .eos_token_id = compiled_model.loaded_model.inner.special_tokens.end_of_text_token_id,
@@ -150,11 +103,12 @@ pub const Session = struct {
     }
 
     pub fn deinit(self: *Session) void {
+        self.prefill.deinit(self.allocator);
+        self.decode.deinit(self.allocator);
         model.KvCache.deinitBuffer(&self.kv_cache_buffers);
         zml.moe.Metadata.deinitBuffer(&self.prefill_moe_metadata_buffers);
         zml.moe.Metadata.deinitBuffer(&self.decode_moe_metadata_buffers);
         zml.Tensor.Rng.deinitBuffer(&self.rng_buffers);
-        self.decode_token_index_buffer.deinit();
         for (self.layer_index_buffers) |*layer_index_buffer| {
             switch (layer_index_buffer.*) {
                 .self_attn => |*buffer| buffer.deinit(),
@@ -162,9 +116,6 @@ pub const Session = struct {
             }
         }
         self.allocator.free(self.layer_index_buffers);
-        self.allocator.free(self.self_attn_layers_caches);
-        self.allocator.free(self.linear_attn_layers_caches);
-        self.step_token_slice.free(self.allocator);
         self.generated_token_slice.free(self.allocator);
     }
 
@@ -176,247 +127,68 @@ pub const Session = struct {
         return tokenizeChatPrompt(allocator, self.tokenizer, prompt, self.special_tokens, false);
     }
 
-    fn storeSelfAttnLayerCache(
-        self: *Session,
-        dense_layer_index: usize,
-        layer_index: usize,
-        layer_cache: zml.Bufferized(model.KvCache.SelfAttnCache),
-    ) void {
-        self.kv_cache_buffers.self_attn.k = layer_cache.k;
-        self.kv_cache_buffers.self_attn.v = layer_cache.v;
-        self.self_attn_layers_caches[dense_layer_index] = layer_cache;
-        self.layer_index_buffers[layer_index] = .{ .self_attn = layer_cache.layer_index };
-    }
-
-    fn storeLinearAttnLayerCache(
-        self: *Session,
-        dense_layer_index: usize,
-        layer_index: usize,
-        layer_cache: zml.Bufferized(model.KvCache.GatedDeltaNetCache),
-    ) void {
-        self.kv_cache_buffers.gated_delta_net.conv_state = layer_cache.conv_state;
-        self.kv_cache_buffers.gated_delta_net.recurrent_state = layer_cache.recurrent_state;
-        self.linear_attn_layers_caches[dense_layer_index] = layer_cache;
-        self.layer_index_buffers[layer_index] = .{ .linear_attn = layer_cache.layer_index };
-    }
-
     pub fn runPrefill(self: *Session, all_tokens: []const u32) !void {
-        const hidden_size = self.compiled_model.loaded_model.inner.config.text_config.hidden_size;
-        const model_dtype = self.compiled_model.loaded_model.inner.text_model.embed_tokens.weight.dtype();
+        const tokens_slice = try zml.Slice.alloc(self.allocator, .init(.{ .b = 1, .s = self.seqlen }, .u32));
+        defer tokens_slice.free(self.allocator);
+        @memset(tokens_slice.items(u32), 0);
+        @memcpy(tokens_slice.items(u32)[0..all_tokens.len], all_tokens);
 
-        const prefill_tokens_shape = zml.Shape.init(.{ .b = 1, .s = self.seqlen }, .u32);
-        const prefill_hidden_shape = zml.Shape.init(.{ .b = 1, .s = self.seqlen, .d = hidden_size }, model_dtype).withPartitioning(.{
-            .b = .replicated,
-            .s = .replicated,
-            .d = .replicated,
+        var tokens_buffer = try zml.Buffer.fromSlice(self.io, self.platform, tokens_slice, .replicated);
+        defer tokens_buffer.deinit();
+        var token_index_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, 0), .u32);
+        defer token_index_buffer.deinit();
+        var valid_len_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, @intCast(all_tokens.len)), .u32);
+        defer valid_len_buffer.deinit();
+
+        inference.run(&self.prefill, .{
+            .io = self.io,
+            .tokens_buffer = &tokens_buffer,
+            .full_attention_token_index_buffer = &token_index_buffer,
+            .linear_attention_token_index_buffer = &valid_len_buffer,
+            .kv_cache_buffers = &self.kv_cache_buffers,
+            .moe_metadata_buffers = self.prefill_moe_metadata_buffers,
+            .rng_buffers = &self.rng_buffers,
+            .layer_index_buffers = self.layer_index_buffers,
         });
 
-        const prefill_tokens_slice = try zml.Slice.alloc(self.allocator, prefill_tokens_shape);
-        defer prefill_tokens_slice.free(self.allocator);
-        @memset(prefill_tokens_slice.items(u32), 0);
-        @memcpy(prefill_tokens_slice.items(u32)[0..all_tokens.len], all_tokens);
-
-        const replicated_sharding: zml.Sharding = .replicated;
-
-        var prefill_tokens_buffer = try zml.Buffer.fromSlice(self.io, self.platform, prefill_tokens_slice, replicated_sharding);
-        defer prefill_tokens_buffer.deinit();
-
-        var prefill_token_index_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, 0), .u32);
-        defer prefill_token_index_buffer.deinit();
-        var prefill_valid_len_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, @intCast(all_tokens.len)), .u32);
-        defer prefill_valid_len_buffer.deinit();
-
-        var prefill_hidden_buffer = try zml.Buffer.uninitialized(self.io, self.platform, prefill_hidden_shape, replicated_sharding, .{});
-        defer prefill_hidden_buffer.deinit();
-
-        var embedding_prefill_args = try self.compiled_model.prefill_embedding_exe.args(self.allocator);
-        defer embedding_prefill_args.deinit(self.allocator);
-        var embedding_prefill_results = try self.compiled_model.prefill_embedding_exe.results(self.allocator);
-        defer embedding_prefill_results.deinit(self.allocator);
-
-        embedding_prefill_args.set(.{ self.model_buffers.text_model.embed_tokens, prefill_tokens_buffer });
-        self.compiled_model.prefill_embedding_exe.call(embedding_prefill_args, &embedding_prefill_results);
-        embedding_prefill_results.fill(.{&prefill_hidden_buffer});
-
-        var prefill_full_layer_args: ?zml.Exe.Arguments = if (self.compiled_model.prefill_full_layer_exe) |exe| try exe.args(self.allocator) else null;
-        defer if (prefill_full_layer_args) |*args| args.deinit(self.allocator);
-        var prefill_full_layer_results: ?zml.Exe.Results = if (self.compiled_model.prefill_full_layer_exe) |exe| try exe.results(self.allocator) else null;
-        defer if (prefill_full_layer_results) |*results| results.deinit(self.allocator);
-
-        var prefill_linear_layer_args: ?zml.Exe.Arguments = if (self.compiled_model.prefill_linear_layer_exe) |exe| try exe.args(self.allocator) else null;
-        defer if (prefill_linear_layer_args) |*args| args.deinit(self.allocator);
-        var prefill_linear_layer_results: ?zml.Exe.Results = if (self.compiled_model.prefill_linear_layer_exe) |exe| try exe.results(self.allocator) else null;
-        defer if (prefill_linear_layer_results) |*results| results.deinit(self.allocator);
-
-        var self_attn_cache_index: usize = 0;
-        var linear_attn_cache_index: usize = 0;
-
-        for (self.model_buffers.text_model.layers, 0..) |layer_weights, i| {
-            switch (self.layer_index_buffers[i]) {
-                .self_attn => {
-                    const exe = self.compiled_model.prefill_full_layer_exe orelse unreachable;
-                    self.self_attn_layers_caches[self_attn_cache_index].k = self.kv_cache_buffers.self_attn.k;
-                    self.self_attn_layers_caches[self_attn_cache_index].v = self.kv_cache_buffers.self_attn.v;
-                    prefill_full_layer_args.?.set(.{ layer_weights, prefill_hidden_buffer, prefill_token_index_buffer, self.self_attn_layers_caches[self_attn_cache_index], self.compiled_model.loaded_model.inner.config, self.prefill_moe_metadata_buffers });
-                    exe.call(prefill_full_layer_args.?, &prefill_full_layer_results.?);
-                    prefill_full_layer_results.?.fill(.{ &prefill_hidden_buffer, &self.kv_cache_buffers.self_attn });
-                    self_attn_cache_index += 1;
-                },
-                .linear_attn => {
-                    const exe = self.compiled_model.prefill_linear_layer_exe orelse unreachable;
-                    self.linear_attn_layers_caches[linear_attn_cache_index].conv_state = self.kv_cache_buffers.gated_delta_net.conv_state;
-                    self.linear_attn_layers_caches[linear_attn_cache_index].recurrent_state = self.kv_cache_buffers.gated_delta_net.recurrent_state;
-                    prefill_linear_layer_args.?.set(.{ layer_weights, prefill_hidden_buffer, prefill_valid_len_buffer, self.linear_attn_layers_caches[linear_attn_cache_index], self.compiled_model.loaded_model.inner.config, self.prefill_moe_metadata_buffers });
-                    exe.call(prefill_linear_layer_args.?, &prefill_linear_layer_results.?);
-                    prefill_linear_layer_results.?.fill(.{ &prefill_hidden_buffer, &self.kv_cache_buffers.gated_delta_net });
-                    linear_attn_cache_index += 1;
-                },
-            }
-        }
-
-        var sampling_prefill_args = try self.compiled_model.prefill_sampling_exe.args(self.allocator);
-        defer sampling_prefill_args.deinit(self.allocator);
-        var sampling_prefill_results = try self.compiled_model.prefill_sampling_exe.results(self.allocator);
-        defer sampling_prefill_results.deinit(self.allocator);
-
-        sampling_prefill_args.set(.{ .{
-            .norm = self.model_buffers.text_model.norm,
-            .lm_head = self.model_buffers.text_model.lm_head,
-            .gen_options = self.compiled_model.loaded_model.inner.text_model.gen_options,
-        }, prefill_hidden_buffer, self.rng_buffers });
-        self.compiled_model.prefill_sampling_exe.call(sampling_prefill_args, &sampling_prefill_results);
-        sampling_prefill_results.fill(.{ &prefill_tokens_buffer, &self.rng_buffers });
-
-        try prefill_tokens_buffer.toSlice(self.io, prefill_tokens_slice);
-        const generated_token = prefill_tokens_slice.items(u32)[all_tokens.len - 1];
-        self.generated_token_slice.items(u32)[0] = generated_token;
+        try tokens_buffer.toSlice(self.io, tokens_slice);
+        self.generated_token_slice.items(u32)[0] = tokens_slice.items(u32)[all_tokens.len - 1];
     }
 
     pub fn runDecode(self: *Session, all_tokens: *std.ArrayList(u32), stdout: *std.Io.Writer) !void {
         var decoder = try self.tokenizer.decoder();
         defer decoder.deinit();
-
-        const out_tokens_buffer: []u8 = try self.allocator.alloc(u8, 1024);
+        const out_tokens_buffer = try self.allocator.alloc(u8, 1024);
         defer self.allocator.free(out_tokens_buffer);
 
-        const hidden_size = self.compiled_model.loaded_model.inner.config.text_config.hidden_size;
-        const model_dtype = self.compiled_model.loaded_model.inner.text_model.embed_tokens.weight.dtype();
-
-        const decode_hidden_shape = zml.Shape.init(.{ .b = 1, .s = 1, .d = hidden_size }, model_dtype).withPartitioning(.{
-            .b = .replicated,
-            .s = .replicated,
-            .d = .replicated,
-        });
-        const replicated_sharding: zml.Sharding = .replicated;
-
-        var embedding_decode_args = try self.compiled_model.decode_embedding_exe.args(self.allocator);
-        defer embedding_decode_args.deinit(self.allocator);
-        var embedding_decode_results = try self.compiled_model.decode_embedding_exe.results(self.allocator);
-        defer embedding_decode_results.deinit(self.allocator);
-
-        var decode_full_layer_args: ?zml.Exe.Arguments = if (self.compiled_model.decode_full_layer_exe) |exe| try exe.args(self.allocator) else null;
-        defer if (decode_full_layer_args) |*args| args.deinit(self.allocator);
-        var decode_full_layer_results: ?zml.Exe.Results = if (self.compiled_model.decode_full_layer_exe) |exe| try exe.results(self.allocator) else null;
-        defer if (decode_full_layer_results) |*results| results.deinit(self.allocator);
-
-        var decode_linear_layer_args: ?zml.Exe.Arguments = if (self.compiled_model.decode_linear_layer_exe) |exe| try exe.args(self.allocator) else null;
-        defer if (decode_linear_layer_args) |*args| args.deinit(self.allocator);
-        var decode_linear_layer_results: ?zml.Exe.Results = if (self.compiled_model.decode_linear_layer_exe) |exe| try exe.results(self.allocator) else null;
-        defer if (decode_linear_layer_results) |*results| results.deinit(self.allocator);
-
-        var sampling_decode_args = try self.compiled_model.decode_sampling_exe.args(self.allocator);
-        defer sampling_decode_args.deinit(self.allocator);
-        var sampling_decode_results = try self.compiled_model.decode_sampling_exe.results(self.allocator);
-        defer sampling_decode_results.deinit(self.allocator);
-
-        var decode_hidden_buffer = try zml.Buffer.uninitialized(self.io, self.platform, decode_hidden_shape, replicated_sharding, .{});
-        defer decode_hidden_buffer.deinit();
-
-        var current_token_buffer = try zml.Buffer.fromSlice(self.io, self.platform, self.generated_token_slice, replicated_sharding);
+        var current_token_buffer = try zml.Buffer.fromSlice(self.io, self.platform, self.generated_token_slice, .replicated);
         defer current_token_buffer.deinit();
-
         var token_index_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, @intCast(all_tokens.items.len)), .u32);
         defer token_index_buffer.deinit();
-
-        var self_attn_layer_index: usize = 0;
-        var linear_attn_layer_index: usize = 0;
 
         generation: while (true) {
             const token_id = self.generated_token_slice.items(u32)[0];
             if (token_id == self.eos_token_id) break :generation;
 
             const token = try decoder.feedOne(token_id, out_tokens_buffer);
-            if (self.think_start) |think_start| if (token_id == think_start) {
-                try stdout.writeAll("\x1b[2m");
-            };
+            if (self.think_start) |think_start| if (token_id == think_start) try stdout.writeAll("\x1b[2m");
             try stdout.writeAll(token);
-            if (self.think_end) |think_end| if (token_id == think_end) {
-                try stdout.writeAll("\x1b[0m");
-            };
+            if (self.think_end) |think_end| if (token_id == think_end) try stdout.writeAll("\x1b[0m");
             try stdout.flush();
 
             try all_tokens.append(self.allocator, token_id);
             if (all_tokens.items.len >= self.seqlen) break :generation;
 
-            self_attn_layer_index = 0;
-            linear_attn_layer_index = 0;
-
-            embedding_decode_args.set(.{ self.model_buffers.text_model.embed_tokens, current_token_buffer });
-            self.compiled_model.decode_embedding_exe.call(embedding_decode_args, &embedding_decode_results);
-            embedding_decode_results.fill(.{&decode_hidden_buffer});
-
-            for (self.model_buffers.text_model.layers, 0..) |layer_weights, layer_index| {
-                switch (self.layer_index_buffers[layer_index]) {
-                    .self_attn => {
-                        const exe = self.compiled_model.decode_full_layer_exe orelse unreachable;
-                        self.self_attn_layers_caches[self_attn_layer_index].k = self.kv_cache_buffers.self_attn.k;
-                        self.self_attn_layers_caches[self_attn_layer_index].v = self.kv_cache_buffers.self_attn.v;
-
-                        decode_full_layer_args.?.set(.{
-                            layer_weights,
-                            decode_hidden_buffer,
-                            token_index_buffer,
-                            self.self_attn_layers_caches[self_attn_layer_index],
-                            self.compiled_model.loaded_model.inner.config,
-                            self.decode_moe_metadata_buffers,
-                        });
-
-                        exe.call(decode_full_layer_args.?, &decode_full_layer_results.?);
-                        decode_full_layer_results.?.fill(.{ &decode_hidden_buffer, &self.kv_cache_buffers.self_attn });
-
-                        self_attn_layer_index += 1;
-                    },
-                    .linear_attn => {
-                        const exe = self.compiled_model.decode_linear_layer_exe orelse unreachable;
-
-                        self.linear_attn_layers_caches[linear_attn_layer_index].conv_state = self.kv_cache_buffers.gated_delta_net.conv_state;
-                        self.linear_attn_layers_caches[linear_attn_layer_index].recurrent_state = self.kv_cache_buffers.gated_delta_net.recurrent_state;
-
-                        decode_linear_layer_args.?.set(.{
-                            layer_weights,
-                            decode_hidden_buffer,
-                            token_index_buffer,
-                            self.linear_attn_layers_caches[linear_attn_layer_index],
-                            self.compiled_model.loaded_model.inner.config,
-                            self.decode_moe_metadata_buffers,
-                        });
-
-                        exe.call(decode_linear_layer_args.?, &decode_linear_layer_results.?);
-                        decode_linear_layer_results.?.fill(.{ &decode_hidden_buffer, &self.kv_cache_buffers.gated_delta_net });
-
-                        linear_attn_layer_index += 1;
-                    },
-                }
-            }
-
-            sampling_decode_args.set(.{ .{
-                .norm = self.model_buffers.text_model.norm,
-                .lm_head = self.model_buffers.text_model.lm_head,
-                .gen_options = self.compiled_model.loaded_model.inner.text_model.gen_options,
-            }, decode_hidden_buffer, self.rng_buffers, token_index_buffer });
-            self.compiled_model.decode_sampling_exe.call(sampling_decode_args, &sampling_decode_results);
-            sampling_decode_results.fill(.{ &current_token_buffer, &self.rng_buffers, &token_index_buffer });
-
+            inference.run(&self.decode, .{
+                .io = self.io,
+                .tokens_buffer = &current_token_buffer,
+                .full_attention_token_index_buffer = &token_index_buffer,
+                .linear_attention_token_index_buffer = &token_index_buffer,
+                .kv_cache_buffers = &self.kv_cache_buffers,
+                .moe_metadata_buffers = self.decode_moe_metadata_buffers,
+                .rng_buffers = &self.rng_buffers,
+                .layer_index_buffers = self.layer_index_buffers,
+            });
             try current_token_buffer.toSlice(self.io, self.generated_token_slice);
         }
 
@@ -436,31 +208,25 @@ fn tokenizeChatPrompt(allocator: std.mem.Allocator, tokenizer: zml.tokenizer.Tok
     if (!is_first_turn) {
         try tokens.append(allocator, im_end);
         const newline = try encoder.encodeAlloc(allocator, "\n");
+        defer allocator.free(newline);
         try tokens.appendSlice(allocator, newline);
-        allocator.free(newline);
     }
 
     try tokens.append(allocator, im_start);
     const user = try encoder.encodeAlloc(allocator, "user\n");
+    defer allocator.free(user);
     try tokens.appendSlice(allocator, user);
-    allocator.free(user);
     const prompt_encoded = try encoder.encodeAlloc(allocator, prompt);
+    defer allocator.free(prompt_encoded);
     try tokens.appendSlice(allocator, prompt_encoded);
-    allocator.free(prompt_encoded);
     try tokens.append(allocator, im_end);
     const newline = try encoder.encodeAlloc(allocator, "\n");
+    defer allocator.free(newline);
     try tokens.appendSlice(allocator, newline);
-    allocator.free(newline);
     try tokens.append(allocator, im_start);
     const assistant = try encoder.encodeAlloc(allocator, "assistant\n");
+    defer allocator.free(assistant);
     try tokens.appendSlice(allocator, assistant);
-    allocator.free(assistant);
 
     return tokens.toOwnedSlice(allocator);
-}
-
-fn encodeSingleToken(encoder: *zml.tokenizer.Tokenizer.Encoder, text: []const u8) !u32 {
-    const encoded = try encoder.encode(text);
-    if (encoded.len != 1) return error.InvalidTokenizerEncoding;
-    return encoded[0];
 }

--- a/zml/exe.zig
+++ b/zml/exe.zig
@@ -4,11 +4,14 @@ const pjrt = @import("pjrt");
 const stdx = @import("stdx");
 
 const Buffer = @import("buffer.zig").Buffer;
+const mem = @import("mem.zig");
 const meta = @import("meta.zig");
+const module = @import("module.zig");
 const Platform = @import("platform.zig").Platform;
 const tracer = @import("profiling/tracer.zig");
 const Shape = @import("shape.zig").Shape;
 const Sharding = @import("Sharding.zig");
+const Tensor = @import("tensor.zig").Tensor;
 
 pub const Exe = struct {
     platform: *const Platform,
@@ -259,6 +262,42 @@ pub const Exe = struct {
         }
     };
 
+    /// An executable together with reusable argument and result storage.
+    /// A runner owns all three values and must not be used concurrently.
+    pub const Runner = struct {
+        exe: Exe,
+        args: Arguments,
+        results: Results,
+
+        /// Takes ownership of the executable and allocates reusable argument and result storage.
+        pub fn init(exe: Exe, allocator: std.mem.Allocator) !Runner {
+            errdefer exe.deinit();
+            var arguments = try exe.args(allocator);
+            errdefer arguments.deinit(allocator);
+            var results_ = try exe.results(allocator);
+            errdefer results_.deinit(allocator);
+            return .{ .exe = exe, .args = arguments, .results = results_ };
+        }
+
+        pub fn deinit(self: *Runner, allocator: std.mem.Allocator) void {
+            self.results.deinit(allocator);
+            self.args.deinit(allocator);
+            self.exe.deinit();
+        }
+
+        pub fn run(self: *Runner, input_values: anytype, output_values: anytype) void {
+            self.args.set(input_values);
+            self.exe.call(self.args, &self.results);
+            self.results.fill(output_values);
+        }
+
+        pub fn runOpts(self: *Runner, io: std.Io, input_values: anytype, output_values: anytype, opts: CallOpts) void {
+            self.args.set(input_values);
+            self.exe.callOpts(io, self.args, &self.results, opts);
+            self.results.fill(output_values);
+        }
+    };
+
     pub fn internalCall(self: *const Exe, io: ?std.Io, arguments: Arguments, results_: *Results, opts: CallOpts) void {
         stdx.debug.assert(opts.wait == false or io != null, "io should not be null when waiting for execution completion", .{});
         var events = [_]?*pjrt.Event{null} ** Platform.MAX_NUM_DEVICES;
@@ -328,3 +367,216 @@ pub const Exe = struct {
         return self.internalCall(null, arguments, results_, .{});
     }
 };
+
+/// A typed executable whose input and output buffer structures are derived from
+/// the function used to compile it.
+pub fn TypedExe(comptime function_: anytype) type {
+    const function_info = switch (@typeInfo(@TypeOf(function_))) {
+        .@"fn" => |info| info,
+        else => @compileError("TypedExe expects a function, got " ++ @typeName(@TypeOf(function_))),
+    };
+    if (function_info.is_var_args or function_info.params.len != 1) {
+        @compileError("TypedExe function must accept exactly one input struct");
+    }
+
+    const FunctionInput = typedFunctionInput(function_);
+    const FunctionOutput = typedFunctionOutput(function_);
+
+    return struct {
+        raw: Exe,
+
+        pub const Input = mem.Bufferized(FunctionInput);
+        pub const Output = typedOutputDestinations(mem.Bufferized(FunctionOutput));
+
+        const Self = @This();
+
+        pub fn init(raw: Exe) Self {
+            return .{ .raw = raw };
+        }
+
+        pub fn compile(
+            allocator: std.mem.Allocator,
+            io: std.Io,
+            platform: *const Platform,
+            opts: module.CompilationOptions,
+            args: std.meta.ArgsTuple(@TypeOf(function_)),
+        ) module.CompileError!Self {
+            return .{ .raw = try module.Compiler(function_).compile(allocator, io, platform, opts, args) };
+        }
+
+        pub fn deinit(self: *const Self) void {
+            self.raw.deinit();
+        }
+
+        /// An executable together with reusable argument and result storage.
+        /// A runner owns all three values and must not be used concurrently.
+        pub fn Runner(comptime baked_fields: anytype) type {
+            const count = countBackedFields(Input, baked_fields);
+
+            return struct {
+                exe: Exe,
+                args: Exe.Arguments,
+                results: Exe.Results,
+
+                const RunnerSelf = @This();
+
+                pub const BakedInput = structFieldRange(Input, 0, count);
+                pub const NonBakedInput = structFieldRange(Input, count, @typeInfo(Input).@"struct".fields.len);
+
+                pub fn init(exe: *const Self, allocator: std.mem.Allocator, baked: BakedInput) !RunnerSelf {
+                    var arguments = try exe.raw.args(allocator);
+                    errdefer arguments.deinit(allocator);
+                    var results = try exe.raw.results(allocator);
+                    errdefer results.deinit(allocator);
+                    arguments.bake(baked);
+                    return .{ .exe = exe.raw, .args = arguments, .results = results };
+                }
+
+                pub fn deinit(self: *RunnerSelf, allocator: std.mem.Allocator) void {
+                    self.results.deinit(allocator);
+                    self.args.deinit(allocator);
+                }
+
+                pub fn run(self: *RunnerSelf, io: std.Io, call: struct {
+                    inputs: NonBakedInput,
+                    outputs: Output,
+                    opts: Exe.CallOpts = .{},
+                }) void {
+                    self.args.set(call.inputs);
+                    self.exe.callOpts(io, self.args, &self.results, call.opts);
+                    self.results.fill(call.outputs);
+                }
+            };
+        }
+    };
+}
+
+fn countBackedFields(comptime Input: type, comptime baked_fields: anytype) usize {
+    const baked_info = switch (@typeInfo(@TypeOf(baked_fields))) {
+        .@"struct" => |info| info,
+        else => @compileError("TypedExe baked fields must be a tuple of enum literals"),
+    };
+    if (!baked_info.is_tuple) {
+        @compileError("TypedExe baked fields must be a tuple of enum literals");
+    }
+
+    const input_fields = @typeInfo(Input).@"struct".fields;
+    if (baked_info.fields.len > input_fields.len) {
+        @compileError("TypedExe baked fields must be a prefix of its bufferized input fields");
+    }
+
+    inline for (baked_info.fields, 0..) |tuple_field, i| {
+        const baked_field = @field(baked_fields, tuple_field.name);
+        if (@TypeOf(baked_field) != @EnumLiteral()) {
+            @compileError("TypedExe baked fields must be enum literals");
+        }
+        if (!std.mem.eql(u8, @tagName(baked_field), input_fields[i].name)) {
+            @compileError("TypedExe baked fields must be an ordered prefix of its bufferized input fields");
+        }
+    }
+    return baked_info.fields.len;
+}
+
+fn structFieldRange(comptime Struct: type, comptime start: usize, comptime end: usize) type {
+    const fields = @typeInfo(Struct).@"struct".fields[start..end];
+    var field_names: [fields.len][]const u8 = undefined;
+    var field_types: [fields.len]type = undefined;
+    var field_attrs: [fields.len]std.builtin.Type.StructField.Attributes = undefined;
+    for (&field_names, &field_types, &field_attrs, fields) |*name, *T, *attrs, field| {
+        name.* = field.name;
+        T.* = field.type;
+        attrs.* = .{
+            .@"comptime" = field.is_comptime,
+            .@"align" = field.alignment,
+            .default_value_ptr = field.default_value_ptr,
+        };
+    }
+    return @Struct(.auto, null, &field_names, &field_types, &field_attrs);
+}
+
+fn typedFunctionInput(comptime function_: anytype) type {
+    const Input = @typeInfo(@TypeOf(function_)).@"fn".params[0].type orelse
+        @compileError("TypedExe function must have a concrete input type");
+    validateTypedExeStruct("input", Input);
+    return Input;
+}
+
+fn typedFunctionOutput(comptime function_: anytype) type {
+    const Output = @typeInfo(@TypeOf(function_)).@"fn".return_type orelse @compileError("TypedExe function must return an output struct");
+    validateTypedExeStruct("output", Output);
+    return Output;
+}
+
+fn validateTypedExeStruct(comptime role: []const u8, comptime T: type) void {
+    const info = switch (@typeInfo(T)) {
+        .@"struct" => |info| info,
+        else => @compileError("TypedExe " ++ role ++ " must be a struct, got " ++ @typeName(T)),
+    };
+    if (info.is_tuple) {
+        @compileError("TypedExe " ++ role ++ " must use named fields");
+    }
+}
+
+fn typedOutputDestinations(comptime BufferizedOutput: type) type {
+    const output_info = @typeInfo(BufferizedOutput).@"struct";
+    const fields = output_info.fields;
+    var field_names: [fields.len][]const u8 = undefined;
+    var field_types: [fields.len]type = undefined;
+    var field_attrs: [fields.len]std.builtin.Type.StructField.Attributes = undefined;
+    for (&field_names, &field_types, &field_attrs, fields) |*name, *T, *attrs, field| {
+        name.* = field.name;
+        T.* = *field.type;
+        attrs.* = .{ .@"align" = @alignOf(*field.type) };
+    }
+    return @Struct(.auto, null, &field_names, &field_types, &field_attrs);
+}
+
+test "TypedExe derives baked and runtime calls from a function" {
+    const Inputs = struct {
+        weights: struct {
+            tensor: Tensor,
+            scale: f32,
+        },
+        bias: Tensor,
+        tokens: Tensor,
+        token_count: usize,
+    };
+    const Outputs = struct {
+        hidden: Tensor,
+        cache: struct {
+            key: Tensor,
+            length: usize,
+        },
+        metadata: usize,
+    };
+    const Functions = struct {
+        fn forward(inputs: Inputs) Outputs {
+            _ = inputs;
+            return undefined;
+        }
+    };
+
+    const Model = TypedExe(Functions.forward);
+    try std.testing.expect(@hasField(Model.Input, "weights"));
+    try std.testing.expect(@hasField(Model.Input, "bias"));
+    try std.testing.expect(@hasField(Model.Input, "tokens"));
+    try std.testing.expect(!@hasField(Model.Input, "token_count"));
+    try std.testing.expect(!@hasField(@FieldType(Model.Input, "weights"), "scale"));
+
+    const Baked = Model.Runner(.{ .weights, .bias }).BakedInput;
+    try std.testing.expect(@hasField(Baked, "weights"));
+    try std.testing.expect(@hasField(Baked, "bias"));
+    try std.testing.expect(!@hasField(Baked, "tokens"));
+
+    const Runtime = Model.Runner(.{ .weights, .bias }).NonBakedInput;
+    try std.testing.expect(!@hasField(Runtime, "weights"));
+    try std.testing.expect(!@hasField(Runtime, "bias"));
+    try std.testing.expectEqual(Buffer, @FieldType(Runtime, "tokens"));
+
+    try std.testing.expectEqual(*Buffer, @FieldType(Model.Output, "hidden"));
+    try std.testing.expectEqual(
+        *mem.Bufferized(@FieldType(Outputs, "cache")),
+        @FieldType(Model.Output, "cache"),
+    );
+    try std.testing.expect(!@hasField(Model.Output, "metadata"));
+}

--- a/zml/module.zig
+++ b/zml/module.zig
@@ -57,6 +57,14 @@ pub const CompilationOptions = struct {
     xla_dump_emitter_re: ?[]const u8 = null,
 };
 
+/// Errors surfaced while lowering and compiling a ZML program.
+pub const CompileError = std.mem.Allocator.Error ||
+    std.Io.Writer.Error ||
+    mlir.Error ||
+    upb.SerializeError ||
+    pjrtx.Client.CompileError ||
+    error{MissingDeviceInTile};
+
 const AttributeList = stdx.BoundedArray(mlir.NamedAttribute, 3);
 
 pub const CompilationContext = struct {
@@ -228,7 +236,7 @@ pub fn Compiler(comptime func: anytype) type {
             platform: *const Platform,
             opts: CompilationOptions,
             args: std.meta.ArgsTuple(@TypeOf(func)),
-        ) !Exe {
+        ) CompileError!Exe {
             return zml_module.compile(allocator, io, func, args, platform, opts);
         }
     };
@@ -241,7 +249,7 @@ pub fn compile(
     args: std.meta.ArgsTuple(@TypeOf(func)),
     platform: *const Platform,
     opts: CompilationOptions,
-) !Exe {
+) CompileError!Exe {
     // TODO: Here we have somewhat of a requirement
     // Emitting MLIR requires to have the compilation context available at all times using `CompilationContext.current()`.
     // If in the future, we inject an Io that is not thread-based, we might have some surprises.

--- a/zml/zml.zig
+++ b/zml/zml.zig
@@ -21,6 +21,7 @@ pub const Data = dtype.Data;
 pub const DataType = dtype.DataType;
 pub const exe = @import("exe.zig");
 pub const Exe = exe.Exe;
+pub const TypedExe = exe.TypedExe;
 pub const floats = @import("floats.zig");
 pub const io = @import("io.zig");
 pub const kernel = @import("kernel.zig");


### PR DESCRIPTION
in LLMD and //examples/llm, we compile multiple executable, re-use the args & results. We do all of this manually, in addition we don't have any type-safety on the arguments/outputs which is a bit too easy to misuse IMHO.

So adding two abstractions:
- Runner: Packs the args, exe and results together to avoid calling  `args.set`, `exe.run` and `results.fill` with similar arguments. Today it owns the Exe. It doensn't strictly needs it, but it's simpler and works for us for now.
- TypedExe: Type-safe version of an Exe, expecting a single input & ouptut to have keyed arguments to have fully unambiguous arguments & results mapping.

I've updated //example/llm with this new pattern.

Also adding an explicit `zml.module.CompileError`.
