### PR TITLE
zml: support F8_E8M0 tensors

### DIFF
--- a/zml/mlirx.zig
+++ b/zml/mlirx.zig
@@ -23,7 +23,7 @@ pub const Type = struct {
             .f8e4m3b11fnuz => .float(ctx, .f8e4m3b11fnuz),
             .f8e5m2 => .float(ctx, .f8e5m2),
             .f8e5m2fnuz => .float(ctx, .f8e5m2fnuz),
-            .f8e8m0 => @panic("Unsupported type"),
+            .f8e8m0 => .float(ctx, .f8e8m0fnu),
             .bf16 => .float(ctx, .bf16),
             .f16 => .float(ctx, .f16),
             .f32 => .float(ctx, .f32),
@@ -51,6 +51,7 @@ pub const Type = struct {
         const mapping = .{
             .{ .bool, mlir.Type.int(ctx, .i1) },
 
+            .{ .f8e8m0, mlir.Type.float(ctx, .f8e8m0fnu) },
             .{ .f8e4m3b11fnuz, mlir.Type.float(ctx, .f8e4m3b11fnuz) },
             .{ .f8e4m3fn, mlir.Type.float(ctx, .f8e4m3fn) },
             .{ .f8e4m3fnuz, mlir.Type.float(ctx, .f8e4m3fnuz) },

--- a/zml/safetensors.zig
+++ b/zml/safetensors.zig
@@ -756,6 +756,7 @@ fn stringToDtype(safetensor_type: []const u8) !DataType {
         .{ "F32", .f32 },
         .{ "F16", .f16 },
         .{ "BF16", .bf16 },
+        .{ "F8_E8M0", .f8e8m0 },
         .{ "F8_E4M3", .f8e4m3fn },
         .{ "F4_E2M1", .f4e2m1 },
         .{ "I64", .i64 },


### PR DESCRIPTION
Adds safetensors parsing and MLIR type support for F8_E8M0 tensors