### PR TITLE
zml/io: wait for loadExecute call before deiniting input buffers

### DIFF
--- a/zml/io.zig
+++ b/zml/io.zig
@@ -472,7 +472,7 @@ pub const Loader = struct {
         var results = try exe.results(arena);
 
         args.set(.{buffers});
-        exe.call(args, &results);
+        exe.callOpts(io, args, &results, .{ .wait = true });
 
         buffer.* = results.get(Buffer);
     }


### PR DESCRIPTION
Sometimes there is a race where the input buffers get deinited at the end of loadExecute before the executable call finishes, which can corrupt data.

Waiting on the call closes that race, but it also prevents concurrency, so we may need another way to keep the buffers alive without blocking.