### PR TITLE
zml/moe: NVFP4 and block-FP8 Metal custom calls

### DIFF
--- a/examples/llm/models/qwen3_5_moe/model.zig
+++ b/examples/llm/models/qwen3_5_moe/model.zig
@@ -805,6 +805,8 @@ pub const Moe = struct {
             self.down_proj,
             null,
             null,
+            null,
+            null,
             moe_metadata,
             moe_parameters,
         ) catch |err| stdx.debug.panic("moe backend failed: {}", .{err});

--- a/zml/moe/metal.zig
+++ b/zml/moe/metal.zig
@@ -15,6 +15,8 @@ pub const Options = struct {
     expert_map: ?Tensor = null,
     w1_scale: ?Tensor = null,
     w2_scale: ?Tensor = null,
+    w1_global_scale: ?Tensor = null,
+    w2_global_scale: ?Tensor = null,
     w1_bias: ?Tensor = null,
     w2_bias: ?Tensor = null,
 };
@@ -56,21 +58,22 @@ pub fn deinitBuffer(bufferized: *zml.Bufferized(Metadata)) void {
     _ = bufferized;
 }
 
-fn validateOptions(opts: Options) !void {
-    if (opts.expert_map != null) return error.InvalidShape;
-    if (opts.w1_scale != null or opts.w2_scale != null) return error.UnsupportedQuantization;
-    if (opts.w1_bias != null or opts.w2_bias != null) return error.UnsupportedBias;
+const QuantMode = enum { none, fp8, nvfp4 };
+
+fn quantMode(gate_up: Tensor, down: Tensor) !QuantMode {
+    if (gate_up.dtype() != down.dtype()) return error.UnsupportedType;
+    return switch (gate_up.dtype()) {
+        .bf16, .f16, .f32 => .none,
+        .f8e4m3fn => .fp8,
+        .u8, .f4e2m1 => .nvfp4,
+        else => error.UnsupportedType,
+    };
 }
 
-fn validateInputs(hidden: Tensor, gate_up: Tensor, down: Tensor, weights: Tensor, ids: Tensor) !void {
-    for ([_]Tensor{ hidden, gate_up, down, weights }) |t| {
-        switch (t.dtype()) {
-            .bf16, .f16, .f32 => {},
-            else => return error.UnsupportedType,
-        }
-    }
-
-    if (ids.dtype() != .i32) return error.UnsupportedType;
+fn requireScalePair(opts: Options, dtype: zml.DataType) !void {
+    const s1 = opts.w1_scale orelse return error.UnsupportedQuantization;
+    const s2 = opts.w2_scale orelse return error.UnsupportedQuantization;
+    if (s1.dtype() != dtype or s2.dtype() != dtype) return error.UnsupportedType;
 }
 
 fn applyActivation(x: Tensor, mode: ActivationMode) Tensor {
@@ -87,6 +90,46 @@ fn applyActivation(x: Tensor, mode: ActivationMode) Tensor {
     return act.rename(.{ .out = .mid });
 }
 
+fn moeGemm(
+    x_rows: Tensor,
+    w: Tensor,
+    scale: ?Tensor,
+    expert_ids: Tensor,
+    out_shape: zml.Shape,
+    mode: QuantMode,
+) Tensor {
+    const side: zml.ops.CustomCallOptions = .{ .has_side_effect = false };
+    return switch (mode) {
+        .none => zml.ops.customCall("__metal$moe_gemm", .{ x_rows, w, expert_ids }, .{out_shape}, .{}, side),
+        .fp8 => zml.ops.customCall("__metal$moe_gemm$f8", .{ x_rows, w, scale.?, expert_ids }, .{out_shape}, .{}, side),
+        .nvfp4 => zml.ops.customCall("__metal$moe_gemm$f4", .{ x_rows, w, scale.?, expert_ids }, .{out_shape}, .{}, side),
+    };
+}
+
+fn applyGateUpGlobalScale(output: Tensor, global_scale: ?Tensor, expert_ids: Tensor) !Tensor {
+    const scale = global_scale orelse return output;
+    if (scale.dtype() != .f32 or scale.rank() != 2 or scale.dim(.proj) != 2) {
+        return error.InvalidShape;
+    }
+
+    const mid = @divExact(output.dim(.out), 2);
+    const selected = scale.gather(.{ .expert = expert_ids }, .{});
+    const expanded = selected.appendAxes(.{.mid})
+        .broad(zml.Shape.init(.{ .r = output.dim(.r), .proj = 2, .mid = mid }, .f32))
+        .merge(.{ .out = .{ .proj, .mid } });
+    return output.convert(.f32).mul(expanded).convert(output.dtype());
+}
+
+fn applyDownGlobalScale(output: Tensor, global_scale: ?Tensor, expert_ids: Tensor) !Tensor {
+    const scale = global_scale orelse return output;
+    if (scale.dtype() != .f32 or scale.rank() != 1) return error.InvalidShape;
+
+    const selected = scale.gather(.{ .expert = expert_ids }, .{})
+        .appendAxes(.{.d})
+        .broad(output.shape().withDtype(.f32));
+    return output.convert(.f32).mul(selected).convert(output.dtype());
+}
+
 pub fn fusedExpertsImpl(
     hidden_states: Tensor,
     gate_up: Tensor,
@@ -97,8 +140,35 @@ pub fn fusedExpertsImpl(
     opts: Options,
 ) !Tensor {
     _ = metadata;
-    try validateOptions(opts);
-    try validateInputs(hidden_states, gate_up, down, topk_weights, topk_ids);
+    if (opts.expert_map != null) return error.InvalidShape;
+    if (opts.w1_bias != null or opts.w2_bias != null) return error.UnsupportedBias;
+
+    const mode = try quantMode(gate_up, down);
+    switch (mode) {
+        .none => {
+            if (opts.w1_scale != null or opts.w2_scale != null) return error.UnsupportedQuantization;
+            if (opts.w1_global_scale != null or opts.w2_global_scale != null) return error.UnsupportedQuantization;
+            switch (hidden_states.dtype()) {
+                .bf16, .f16, .f32 => {},
+                else => return error.UnsupportedType,
+            }
+        },
+        .fp8 => {
+            try requireScalePair(opts, .bf16);
+            if (opts.w1_global_scale != null or opts.w2_global_scale != null) return error.UnsupportedQuantization;
+            if (hidden_states.dtype() != .bf16) return error.UnsupportedType;
+        },
+        .nvfp4 => {
+            try requireScalePair(opts, .f8e4m3fn);
+            if (hidden_states.dtype() != .bf16) return error.UnsupportedType;
+        },
+    }
+
+    switch (topk_weights.dtype()) {
+        .bf16, .f16, .f32 => {},
+        else => return error.UnsupportedType,
+    }
+    if (topk_ids.dtype() != .i32) return error.UnsupportedType;
 
     const b = hidden_states.dim(.b);
     const s = hidden_states.dim(.s);
@@ -107,29 +177,39 @@ pub fn fusedExpertsImpl(
     const top_expert = topk_ids.dim(.top_expert);
     const num_routes = num_tokens * top_expert;
 
+    const act_dtype: zml.DataType = switch (mode) {
+        .none => hidden_states.dtype(),
+        .fp8, .nvfp4 => .bf16,
+    };
+
     const hidden = hidden_states.reshape(.{ .token = num_tokens, .d = d }).withTags(.{ .token, .d });
     const x_rows = hidden.insertAxes(.d, .{.top_expert})
-        .broad(zml.Shape.init(.{ .token = num_tokens, .top_expert = top_expert, .d = d }, hidden.dtype()))
+        .broad(zml.Shape.init(.{ .token = num_tokens, .top_expert = top_expert, .d = d }, act_dtype))
         .merge(.{ .r = .{ .token, .top_expert } });
     const expert_ids = topk_ids.reshape(.{ .token = num_tokens, .top_expert = top_expert }).withTags(.{ .token, .top_expert })
         .merge(.{ .r = .{ .token, .top_expert } }).convert(.i32);
 
-    const gate_up_out = zml.ops.customCall(
-        "__metal$moe_gemm",
-        .{ x_rows, gate_up, expert_ids },
-        .{zml.Shape.init(.{ .r = num_routes, .out = gate_up.dim(.dout) }, x_rows.dtype())},
-        .{},
-        .{ .has_side_effect = false },
-    );
+    const gate_up_w = if (gate_up.dtype() == .u8) zml.nn.unpackNvfp4(gate_up, .d) else gate_up;
+    const down_w = if (down.dtype() == .u8) zml.nn.unpackNvfp4(down, .dout) else down;
+
+    const gate_up_out = try applyGateUpGlobalScale(moeGemm(
+        x_rows,
+        gate_up_w,
+        opts.w1_scale,
+        expert_ids,
+        zml.Shape.init(.{ .r = num_routes, .out = gate_up_w.dim(.dout) }, act_dtype),
+        mode,
+    ), opts.w1_global_scale, expert_ids);
     const activated = applyActivation(gate_up_out, opts.activation);
 
-    const down_out = zml.ops.customCall(
-        "__metal$moe_gemm",
-        .{ activated, down, expert_ids },
-        .{zml.Shape.init(.{ .r = num_routes, .d = down.dim(.d) }, activated.dtype())},
-        .{},
-        .{ .has_side_effect = false },
-    );
+    const down_out = try applyDownGlobalScale(moeGemm(
+        activated,
+        down_w,
+        opts.w2_scale,
+        expert_ids,
+        zml.Shape.init(.{ .r = num_routes, .d = down_w.dim(.d) }, act_dtype),
+        mode,
+    ), opts.w2_global_scale, expert_ids);
 
     const weights = topk_weights.reshape(.{ .token = num_tokens, .top_expert = top_expert }).withTags(.{ .token, .top_expert })
         .merge(.{ .r = .{ .token, .top_expert } });

--- a/zml/moe/moe.zig
+++ b/zml/moe/moe.zig
@@ -30,7 +30,7 @@ pub const Backend = enum {
                 else => error.UnsupportedDataType,
             },
             .metal => switch (weights_dtype) {
-                .bf16, .f16, .f32 => .metal,
+                .bf16, .f16, .f32, .f4e2m1, .u8, .f8e4m3fn => .metal,
                 else => error.UnsupportedDataType,
             },
             else => error.UnimplementedMoEBackend,
@@ -159,6 +159,8 @@ pub fn forwardMoe(
     weights_down: zml.Tensor,
     scales_down: ?zml.Tensor,
     bias_down: ?zml.Tensor,
+    w1_global_scale: ?zml.Tensor,
+    w2_global_scale: ?zml.Tensor,
     metadata: Metadata,
     parameters: Parameters,
 ) !zml.Tensor {
@@ -334,6 +336,8 @@ pub fn forwardMoe(
                     .global_num_experts = weights_gate_up.dim(.expert),
                     .w1_scale = scales_gate_up,
                     .w2_scale = scales_down,
+                    .w1_global_scale = w1_global_scale,
+                    .w2_global_scale = w2_global_scale,
                     .w1_bias = bias_gate_up,
                     .w2_bias = bias_down,
                 },


### PR DESCRIPTION
Emits `__metal$moe_gemm` / `$f4` / `$f8` so a MoE layer can run bf16, NVFP4 or DeepSeek block-FP8 (`f8e4m3fn` weights + bf16 128×128 scales)

`forwardMoe` takes two new optional arguments, `w1_global_scale` and `w2_global_scale`. The per-expert global (`weight_scale_2`) is applied in-graph after the GEMM.