### PR TITLE
docs: add CONTRIBUTING.md and update references in README and concepts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to ZML
+
+Thanks for contributing. This file is the short entry point; day-to-day agent and
+contributor conventions also live in [`AGENTS.md`](./AGENTS.md).
+
+## Layout
+
+- `zml/` — core library (Tensor, Shape, Buffer, compile, IO, attention, MoE, …)
+- `stdx/` — shared Zig utilities
+- `ffi/`, `upb/` — C helpers and protobuf (XLA compile options)
+- `mlir/`, `pjrt/`, `platforms/` — MLIR bindings, PJRT, accelerator plugins
+- `examples/`, `docs/` — runnable examples and documentation
+- `bazel/`, `third_party/` — build wiring and vendored deps
+
+## Build and test
+
+```bash
+bazel build //zml
+bazel test //zml:test
+bazel test //stdx:test
+bazel test //zml/tokenizer:test
+bazel run //examples/mnist
+```
+
+Platform flags when relevant, for example:
+
+```bash
+--@zml//platforms:cuda=true
+--@zml//platforms:rocm=true
+--@zml//platforms:tpu=true
+--@zml//platforms:cpu=false
+```
+
+Format Zig with `zig fmt` (CI runs `zig fmt --check` outside `third_party/`).
+Format Starlark with `./tools/buildifier.sh`.
+
+## Style
+
+Follow the [Zig style guide](https://ziglang.org/documentation/master/#Style-Guide)
+and [`docs/misc/style_guide.md`](./docs/misc/style_guide.md). Prefer
+`const x: Foo = .{ .bar = 1 };`, `pub fn method(self: Foo)`, PascalCase types,
+lowerCamelCase functions/fields.
+
+## Pull requests
+
+- Scoped, imperative subjects (e.g. `zml/tensor: add Tensor.onMemory()`).
+- Short description, linked issue if any, platform impact, and the exact
+  `bazel build` / `bazel test` commands you ran.
+- Keep docs in sync with public APIs (`zml.Slice`, `zml.Exe`, `zml.Bufferized`,
+  `zml.io.TensorStore` / `Loader` — not older names like HostBuffer / Executable / aio).
+
+## License
+
+Contributions are under the [Apache 2.0 license](./LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,8 +23,10 @@ Ready to write some code? Try starting with [your first model in ZML](./tutorial
 
 ## Learn more...
 
-- [ZML Concepts](./learn/concepts.md) : **Tensors, Models, Executables, etc. explained**
+- [ZML Concepts](./learn/concepts.md) : **Tensors, Models, Exe, Bufferized, etc. explained**
 
 ## Contribute
 
+- [Contributing](../CONTRIBUTING.md)
 - [Style Guide](./misc/style_guide.md)
+- [AGENTS.md](../AGENTS.md) (repo layout, commands, conventions)

--- a/docs/learn/concepts.md
+++ b/docs/learn/concepts.md
@@ -1,28 +1,28 @@
-
 # ZML Concepts
 
 ## Model lifecycle
 
 ZML is an inference stack that helps running Machine Learning (ML) models, and
-particulary Neural Networks (NN).
+particularly Neural Networks (NN).
 
 The lifecycle of a model is implemented in the following steps:
 
-1. Open the model file and read the shapes of the weights, but don't load the weights 
+1. Open the model file and read the shapes of the weights, but don't load the weights
    yet.
 
 2. Using the loaded shapes and optional metadata, instantiate a model struct
    with `Tensor`s, representing the shape and layout of each layer of the NN.
 
-3. Compile the model struct and it's `forward` function into an accelerator
-   specific executable. The `forward` function describes the mathematical
+3. Compile the model struct and its `forward` function into an accelerator
+   specific executable (`zml.Exe`). The `forward` function describes the mathematical
    operations corresponding to the model inference.
 
-4. Load the model weights from disk, onto the accelerator memory.
+4. Load the model weights from disk, onto the accelerator memory
+   (typically via `zml.io.TensorStore` + `zml.io.Loader` into a `zml.Bufferized(Model)`).
 
 5. Load some user inputs, and copy them to the accelerator.
 
-6. Call the executable using the weights and the user inputs.
+6. Call the executable using the weights and the user inputs (`Exe.call`).
 
 7. Fetch the returned model output from accelerator into host memory, and
    finally present it to the user.
@@ -58,15 +58,18 @@ Let's explain all that.
     `Shape` struct can also represent a regular number, aka a scalar:
     `Shape.init(.{}, .i32)` represents a 32-bit signed integer.
 
+    Axes can also be **tagged** (named) for clearer ops and sharding; see
+    [Working with tensors](../tutorials/working_with_tensors.md).
+
 * `Slice`: _is_ the combination of a `Shape` and raw bytes (bytes that are **on the CPU**).
-  - can own the underlying memory - but can also accomodate non-owned memory.
+  - can own the underlying memory - but can also accommodate non-owned memory.
 
 * `Buffer`: _is_ a multi-dimension array, whose memory is allocated **on an
   accelerator**.
     - contains a handle that the ZML runtime can use to convert it into a
       physical address, but there is no guarantee this address is visible from
       the CPU.
-    - can be created from a `Slice` by calling `Buffer.fromSlice(...)`. 
+    - can be created from a `Slice` by calling `Buffer.fromSlice(...)`.
 
 * `Tensor`: is a mathematical object representing an intermediary result of a
   computation or an input to an executable (including weights).
@@ -76,7 +79,7 @@ Let's explain all that.
 ## The model struct
 
 The model struct is the Zig code that describes your Neural Network (NN).
-Let's look a the following model architecture:
+Let's look at the following model architecture:
 
 ![Multilayer perceptrons](https://raw.githubusercontent.com/zml/zml.github.io/refs/heads/main/docs-assets/perceptron.png)
 
@@ -116,7 +119,7 @@ models.
 
 Since the `Model` struct contains `Tensor`s, it is only ever useful during the
 compilation stage, but not during inference. If we want to represent the model
-with actual `Buffer`s, we can use the `zml.Bufferize(Model)`, which is a mirror
+with actual `Buffer`s, we can use `zml.Bufferized(Model)`, which is a mirror
 struct of `Model` but with a `Buffer` replacing every `Tensor`.
 
 ## Strong type checking
@@ -125,21 +128,23 @@ Let's look at the model life cycle again, but this time annotated with the
 corresponding types.
 
 1. Open the model file and read the shapes of the weights -> `zml.Shape`
+   (e.g. via `zml.safetensors.TensorRegistry`)
 
 2. Instantiate a model struct -> `Model` struct (with `zml.Tensor` inside)
 
 3. Compile the model struct and its `forward` function into an executable.
-   `foward` is a `Tensor -> Tensor` function, executable is a
-   `zml.Executable`
+   `forward` is a `Tensor -> Tensor` function; the executable is a
+   `zml.Exe`
 
 4. Load the model weights from disk, onto accelerator memory ->
-   `zml.Bufferized(Model)` struct (with `zml.Buffer` inside)
+   `zml.Bufferized(Model)` struct (with `zml.Buffer` inside), typically via
+   `zml.io.Loader`
 
 5. Load some user inputs (custom struct), encode them into arrays of numbers
    (`zml.Slice`), and copy them to the accelerator (`zml.Buffer`).
 
-6. Call the executable on the user inputs. `module.call` accepts `zml.Buffer`
-   arguments and returns `zml.Buffer`
+6. Call the executable on the user inputs. `Exe.call` / `Exe.callOpts` accept
+   `zml.Buffer` arguments (via `Exe.Arguments`) and produce `zml.Buffer` results.
 
 7. Return the model output (`zml.Buffer`) to the host (`zml.Slice`),
    decode it (custom struct) and finally return to the user.

--- a/docs/tutorials/working_with_tensors.md
+++ b/docs/tutorials/working_with_tensors.md
@@ -1,7 +1,56 @@
-
 # Simplifying Dimension Handling with Tagged Tensors
 
-### Coming Soon...
+In most frameworks, axes are anonymous indices: `x.transpose(1, 2)` or
+`matmul(a, b)` and you hope the ranks line up. ZML lets you **name** axes with
+tags so ops, reshapes, and sharding refer to meaning instead of positions.
 
-See [ZML Concepts](../learn/concepts.md) for an introduction to Tensors and Shapes.
+## Shapes with tags
 
+Pass enum literals (or other tag sources) when building a `Shape`:
+
+```zig
+const s = zml.Shape.init(.{ .batch = 32, .seq = 128, .d = 4096 }, .f16);
+```
+
+Or attach tags to an existing tensor:
+
+```zig
+const x = input.flatten().convert(.f32).withTags(.{.d});
+```
+
+Query by name:
+
+```zig
+const seq_len = x.dim(.seq);
+const axis = x.axis(.d);
+```
+
+## Ops that use tags
+
+Contract / reduce on a named axis instead of a raw index:
+
+```zig
+// From examples/mnist — linear layer
+return self.weight.dot(input, .d).add(self.bias).relu().withTags(.{.d});
+```
+
+Tags also show up when partitioning for multi-device:
+
+```zig
+shape.withPartitioning(.{ .batch = .data, .hidden = .model });
+```
+
+Logical mesh axes (`.data`, `.model`, …) are registered on the `Platform` /
+`Sharding` mesh; see `examples/sharding` and `zml/Sharding.zig`.
+
+## Why bother
+
+- Fewer off-by-one axis bugs when ranks grow (attention, MoE, KV cache).
+- Broadcast and contract rules can check matching tags.
+- Sharding binds **logical** tags to **mesh** axes without hard-coding dim indices.
+
+## Related
+
+- [ZML Concepts](../learn/concepts.md) — `Shape` / `Slice` / `Buffer` / `Tensor`
+- [Writing your first model](./write_first_model.md)
+- MNIST example: `examples/mnist/mnist.zig`

--- a/docs/tutorials/write_first_model.md
+++ b/docs/tutorials/write_first_model.md
@@ -47,34 +47,34 @@ touch simple_layer/BUILD.bazel
 Before firing up our editor, let's quickly talk about a few basic ZML
 fundamentals.
 
-In ZML, we describe a _Module_, which represents our AI model, as a Zig
-`struct`. That struct can contain Tensor fields that are used for computation,
-e.g. weights and biases. In the _forward_ function of a Module, we describe the
-computation by calling tensor operations like _mul_, _add_, _dot_,
-_conv2D_, etc., or even nested Modules.
+In ZML, we describe an AI model as a Zig `struct`. That struct can contain
+Tensor fields that are used for computation, e.g. weights and biases. In the
+_forward_ function, we describe the computation by calling tensor operations
+like _mul_, _add_, _dot_, _conv2D_, etc., or even nested layer structs.
 
-ZML creates an MLIR representation of the computation when we compile the
-_Module_. For compilation, only the _Tensors_ are required. No actual tensor data
-is needed at this step. This is important for large models: we can compile them 
-while the actual weight data is being fetched from disk.
+ZML creates an MLIR representation of the computation when we compile that
+struct's forward method. For compilation, only the _Tensors_ are required. No
+actual tensor data is needed at this step. This is important for large models:
+we can compile them while the actual weight data is being fetched from disk.
 
-To accomplish this, ZML uses a _TensorStore_. The _TensorStore_ loads everything
-that is required to make _Tensors_ and later materialize them to _Buffers_. In our
-example though, we won't even use a _TensorStore_ as it's optional. We will directly
-create tensors using their shape and data type.
+To accomplish this for real checkpoints, ZML uses a _TensorStore_
+(`zml.io.TensorStore`). The _TensorStore_ maps names/ids to sources so you can
+build _Tensors_ and later materialize them to _Buffers_ (via `zml.io.Loader`).
+In our example though, we won't use a _TensorStore_. We will directly create
+tensors using their shape and data type.
 
-After compilation is done, we get what we call an _Executable_. From this _Executable_ 
-we can create _Args_ and _Results_, two structs that will store respectively the inputs 
-and outputs of a computation done with an _Executable_.
+After compilation is done, we get what we call an _Exe_ (`zml.Exe`). From this _Exe_
+we can create _Args_ and _Results_, two structs that will store respectively the inputs
+and outputs of a computation done with an _Exe_.
 
 **So the steps for us are:**
 
-- describe the computation as ZML _Module_, using tensor operations
-- initialize the _Module_
-- compile the _Module_ to produce an _Executable_
-- make a "bufferized" version of the _Module_, containing the actual data on the 
+- describe the computation as a ZML model struct (often called a module in prose), using tensor operations
+- initialize the model
+- compile it to produce an _Exe_
+- make a "bufferized" version of the model (`zml.Bufferized(T)`), containing the actual data on the
   computation device
-- prepare the _Args_ and _Results_ of a computation and call the _Executable_
+- prepare the _Args_ and _Results_ of a computation and call the _Exe_
 - get the result back to CPU memory and print it
 
 If you like to read more about the underlying concepts of the above, please see
@@ -146,9 +146,9 @@ boilerplate code for allocations and io.
 
 We also get our ZML CPU platform `platform` automatically.
 
-### Initializing the Module
+### Initializing the model
 
-Next, we need to initialize the module so that we can compile it.
+Next, we need to initialize the model so that we can compile it.
 
 ```zig
 const layer: Layer = .{
@@ -158,11 +158,11 @@ const layer: Layer = .{
 ```
 
 As you can see, it's pretty simple. You can create _Tensors_ from their shape and data type.
-Alternatively, you are free to add an arbitrary `.init()` function to your _Module_ if the
+Alternatively, you are free to add an arbitrary `.init()` function to your model if the
 initialization code is complex.
 
 
-### Compiling our Module for the accelerator
+### Compiling for the accelerator
 
 We're only going to use the CPU for our simple model, but we need to compile the
 `forward()` function nonetheless:
@@ -171,13 +171,13 @@ We're only going to use the CPU for our simple model, but we need to compile the
 // Our computation require an input tensor
 const input: zml.Tensor = .init(.{3}, .f16);
 
-var executable = try platform.compile(allocator, io, layer, .forward, .{input}, .{});
-defer executable.deinit();
+var exe = try platform.compile(allocator, io, layer, .forward, .{input}, .{});
+defer exe.deinit();
 ```
 
-You might wonder what this `sharding` variable is for ? ZML supports sharding tensors across multiple devices,
-and the `compile()` function needs to know how the tensors are sharded in order to compile the module correctly.
-For this simple example, we just replicate the tensors across all devices for simplicity.
+The last argument is `zml.CompilationOptions` (here empty `.{}`). You can pass
+shardings and a partitioner when targeting multiple devices; see `examples/sharding`
+and `zml.Sharding`. For this example, defaults are enough (replicated across devices).
 
 
 ### Creating the "bufferized" Model
@@ -201,14 +201,14 @@ defer layer_buffers.bias.?.deinit();
 
 ### Calling / running the Model
 
-Before being able to run our _Executable_ there is still two steps:
+Before being able to run our _Exe_ there are still two steps:
 - create the input buffer
 - create and fill the _Args_ and _Results_ structs
 
-To create the `input` we already know how to do it, as we did it for the _Module_ 
+To create the `input` we already know how to do it, as we did it for the model
 buffers.
 
-To create the _Args_ and _Results_, the _Executable_ exposes two conveniences.
+To create the _Args_ and _Results_, the _Exe_ exposes two conveniences.
 
 ```zig
 // create the input buffer
@@ -217,17 +217,17 @@ var input_buffer: zml.Buffer = try .fromSlice(io, platform, input_slice, .replic
 defer input_buffer.deinit();
 
 // create the Args and Results structs
-var args = try executable.args(allocator);
+var args = try exe.args(allocator);
 defer args.deinit(allocator);
 
-var results = try executable.results(allocator);
+var results = try exe.results(allocator);
 defer results.deinit(allocator);
 
 // fill the Args
 args.set(.{ layer_buffers, input_buffer });
 
-// call our executable 
-executable.call(args, &results);
+// call our executable
+exe.call(args, &results);
 
 // Retrieve the resulting buffer
 var result = results.get(zml.Buffer);
@@ -357,8 +357,8 @@ pub fn main(init: std.process.Init) !void {
     // Our computation require an input tensor
     const input: zml.Tensor = .init(.{3}, .f16);
 
-    var executable = try platform.compile(allocator, io, layer, .forward, .{input}, .{});
-    defer executable.deinit();
+    var exe = try platform.compile(allocator, io, layer, .forward, .{input}, .{});
+    defer exe.deinit();
 
     const weight_slice: zml.Slice = .init(layer.weight.shape(), std.mem.sliceAsBytes(&[3]f16{ 1.0, 2.0, 3.0 }));
     const bias_slice: zml.Slice = .init(layer.bias.?.shape(), std.mem.sliceAsBytes(&[3]f16{ 1.0, 1.0, 1.0 }));
@@ -375,17 +375,17 @@ pub fn main(init: std.process.Init) !void {
     defer input_buffer.deinit();
 
     // create the Args and Results structs
-    var args = try executable.args(allocator);
+    var args = try exe.args(allocator);
     defer args.deinit(allocator);
 
-    var results = try executable.results(allocator);
+    var results = try exe.results(allocator);
     defer results.deinit(allocator);
 
     // fill the Args
     args.set(.{ layer_buffers, input_buffer });
 
     // call our executable
-    executable.call(args, &results);
+    exe.call(args, &results);
 
     // Retrieve the resulting buffer
     var result = results.get(zml.Buffer);

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -26,8 +26,8 @@ test {
 /// Buffer is a multi-dimension array, whose memory is allocated on an accelerator.
 ///
 /// * contains a handle that the ZML runtime can use to convert into a physical address, but there is no guarantee this address is visible from the CPU.
-/// * loading weights from disk directly to the `device zml.aio.loadBuffers`
-/// * can be created by calling `HostBuffer.toDevice(platform)`.
+/// * weights can be loaded from disk onto device via `zml.io.Loader` / `TensorStore`.
+/// * can be created from a host `Slice` with `Buffer.fromSlice` / `fromSliceOpts`.
 pub const Buffer = struct {
     _platform: *const Platform,
     _shape: Shape,

--- a/zml/testing.zig
+++ b/zml/testing.zig
@@ -46,8 +46,8 @@ fn toSlice(allocator: std.mem.Allocator, io: std.Io, slice_or_buffer: anytype) !
     } else .{ slice_or_buffer, false };
 }
 
-/// Testing utility. Accepts both zml.Buffer and zml.HostBuffer but zml.Buffer will be copied to the
-/// host for comparison !
+/// Testing utility. Accepts both `zml.Buffer` and `zml.Slice`; a `Buffer` is copied to the
+/// host for comparison.
 pub fn expectClose(io: std.Io, left_: anytype, right_: anytype, opts: CompareOpts) !void {
     const allocator = if (builtin.is_test) std.testing.allocator else std.heap.smp_allocator;
     var left: Slice, const should_free_left = try toSlice(allocator, io, left_);


### PR DESCRIPTION
This commit introduces a new CONTRIBUTING.md file outlining guidelines for contributing to the ZML project. It also updates the README to link to the new contributing document and modifies terminology in the concepts documentation to reflect recent changes, including the use of 'Exe' instead of 'Executable'. Additionally, the tutorials have been enhanced with new content on tagged tensors, improving clarity on dimension handling.