### PR TITLE
zml: handle packed fp4 on CPU side

### DIFF
--- a/examples/benchmark/main.zig
+++ b/examples/benchmark/main.zig
@@ -102,18 +102,19 @@ fn createRandomBuffer(allocator: std.mem.Allocator, io: std.Io, platform: *const
 
     switch (shape.dtype()) {
         inline else => |v| {
-            const ZigType = v.toZigType();
+            const ZigType = v.toPackedZigType();
             switch (comptime v.class()) {
                 .bool => unreachable,
                 .integer => {
-                    for (slice.items(ZigType)) |*e| e.* = random.int(ZigType);
+                    for (slice.items(ZigType)) |*e| e.* = @bitCast(random.int(@Int(.unsigned, @bitSizeOf(ZigType))));
                 },
                 .float => {
                     const value = random.float(f32);
                     for (slice.items(ZigType)) |*e| e.* = switch (ZigType) {
                         f64, f32 => value,
                         f16 => @floatCast(value),
-                        inline else => |T| if (@hasDecl(T, "fromF32")) T.fromF32(value) else unreachable,
+                        zml.floats.Float4E2M1.Packed => .fromF32(value, -value),
+                        inline else => |T| if (@hasDecl(T, "fromF32")) .fromF32(value) else unreachable,
                     };
                 },
                 .complex => unreachable,

--- a/stdx/fmt.zig
+++ b/stdx/fmt.zig
@@ -37,15 +37,32 @@ pub fn formatFloat(value: anytype, spec: std.fmt.Number, writer: *std.Io.Writer)
         .float => value,
         else => @compileError("formatFloat expects a float, got: " ++ @typeName(@TypeOf(value))),
     };
-    return writer.printFloat(x, spec);
+    switch (@typeInfo(@TypeOf(x))) {
+        .float => try writer.printFloat(x, spec),
+        // Handle F4.toF32() being a [2]f32
+        .array => inline for (0.., x) |i, xi| {
+            try writer.printFloat(xi, spec);
+            if (i < x.len - 1) try writer.writeByte(',');
+        },
+        else => @compileError("formatFloat expects a float, got: " ++ @typeName(@TypeOf(value))),
+    }
 }
 
 pub fn formatInt(value: anytype, spec: std.fmt.Number, writer: *std.Io.Writer) !void {
-    switch (@typeInfo(@TypeOf(value))) {
-        .int => {},
+    return switch (@typeInfo(@TypeOf(value))) {
+        .int => try writer.printInt(value, spec.mode.base().?, spec.case, .{ .alignment = spec.alignment, .fill = spec.fill }),
+        .vector => {
+            const vector = @typeInfo(@TypeOf(value)).vector;
+            const array: [vector.len]vector.child = value;
+            for (&array, 0..) |elem, i| {
+                try writer.printInt(elem, spec.mode.base().?, spec.case, .{ .alignment = spec.alignment, .fill = spec.fill });
+                if (i < array.len - 1) {
+                    try writer.writeAll(", ");
+                }
+            }
+        },
         else => @compileError("formatInt expects an int, got: " ++ @typeName(@TypeOf(value))),
-    }
-    return writer.printInt(value, spec.mode.base().?, spec.case, .{ .alignment = spec.alignment, .fill = spec.fill });
+    };
 }
 
 pub fn formatComplex(value: anytype, spec: std.fmt.Number, writer: *std.Io.Writer) !void {

--- a/zml/Compiler.zig
+++ b/zml/Compiler.zig
@@ -458,9 +458,17 @@ fn createBlockArguments(compiler: *Compiler, scope: *Scope, v: anytype) error{Ou
         infos: std.MultiArrayList(TensorInfo) = .empty,
 
         fn cb(ctx: *@This(), tensor: *const Tensor) error{OutOfMemory}!void {
-            const mlir_type = mlirx.Type.rankedTensor(ctx.compiler.mlir_ctx, tensor._shape);
+            // Declare the program argument as a packed u8
+            const og_shape = tensor._shape;
+            const packed_shape = og_shape.packedShape();
+            const mlir_type = mlirx.Type.rankedTensor(ctx.compiler.mlir_ctx, packed_shape);
+            var value = ctx.scope.block.addArgument(mlir_type, .unknown(ctx.compiler.mlir_ctx));
 
-            const value = ctx.scope.block.addArgument(mlir_type, .unknown(ctx.compiler.mlir_ctx));
+            // But immediately create the MLIR value corresponding to the fp4 data.
+            // That way the user code only sees a proper fp4 tensor.
+            if (tensor.dtype().bitSizeOf() < 8) {
+                value = unpack(ctx.compiler, ctx.scope, og_shape, value);
+            }
             const gop = ctx.scope.id_to_argument.getOrPutValue(ctx.scope.arena.allocator(), tensor.id, value) catch @panic("OOM");
             if (gop.found_existing) std.debug.panic("Tensor with id {} has already been used once as an argument", .{tensor.id});
 
@@ -469,15 +477,15 @@ fn createBlockArguments(compiler: *Compiler, scope: *Scope, v: anytype) error{Ou
 
             defer ctx.current_argument_id += 1;
 
-            const input_sharding = ctx.compiler.partitioning.selectSharding(tensor._shape) catch |err| switch (err) {
+            const input_sharding = ctx.compiler.partitioning.selectSharding(packed_shape) catch |err| switch (err) {
                 error.NoSuitableSharding => std.debug.panic(
                     "Failed to resolve sharding for input {f}({d}) because it's using unknown sharding. Pass more shardings to `platform.compile`. Known shardings: {f}",
-                    .{ tensor._shape, ctx.current_argument_id, stdx.fmt.slice(ctx.compiler.partitioning.shardings) },
+                    .{ packed_shape, ctx.current_argument_id, stdx.fmt.slice(ctx.compiler.partitioning.shardings) },
                 ),
             };
             try ctx.infos.append(ctx.compiler.allocator, .{
                 .id = tensor.id,
-                .shape = tensor._shape,
+                .shape = og_shape,
                 .sharding = input_sharding,
                 .value = value,
             });
@@ -500,15 +508,21 @@ fn collectOutputInfo(compiler: *Compiler, scope: *Scope, v: anytype) error{OutOf
         infos: std.MultiArrayList(TensorInfo) = .empty,
 
         fn cb(ctx: *@This(), tensor: *const Tensor) !void {
-            const value = ctx.scope.id_to_argument.get(tensor.id) orelse
+            const og_shape = tensor.shape();
+            const packed_shape = og_shape.packedShape();
+            var value = ctx.scope.id_to_argument.get(tensor.id) orelse
                 tensor._value orelse
                 @panic("no value found for output tensor");
 
+            if (tensor.dtype().bitSizeOf() < 8) {
+                value = repack(ctx.compiler, ctx.scope, og_shape, value);
+            }
+
             try ctx.infos.append(ctx.compiler.allocator, .{
                 .id = tensor.id,
-                .shape = tensor._shape,
-                // Note: the panic should have been triggered during emitMlir or collectInputInfo
-                .sharding = ctx.compiler.partitioning.selectSharding(tensor._shape) catch @panic("failed to resolve output sharding"),
+                .shape = og_shape,
+                // Note: the panic should have been triggered during createBlockArguments or emitMlir
+                .sharding = ctx.compiler.partitioning.selectSharding(packed_shape) catch @panic("failed to resolve output sharding"),
                 .value = value,
             });
         }
@@ -570,6 +584,50 @@ fn finalizeMlirFunc(compiler: *Compiler, fn_scope: *Scope, input_info: std.Multi
         .input_info = input_info,
         .output_info = output_info,
     };
+}
+
+fn unpack(compiler: *Compiler, scope: *Scope, og_shape: Shape, tensor_value: *const mlir.Value) *const mlir.Value {
+    const true_type = mlirx.Type.rankedTensor(compiler.mlir_ctx, og_shape);
+    const elem_per_bytes = @divExact(8, og_shape.dtype().bitSizeOf());
+    const intermediary_type = mlirx.Type.rankedTensor(compiler.mlir_ctx, og_shape.splitAxis(-1, .{ -1, elem_per_bytes }));
+
+    const bit_cast_op = dialects.stablehlo.bitcast_convert(
+        compiler.mlir_ctx,
+        tensor_value,
+        intermediary_type,
+        .unknown(compiler.mlir_ctx),
+    ).appendTo(scope.block);
+
+    const reshape_op = dialects.stablehlo.reshape(
+        compiler.mlir_ctx,
+        bit_cast_op.result(0),
+        true_type,
+        .unknown(compiler.mlir_ctx),
+    ).appendTo(scope.block);
+
+    return reshape_op.result(0);
+}
+
+fn repack(compiler: *Compiler, scope: *Scope, og_shape: Shape, value: *const mlir.Value) *const mlir.Value {
+    const packed_type = mlirx.Type.rankedTensor(compiler.mlir_ctx, og_shape.packedShape());
+    const elem_per_bytes = @divExact(8, og_shape.dtype().bitSizeOf());
+    const intermediary_type = mlirx.Type.rankedTensor(compiler.mlir_ctx, og_shape.splitAxis(-1, .{ -1, elem_per_bytes }));
+
+    const reshape_op = dialects.stablehlo.reshape(
+        compiler.mlir_ctx,
+        value,
+        intermediary_type,
+        .unknown(compiler.mlir_ctx),
+    ).appendTo(scope.block);
+
+    const bit_cast_op = dialects.stablehlo.bitcast_convert(
+        compiler.mlir_ctx,
+        reshape_op.result(0),
+        packed_type,
+        .unknown(compiler.mlir_ctx),
+    ).appendTo(scope.block);
+
+    return bit_cast_op.result(0);
 }
 
 fn setXlaOverrideFlag(map: *c.upb_Map, flag: []const u8, value: anytype, upb_arena: *c.upb_Arena) !void {

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -112,14 +112,16 @@ pub const Buffer = struct {
     pub fn from(
         io: std.Io,
         platform: *const Platform,
-        sh: Shape,
+        shape_: Shape,
         sharding: Sharding,
         data_: []const u8,
         opts: FromOptions,
     ) !Buffer {
+        // Use the PJRT shape for everything
+        const sh = shape_.packedShape();
         var res: Buffer = .{
             ._platform = platform,
-            ._shape = sh,
+            ._shape = shape_,
             ._sharding = sharding.resolve(platform),
             ._shards = .empty,
         };

--- a/zml/dtype.zig
+++ b/zml/dtype.zig
@@ -7,8 +7,8 @@ const C128 = std.math.Complex(f64);
 
 pub const DataType = enum(u8) {
     bool,
-    // Note: the support of the float8 is a bit spotty, f8e4m3b11fnuz seems to be the most supported one on Cuda.
     f4e2m1,
+    // Note: the support of the float8 is a bit spotty, f8e4m3b11fnuz seems to be the most supported one on Cuda.
     f8e3m4,
     f8e4m3,
     f8e4m3b11fnuz,
@@ -151,6 +151,7 @@ pub const DataType = enum(u8) {
 
     pub fn bitSizeOf(self: DataType) u16 {
         return switch (self) {
+            .bool => 8, // In PJRT/stablehlo bool always occupy a full byte
             inline else => |tag| @bitSizeOf(tag.toZigType()),
         };
     }

--- a/zml/dtype.zig
+++ b/zml/dtype.zig
@@ -136,9 +136,22 @@ pub const DataType = enum(u8) {
         return @FieldType(Value, @tagName(dtype));
     }
 
+    pub fn toPackedZigType(comptime dtype: DataType) type {
+        return switch (dtype) {
+            .bool => bool,
+            .i2, .i4, .u2, .u4 => |dt| @Vector(8 / dt.bitSizeOf(), @FieldType(Value, @tagName(dtype))),
+            .f4e2m1 => floats.Float4E2M1.Packed,
+            else => {
+                const T = @FieldType(Value, @tagName(dtype));
+                if (@bitSizeOf(T) < 8) @compileLog("Forgot type !", T);
+                return T;
+            },
+        };
+    }
+
     pub fn isSignedInt(dtype: DataType) bool {
         return switch (dtype) {
-            .i4, .i8, .i16, .i32, .i64 => true,
+            .i2, .i4, .i8, .i16, .i32, .i64 => true,
             else => false,
         };
     }

--- a/zml/floats.zig
+++ b/zml/floats.zig
@@ -502,6 +502,19 @@ pub const Float4E2M1 = packed struct(u4) {
         }
         try std.testing.expectEqualSlices(u4, &.{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 }, @ptrCast(&from_f32_res));
     }
+
+    pub const Packed = packed struct(@Int(.unsigned, @bitSizeOf(Float4E2M1) * 2)) {
+        x: Float4E2M1,
+        y: Float4E2M1,
+
+        pub fn fromF32(x: f32, y: f32) Packed {
+            return .{ .x = .fromF32(x), .y = .fromF32(y) };
+        }
+
+        pub fn toF32(xy: Packed) [2]f32 {
+            return .{ xy.x.toF32(), xy.y.toF32() };
+        }
+    };
 };
 
 pub fn floatCast(T: type, x: anytype) T {

--- a/zml/floats.zig
+++ b/zml/floats.zig
@@ -514,6 +514,12 @@ pub const Float4E2M1 = packed struct(u4) {
         pub fn toF32(xy: Packed) [2]f32 {
             return .{ xy.x.toF32(), xy.y.toF32() };
         }
+
+        pub fn formatNumber(xy: Packed, w: *std.Io.Writer, n: std.fmt.Number) std.Io.Writer.Error!void {
+            try xy.x.formatNumber(w, n);
+            w.writeByte(',');
+            try xy.y.formatNumber(w, n);
+        }
     };
 };
 

--- a/zml/shape.zig
+++ b/zml/shape.zig
@@ -500,22 +500,7 @@ pub const Shape = struct {
 
     /// Total size in bytes needed to represent this shape on host
     pub fn byteSize(self: Shape) usize {
-        return self.dtype().sizeOf() * self.count();
-    }
-
-    /// Total size in bytes needed to represent this shape on device
-    /// https://github.com/openxla/xla/blob/0f7240cad3fa14b52a809ac1f4a351a9edfc541e/xla/primitive_util.h#L807
-    pub fn deviceByteSize(self: Shape) usize {
-        const bits_per_element: usize = switch (self.dtype()) {
-            .bool => 8,
-            else => self.dtype().bitSizeOf(),
-        };
-
-        return std.math.divCeil(
-            usize,
-            self.count() * bits_per_element,
-            8,
-        ) catch unreachable;
+        return std.math.divCeil(usize, self.count() * self.dtype().bitSizeOf(), 8) catch unreachable;
     }
 
     /// Compares the two shapes described, ignoring tagging.
@@ -1639,6 +1624,22 @@ pub const Shape = struct {
             .current_coords = @splat(0),
             .flat_index = 0,
         };
+    }
+
+    /// Generate the packed shape visible to PJRT
+    pub fn packedShape(sh: Shape) Shape {
+        const bit_size = sh.dtype().bitSizeOf();
+        if (bit_size >= 8) return sh;
+
+        const items_per_byte = @divExact(8, bit_size);
+        var res: Shape = sh.setDim(-1, @divExact(sh.dim(-1), items_per_byte));
+        res._dtype = .u8;
+        return res;
+    }
+
+    test packedShape {
+        const x: Shape = .init(.{ 4, 8 }, .u2);
+        try expectEqualShapes(.init(.{ 4, 2 }, .u8), x.packedShape());
     }
 };
 

--- a/zml/slice.zig
+++ b/zml/slice.zig
@@ -147,6 +147,7 @@ pub const Slice = struct {
     }
 
     pub fn items(slice: Slice, comptime T: type) []T {
+        stdx.debug.assertComptime(@bitSizeOf(T) >= 8, "zml.Slice stores packed sub-bytes type so you need to pass a packed type here like @Vector({}, {}). Got: {}", .{ @divFloor(8, @bitSizeOf(T)), T, T });
         return @ptrCast(@alignCast(slice.data()));
     }
 
@@ -273,14 +274,17 @@ pub const Slice = struct {
             try writer.splatByteAll(' ', indent_level);
             switch (slice.dtype()) {
                 inline else => |dt| {
-                    const T = dt.toZigType();
+                    const T = dt.toPackedZigType();
                     const n = slice.shape.dim(0);
+                    const elem_per_bytes: comptime_int = @max(1, 8 / comptime dt.bitSizeOf());
+                    const stride = @divExact(slice.byte_strides.get(0), @as(i64, @sizeOf(T)));
 
-                    const stride = @divExact(slice.byte_strides.get(0), @as(i64, @intCast(@sizeOf(T))));
+                    // Fetch n next elements, accounting for strides and packing
+                    const needed_len: usize = @as(usize, if (n == 0) 0 else @intCast(@abs((n - 1) * stride) + 1)) / elem_per_bytes;
 
-                    const needed_len: usize = if (n == 0) 0 else @intCast(@abs((n - 1) * stride) + 1);
                     // The formatter consumes this physical tail using `stride`, so this
                     // rank-1 path can read raw items without requiring contiguity.
+                    std.log.warn("Printing {} elems from offset {} out of {} total elems @ {}", .{ n, slice.offset_bytes, needed_len, stride });
                     const raw_values: []const T = @ptrCast(@alignCast(slice.bytes[slice.offset_bytes..]));
                     const values = raw_values[0..needed_len];
 
@@ -510,5 +514,14 @@ test "slice pretty print ellipsis" {
         \\  {8},
         \\}
     ;
+    try std.testing.expectFmt(expected, "{d}", .{slice});
+}
+
+test "slice pretty print f4" {
+    const x_f4_packed = [_]floats.Float4E2M1.Packed{ .fromF32(0, 0.5), .fromF32(1, 1.5), .fromF32(2, 3), .fromF32(4, 6) };
+    const slice = Slice.initConst(.init(.{8}, .f4e2m1), @ptrCast(&x_f4_packed));
+
+    const expected = "{0,0.5,1,1.5,2,3,4,6}";
+
     try std.testing.expectFmt(expected, "{d}", .{slice});
 }

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -83,7 +83,9 @@ pub const Tensor = struct {
         if (builtin.mode == .Debug) {
             // Check that the MLIR value actually have the same shape.
             const other = fromMlirValue(val);
-            stdx.debug.internalAssert(sh.eql(other._shape), "Created a {f} from Mlir value but expected {f}", .{ other._shape, res._shape });
+            const eql_dtype = sh.dtype() == other.dtype();
+            const eql_dims = std.mem.eql(i64, sh.dims(), other.dims());
+            stdx.debug.internalAssert(eql_dims and eql_dtype, "Created a {f} from Mlir value but expected {f}", .{ other._shape, res._shape });
         }
 
         return res;
@@ -1208,73 +1210,141 @@ pub const Tensor = struct {
             return self;
         }
 
-        const res_type = mlir.Type.rankedTensor(self.shape().dims(), mlirx.Type.fromDType(mlirCtx(), to));
+        const res_type = mlirx.Type.rankedTensor(mlirCtx(), self.shape().withDtype(to));
         const op = dialects.stablehlo.convert(mlirCtx(), self.value(), res_type, .unknown(mlirCtx())).appendTo(currentBlock());
         return _result(self._shape.withDtype(to), op.result(0));
     }
 
-    test convert {
+    test "convert f32 -> f4e2m1" {
         const floats = @import("floats.zig");
         const zml = @import("zml.zig");
         const platform = zml.testing.env();
+        const x_f32 = [_]f32{ 0.0, 0.5, 1, 1.5, 2, 3, 4, 6, -0.0, -0.5, -1, -1.5, -2, -3, -4, -6 };
+        var x_f4: [x_f32.len / 2]floats.Float4E2M1.Packed = undefined;
+        for (&x_f4, 0..) |*f4_pack, i| {
+            f4_pack.* = .fromF32(x_f32[2 * i], x_f32[2 * i + 1]);
+        }
 
-        // f4e2m1
-        {
-            const x = [_]f32{ 0.0, 0.5, 1, 1.5, 2, 3, 4, 6, -0.0, -0.5, -1, -1.5, -2, -3, -4, -6 };
-            var x_f4_packed: [x.len / 2]floats.Float4E2M1.Packed = undefined;
-            for (&x_f4_packed, 0..) |*f4_as_u4, i| {
-                f4_as_u4.* = .fromF32(x[2 * i], x[2 * i + 1]);
+        const x_d: Tensor = .init(.{x_f32.len}, .f32);
+        const exe = try zml.module.compile(
+            std.testing.allocator,
+            std.testing.io,
+            Tensor.convert,
+            .{ x_d, .f4e2m1 },
+            platform,
+            .{},
+        );
+        defer exe.deinit();
+
+        var x_d_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, x_d.shape(), .replicated, @ptrCast(&x_f32));
+        defer x_d_buffer.deinit();
+
+        var x_f4_xla_d = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Tensor.convert, .{x_d_buffer});
+        const x_f4_xla = try x_f4_xla_d.toSliceAlloc(std.testing.allocator, std.testing.io);
+        defer x_f4_xla.free(std.testing.allocator);
+
+        errdefer std.log.warn("convert(f32 -> f4e2m1) failed !\ninput f32:\n{d}\nzml.floats computed:\n{d}\nxla computed:\n{f}", .{ stdx.fmt.slice(&x_f32), stdx.fmt.slice(&x_f4), x_f4_xla });
+        try std.testing.expectEqualSlices(u8, @ptrCast(&x_f4), x_f4_xla.constData());
+    }
+
+    test "convert f32 -> f8e3m4" {
+        const zml = @import("zml.zig");
+        const platform = zml.testing.env();
+
+        const x = [_]f32{ 1.1 / 4.0, 1.1 / 8.0, 1.1 / 16.0, 1.1 / 32.0, 1.1 / 64.0, 1.1 / 128.0 };
+        var x_f8e3: [x.len]zml.floats.Float8E3M4 = undefined;
+        for (&x_f8e3, &x) |*xi_f8e3, xi| xi_f8e3.* = .fromF32(xi);
+
+        const x_d: Tensor = .init(.{x.len}, .f32);
+        const exe = try zml.module.compile(
+            std.testing.allocator,
+            std.testing.io,
+            Tensor.convert,
+            .{ x_d, .f8e3m4 },
+            platform,
+            .{},
+        );
+        defer exe.deinit();
+
+        var x_d_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, x_d.shape(), .replicated, std.mem.sliceAsBytes(&x));
+        defer x_d_buffer.deinit();
+
+        var x_f8e3_xla_d = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Tensor.convert, .{x_d_buffer});
+        const x_f8e3_xla = try x_f8e3_xla_d.toSliceAlloc(std.testing.allocator, std.testing.io);
+        defer x_f8e3_xla.free(std.testing.allocator);
+
+        errdefer std.log.warn("convert(.f8e3m4) failed !\ninput f32:\n{d}\nzml.floats computed:\n{d}\nxla computed:\n{d}", .{ stdx.fmt.slice(&x), stdx.fmt.slice(&x_f8e3), x_f8e3_xla });
+        try std.testing.expectEqualSlices(u8, @ptrCast(&x_f8e3), x_f8e3_xla.constData());
+    }
+
+    test "convert u2x4 -> u8" {
+        const zml = @import("zml.zig");
+        const platform = zml.testing.env();
+        const x_u2: [2]@Vector(4, u2) = .{ .{ 0, 1, 2, 3 }, .{ 3, 2, 1, 0 } };
+        std.debug.assert(@sizeOf(@TypeOf(x_u2)) == 2);
+        const x_u8: [8]u8 = .{ 0, 1, 2, 3, 3, 2, 1, 0 };
+
+        const Local = struct {
+            fn fwd(x_u2x4: Tensor) Tensor {
+                return x_u2x4.convert(.u8);
             }
+        };
 
-            const x_d: Tensor = .init(.{x.len}, .f32);
-            const exe = try zml.module.compile(
-                std.testing.allocator,
-                std.testing.io,
-                Tensor.convert,
-                .{ x_d, .f4e2m1 },
-                platform,
-                .{},
-            );
-            defer exe.deinit();
+        const x_u2_t: Tensor = .init(.{8}, .u2);
+        const exe = try zml.module.compile(
+            std.testing.allocator,
+            std.testing.io,
+            Local.fwd,
+            .{x_u2_t},
+            platform,
+            .{},
+        );
+        defer exe.deinit();
 
-            var x_d_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, x_d.shape(), .replicated, std.mem.sliceAsBytes(&x));
-            defer x_d_buffer.deinit();
+        var x_d_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, x_u2_t.shape(), .replicated, @ptrCast(&x_u2));
+        defer x_d_buffer.deinit();
 
-            var x_f4_xla_d = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Tensor.convert, .{x_d_buffer});
-            const x_f4_xla = try x_f4_xla_d.toSliceAlloc(std.testing.allocator, std.testing.io);
-            defer x_f4_xla.free(std.testing.allocator);
+        var x_u8_xla_d = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Tensor.convert, .{x_d_buffer});
+        defer x_u8_xla_d.deinit();
+        const x_u8_xla = try x_u8_xla_d.toSliceAlloc(std.testing.allocator, std.testing.io);
+        defer x_u8_xla.free(std.testing.allocator);
 
-            errdefer std.log.warn("convert(.f4e2m1) failed !\ninput f32:\n{e}\nzml.floats computed:\n{any}\nxla computed:\n{any}", .{ stdx.fmt.slice(&x), x_f4_packed, x_f4_xla });
-            try std.testing.expectEqualSlices(u8, @ptrCast(&x_f4_packed), x_f4_xla.constData());
-        }
+        try std.testing.expectEqualSlices(u8, &x_u8, x_u8_xla.constData());
+    }
 
-        // f8e3m4
-        {
-            const x = [_]f32{ 1.1 / 4.0, 1.1 / 8.0, 1.1 / 16.0, 1.1 / 32.0, 1.1 / 64.0, 1.1 / 128.0 };
-            var x_f8e3: [x.len]floats.Float8E3M4 = undefined;
-            for (&x_f8e3, &x) |*xi_f8e3, xi| xi_f8e3.* = .fromF32(xi);
+    test "convert f4e2m1x2 -> f32" {
+        const floats = @import("floats.zig");
+        const zml = @import("zml.zig");
+        const platform = zml.testing.env();
+        const x_f4_packed = [_]floats.Float4E2M1.Packed{ .fromF32(0, 0.5), .fromF32(1, 1.5), .fromF32(2, 3), .fromF32(4, 6) };
 
-            const x_d: Tensor = .init(.{x.len}, .f32);
-            const exe = try zml.module.compile(
-                std.testing.allocator,
-                std.testing.io,
-                Tensor.convert,
-                .{ x_d, .f8e3m4 },
-                platform,
-                .{},
-            );
-            defer exe.deinit();
+        const Local = struct {
+            fn fwd(x_f4_x2: Tensor) Tensor {
+                return x_f4_x2.convert(.f32);
+            }
+        };
 
-            var x_d_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, x_d.shape(), .replicated, std.mem.sliceAsBytes(&x));
-            defer x_d_buffer.deinit();
+        const x_t: Tensor = .init(.{x_f4_packed.len * 2}, .f4e2m1);
+        const exe = try zml.module.compile(
+            std.testing.allocator,
+            std.testing.io,
+            Local.fwd,
+            .{x_t},
+            platform,
+            .{},
+        );
+        defer exe.deinit();
 
-            var x_f8e3_xla_d = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Tensor.convert, .{x_d_buffer});
-            const x_f8e3_xla = try x_f8e3_xla_d.toSliceAlloc(std.testing.allocator, std.testing.io);
-            defer x_f8e3_xla.free(std.testing.allocator);
+        var x_f4_d: zml.Buffer = try .fromBytes(std.testing.io, platform, x_t.shape(), .replicated, @ptrCast(&x_f4_packed));
+        defer x_f4_d.deinit();
 
-            errdefer std.log.warn("convert(.f8e3m4) failed !\ninput f32:\n{e}\nzml.floats computed:\n{any}\nxla computed:\n{any}", .{ stdx.fmt.slice(&x), x_f8e3, x_f8e3_xla });
-            try std.testing.expectEqualDeep(&x_f8e3, x_f8e3_xla.items(floats.Float8E3M4));
-        }
+        var x_f32_d = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Local.fwd, .{x_f4_d});
+        const x_f32_h = try x_f32_d.toSliceAlloc(std.testing.allocator, std.testing.io);
+        defer x_f32_h.free(std.testing.allocator);
+
+        const x_f32_expected = [_]f32{ 0.0, 0.5, 1, 1.5, 2, 3, 4, 6 };
+        errdefer std.log.warn("convert(f4e2m1x2 -> f32) failed !\ninput f4e2m1x2:\n{e}\nexpected:\n{any}\nxla computed:\n{any}", .{ stdx.fmt.slice(&x_f4_packed), x_f32_expected, x_f32_h });
+        try std.testing.expectEqualSlices(f32, &x_f32_expected, x_f32_h.items(f32));
     }
 
     /// Returns a Tensor containing the element-wise rounding operation of the input Tensor.

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1242,9 +1242,10 @@ pub const Tensor = struct {
         var x_f4_xla_d = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Tensor.convert, .{x_d_buffer});
         const x_f4_xla = try x_f4_xla_d.toSliceAlloc(std.testing.allocator, std.testing.io);
         defer x_f4_xla.free(std.testing.allocator);
+        const x_f4_items = x_f4_xla.items(floats.Float4E2M1.Packed);
 
-        errdefer std.log.warn("convert(f32 -> f4e2m1) failed !\ninput f32:\n{d}\nzml.floats computed:\n{d}\nxla computed:\n{f}", .{ stdx.fmt.slice(&x_f32), stdx.fmt.slice(&x_f4), x_f4_xla });
-        try std.testing.expectEqualSlices(u8, @ptrCast(&x_f4), x_f4_xla.constData());
+        errdefer std.log.warn("convert(f32 -> f4e2m1) failed !\ninput f32:\n{d}\nzml.floats computed:\n{d}\nxla computed:\n{d}", .{ stdx.fmt.slice(&x_f32), stdx.fmt.slice(&x_f4), x_f4_xla });
+        try std.testing.expectEqualSlices(floats.Float4E2M1.Packed, &x_f4, x_f4_items);
     }
 
     test "convert f32 -> f8e3m4" {
@@ -1277,25 +1278,19 @@ pub const Tensor = struct {
         try std.testing.expectEqualSlices(u8, @ptrCast(&x_f8e3), x_f8e3_xla.constData());
     }
 
-    test "convert u2x4 -> u8" {
+    test "convert u2 -> u8" {
         const zml = @import("zml.zig");
         const platform = zml.testing.env();
         const x_u2: [2]@Vector(4, u2) = .{ .{ 0, 1, 2, 3 }, .{ 3, 2, 1, 0 } };
         std.debug.assert(@sizeOf(@TypeOf(x_u2)) == 2);
         const x_u8: [8]u8 = .{ 0, 1, 2, 3, 3, 2, 1, 0 };
 
-        const Local = struct {
-            fn fwd(x_u2x4: Tensor) Tensor {
-                return x_u2x4.convert(.u8);
-            }
-        };
-
         const x_u2_t: Tensor = .init(.{8}, .u2);
         const exe = try zml.module.compile(
             std.testing.allocator,
             std.testing.io,
-            Local.fwd,
-            .{x_u2_t},
+            Tensor.convert,
+            .{ x_u2_t, .u8 },
             platform,
             .{},
         );
@@ -1312,24 +1307,18 @@ pub const Tensor = struct {
         try std.testing.expectEqualSlices(u8, &x_u8, x_u8_xla.constData());
     }
 
-    test "convert f4e2m1x2 -> f32" {
+    test "convert f4e2m1 -> f32" {
         const floats = @import("floats.zig");
         const zml = @import("zml.zig");
         const platform = zml.testing.env();
         const x_f4_packed = [_]floats.Float4E2M1.Packed{ .fromF32(0, 0.5), .fromF32(1, 1.5), .fromF32(2, 3), .fromF32(4, 6) };
 
-        const Local = struct {
-            fn fwd(x_f4_x2: Tensor) Tensor {
-                return x_f4_x2.convert(.f32);
-            }
-        };
-
         const x_t: Tensor = .init(.{x_f4_packed.len * 2}, .f4e2m1);
         const exe = try zml.module.compile(
             std.testing.allocator,
             std.testing.io,
-            Local.fwd,
-            .{x_t},
+            Tensor.convert,
+            .{ x_t, .f32 },
             platform,
             .{},
         );
@@ -1338,7 +1327,7 @@ pub const Tensor = struct {
         var x_f4_d: zml.Buffer = try .fromBytes(std.testing.io, platform, x_t.shape(), .replicated, @ptrCast(&x_f4_packed));
         defer x_f4_d.deinit();
 
-        var x_f32_d = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Local.fwd, .{x_f4_d});
+        var x_f32_d = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Tensor.convert, .{x_f4_d});
         const x_f32_h = try x_f32_d.toSliceAlloc(std.testing.allocator, std.testing.io);
         defer x_f32_h.free(std.testing.allocator);
 

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1221,8 +1221,10 @@ pub const Tensor = struct {
         // f4e2m1
         {
             const x = [_]f32{ 0.0, 0.5, 1, 1.5, 2, 3, 4, 6, -0.0, -0.5, -1, -1.5, -2, -3, -4, -6 };
-            var x_f4: [x.len]floats.Float4E2M1 = undefined;
-            for (&x_f4, &x) |*xi_f4, xi| xi_f4.* = .fromF32(xi);
+            var x_f4_packed: [x.len / 2]floats.Float4E2M1.Packed = undefined;
+            for (&x_f4_packed, 0..) |*f4_as_u4, i| {
+                f4_as_u4.* = .fromF32(x[2 * i], x[2 * i + 1]);
+            }
 
             const x_d: Tensor = .init(.{x.len}, .f32);
             const exe = try zml.module.compile(
@@ -1242,8 +1244,8 @@ pub const Tensor = struct {
             const x_f4_xla = try x_f4_xla_d.toSliceAlloc(std.testing.allocator, std.testing.io);
             defer x_f4_xla.free(std.testing.allocator);
 
-            errdefer std.log.warn("convert(.f4e2m1) failed !\ninput f32:\n{e}\nzml.floats computed:\n{any}\nxla computed:\n{any}", .{ stdx.fmt.slice(&x), x_f4, x_f4_xla });
-            try std.testing.expectEqualDeep(&x_f4, x_f4_xla.items(floats.Float4E2M1));
+            errdefer std.log.warn("convert(.f4e2m1) failed !\ninput f32:\n{e}\nzml.floats computed:\n{any}\nxla computed:\n{any}", .{ stdx.fmt.slice(&x), x_f4_packed, x_f4_xla });
+            try std.testing.expectEqualSlices(u8, @ptrCast(&x_f4_packed), x_f4_xla.constData());
         }
 
         // f8e3m4

--- a/zml/testing.zig
+++ b/zml/testing.zig
@@ -285,7 +285,11 @@ pub const CompareOpts = struct {
             std.debug.assert(left.len == right.len);
 
             for (left, right) |l, r| {
-                self.count_close += if (l == r) 1 else 0;
+                switch (@typeInfo(T)) {
+                    .int, .float => self.count_close += if (l == r) 1 else 0,
+                    .vector => |vec| self.count_close += @popCount(@as(@Int(.unsigned, vec.len), @bitCast(l == r))),
+                    else => @panic("cmpIntSlices expect int or vector of int"),
+                }
             }
             self.processed_count += left.len;
         }


### PR DESCRIPTION
The XLA API assumes that all sub-bytes data is given to it unpacked.
But when you read safetensors files the data is packed.

My proposition is the following: when we have a zml.fp4 tensor/buffer we say to pjrt it's a u8 buffer instead.
Since PJRT infers the input/output shape from stablehlo I had to introduce some bitcast at the edge of the compilation:
- fp4 input are declared as u8, but I insert bitcast operand before calling the zig code, so the model code only see the fp4 tensors.
- when the model code returns a fp4 output, I bitcast to u8 before exiting the final compilation

Breaking changes: none
Currently fp4 can't cross the pjrt boundary, so all fp4 code already manually lie about the data being u8, and it will keep working. In the future this code will be able to be "upgraded" by explicitly tagging the input as fp4 and remove the "unpacking" code from their model code.

Note: the tracking XLA issue seems pretty cold https://github.com/openxla/xla/issues/16795

<details> 
  <summary>Previous version of the proposal (dropped) </summary>
  My proposition to handle this is to add more dtypes to represent packed data.
In this PR I only put f4x2 and u2x4. Those types are passed to PJRT as u8, and in stablehlo they have no associated type, meaning you can't do any operation with them until you call `unpack` 
</details>