### PR TITLE
zml/nn: classify quantization schemes and serve them on Linear

### DIFF
--- a/zml/exe.zig
+++ b/zml/exe.zig
@@ -336,7 +336,12 @@ pub const Exe = struct {
             .cpu, .cuda, .rocm, .tpu, .oneapi, .metal => if (opts.wait) {
                 for (events_slice.?) |e| {
                     if (e) |ev| {
-                        ev.await(self.platform.pjrt_api, io.?) catch unreachable;
+                        // A failed execution reports through this event, not through `execute`:
+                        // swallowing it here leaves the caller holding an untouched result buffer.
+                        ev.await(self.platform.pjrt_api, io.?) catch |err| {
+                            std.debug.panic("PJRT execution failed with: {}", .{err});
+                        };
+                        ev.deinit(self.platform.pjrt_api);
                     }
                 }
             },

--- a/zml/exe.zig
+++ b/zml/exe.zig
@@ -327,7 +327,9 @@ pub const Exe = struct {
                 for (events_slice.?) |e| {
                     if (e) |ev| {
                         if (opts.wait) {
-                            ev.await(self.platform.pjrt_api, io.?) catch unreachable;
+                            ev.await(self.platform.pjrt_api, io.?) catch |err| {
+                                std.debug.panic("PJRT execution failed with: {}", .{err});
+                            };
                         }
                         ev.deinit(self.platform.pjrt_api);
                     }
@@ -336,8 +338,6 @@ pub const Exe = struct {
             .cpu, .cuda, .rocm, .tpu, .oneapi, .metal => if (opts.wait) {
                 for (events_slice.?) |e| {
                     if (e) |ev| {
-                        // A failed execution reports through this event, not through `execute`:
-                        // swallowing it here leaves the caller holding an untouched result buffer.
                         ev.await(self.platform.pjrt_api, io.?) catch |err| {
                             std.debug.panic("PJRT execution failed with: {}", .{err});
                         };

--- a/zml/io.zig
+++ b/zml/io.zig
@@ -59,17 +59,12 @@ pub const TensorStore = struct {
         return tensor_desc_ptr;
     }
 
-    /// A stable copy of a registry entry, owned by the store.
-    ///
-    /// `registry.tensors` is a hash map, so registering a derived tensor -- which models do
-    /// while they are still creating other tensors -- can rehash it and invalidate every
-    /// pointer previously taken into it. Sources therefore refer to these copies, never to
-    /// the map. `name` and `file_uri` already live in the registry's arena, which does not
-    /// move, so copying the descriptor is enough.
     fn dupeSource(self: *TensorStore, key: []const u8) ?*safetensors.Tensor {
         const entry = self.getPtrFromKey(key) orelse return null;
-        const copy = self.arena.allocator().create(safetensors.Tensor) catch |e| std.debug.panic("Not handling {} errors", .{e});
+
+        const copy = self.arena.allocator().create(safetensors.Tensor) catch @panic("OOM");
         copy.* = entry.*;
+
         return copy;
     }
 
@@ -149,8 +144,6 @@ pub const TensorStore = struct {
             };
         }
 
-        /// The prefix every subkey is resolved against, `null` at the root. Needed to build
-        /// a full registry key, which is what registering a derived tensor takes.
         pub fn prefix(self: *const View) ?[]const u8 {
             return if (self.prefix_length == 0) null else self.prefix_buffer[0..self.prefix_length];
         }

--- a/zml/io.zig
+++ b/zml/io.zig
@@ -59,6 +59,20 @@ pub const TensorStore = struct {
         return tensor_desc_ptr;
     }
 
+    /// A stable copy of a registry entry, owned by the store.
+    ///
+    /// `registry.tensors` is a hash map, so registering a derived tensor -- which models do
+    /// while they are still creating other tensors -- can rehash it and invalidate every
+    /// pointer previously taken into it. Sources therefore refer to these copies, never to
+    /// the map. `name` and `file_uri` already live in the registry's arena, which does not
+    /// move, so copying the descriptor is enough.
+    fn dupeSource(self: *TensorStore, key: []const u8) ?*safetensors.Tensor {
+        const entry = self.getPtrFromKey(key) orelse return null;
+        const copy = self.arena.allocator().create(safetensors.Tensor) catch |e| std.debug.panic("Not handling {} errors", .{e});
+        copy.* = entry.*;
+        return copy;
+    }
+
     fn getPtrFromId(self: *const TensorStore, id: usize) ?*safetensors.Tensor {
         const sources = self.id_to_sources.get(id) orelse return null;
         stdx.debug.assert(sources.len == 1, "Expect tensor with id {} to have only one source, got {}", .{ id, sources.len });
@@ -135,7 +149,9 @@ pub const TensorStore = struct {
             };
         }
 
-        fn prefix(self: *const View) ?[]const u8 {
+        /// The prefix every subkey is resolved against, `null` at the root. Needed to build
+        /// a full registry key, which is what registering a derived tensor takes.
+        pub fn prefix(self: *const View) ?[]const u8 {
             return if (self.prefix_length == 0) null else self.prefix_buffer[0..self.prefix_length];
         }
 
@@ -150,7 +166,7 @@ pub const TensorStore = struct {
         pub fn maybeCreateTensor(self: View, subkey: []const u8, tagz: anytype, partitioning: anytype) ?Tensor {
             var buffer: [256]u8 = undefined;
             const key = makeKey(&buffer, "{s}{s}", .{ self.prefix() orelse "", subkey });
-            const source = self.store.getPtrFromKey(key) orelse return null;
+            const source = self.store.dupeSource(key) orelse return null;
 
             const sources = self.store.arena.allocator().alloc(*safetensors.Tensor, 1) catch |e| std.debug.panic("Not handling {} errors", .{e});
             errdefer self.store.arena.allocator().free(sources);
@@ -167,7 +183,8 @@ pub const TensorStore = struct {
         }
 
         pub fn createTensor(self: View, subkey: []const u8, tagz: anytype, partitioning: anytype) Tensor {
-            return self.maybeCreateTensor(subkey, tagz, partitioning).?;
+            return self.maybeCreateTensor(subkey, tagz, partitioning) orelse
+                stdx.debug.panic("Checkpoint has no tensor named {s}{s}", .{ self.prefix() orelse "", subkey });
         }
 
         fn applyTags(shape_: Shape, tagz: anytype) Shape {
@@ -211,7 +228,7 @@ pub const TensorStore = struct {
             var buffer: [256]u8 = undefined;
             for (sources) |subkey| {
                 const key = makeKey(&buffer, "{s}{s}", .{ self.prefix() orelse "", subkey });
-                const tensor = self.store.getPtrFromKey(key) orelse return null;
+                const tensor = self.store.dupeSource(key) orelse return null;
                 tensor_list.appendAssumeCapacity(tensor);
             }
 

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -21,45 +21,28 @@ pub const Linear = struct {
     tag: Shape.Tag,
     quant: ?Quant = null,
 
-    /// What turns `weight` back into real numbers. `scheme` is decided when the checkpoint is
-    /// read, not re-derived here: only the loader has seen the key names.
     pub const Quant = struct {
-        scheme: QuantScheme,
-        /// Per-block or per-channel scales, laid out as `scheme` describes.
+        scheme: QuantScheme, // decided when the checkpoint is read
         scales: Tensor,
-        /// Per-tensor weight scale. A single value, or one per output channel when
-        /// projections with different scales were fused into one weight -- in which case it
-        /// is tagged with the output axis so it broadcasts onto the accumulator.
         weight_scale: ?TensorScale = null,
-        /// Per-tensor activation scale. Only a scheme that quantizes x uses it.
         input_scale: ?TensorScale = null,
     };
 
-    /// A per-tensor scale, carrying the direction its producer wrote it in: ModelOpt writes
-    /// `amax/(448*6)` and means a multiplier, compressed-tensors `448*6/amax` and means a
-    /// divisor. Only the key name separates them, so the loader decides.
-    ///
-    /// The direction travels with the value rather than beside it, because a model struct holds
-    /// `Tensor.fromShape` placeholders: no op can run at load, so nothing can be normalised
-    /// there, and every reader would otherwise have to remember a flag.
-    pub const TensorScale = union(Direction) {
-        multiplier: Tensor,
-        divisor: Tensor,
+    pub const TensorScale = struct {
+        value: Tensor,
+        direction: Direction,
 
-        /// Named so callers can spell the field type.
         pub const Direction = enum { multiplier, divisor };
 
         /// The value as a multiplier, ready to broadcast onto an accumulator. A single value
         /// carries no meaningful axis name, so it becomes a scalar and broadcasts anywhere; a
         /// per-output-channel vector keeps its axis and broadcasts by tag.
         pub fn asMultiplier(self: TensorScale) Tensor {
-            const raw = switch (self) {
-                inline else => |t| t,
-            };
-            const s = if (raw.shape().count() == 1) raw.convert(.f32).asScalar() else raw.convert(.f32);
-            return switch (self) {
-                .multiplier => s,
-                .divisor => Tensor.scalar(1.0, .f32).broad(s.shape()).div(s),
+            const s = self.value.convert(.f32);
+            const flat = if (s.shape().count() == 1) s.asScalar() else s;
+            return switch (self.direction) {
+                .multiplier => flat,
+                .divisor => Tensor.scalar(1.0, .f32).broad(flat.shape()).div(flat),
             };
         }
     };
@@ -91,8 +74,6 @@ pub const Linear = struct {
 
         var lhs = x.convert(.bf16);
         var lhs_scale: ?Tensor = null;
-        // What quantizing x divided out, to be multiplied back into the accumulator. Stays
-        // `null` when x was never divided -- multiplying it in then would scale twice.
         var undo: ?Tensor = null;
 
         const platform = zml.module.CompilationContext.current().platform;
@@ -110,7 +91,6 @@ pub const Linear = struct {
     }
 };
 
-/// Number of contracted values sharing one NVFP4 scale.
 pub const nvfp4_block_size = 16;
 
 /// How a `Linear`'s scales map onto its weight, which is always `[out, contracted]` with the

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -28,7 +28,7 @@ pub const Linear = struct {
         input_scale: ?TensorScale = null,
     };
 
-    // Subject to change if doing operations at load time becomes easier
+    /// A per-tensor scale and the polarity its producer wrote it in
     pub const TensorScale = struct {
         value: Tensor,
         direction: Direction,
@@ -161,10 +161,6 @@ pub const ActivationQuant = enum {
 
 pub fn isPackedNvfp4(scheme: ?QuantScheme, weight_dtype: DataType) bool {
     return scheme == .nvfp4 and weight_dtype == .u8;
-}
-
-pub fn storedContractionTag(scheme: ?QuantScheme, weight_dtype: DataType, k_tag: Shape.Tag) Shape.Tag {
-    return if (isPackedNvfp4(scheme, weight_dtype)) Shape.toTag(.kw) else k_tag;
 }
 
 // Note: This test will evolve as we support more (for example, MXFP4/8 will be added)
@@ -353,9 +349,6 @@ pub fn scaledDot(
         break :blk Tensor.constantTensor(onesGrid(lhs.shape(), .bf16), DataType.bf16.one().asBytes());
     };
 
-    // XLA's composite rewriter requires a scale to have the rank of the operand it scales, so a
-    // per-tensor scale goes in as an all-ones grid. A scalar would leave the composite
-    // unclaimed, which is a compile failure naming `zml$scaled_dot_unmatched`, not a slow path.
     const rhs_scale_operand = if (rhs_scale.rank() != rhs.rank() and rhs_scale.shape().count() == 1)
         rhs_scale.reshape(onesGrid(rhs.shape(), rhs_scale.dtype()))
     else
@@ -382,11 +375,13 @@ pub fn scaledDot(
     return outs[0];
 }
 
-/// `shape` with every dimension collapsed to 1: the shape a scale takes when it is constant
-/// over the operand it scales.
+/// `shape` with every dimension collapsed to 1
 fn onesGrid(shape: Shape, dt: DataType) Shape {
     var res = shape.withDtype(dt);
-    for (0..res.rank()) |i| res = res.setDim(i, 1);
+    for (0..res.rank()) |i| {
+        res = res.setDim(i, 1);
+    }
+
     return res;
 }
 
@@ -412,15 +407,20 @@ fn supportsNvfp4ActivationQuant(platform: *const zml.Platform) bool {
     return major >= 10;
 }
 
-/// Rescales an accumulator by the per-tensor scales the quantized dot left out. `wgs` is a
-/// scalar for a single projection and one value per output channel for a fused one. The two are
-/// applied separately rather than pre-multiplied, so a scalar and a vector can mix.
 fn applyGlobalScale(acc: Tensor, igs: ?Tensor, wgs: ?Tensor) Tensor {
-    if (igs == null and wgs == null) return acc;
+    if (igs == null and wgs == null) {
+        return acc;
+    }
 
     var res = acc.convert(.f32);
-    if (wgs) |w| res = res.mul(w.convert(.f32).broad(res.shape()));
-    if (igs) |i| res = res.mul(i.convert(.f32).broad(res.shape()));
+    if (wgs) |w| {
+        res = res.mul(w.convert(.f32).broad(res.shape()));
+    }
+
+    if (igs) |i| {
+        res = res.mul(i.convert(.f32).broad(res.shape()));
+    }
+
     return res.convert(acc.dtype());
 }
 

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -121,10 +121,13 @@ pub const nvfp4_block_size = 16;
 /// and a plain dot.
 pub const QuantScheme = enum {
     /// f4e2m1 values (`u8`-packed or native), f8e4m3fn scale per 16 contracted values.
+    /// Emitted by llm-compressor and by NVIDIA's ModelOpt.
     nvfp4,
     /// f8e4m3fn values, one bf16 scale per output channel, constant along the contraction.
+    /// Emitted by llm-compressor, including for the layers an NVFP4 recipe leaves in FP8.
     fp8_per_channel,
-    /// f8e4m3fn values, one bf16 scale per 128x128 tile.
+    /// f8e4m3fn values, one bf16 scale per 128x128 tile. The DeepSeek-style FP8 that model
+    /// vendors publish themselves, under `weight_scale_inv`.
     fp8_block128,
     /// f8e4m3fn values, one scale for the whole tensor. Spelled `[1, 1]` rather than as a
     /// scalar: XLA's composite rewriter requires the scale to have the operand's rank.
@@ -217,7 +220,8 @@ pub fn storedContractionTag(scheme: ?QuantScheme, weight_dtype: DataType, k_tag:
 test "QuantScheme.classify" {
     const expect = std.testing.expectEqual;
 
-    // unsloth/Qwen3.6-27B-NVFP4, which carries both of its schemes under `weight_scale`.
+    // unsloth/Qwen3.6-27B-NVFP4: compressed-tensors, carrying both of its schemes under
+    // `weight_scale` -- NVFP4 on the MLPs of layers 0-55, FP8 per-channel everywhere else.
     const nvfp4_packed: Shape = .init(.{ .dout = 17408, .kw = 2560 }, .u8);
     try expect(@as(?QuantScheme, .nvfp4), QuantScheme.classify(nvfp4_packed, .init(.{ .dout = 17408, .sc = 320 }, .f8e4m3fn)));
     try expect(@as(?QuantScheme, .fp8_per_channel), QuantScheme.classify(
@@ -247,7 +251,7 @@ test "QuantScheme.classify" {
         .init(.{ .dout = 40, .sc = 48 }, .bf16),
     ));
 
-    // Ministral: one scale for the whole tensor, rank 0 or [1].
+    // Mistral's per-tensor FP8: one scale for the whole tensor, rank 0 or [1].
     try expect(@as(?QuantScheme, .fp8_per_tensor), QuantScheme.classify(.init(.{ .dout = 4096, .d = 4096 }, .f8e4m3fn), .init(.{}, .f32)));
     try expect(@as(?QuantScheme, .fp8_per_tensor), QuantScheme.classify(.init(.{ .dout = 4096, .d = 4096 }, .f8e4m3fn), .init(.{ .g = 1 }, .f32)));
 

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -28,18 +28,17 @@ pub const Linear = struct {
         input_scale: ?TensorScale = null,
     };
 
+    // Subject to change if doing operations at load time becomes easier
     pub const TensorScale = struct {
         value: Tensor,
         direction: Direction,
 
         pub const Direction = enum { multiplier, divisor };
 
-        /// The value as a multiplier, ready to broadcast onto an accumulator. A single value
-        /// carries no meaningful axis name, so it becomes a scalar and broadcasts anywhere; a
-        /// per-output-channel vector keeps its axis and broadcasts by tag.
         pub fn asMultiplier(self: TensorScale) Tensor {
             const s = self.value.convert(.f32);
-            const flat = if (s.shape().count() == 1) s.asScalar() else s;
+            const flat = if (s.shape().count() == 1) s.asScalar() else s; // essentially normalization
+
             return switch (self.direction) {
                 .multiplier => flat,
                 .divisor => Tensor.scalar(1.0, .f32).broad(flat.shape()).div(flat),
@@ -93,23 +92,6 @@ pub const Linear = struct {
 
 pub const nvfp4_block_size = 16;
 
-/// How a `Linear`'s scales map onto its weight, which is always `[out, contracted]` with the
-/// contracted axis last and named by `Linear.tag`.
-///
-/// Every scheme here is legal to emit as an `xla.scaled_dot` composite, but where it lands
-/// depends on the backend, and "not claimed" does not mean the same thing everywhere:
-///
-/// - A backend claims the scaled dot directly -- Metal's `ClassifyMetalScaledMatmul`, Triton's
-///   `IsSupportedScaleGrid`, cuDNN's `blockScaledDot`.
-/// - Otherwise `ScaledDotRewriter` expands it into convert + broadcast + multiply + dot. On
-///   Metal that is the end of it -- nothing fuses into `__metal$gemm`, so the dequantized
-///   weight is materialized in HBM. On CUDA `GemmFusion` may pull the chain back into a Triton
-///   GEMM, leaving the weight quantized; whether it does depends on the scale grid, and a
-///   128x128 grid expands to a broadcast plus a reshape that `CalculateBitcastOfBroadcast`
-///   refuses to hoist ("mixes operand and broadcast dimensions"). Unmeasured -- check the
-///   fusion's parameter dtype in a dump before assuming either way.
-/// - On CPU and TPU there is no expansion at all: `CompositeRewriter` is GPU-only, so the
-///   composite inlines to `scaledDotReference` and fails on `zml$scaled_dot_unmatched`.
 pub const QuantScheme = enum {
     /// f4e2m1 values (`u8`-packed or native), f8e4m3fn scale per 16 contracted values.
     /// Emitted by llm-compressor and by NVIDIA's ModelOpt.
@@ -124,15 +106,10 @@ pub const QuantScheme = enum {
     /// scalar: XLA's composite rewriter requires the scale to have the operand's rank.
     fp8_per_tensor,
 
-    /// Whether `scale` is a grid this scheme can wear over `weight`. Mirrors the question the
-    /// backends ask of the composite, so a pair accepted here is one a backend is expected to
-    /// claim. The arms are mutually exclusive, so `classify` does not depend on their order.
     pub fn accepts(self: QuantScheme, weight: Shape, scale: Shape) bool {
-        // Rank 3 is a stacked MoE weight, which goes through the MoE custom calls, not this path.
         if (weight.rank() != 2) return false;
 
         const n = weight.dim(0);
-        // Two f4e2m1 per byte, so a packed weight's logical contraction is twice the stored one.
         const k = if (isPackedNvfp4(self, weight.dtype())) 2 * weight.dim(1) else weight.dim(1);
 
         return switch (self) {
@@ -140,8 +117,6 @@ pub const QuantScheme = enum {
                 scale.dtype() == .f8e4m3fn and scale.rank() == 2 and
                 scale.dim(0) == n and scale.dim(1) * nvfp4_block_size == k,
             .fp8_per_tensor => weight.dtype() == .f8e4m3fn and scale.count() == 1,
-            // `count() > 1` is what keeps the two grids disjoint from per-tensor: a lone value
-            // over a 128x128 weight would otherwise also read as a one-tile block grid.
             .fp8_per_channel => weight.dtype() == .f8e4m3fn and scale.dtype() == .bf16 and
                 scale.count() > 1 and scale.rank() == 2 and
                 scale.dim(0) == n and scale.dim(1) == 1,
@@ -152,18 +127,14 @@ pub const QuantScheme = enum {
         };
     }
 
-    /// The scheme a weight and its scale describe, or `null` when no backend can express the
-    /// pair. Diagnostics belong to the caller, which knows the key names.
     pub fn classify(weight: Shape, scale: Shape) ?QuantScheme {
         for (std.enums.values(QuantScheme)) |scheme| {
             if (scheme.accepts(weight, scale)) return scheme;
         }
+
         return null;
     }
 
-    /// How this scheme quantizes x, or `null` if it is weight-only and x stays bf16. The
-    /// weight-only schemes are listed rather than left to an `else`, so a new scheme stops the
-    /// build here instead of quietly inheriting the weight-only path.
     pub fn activationQuant(self: QuantScheme) ?ActivationQuant {
         return switch (self) {
             .nvfp4 => .nvfp4,
@@ -172,14 +143,9 @@ pub const QuantScheme = enum {
     }
 };
 
-/// How a scheme quantizes activations. Two readers: `Linear.forwardWeight` decides whether to
-/// quantize x, and the loader decides whether an `input_scale` belongs in the model struct at
-/// all -- which is why `supportedOn` takes the platform rather than the scheme knowing it, a
-/// model struct being built before a platform is known.
 pub const ActivationQuant = enum {
     nvfp4,
 
-    /// Whether a backend on this platform takes x quantized this way.
     fn supportedOn(self: ActivationQuant, platform: *const zml.Platform) bool {
         return switch (self) {
             .nvfp4 => supportsNvfp4ActivationQuant(platform),
@@ -193,21 +159,15 @@ pub const ActivationQuant = enum {
     }
 };
 
-/// Whether the checkpoint stores this weight bit-packed -- two f4e2m1 per `u8` -- so its last
-/// axis is half the logical contraction and has to be widened before the dot. NVFP4 ships both
-/// ways, so neither the scheme nor the dtype answers it alone, and both sides of the seam must
-/// ask the same question: the loader names the packed axis `.kw` exactly when `forwardWeight`
-/// will unpack it, and a mismatch leaves the dot with no axis to contract.
 pub fn isPackedNvfp4(scheme: ?QuantScheme, weight_dtype: DataType) bool {
     return scheme == .nvfp4 and weight_dtype == .u8;
 }
 
-/// The tag a stored weight's last axis must carry: `.kw` when `unpackNvfp4` will merge it with
-/// the unpacked pair, the caller's own contraction tag otherwise.
 pub fn storedContractionTag(scheme: ?QuantScheme, weight_dtype: DataType, k_tag: Shape.Tag) Shape.Tag {
     return if (isPackedNvfp4(scheme, weight_dtype)) Shape.toTag(.kw) else k_tag;
 }
 
+// Note: This test will evolve as we support more (for example, MXFP4/8 will be added)
 test "QuantScheme.classify" {
     const expect = std.testing.expectEqual;
 
@@ -275,12 +235,11 @@ test "QuantScheme.classify" {
 /// which is merged with the unpacked pair and renamed to `k_tag`.
 pub fn unpackNvfp4(w: Tensor, k_tag: anytype) Tensor {
     stdx.debug.assert(w.dtype() == .u8, "unpackNvfp4 expects packed u8 weights, got {}", .{w.dtype()});
-    return w.bitCast(.f4e2m1)
+    return w.bitCast(.f4e2m1) // bitcast inserts a tag (it respects shlo), but maybe we should simplify it
         .merge(.{ .kb = .{ .kw, .bitcast } })
         .renameTag(.kb, Shape.toTag(k_tag));
 }
 
-/// A quantized activation: the values, and the per-block scales that undo the quantization.
 pub const QuantizedActivations = struct {
     values: Tensor,
     scales: Tensor,

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -19,14 +19,29 @@ pub const Linear = struct {
     weight: Tensor,
     bias: ?Tensor = null,
     tag: Shape.Tag,
-    scales: ?Tensor = null,
-    global_scale: ?Tensor = null,
-    input_global_scale: ?Tensor = null,
-    /// compressed-tensors stores global scales as divisors (`448*6/amax`) where ModelOpt
-    /// stores multipliers (`amax/(448*6)`). Everything downstream wants multipliers, so a
-    /// checkpoint using the former is flagged here and inverted at forward time (we can't
-    /// invert at load: building the model struct emits no ops).
-    reciprocal_global_scales: bool = false,
+    quant: ?Quant = null,
+
+    /// What turns `weight` back into real numbers.
+    ///
+    /// `scheme` is decided when the checkpoint is read, not re-derived here. A checkpoint
+    /// routinely mixes schemes layer by layer -- the same `mlp.gate_proj` is NVFP4 in one
+    /// layer and FP8 in another -- and only the loader has seen the key names that tell
+    /// the conventions apart.
+    pub const Quant = struct {
+        scheme: QuantScheme,
+        /// Per-block or per-channel scales, laid out as `scheme` describes.
+        scales: Tensor,
+        /// Per-tensor weight scale. A single value, or one per output channel when
+        /// projections with different scales were fused into one weight -- in which case it
+        /// is tagged with the output axis so it broadcasts onto the accumulator.
+        weight_scale: ?Tensor = null,
+        /// Per-tensor activation scale. Only NVFP4 uses it, to quantize x.
+        input_scale: ?Tensor = null,
+        /// `weight_scale` and `input_scale` hold divisors rather than multipliers:
+        /// compressed-tensors writes `448*6/amax` where ModelOpt writes `amax/(448*6)`.
+        /// Inverted at forward time, since building the model struct emits no ops.
+        reciprocal_tensor_scales: bool = false,
+    };
 
     pub fn init(weight: Tensor, bias: ?Tensor, tag: anytype) Linear {
         return .{
@@ -34,71 +49,6 @@ pub const Linear = struct {
             .bias = bias,
             .tag = zml.Shape.toTag(tag),
         };
-    }
-
-    /// How tensor parallelism cuts a `Linear`.
-    pub const Shard = enum {
-        /// Split the output axis: each device owns a slice of the outputs (column parallel).
-        out,
-        /// Split the contracted axis: each device computes a partial sum (row parallel).
-        contracted,
-        /// Replicate the whole layer.
-        none,
-    };
-
-    /// Loads a `Linear` from a checkpoint, quantized or not.
-    ///
-    /// Recognizes both quantization naming conventions in the wild, and checkpoints that mix
-    /// schemes layer by layer -- which scheme a tensor uses is decided from its shapes by
-    /// `QuantScheme.of`, never from a config:
-    ///   - ModelOpt:           `weight`,        `weight_scale`, `weight_scale_2`,      `input_scale`
-    ///   - compressed-tensors: `weight_packed`, `weight_scale`, `weight_global_scale`, `input_global_scale`
-    ///
-    /// `out_tag` names the weight's axis 0 and `k_tag` its contracted axis 1. Tensors are
-    /// built with internal axis names and renamed after, because partitioning is keyed by
-    /// comptime field name and the caller's tags aren't known here.
-    pub fn initFromStore(
-        store: zml.io.TensorStore.View,
-        comptime out_tag: @EnumLiteral(),
-        comptime k_tag: @EnumLiteral(),
-        shard: Shard,
-    ) Linear {
-        // Probe with `getShape`, not `hasKey`: `hasKey` matches on prefix, so `hasKey("weight")`
-        // is true for a layer that only has `weight_packed`.
-        const is_packed = store.getShape("weight_packed") != null;
-        const weight_key = if (is_packed) "weight_packed" else "weight";
-
-        const weight_ = switch (shard) {
-            .out => store.createTensor(weight_key, .{ .doutq, .kq }, .{ .doutq = .model, .kq = .replicated }),
-            .contracted => store.createTensor(weight_key, .{ .doutq, .kq }, .{ .doutq = .replicated, .kq = .model }),
-            .none => store.createTensor(weight_key, .{ .doutq, .kq }, .replicated),
-        };
-        const out_named = weight_.renameAxis(0, out_tag);
-        // `unpackNvfp4` wants the packed axis named `.kw` and renames the unpacked result
-        // to `k_tag` itself.
-        const weight = if (is_packed) out_named.renameAxis(1, .kw) else out_named.renameAxis(1, k_tag);
-
-        const bias = switch (shard) {
-            .out => store.maybeCreateTensor("bias", .{.doutq}, .{ .doutq = .model }),
-            .contracted, .none => store.maybeCreateTensor("bias", .{.doutq}, .{ .doutq = .replicated }),
-        };
-
-        const globals = loadGlobalScales(store);
-        return .{
-            .weight = weight,
-            .bias = if (bias) |b| b.renameAxis(0, out_tag) else null,
-            .tag = zml.Shape.toTag(k_tag),
-            .scales = loadScales(store, shard),
-            .global_scale = globals.weight,
-            .input_global_scale = globals.input,
-            .reciprocal_global_scales = globals.reciprocal,
-        };
-    }
-
-    /// Global scales are scalars, so they carry no meaningful axis names.
-    fn asMultiplier(self: Linear, g: Tensor) Tensor {
-        const s = g.convert(.f32).asScalar();
-        return if (self.reciprocal_global_scales) Tensor.scalar(1.0, .f32).div(s) else s;
     }
 
     pub fn unloadBuffers(self: *zml.Bufferized(Linear)) void {
@@ -111,159 +61,62 @@ pub const Linear = struct {
     }
 
     fn forwardWeight(self: Linear, x: Tensor) Tensor {
-        const scales = self.scales orelse return x.dot(self.weight, self.tag);
+        const q = self.quant orelse return x.dot(self.weight, self.tag);
 
-        const igs: ?Tensor = if (self.input_global_scale) |g| self.asMultiplier(g) else null;
-        const wgs: ?Tensor = if (self.global_scale) |g| self.asMultiplier(g) else null;
+        const wgs: ?Tensor = if (q.weight_scale) |g| asMultiplier(g, q.reciprocal_tensor_scales) else null;
+        const igs: ?Tensor = if (q.input_scale) |g| asMultiplier(g, q.reciprocal_tensor_scales) else null;
+
+        // A packed NVFP4 weight arrives as `u8` with a halved contracted axis; the bitcast
+        // that widens it is free, so it stays in the graph rather than being a store-level
+        // reinterpret (`Shape.byteSize` has no sub-byte case).
+        const weight = if (self.weight.dtype() == .u8) unpackNvfp4(self.weight, self.tag) else self.weight;
 
         const platform = zml.module.CompilationContext.current().platform;
-        const scheme: QuantScheme = .of(self.weight.shape(), scales.shape());
-
-        const weight = unpackWeight(self.weight, self.tag);
-        if (scheme == .nvfp4 and supportsNvfp4ActivationQuant(platform)) {
-            const q = quantizeNvfp4(x.convert(.bf16), igs, self.tag);
-            const acc = scaledDot(q.values, weight, q.scales, scales, self.tag);
+        if (q.scheme == .nvfp4 and supportsNvfp4ActivationQuant(platform)) {
+            const quantized = quantizeNvfp4(x.convert(.bf16), igs, self.tag);
+            const acc = scaledDot(quantized.values, weight, quantized.scales, q.scales, self.tag);
             return applyGlobalScale(acc, igs, wgs).convert(x.dtype());
         }
 
-        const acc = scaledDot(x.convert(.bf16), weight, null, scales, self.tag);
+        const acc = scaledDot(x.convert(.bf16), weight, null, q.scales, self.tag);
         return applyGlobalScale(acc, null, wgs).convert(x.dtype());
     }
 };
 
-/// Loads `weight_scale`, cutting it the same way as the weight it scales. A scale with a
-/// single group per row (per-channel, `[N, 1]`) can't be split along the contraction, so a
-/// row-parallel layer replicates it.
-fn loadScales(store: zml.io.TensorStore.View, shard: Linear.Shard) ?Tensor {
-    const shape = store.getShape("weight_scale") orelse return null;
-    if (shape.rank() == 0) return store.createTensor("weight_scale", .{}, .replicated);
-
-    stdx.debug.assert(shape.rank() == 2, "Linear.initFromStore expects weight_scale to be a scalar or rank 2 [out, groups], got {f}", .{shape});
-    return switch (shard) {
-        .out => store.createTensor("weight_scale", .{ .doutq, .sc }, .{ .doutq = .model, .sc = .replicated }),
-        .contracted => if (shape.dim(1) > 1)
-            store.createTensor("weight_scale", .{ .doutq, .sc }, .{ .doutq = .replicated, .sc = .model })
-        else
-            store.createTensor("weight_scale", .{ .doutq, .sc }, .replicated),
-        .none => store.createTensor("weight_scale", .{ .doutq, .sc }, .replicated),
-    };
-}
-
-/// The weight and activation global scales, under either naming convention.
-fn loadGlobalScales(store: zml.io.TensorStore.View) struct { weight: ?Tensor, input: ?Tensor, reciprocal: bool } {
-    // ModelOpt spells these `weight_scale_2` / `input_scale` and means multipliers;
-    // compressed-tensors spells them `*_global_scale` and means divisors.
-    if (store.getShape("weight_scale_2") != null or store.getShape("input_scale") != null) {
-        return .{
-            .weight = loadScalar(store, "weight_scale_2"),
-            .input = loadScalar(store, "input_scale"),
-            .reciprocal = false,
-        };
-    }
-    return .{
-        .weight = loadScalar(store, "weight_global_scale"),
-        .input = loadScalar(store, "input_global_scale"),
-        .reciprocal = true,
-    };
-}
-
-/// Loads a single-element tensor, which checkpoints spell as either rank 0 or `[1]`.
-fn loadScalar(store: zml.io.TensorStore.View, key: []const u8) ?Tensor {
-    const shape = store.getShape(key) orelse return null;
-    stdx.debug.assert(shape.count() == 1, "Linear.initFromStore expects {s} to hold a single value, got {f}", .{ key, shape });
-    return if (shape.rank() == 0)
-        store.createTensor(key, .{}, .replicated)
-    else
-        store.createTensor(key, .{.g}, .replicated);
+/// A per-tensor scale as a multiplier, whichever way round the checkpoint stored it.
+///
+/// A single value carries no meaningful axis name, so it is flattened to a scalar and
+/// broadcasts anywhere. A per-output-channel vector keeps its axis, and broadcasts by tag.
+fn asMultiplier(scale: Tensor, reciprocal: bool) Tensor {
+    const s = if (scale.shape().count() == 1) scale.convert(.f32).asScalar() else scale.convert(.f32);
+    return if (reciprocal) Tensor.scalar(1.0, .f32).broad(s.shape()).div(s) else s;
 }
 
 /// Number of contracted values sharing one NVFP4 scale.
 pub const nvfp4_block_size = 16;
 
-/// How a `Linear`'s `scales` maps onto its `weight`: a pure function of shapes and dtypes.
+/// How a `Linear`'s scales map onto its weight.
 ///
-/// This mirrors the backend-side classifiers (XLA's `ClassifyMetalScaledMatmul`) predicate
-/// for predicate, and the two must stay in sync. A checkpoint routinely mixes schemes layer
-/// by layer -- the same `mlp.gate_proj` is NVFP4 in one layer and FP8 in another -- so the
-/// scheme is read off the shapes per tensor, never from a config.
+/// Every scheme here is legal to emit as an `xla.scaled_dot` composite: a backend either
+/// claims it (Metal's `ClassifyMetalScaledMatmul`, Triton, cuDNN) or XLA expands it into a
+/// dequantize and a plain dot. Which one a tensor uses is settled by whoever read the
+/// checkpoint -- see `llmd/quant.zig` -- because the key names, not the shapes, are what
+/// separate the naming conventions.
 ///
 /// A weight is always `[out, contracted]`, with the contracted axis last and named by
 /// `Linear.tag`. The tag says nothing about which axis is which: a row-parallel `down_proj`
 /// names its output axis `.d` and its contracted axis `.dout`.
 pub const QuantScheme = enum {
-    /// f4e2m1 values (`u8`-packed or native) with an f8e4m3fn scale per 16 contracted values.
+    /// f4e2m1 values (`u8`-packed or native), f8e4m3fn scale per 16 contracted values.
     nvfp4,
-    /// f8e4m3fn values with one bf16 scale per output channel, constant along the contraction.
+    /// f8e4m3fn values, one bf16 scale per output channel, constant along the contraction.
     fp8_per_channel,
-    /// A layout no backend is known to fuse. `Linear` emits the composite anyway, so this
-    /// surfaces as a compile error naming `zml$scaled_dot_unmatched` rather than silently
-    /// running slow -- see `scaledDotReference`.
-    unknown,
-
-    pub fn of(weight: Shape, scales: Shape) QuantScheme {
-        if (weight.rank() != 2 or scales.rank() != 2) return .unknown;
-        if (scales.dim(0) != weight.dim(0)) return .unknown;
-        const k = logicalContractedSize(weight);
-
-        if (weight.dtype() == .u8 or weight.dtype() == .f4e2m1) {
-            if (scales.dtype() == .f8e4m3fn and scales.dim(1) * nvfp4_block_size == k) return .nvfp4;
-            return .unknown;
-        }
-        if (weight.dtype() == .f8e4m3fn and scales.dtype() == .bf16 and scales.dim(1) == 1) {
-            return .fp8_per_channel;
-        }
-        return .unknown;
-    }
+    /// f8e4m3fn values, one bf16 scale per 128x128 tile.
+    fp8_block128,
+    /// f8e4m3fn values, one scale for the whole tensor. Spelled `[1, 1]` rather than as a
+    /// scalar: XLA's composite rewriter requires the scale to have the operand's rank.
+    fp8_per_tensor,
 };
-
-/// Size of the contracted axis, accounting for `u8` sub-byte packing.
-fn logicalContractedSize(weight: Shape) i64 {
-    const k = weight.dim(weight.rank() - 1);
-    return if (weight.dtype() == .u8) 2 * k else k;
-}
-
-test QuantScheme {
-    const of = QuantScheme.of;
-    // Shapes taken from Qwen3.6-27B-NVFP4, which carries both schemes at once.
-    const nvfp4_weight: Shape = .init(.{ .dout = 17408, .kw = 2560 }, .u8);
-    const fp8_weight: Shape = .init(.{ .dout = 10240, .d = 5120 }, .f8e4m3fn);
-
-    try std.testing.expectEqual(QuantScheme.nvfp4, of(nvfp4_weight, .init(.{ .dout = 17408, .sc = 320 }, .f8e4m3fn)));
-    try std.testing.expectEqual(QuantScheme.fp8_per_channel, of(fp8_weight, .init(.{ .dout = 10240, .sc = 1 }, .bf16)));
-
-    // Native (unpacked) f4e2m1 values are the same scheme, with K no longer doubled.
-    try std.testing.expectEqual(QuantScheme.nvfp4, of(
-        .init(.{ .dout = 17408, .d = 5120 }, .f4e2m1),
-        .init(.{ .dout = 17408, .sc = 320 }, .f8e4m3fn),
-    ));
-
-    // Everything a backend would refuse, and must therefore not be classified.
-    const unknown: QuantScheme = .unknown;
-    // Group 32 (MXFP4) rather than 16.
-    try std.testing.expectEqual(unknown, of(nvfp4_weight, .init(.{ .dout = 17408, .sc = 160 }, .f8e4m3fn)));
-    // e8m0 scales.
-    try std.testing.expectEqual(unknown, of(nvfp4_weight, .init(.{ .dout = 17408, .sc = 320 }, .f8e8m0)));
-    // Per-tensor: a scalar scale.
-    try std.testing.expectEqual(unknown, of(fp8_weight, .init(.{}, .f32)));
-    // Per-channel, but f32 rather than bf16.
-    try std.testing.expectEqual(unknown, of(fp8_weight, .init(.{ .dout = 10240, .sc = 1 }, .f32)));
-    // A 128x128 block grid: the scale has fewer rows than the weight.
-    try std.testing.expectEqual(unknown, of(
-        .init(.{ .dout = 32768, .d = 1024 }, .f8e4m3fn),
-        .init(.{ .dout = 256, .sc = 8 }, .bf16),
-    ));
-    // FP8 values with a group scale: valid MXFP8, but nothing here fuses it.
-    try std.testing.expectEqual(unknown, of(fp8_weight, .init(.{ .dout = 10240, .sc = 160 }, .f8e8m0)));
-}
-
-/// Unpacks `u8`-packed NVFP4 values; any other dtype passes through unchanged.
-///
-/// A packed weight must arrive tagged `[<out>, .kw]`. We deliberately don't retag it here:
-/// naming the output axis `.dout` would collide with `k_tag` on a layer that contracts
-/// along `.dout`, like a row-parallel `down_proj`.
-fn unpackWeight(weight: Tensor, k_tag: Shape.Tag) Tensor {
-    return if (weight.dtype() == .u8) unpackNvfp4(weight, k_tag) else weight;
-}
 
 /// Unpacks two f4e2m1 values per byte. `w` must be tagged with `.kw` on the packed axis,
 /// which is merged with the unpacked pair and renamed to `k_tag`.
@@ -382,12 +235,17 @@ pub fn scaledDot(
     }
 
     const lhs_scale_operand = lhs_scale orelse blk: {
-        var lhs_scale_shape = lhs.shape().withDtype(.bf16);
-        for (0..lhs.rank()) |i| {
-            lhs_scale_shape = lhs_scale_shape.setDim(i, 1);
-        }
-        break :blk Tensor.constantTensor(lhs_scale_shape, DataType.bf16.one().asBytes());
+        break :blk Tensor.constantTensor(onesGrid(lhs.shape(), .bf16), DataType.bf16.one().asBytes());
     };
+
+    // XLA's composite rewriter requires a scale to have the rank of the operand it scales
+    // (`composite_rewriter.cc`, `IsSupportedScaledOperand`), so a per-tensor scale goes in as
+    // an all-ones grid. A scalar would leave the composite unclaimed, which is not a slow
+    // path but a compile failure naming `zml$scaled_dot_unmatched`.
+    const rhs_scale_operand = if (rhs_scale.rank() != rhs.rank() and rhs_scale.shape().count() == 1)
+        rhs_scale.reshape(onesGrid(rhs.shape(), rhs_scale.dtype()))
+    else
+        rhs_scale;
 
     const mlir_ctx = zml.module.CompilationContext.current().mlir_ctx;
     const dnums = mlir.Attribute.array(mlir_ctx, &.{
@@ -401,13 +259,21 @@ pub fn scaledDot(
         }),
     });
 
-    const operands: []const Tensor = &.{ lhs, rhs, lhs_scale_operand, rhs_scale };
+    const operands: []const Tensor = &.{ lhs, rhs, lhs_scale_operand, rhs_scale_operand };
 
     const outs = ops.composite("xla.scaled_dot", operands, &.{res_shape}, scaledDotReference, res_shape, .{
         .composite_attributes = &.{.named(mlir_ctx, "dimension_numbers", dnums)},
     });
 
     return outs[0];
+}
+
+/// `shape` with every dimension collapsed to 1: the shape a scale takes when it is constant
+/// over the operand it scales.
+fn onesGrid(shape: Shape, dt: DataType) Shape {
+    var res = shape.withDtype(dt);
+    for (0..res.rank()) |i| res = res.setDim(i, 1);
+    return res;
 }
 
 fn scaledDotReference(in: []const Tensor, out_shape: Shape) Tensor {
@@ -432,14 +298,19 @@ fn supportsNvfp4ActivationQuant(platform: *const zml.Platform) bool {
     return major >= 10;
 }
 
+/// Rescales an accumulator by the per-tensor scales the quantized dot left out.
+///
+/// `wgs` is a scalar for a single projection, and one value per output channel when several
+/// projections with different per-tensor scales were fused into one weight -- which is exact,
+/// since the scale multiplies output rows and every row belongs to exactly one projection.
+/// The two are applied separately rather than pre-multiplied so a scalar and a vector can mix.
 fn applyGlobalScale(acc: Tensor, igs: ?Tensor, wgs: ?Tensor) Tensor {
-    const combined: ?Tensor = if (igs) |i|
-        (if (wgs) |w| i.mul(w) else i)
-    else
-        wgs;
-    const alpha = combined orelse return acc;
-    const f32_acc = acc.convert(.f32);
-    return f32_acc.mul(alpha.broad(f32_acc.shape())).convert(acc.dtype());
+    if (igs == null and wgs == null) return acc;
+
+    var res = acc.convert(.f32);
+    if (wgs) |w| res = res.mul(w.convert(.f32).broad(res.shape()));
+    if (igs) |i| res = res.mul(i.convert(.f32).broad(res.shape()));
+    return res.convert(acc.dtype());
 }
 
 pub const TokenEmbedding = struct {

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -22,6 +22,11 @@ pub const Linear = struct {
     scales: ?Tensor = null,
     global_scale: ?Tensor = null,
     input_global_scale: ?Tensor = null,
+    /// compressed-tensors stores global scales as divisors (`448*6/amax`) where ModelOpt
+    /// stores multipliers (`amax/(448*6)`). Everything downstream wants multipliers, so a
+    /// checkpoint using the former is flagged here and inverted at forward time (we can't
+    /// invert at load: building the model struct emits no ops).
+    reciprocal_global_scales: bool = false,
 
     pub fn init(weight: Tensor, bias: ?Tensor, tag: anytype) Linear {
         return .{
@@ -29,6 +34,71 @@ pub const Linear = struct {
             .bias = bias,
             .tag = zml.Shape.toTag(tag),
         };
+    }
+
+    /// How tensor parallelism cuts a `Linear`.
+    pub const Shard = enum {
+        /// Split the output axis: each device owns a slice of the outputs (column parallel).
+        out,
+        /// Split the contracted axis: each device computes a partial sum (row parallel).
+        contracted,
+        /// Replicate the whole layer.
+        none,
+    };
+
+    /// Loads a `Linear` from a checkpoint, quantized or not.
+    ///
+    /// Recognizes both quantization naming conventions in the wild, and checkpoints that mix
+    /// schemes layer by layer -- which scheme a tensor uses is decided from its shapes by
+    /// `QuantScheme.of`, never from a config:
+    ///   - ModelOpt:           `weight`,        `weight_scale`, `weight_scale_2`,      `input_scale`
+    ///   - compressed-tensors: `weight_packed`, `weight_scale`, `weight_global_scale`, `input_global_scale`
+    ///
+    /// `out_tag` names the weight's axis 0 and `k_tag` its contracted axis 1. Tensors are
+    /// built with internal axis names and renamed after, because partitioning is keyed by
+    /// comptime field name and the caller's tags aren't known here.
+    pub fn initFromStore(
+        store: zml.io.TensorStore.View,
+        comptime out_tag: @EnumLiteral(),
+        comptime k_tag: @EnumLiteral(),
+        shard: Shard,
+    ) Linear {
+        // Probe with `getShape`, not `hasKey`: `hasKey` matches on prefix, so `hasKey("weight")`
+        // is true for a layer that only has `weight_packed`.
+        const is_packed = store.getShape("weight_packed") != null;
+        const weight_key = if (is_packed) "weight_packed" else "weight";
+
+        const weight_ = switch (shard) {
+            .out => store.createTensor(weight_key, .{ .doutq, .kq }, .{ .doutq = .model, .kq = .replicated }),
+            .contracted => store.createTensor(weight_key, .{ .doutq, .kq }, .{ .doutq = .replicated, .kq = .model }),
+            .none => store.createTensor(weight_key, .{ .doutq, .kq }, .replicated),
+        };
+        const out_named = weight_.renameAxis(0, out_tag);
+        // `unpackNvfp4` wants the packed axis named `.kw` and renames the unpacked result
+        // to `k_tag` itself.
+        const weight = if (is_packed) out_named.renameAxis(1, .kw) else out_named.renameAxis(1, k_tag);
+
+        const bias = switch (shard) {
+            .out => store.maybeCreateTensor("bias", .{.doutq}, .{ .doutq = .model }),
+            .contracted, .none => store.maybeCreateTensor("bias", .{.doutq}, .{ .doutq = .replicated }),
+        };
+
+        const globals = loadGlobalScales(store);
+        return .{
+            .weight = weight,
+            .bias = if (bias) |b| b.renameAxis(0, out_tag) else null,
+            .tag = zml.Shape.toTag(k_tag),
+            .scales = loadScales(store, shard),
+            .global_scale = globals.weight,
+            .input_global_scale = globals.input,
+            .reciprocal_global_scales = globals.reciprocal,
+        };
+    }
+
+    /// Global scales are scalars, so they carry no meaningful axis names.
+    fn asMultiplier(self: Linear, g: Tensor) Tensor {
+        const s = g.convert(.f32).asScalar();
+        return if (self.reciprocal_global_scales) Tensor.scalar(1.0, .f32).div(s) else s;
     }
 
     pub fn unloadBuffers(self: *zml.Bufferized(Linear)) void {
@@ -43,16 +113,14 @@ pub const Linear = struct {
     fn forwardWeight(self: Linear, x: Tensor) Tensor {
         const scales = self.scales orelse return x.dot(self.weight, self.tag);
 
-        const weight = if (self.weight.dtype() == .u8)
-            unpackNvfp4(self.weight.withTags(.{ .dout, .kw }), self.tag)
-        else
-            self.weight;
-
-        const igs: ?Tensor = if (self.input_global_scale) |g| g.convert(.f32).asScalar() else null;
-        const wgs: ?Tensor = if (self.global_scale) |g| g.convert(.f32).asScalar() else null;
+        const igs: ?Tensor = if (self.input_global_scale) |g| self.asMultiplier(g) else null;
+        const wgs: ?Tensor = if (self.global_scale) |g| self.asMultiplier(g) else null;
 
         const platform = zml.module.CompilationContext.current().platform;
-        if (weight.dtype() == .f4e2m1 and supportsNvfp4ActivationQuant(platform)) {
+        const scheme: QuantScheme = .of(self.weight.shape(), scales.shape());
+
+        const weight = unpackWeight(self.weight, self.tag);
+        if (scheme == .nvfp4 and supportsNvfp4ActivationQuant(platform)) {
             const q = quantizeNvfp4(x.convert(.bf16), igs, self.tag);
             const acc = scaledDot(q.values, weight, q.scales, scales, self.tag);
             return applyGlobalScale(acc, igs, wgs).convert(x.dtype());
@@ -63,6 +131,142 @@ pub const Linear = struct {
     }
 };
 
+/// Loads `weight_scale`, cutting it the same way as the weight it scales. A scale with a
+/// single group per row (per-channel, `[N, 1]`) can't be split along the contraction, so a
+/// row-parallel layer replicates it.
+fn loadScales(store: zml.io.TensorStore.View, shard: Linear.Shard) ?Tensor {
+    const shape = store.getShape("weight_scale") orelse return null;
+    if (shape.rank() == 0) return store.createTensor("weight_scale", .{}, .replicated);
+
+    stdx.debug.assert(shape.rank() == 2, "Linear.initFromStore expects weight_scale to be a scalar or rank 2 [out, groups], got {f}", .{shape});
+    return switch (shard) {
+        .out => store.createTensor("weight_scale", .{ .doutq, .sc }, .{ .doutq = .model, .sc = .replicated }),
+        .contracted => if (shape.dim(1) > 1)
+            store.createTensor("weight_scale", .{ .doutq, .sc }, .{ .doutq = .replicated, .sc = .model })
+        else
+            store.createTensor("weight_scale", .{ .doutq, .sc }, .replicated),
+        .none => store.createTensor("weight_scale", .{ .doutq, .sc }, .replicated),
+    };
+}
+
+/// The weight and activation global scales, under either naming convention.
+fn loadGlobalScales(store: zml.io.TensorStore.View) struct { weight: ?Tensor, input: ?Tensor, reciprocal: bool } {
+    // ModelOpt spells these `weight_scale_2` / `input_scale` and means multipliers;
+    // compressed-tensors spells them `*_global_scale` and means divisors.
+    if (store.getShape("weight_scale_2") != null or store.getShape("input_scale") != null) {
+        return .{
+            .weight = loadScalar(store, "weight_scale_2"),
+            .input = loadScalar(store, "input_scale"),
+            .reciprocal = false,
+        };
+    }
+    return .{
+        .weight = loadScalar(store, "weight_global_scale"),
+        .input = loadScalar(store, "input_global_scale"),
+        .reciprocal = true,
+    };
+}
+
+/// Loads a single-element tensor, which checkpoints spell as either rank 0 or `[1]`.
+fn loadScalar(store: zml.io.TensorStore.View, key: []const u8) ?Tensor {
+    const shape = store.getShape(key) orelse return null;
+    stdx.debug.assert(shape.count() == 1, "Linear.initFromStore expects {s} to hold a single value, got {f}", .{ key, shape });
+    return if (shape.rank() == 0)
+        store.createTensor(key, .{}, .replicated)
+    else
+        store.createTensor(key, .{.g}, .replicated);
+}
+
+/// Number of contracted values sharing one NVFP4 scale.
+pub const nvfp4_block_size = 16;
+
+/// How a `Linear`'s `scales` maps onto its `weight`: a pure function of shapes and dtypes.
+///
+/// This mirrors the backend-side classifiers (XLA's `ClassifyMetalScaledMatmul`) predicate
+/// for predicate, and the two must stay in sync. A checkpoint routinely mixes schemes layer
+/// by layer -- the same `mlp.gate_proj` is NVFP4 in one layer and FP8 in another -- so the
+/// scheme is read off the shapes per tensor, never from a config.
+///
+/// A weight is always `[out, contracted]`, with the contracted axis last and named by
+/// `Linear.tag`. The tag says nothing about which axis is which: a row-parallel `down_proj`
+/// names its output axis `.d` and its contracted axis `.dout`.
+pub const QuantScheme = enum {
+    /// f4e2m1 values (`u8`-packed or native) with an f8e4m3fn scale per 16 contracted values.
+    nvfp4,
+    /// f8e4m3fn values with one bf16 scale per output channel, constant along the contraction.
+    fp8_per_channel,
+    /// A layout no backend is known to fuse. `Linear` emits the composite anyway, so this
+    /// surfaces as a compile error naming `zml$scaled_dot_unmatched` rather than silently
+    /// running slow -- see `scaledDotReference`.
+    unknown,
+
+    pub fn of(weight: Shape, scales: Shape) QuantScheme {
+        if (weight.rank() != 2 or scales.rank() != 2) return .unknown;
+        if (scales.dim(0) != weight.dim(0)) return .unknown;
+        const k = logicalContractedSize(weight);
+
+        if (weight.dtype() == .u8 or weight.dtype() == .f4e2m1) {
+            if (scales.dtype() == .f8e4m3fn and scales.dim(1) * nvfp4_block_size == k) return .nvfp4;
+            return .unknown;
+        }
+        if (weight.dtype() == .f8e4m3fn and scales.dtype() == .bf16 and scales.dim(1) == 1) {
+            return .fp8_per_channel;
+        }
+        return .unknown;
+    }
+};
+
+/// Size of the contracted axis, accounting for `u8` sub-byte packing.
+fn logicalContractedSize(weight: Shape) i64 {
+    const k = weight.dim(weight.rank() - 1);
+    return if (weight.dtype() == .u8) 2 * k else k;
+}
+
+test QuantScheme {
+    const of = QuantScheme.of;
+    // Shapes taken from Qwen3.6-27B-NVFP4, which carries both schemes at once.
+    const nvfp4_weight: Shape = .init(.{ .dout = 17408, .kw = 2560 }, .u8);
+    const fp8_weight: Shape = .init(.{ .dout = 10240, .d = 5120 }, .f8e4m3fn);
+
+    try std.testing.expectEqual(QuantScheme.nvfp4, of(nvfp4_weight, .init(.{ .dout = 17408, .sc = 320 }, .f8e4m3fn)));
+    try std.testing.expectEqual(QuantScheme.fp8_per_channel, of(fp8_weight, .init(.{ .dout = 10240, .sc = 1 }, .bf16)));
+
+    // Native (unpacked) f4e2m1 values are the same scheme, with K no longer doubled.
+    try std.testing.expectEqual(QuantScheme.nvfp4, of(
+        .init(.{ .dout = 17408, .d = 5120 }, .f4e2m1),
+        .init(.{ .dout = 17408, .sc = 320 }, .f8e4m3fn),
+    ));
+
+    // Everything a backend would refuse, and must therefore not be classified.
+    const unknown: QuantScheme = .unknown;
+    // Group 32 (MXFP4) rather than 16.
+    try std.testing.expectEqual(unknown, of(nvfp4_weight, .init(.{ .dout = 17408, .sc = 160 }, .f8e4m3fn)));
+    // e8m0 scales.
+    try std.testing.expectEqual(unknown, of(nvfp4_weight, .init(.{ .dout = 17408, .sc = 320 }, .f8e8m0)));
+    // Per-tensor: a scalar scale.
+    try std.testing.expectEqual(unknown, of(fp8_weight, .init(.{}, .f32)));
+    // Per-channel, but f32 rather than bf16.
+    try std.testing.expectEqual(unknown, of(fp8_weight, .init(.{ .dout = 10240, .sc = 1 }, .f32)));
+    // A 128x128 block grid: the scale has fewer rows than the weight.
+    try std.testing.expectEqual(unknown, of(
+        .init(.{ .dout = 32768, .d = 1024 }, .f8e4m3fn),
+        .init(.{ .dout = 256, .sc = 8 }, .bf16),
+    ));
+    // FP8 values with a group scale: valid MXFP8, but nothing here fuses it.
+    try std.testing.expectEqual(unknown, of(fp8_weight, .init(.{ .dout = 10240, .sc = 160 }, .f8e8m0)));
+}
+
+/// Unpacks `u8`-packed NVFP4 values; any other dtype passes through unchanged.
+///
+/// A packed weight must arrive tagged `[<out>, .kw]`. We deliberately don't retag it here:
+/// naming the output axis `.dout` would collide with `k_tag` on a layer that contracts
+/// along `.dout`, like a row-parallel `down_proj`.
+fn unpackWeight(weight: Tensor, k_tag: Shape.Tag) Tensor {
+    return if (weight.dtype() == .u8) unpackNvfp4(weight, k_tag) else weight;
+}
+
+/// Unpacks two f4e2m1 values per byte. `w` must be tagged with `.kw` on the packed axis,
+/// which is merged with the unpacked pair and renamed to `k_tag`.
 pub fn unpackNvfp4(w: Tensor, k_tag: anytype) Tensor {
     stdx.debug.assert(w.dtype() == .u8, "unpackNvfp4 expects packed u8 weights, got {}", .{w.dtype()});
     return w.bitCast(.f4e2m1)

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -21,12 +21,8 @@ pub const Linear = struct {
     tag: Shape.Tag,
     quant: ?Quant = null,
 
-    /// What turns `weight` back into real numbers.
-    ///
-    /// `scheme` is decided when the checkpoint is read, not re-derived here. A checkpoint
-    /// routinely mixes schemes layer by layer -- the same `mlp.gate_proj` is NVFP4 in one
-    /// layer and FP8 in another -- and only the loader has seen the key names that tell
-    /// the conventions apart.
+    /// What turns `weight` back into real numbers. `scheme` is decided when the checkpoint is
+    /// read, not re-derived here: only the loader has seen the key names.
     pub const Quant = struct {
         scheme: QuantScheme,
         /// Per-block or per-channel scales, laid out as `scheme` describes.
@@ -39,24 +35,23 @@ pub const Linear = struct {
         input_scale: ?TensorScale = null,
     };
 
-    /// A per-tensor scale, carrying the direction the producer wrote it in.
+    /// A per-tensor scale, carrying the direction its producer wrote it in: ModelOpt writes
+    /// `amax/(448*6)` and means a multiplier, compressed-tensors `448*6/amax` and means a
+    /// divisor. Only the key name separates them, so the loader decides.
     ///
-    /// ModelOpt writes `amax/(448*6)` and means a multiplier; compressed-tensors writes
-    /// `448*6/amax` and means a divisor. Only the key name separates them, so the loader
-    /// decides -- and the direction travels with the value rather than beside it, because a
-    /// model struct is built from `Tensor.fromShape` placeholders (`io.zig`,
-    /// `View.maybeCreateTensor`): no op can run there, so nothing can be normalised at load.
+    /// The direction travels with the value rather than beside it, because a model struct holds
+    /// `Tensor.fromShape` placeholders: no op can run at load, so nothing can be normalised
+    /// there, and every reader would otherwise have to remember a flag.
     pub const TensorScale = union(Direction) {
         multiplier: Tensor,
         divisor: Tensor,
 
-        /// Named rather than inferred so callers can spell the field type, and so a mismatch
-        /// names `Direction` instead of an anonymous tag type.
+        /// Named so callers can spell the field type.
         pub const Direction = enum { multiplier, divisor };
 
         /// The value as a multiplier, ready to broadcast onto an accumulator. A single value
-        /// carries no meaningful axis name, so it is flattened to a scalar and broadcasts
-        /// anywhere; a per-output-channel vector keeps its axis and broadcasts by tag.
+        /// carries no meaningful axis name, so it becomes a scalar and broadcasts anywhere; a
+        /// per-output-channel vector keeps its axis and broadcasts by tag.
         pub fn asMultiplier(self: TensorScale) Tensor {
             const raw = switch (self) {
                 inline else => |t| t,
@@ -92,9 +87,6 @@ pub const Linear = struct {
         const wgs: ?Tensor = if (q.weight_scale) |s| s.asMultiplier() else null;
         const igs: ?Tensor = if (q.input_scale) |s| s.asMultiplier() else null;
 
-        // A packed NVFP4 weight arrives as `u8` with a halved contracted axis; the bitcast
-        // that widens it is free, so it stays in the graph rather than being a store-level
-        // reinterpret (`Shape.byteSize` has no sub-byte case).
         const weight = if (isPackedNvfp4(q.scheme, self.weight.dtype())) unpackNvfp4(self.weight, self.tag) else self.weight;
 
         var lhs = x.convert(.bf16);
@@ -121,17 +113,12 @@ pub const Linear = struct {
 /// Number of contracted values sharing one NVFP4 scale.
 pub const nvfp4_block_size = 16;
 
-/// How a `Linear`'s scales map onto its weight.
+/// How a `Linear`'s scales map onto its weight, which is always `[out, contracted]` with the
+/// contracted axis last and named by `Linear.tag`.
 ///
-/// Every scheme here is legal to emit as an `xla.scaled_dot` composite: a backend either
-/// claims it (Metal's `ClassifyMetalScaledMatmul`, Triton, cuDNN) or XLA expands it into a
-/// dequantize and a plain dot. Which one a tensor uses is settled by whoever read the
-/// checkpoint -- see `llmd/quant.zig` -- because the key names, not the shapes, are what
-/// separate the naming conventions.
-///
-/// A weight is always `[out, contracted]`, with the contracted axis last and named by
-/// `Linear.tag`. The tag says nothing about which axis is which: a row-parallel `down_proj`
-/// names its output axis `.d` and its contracted axis `.dout`.
+/// Every scheme here is legal to emit as an `xla.scaled_dot` composite: a backend either claims
+/// it (Metal's `ClassifyMetalScaledMatmul`, Triton, cuDNN) or XLA expands it into a dequantize
+/// and a plain dot.
 pub const QuantScheme = enum {
     /// f4e2m1 values (`u8`-packed or native), f8e4m3fn scale per 16 contracted values.
     nvfp4,
@@ -143,14 +130,9 @@ pub const QuantScheme = enum {
     /// scalar: XLA's composite rewriter requires the scale to have the operand's rank.
     fp8_per_tensor,
 
-    /// Whether `scale` is a grid this scheme can wear over a `[out, contracted]` `weight`.
-    ///
-    /// This mirrors the question the backends ask of the composite (Metal's
-    /// `ClassifyMetalScaledMatmul`, Triton's `IsSupportedScaleGrid`): a pair accepted here is
-    /// one a backend is expected to claim. Adding a scheme is an enum value plus an arm here --
-    /// the switch is exhaustive, so it cannot be forgotten.
-    ///
-    /// The arms are mutually exclusive, so `classify` does not depend on their order.
+    /// Whether `scale` is a grid this scheme can wear over `weight`. Mirrors the question the
+    /// backends ask of the composite, so a pair accepted here is one a backend is expected to
+    /// claim. The arms are mutually exclusive, so `classify` does not depend on their order.
     pub fn accepts(self: QuantScheme, weight: Shape, scale: Shape) bool {
         // Rank 3 is a stacked MoE weight, which goes through the MoE custom calls, not this path.
         if (weight.rank() != 2) return false;
@@ -163,12 +145,9 @@ pub const QuantScheme = enum {
             .nvfp4 => (weight.dtype() == .u8 or weight.dtype() == .f4e2m1) and
                 scale.dtype() == .f8e4m3fn and scale.rank() == 2 and
                 scale.dim(0) == n and scale.dim(1) * nvfp4_block_size == k,
-            // A per-tensor scale is spelled as a scalar or `[1]`, and by DeepSeek-style
-            // producers also under the `weight_scale_inv` key.
             .fp8_per_tensor => weight.dtype() == .f8e4m3fn and scale.count() == 1,
-            // The `count() > 1` on the two grids is what keeps the arms disjoint: a lone value
-            // is per-tensor even where a `[1, 1]` bf16 scale over a 128x128 weight would also
-            // read as a one-tile block grid.
+            // `count() > 1` is what keeps the two grids disjoint from per-tensor: a lone value
+            // over a 128x128 weight would otherwise also read as a one-tile block grid.
             .fp8_per_channel => weight.dtype() == .f8e4m3fn and scale.dtype() == .bf16 and
                 scale.count() > 1 and scale.rank() == 2 and
                 scale.dim(0) == n and scale.dim(1) == 1,
@@ -188,11 +167,9 @@ pub const QuantScheme = enum {
         return null;
     }
 
-    /// How this scheme quantizes x, or `null` if it is weight-only and x stays bf16.
-    ///
-    /// Listing the weight-only schemes rather than writing `else` is deliberate: a scheme added
-    /// to this enum stops the build here, instead of inheriting the weight-only path and
-    /// quietly running at the wrong speed.
+    /// How this scheme quantizes x, or `null` if it is weight-only and x stays bf16. The
+    /// weight-only schemes are listed rather than left to an `else`, so a new scheme stops the
+    /// build here instead of quietly inheriting the weight-only path.
     pub fn activationQuant(self: QuantScheme) ?ActivationQuant {
         return switch (self) {
             .nvfp4 => .nvfp4,
@@ -201,10 +178,10 @@ pub const QuantScheme = enum {
     }
 };
 
-/// How a scheme quantizes activations. One switch, two readers: `Linear.forwardWeight` decides
-/// whether to quantize x, and `llmd/quant.zig` decides whether an `input_scale` belongs in the
-/// model struct at all -- which is why the platform check is on `ActivationQuant` and not on
-/// `QuantScheme` (a model struct is built before a platform is known).
+/// How a scheme quantizes activations. Two readers: `Linear.forwardWeight` decides whether to
+/// quantize x, and the loader decides whether an `input_scale` belongs in the model struct at
+/// all -- which is why `supportedOn` takes the platform rather than the scheme knowing it, a
+/// model struct being built before a platform is known.
 pub const ActivationQuant = enum {
     nvfp4,
 
@@ -222,13 +199,11 @@ pub const ActivationQuant = enum {
     }
 };
 
-/// Whether the checkpoint stores this weight bit-packed -- two f4e2m1 per `u8` byte -- so its
-/// last axis is half the logical contraction and has to be widened before the dot.
-///
-/// NVFP4 ships both ways: ModelOpt packs into `u8`, other producers write native `f4e2m1`. So
-/// neither the scheme nor the dtype answers it alone, and both sides of the seam must ask the
-/// same question -- the loader names the packed axis `.kw` exactly when `forwardWeight` will
-/// unpack it, and a mismatch leaves the dot with no axis to contract.
+/// Whether the checkpoint stores this weight bit-packed -- two f4e2m1 per `u8` -- so its last
+/// axis is half the logical contraction and has to be widened before the dot. NVFP4 ships both
+/// ways, so neither the scheme nor the dtype answers it alone, and both sides of the seam must
+/// ask the same question: the loader names the packed axis `.kw` exactly when `forwardWeight`
+/// will unpack it, and a mismatch leaves the dot with no axis to contract.
 pub fn isPackedNvfp4(scheme: ?QuantScheme, weight_dtype: DataType) bool {
     return scheme == .nvfp4 and weight_dtype == .u8;
 }
@@ -424,10 +399,9 @@ pub fn scaledDot(
         break :blk Tensor.constantTensor(onesGrid(lhs.shape(), .bf16), DataType.bf16.one().asBytes());
     };
 
-    // XLA's composite rewriter requires a scale to have the rank of the operand it scales
-    // (`composite_rewriter.cc`, `IsSupportedScaledOperand`), so a per-tensor scale goes in as
-    // an all-ones grid. A scalar would leave the composite unclaimed, which is not a slow
-    // path but a compile failure naming `zml$scaled_dot_unmatched`.
+    // XLA's composite rewriter requires a scale to have the rank of the operand it scales, so a
+    // per-tensor scale goes in as an all-ones grid. A scalar would leave the composite
+    // unclaimed, which is a compile failure naming `zml$scaled_dot_unmatched`, not a slow path.
     const rhs_scale_operand = if (rhs_scale.rank() != rhs.rank() and rhs_scale.shape().count() == 1)
         rhs_scale.reshape(onesGrid(rhs.shape(), rhs_scale.dtype()))
     else
@@ -484,12 +458,9 @@ fn supportsNvfp4ActivationQuant(platform: *const zml.Platform) bool {
     return major >= 10;
 }
 
-/// Rescales an accumulator by the per-tensor scales the quantized dot left out.
-///
-/// `wgs` is a scalar for a single projection, and one value per output channel when several
-/// projections with different per-tensor scales were fused into one weight -- which is exact,
-/// since the scale multiplies output rows and every row belongs to exactly one projection.
-/// The two are applied separately rather than pre-multiplied so a scalar and a vector can mix.
+/// Rescales an accumulator by the per-tensor scales the quantized dot left out. `wgs` is a
+/// scalar for a single projection and one value per output channel for a fused one. The two are
+/// applied separately rather than pre-multiplied, so a scalar and a vector can mix.
 fn applyGlobalScale(acc: Tensor, igs: ?Tensor, wgs: ?Tensor) Tensor {
     if (igs == null and wgs == null) return acc;
 

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -122,9 +122,12 @@ pub const nvfp4_block_size = 16;
 /// - A backend claims the scaled dot directly -- Metal's `ClassifyMetalScaledMatmul`, Triton's
 ///   `IsSupportedScaleGrid`, cuDNN's `blockScaledDot`.
 /// - Otherwise `ScaledDotRewriter` expands it into convert + broadcast + multiply + dot. On
-///   CUDA that expansion is pulled straight back into a Triton GEMM fusion, so the weight
-///   stays quantized in HBM and is widened in-register; on Metal nothing fuses into
-///   `__metal$gemm`, so the dequantized weight really is materialized.
+///   Metal that is the end of it -- nothing fuses into `__metal$gemm`, so the dequantized
+///   weight is materialized in HBM. On CUDA `GemmFusion` may pull the chain back into a Triton
+///   GEMM, leaving the weight quantized; whether it does depends on the scale grid, and a
+///   128x128 grid expands to a broadcast plus a reshape that `CalculateBitcastOfBroadcast`
+///   refuses to hoist ("mixes operand and broadcast dimensions"). Unmeasured -- check the
+///   fusion's parameter dtype in a dump before assuming either way.
 /// - On CPU and TPU there is no expansion at all: `CompositeRewriter` is GPU-only, so the
 ///   composite inlines to `scaledDotReference` and fails on `zml$scaled_dot_unmatched`.
 pub const QuantScheme = enum {

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -116,9 +116,17 @@ pub const nvfp4_block_size = 16;
 /// How a `Linear`'s scales map onto its weight, which is always `[out, contracted]` with the
 /// contracted axis last and named by `Linear.tag`.
 ///
-/// Every scheme here is legal to emit as an `xla.scaled_dot` composite: a backend either claims
-/// it (Metal's `ClassifyMetalScaledMatmul`, Triton, cuDNN) or XLA expands it into a dequantize
-/// and a plain dot.
+/// Every scheme here is legal to emit as an `xla.scaled_dot` composite, but where it lands
+/// depends on the backend, and "not claimed" does not mean the same thing everywhere:
+///
+/// - A backend claims the scaled dot directly -- Metal's `ClassifyMetalScaledMatmul`, Triton's
+///   `IsSupportedScaleGrid`, cuDNN's `blockScaledDot`.
+/// - Otherwise `ScaledDotRewriter` expands it into convert + broadcast + multiply + dot. On
+///   CUDA that expansion is pulled straight back into a Triton GEMM fusion, so the weight
+///   stays quantized in HBM and is widened in-register; on Metal nothing fuses into
+///   `__metal$gemm`, so the dequantized weight really is materialized.
+/// - On CPU and TPU there is no expansion at all: `CompositeRewriter` is GPU-only, so the
+///   composite inlines to `scaledDotReference` and fails on `zml$scaled_dot_unmatched`.
 pub const QuantScheme = enum {
     /// f4e2m1 values (`u8`-packed or native), f8e4m3fn scale per 16 contracted values.
     /// Emitted by llm-compressor and by NVIDIA's ModelOpt.

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -34,13 +34,39 @@ pub const Linear = struct {
         /// Per-tensor weight scale. A single value, or one per output channel when
         /// projections with different scales were fused into one weight -- in which case it
         /// is tagged with the output axis so it broadcasts onto the accumulator.
-        weight_scale: ?Tensor = null,
-        /// Per-tensor activation scale. Only NVFP4 uses it, to quantize x.
-        input_scale: ?Tensor = null,
-        /// `weight_scale` and `input_scale` hold divisors rather than multipliers:
-        /// compressed-tensors writes `448*6/amax` where ModelOpt writes `amax/(448*6)`.
-        /// Inverted at forward time, since building the model struct emits no ops.
-        reciprocal_tensor_scales: bool = false,
+        weight_scale: ?TensorScale = null,
+        /// Per-tensor activation scale. Only a scheme that quantizes x uses it.
+        input_scale: ?TensorScale = null,
+    };
+
+    /// A per-tensor scale, carrying the direction the producer wrote it in.
+    ///
+    /// ModelOpt writes `amax/(448*6)` and means a multiplier; compressed-tensors writes
+    /// `448*6/amax` and means a divisor. Only the key name separates them, so the loader
+    /// decides -- and the direction travels with the value rather than beside it, because a
+    /// model struct is built from `Tensor.fromShape` placeholders (`io.zig`,
+    /// `View.maybeCreateTensor`): no op can run there, so nothing can be normalised at load.
+    pub const TensorScale = union(Direction) {
+        multiplier: Tensor,
+        divisor: Tensor,
+
+        /// Named rather than inferred so callers can spell the field type, and so a mismatch
+        /// names `Direction` instead of an anonymous tag type.
+        pub const Direction = enum { multiplier, divisor };
+
+        /// The value as a multiplier, ready to broadcast onto an accumulator. A single value
+        /// carries no meaningful axis name, so it is flattened to a scalar and broadcasts
+        /// anywhere; a per-output-channel vector keeps its axis and broadcasts by tag.
+        pub fn asMultiplier(self: TensorScale) Tensor {
+            const raw = switch (self) {
+                inline else => |t| t,
+            };
+            const s = if (raw.shape().count() == 1) raw.convert(.f32).asScalar() else raw.convert(.f32);
+            return switch (self) {
+                .multiplier => s,
+                .divisor => Tensor.scalar(1.0, .f32).broad(s.shape()).div(s),
+            };
+        }
     };
 
     pub fn init(weight: Tensor, bias: ?Tensor, tag: anytype) Linear {
@@ -63,34 +89,34 @@ pub const Linear = struct {
     fn forwardWeight(self: Linear, x: Tensor) Tensor {
         const q = self.quant orelse return x.dot(self.weight, self.tag);
 
-        const wgs: ?Tensor = if (q.weight_scale) |g| asMultiplier(g, q.reciprocal_tensor_scales) else null;
-        const igs: ?Tensor = if (q.input_scale) |g| asMultiplier(g, q.reciprocal_tensor_scales) else null;
+        const wgs: ?Tensor = if (q.weight_scale) |s| s.asMultiplier() else null;
+        const igs: ?Tensor = if (q.input_scale) |s| s.asMultiplier() else null;
 
         // A packed NVFP4 weight arrives as `u8` with a halved contracted axis; the bitcast
         // that widens it is free, so it stays in the graph rather than being a store-level
         // reinterpret (`Shape.byteSize` has no sub-byte case).
-        const weight = if (self.weight.dtype() == .u8) unpackNvfp4(self.weight, self.tag) else self.weight;
+        const weight = if (isPackedNvfp4(q.scheme, self.weight.dtype())) unpackNvfp4(self.weight, self.tag) else self.weight;
+
+        var lhs = x.convert(.bf16);
+        var lhs_scale: ?Tensor = null;
+        // What quantizing x divided out, to be multiplied back into the accumulator. Stays
+        // `null` when x was never divided -- multiplying it in then would scale twice.
+        var undo: ?Tensor = null;
 
         const platform = zml.module.CompilationContext.current().platform;
-        if (q.scheme == .nvfp4 and supportsNvfp4ActivationQuant(platform)) {
-            const quantized = quantizeNvfp4(x.convert(.bf16), igs, self.tag);
-            const acc = scaledDot(quantized.values, weight, quantized.scales, q.scales, self.tag);
-            return applyGlobalScale(acc, igs, wgs).convert(x.dtype());
+        if (q.scheme.activationQuant()) |aq| {
+            if (aq.supportedOn(platform)) {
+                const quantized = aq.apply(lhs, igs, self.tag);
+                lhs = quantized.values;
+                lhs_scale = quantized.scales;
+                undo = igs;
+            }
         }
 
-        const acc = scaledDot(x.convert(.bf16), weight, null, q.scales, self.tag);
-        return applyGlobalScale(acc, null, wgs).convert(x.dtype());
+        const acc = scaledDot(lhs, weight, lhs_scale, q.scales, self.tag);
+        return applyGlobalScale(acc, undo, wgs).convert(x.dtype());
     }
 };
-
-/// A per-tensor scale as a multiplier, whichever way round the checkpoint stored it.
-///
-/// A single value carries no meaningful axis name, so it is flattened to a scalar and
-/// broadcasts anywhere. A per-output-channel vector keeps its axis, and broadcasts by tag.
-fn asMultiplier(scale: Tensor, reciprocal: bool) Tensor {
-    const s = if (scale.shape().count() == 1) scale.convert(.f32).asScalar() else scale.convert(.f32);
-    return if (reciprocal) Tensor.scalar(1.0, .f32).broad(s.shape()).div(s) else s;
-}
 
 /// Number of contracted values sharing one NVFP4 scale.
 pub const nvfp4_block_size = 16;
@@ -116,7 +142,164 @@ pub const QuantScheme = enum {
     /// f8e4m3fn values, one scale for the whole tensor. Spelled `[1, 1]` rather than as a
     /// scalar: XLA's composite rewriter requires the scale to have the operand's rank.
     fp8_per_tensor,
+
+    /// Whether `scale` is a grid this scheme can wear over a `[out, contracted]` `weight`.
+    ///
+    /// This mirrors the question the backends ask of the composite (Metal's
+    /// `ClassifyMetalScaledMatmul`, Triton's `IsSupportedScaleGrid`): a pair accepted here is
+    /// one a backend is expected to claim. Adding a scheme is an enum value plus an arm here --
+    /// the switch is exhaustive, so it cannot be forgotten.
+    ///
+    /// The arms are mutually exclusive, so `classify` does not depend on their order.
+    pub fn accepts(self: QuantScheme, weight: Shape, scale: Shape) bool {
+        // Rank 3 is a stacked MoE weight, which goes through the MoE custom calls, not this path.
+        if (weight.rank() != 2) return false;
+
+        const n = weight.dim(0);
+        // Two f4e2m1 per byte, so a packed weight's logical contraction is twice the stored one.
+        const k = if (isPackedNvfp4(self, weight.dtype())) 2 * weight.dim(1) else weight.dim(1);
+
+        return switch (self) {
+            .nvfp4 => (weight.dtype() == .u8 or weight.dtype() == .f4e2m1) and
+                scale.dtype() == .f8e4m3fn and scale.rank() == 2 and
+                scale.dim(0) == n and scale.dim(1) * nvfp4_block_size == k,
+            // A per-tensor scale is spelled as a scalar or `[1]`, and by DeepSeek-style
+            // producers also under the `weight_scale_inv` key.
+            .fp8_per_tensor => weight.dtype() == .f8e4m3fn and scale.count() == 1,
+            // The `count() > 1` on the two grids is what keeps the arms disjoint: a lone value
+            // is per-tensor even where a `[1, 1]` bf16 scale over a 128x128 weight would also
+            // read as a one-tile block grid.
+            .fp8_per_channel => weight.dtype() == .f8e4m3fn and scale.dtype() == .bf16 and
+                scale.count() > 1 and scale.rank() == 2 and
+                scale.dim(0) == n and scale.dim(1) == 1,
+            .fp8_block128 => weight.dtype() == .f8e4m3fn and scale.dtype() == .bf16 and
+                scale.count() > 1 and scale.rank() == 2 and
+                @rem(n, 128) == 0 and @rem(k, 128) == 0 and
+                scale.dim(0) == @divExact(n, 128) and scale.dim(1) == @divExact(k, 128),
+        };
+    }
+
+    /// The scheme a weight and its scale describe, or `null` when no backend can express the
+    /// pair. Diagnostics belong to the caller, which knows the key names.
+    pub fn classify(weight: Shape, scale: Shape) ?QuantScheme {
+        for (std.enums.values(QuantScheme)) |scheme| {
+            if (scheme.accepts(weight, scale)) return scheme;
+        }
+        return null;
+    }
+
+    /// How this scheme quantizes x, or `null` if it is weight-only and x stays bf16.
+    ///
+    /// Listing the weight-only schemes rather than writing `else` is deliberate: a scheme added
+    /// to this enum stops the build here, instead of inheriting the weight-only path and
+    /// quietly running at the wrong speed.
+    pub fn activationQuant(self: QuantScheme) ?ActivationQuant {
+        return switch (self) {
+            .nvfp4 => .nvfp4,
+            .fp8_per_channel, .fp8_block128, .fp8_per_tensor => null,
+        };
+    }
 };
+
+/// How a scheme quantizes activations. One switch, two readers: `Linear.forwardWeight` decides
+/// whether to quantize x, and `llmd/quant.zig` decides whether an `input_scale` belongs in the
+/// model struct at all -- which is why the platform check is on `ActivationQuant` and not on
+/// `QuantScheme` (a model struct is built before a platform is known).
+pub const ActivationQuant = enum {
+    nvfp4,
+
+    /// Whether a backend on this platform takes x quantized this way.
+    fn supportedOn(self: ActivationQuant, platform: *const zml.Platform) bool {
+        return switch (self) {
+            .nvfp4 => supportsNvfp4ActivationQuant(platform),
+        };
+    }
+
+    fn apply(self: ActivationQuant, x: Tensor, global_scale: ?Tensor, axis: Shape.Tag) QuantizedActivations {
+        return switch (self) {
+            .nvfp4 => quantizeNvfp4(x, global_scale, axis),
+        };
+    }
+};
+
+/// Whether the checkpoint stores this weight bit-packed -- two f4e2m1 per `u8` byte -- so its
+/// last axis is half the logical contraction and has to be widened before the dot.
+///
+/// NVFP4 ships both ways: ModelOpt packs into `u8`, other producers write native `f4e2m1`. So
+/// neither the scheme nor the dtype answers it alone, and both sides of the seam must ask the
+/// same question -- the loader names the packed axis `.kw` exactly when `forwardWeight` will
+/// unpack it, and a mismatch leaves the dot with no axis to contract.
+pub fn isPackedNvfp4(scheme: ?QuantScheme, weight_dtype: DataType) bool {
+    return scheme == .nvfp4 and weight_dtype == .u8;
+}
+
+/// The tag a stored weight's last axis must carry: `.kw` when `unpackNvfp4` will merge it with
+/// the unpacked pair, the caller's own contraction tag otherwise.
+pub fn storedContractionTag(scheme: ?QuantScheme, weight_dtype: DataType, k_tag: Shape.Tag) Shape.Tag {
+    return if (isPackedNvfp4(scheme, weight_dtype)) Shape.toTag(.kw) else k_tag;
+}
+
+test "QuantScheme.classify" {
+    const expect = std.testing.expectEqual;
+
+    // unsloth/Qwen3.6-27B-NVFP4, which carries both of its schemes under `weight_scale`.
+    const nvfp4_packed: Shape = .init(.{ .dout = 17408, .kw = 2560 }, .u8);
+    try expect(@as(?QuantScheme, .nvfp4), QuantScheme.classify(nvfp4_packed, .init(.{ .dout = 17408, .sc = 320 }, .f8e4m3fn)));
+    try expect(@as(?QuantScheme, .fp8_per_channel), QuantScheme.classify(
+        .init(.{ .dout = 17408, .d = 5120 }, .f8e4m3fn),
+        .init(.{ .dout = 17408, .sc = 1 }, .bf16),
+    ));
+
+    // nvidia/Gemma-4-31B-IT-NVFP4: ModelOpt, packed values under the plain `weight` name.
+    try expect(@as(?QuantScheme, .nvfp4), QuantScheme.classify(
+        .init(.{ .dout = 21504, .kw = 2688 }, .u8),
+        .init(.{ .dout = 21504, .sc = 336 }, .f8e4m3fn),
+    ));
+
+    // Native (unpacked) f4e2m1, with K no longer doubled.
+    try expect(@as(?QuantScheme, .nvfp4), QuantScheme.classify(
+        .init(.{ .dout = 17408, .d = 5120 }, .f4e2m1),
+        .init(.{ .dout = 17408, .sc = 320 }, .f8e4m3fn),
+    ));
+
+    // Qwen/Qwen3.6-27B-FP8: block 128, spelled `weight_scale_inv`.
+    try expect(@as(?QuantScheme, .fp8_block128), QuantScheme.classify(
+        .init(.{ .dout = 17408, .d = 5120 }, .f8e4m3fn),
+        .init(.{ .dout = 136, .sc = 40 }, .bf16),
+    ));
+    try expect(@as(?QuantScheme, .fp8_block128), QuantScheme.classify(
+        .init(.{ .dout = 5120, .d = 6144 }, .f8e4m3fn),
+        .init(.{ .dout = 40, .sc = 48 }, .bf16),
+    ));
+
+    // Ministral: one scale for the whole tensor, rank 0 or [1].
+    try expect(@as(?QuantScheme, .fp8_per_tensor), QuantScheme.classify(.init(.{ .dout = 4096, .d = 4096 }, .f8e4m3fn), .init(.{}, .f32)));
+    try expect(@as(?QuantScheme, .fp8_per_tensor), QuantScheme.classify(.init(.{ .dout = 4096, .d = 4096 }, .f8e4m3fn), .init(.{ .g = 1 }, .f32)));
+
+    // Rejected: everything no backend here can express.
+    const fp8: Shape = .init(.{ .dout = 10240, .d = 5120 }, .f8e4m3fn);
+    // Group 32 (MXFP4) rather than 16.
+    try expect(@as(?QuantScheme, null), QuantScheme.classify(nvfp4_packed, .init(.{ .dout = 17408, .sc = 160 }, .f8e4m3fn)));
+    // e8m0 scales: valid MX, nothing here fuses or expands it.
+    try expect(@as(?QuantScheme, null), QuantScheme.classify(nvfp4_packed, .init(.{ .dout = 17408, .sc = 320 }, .f8e8m0)));
+    try expect(@as(?QuantScheme, null), QuantScheme.classify(fp8, .init(.{ .dout = 10240, .sc = 160 }, .f8e8m0)));
+    // Per-channel, but f32 rather than bf16.
+    try expect(@as(?QuantScheme, null), QuantScheme.classify(fp8, .init(.{ .dout = 10240, .sc = 1 }, .f32)));
+    // A block grid that is neither per-channel nor 128x128.
+    try expect(@as(?QuantScheme, null), QuantScheme.classify(fp8, .init(.{ .dout = 160, .sc = 80 }, .bf16)));
+    // Stacked MoE weights are rank 3 and go through the MoE path, not this one.
+    try expect(@as(?QuantScheme, null), QuantScheme.classify(
+        .init(.{ .expert = 128, .dout = 1408, .kw = 1408 }, .u8),
+        .init(.{ .expert = 128, .dout = 1408, .sc = 176 }, .f8e4m3fn),
+    ));
+
+    // A one-tile block grid is indistinguishable from a per-tensor scale by shape alone; the
+    // `count() > 1` guard on the grids is what makes per-tensor win.
+    try expect(@as(?QuantScheme, .fp8_per_tensor), QuantScheme.classify(
+        .init(.{ .dout = 128, .d = 128 }, .f8e4m3fn),
+        .init(.{ .dout = 1, .sc = 1 }, .bf16),
+    ));
+}
 
 /// Unpacks two f4e2m1 values per byte. `w` must be tagged with `.kw` on the packed axis,
 /// which is merged with the unpacked pair and renamed to `k_tag`.
@@ -127,11 +310,14 @@ pub fn unpackNvfp4(w: Tensor, k_tag: anytype) Tensor {
         .renameTag(.kb, Shape.toTag(k_tag));
 }
 
-pub fn quantizeNvfp4(x: Tensor, input_global_scale: ?Tensor, axis: anytype) struct {
+/// A quantized activation: the values, and the per-block scales that undo the quantization.
+pub const QuantizedActivations = struct {
     values: Tensor,
     scales: Tensor,
-} {
-    const block_size = 16;
+};
+
+pub fn quantizeNvfp4(x: Tensor, input_global_scale: ?Tensor, axis: anytype) QuantizedActivations {
+    const block_size = nvfp4_block_size;
     const value_max = 6.0;
     const scale_min_normal = 0x1p-6;
     const scale_max = DataType.f8e4m3fn.maxValue().as(f32);

--- a/zml/safetensors.zig
+++ b/zml/safetensors.zig
@@ -757,6 +757,7 @@ fn stringToDtype(safetensor_type: []const u8) !DataType {
         .{ "F16", .f16 },
         .{ "BF16", .bf16 },
         .{ "F8_E4M3", .f8e4m3fn },
+        .{ "F4_E2M1", .f4e2m1 },
         .{ "I64", .i64 },
         .{ "I32", .i32 },
         .{ "I16", .i16 },


### PR DESCRIPTION
`QuantScheme` classifies a checkpoint's scheme from the weight and scale shapes rather than from key names, and `Linear.forward` serves it:

| scheme | stored as |
|---|---|
| NVFP4 | `f4e2m1`, or two values per byte in `u8` |
| FP8 per-channel | `f8e4m3fn` + `[N, 1]` bf16 |
| FP8 block-128 | `f8e4m3fn` + `[N/128, K/128]` bf16 |