### PR TITLE
zml: Use zml.nn.Linear for forwardMoe and rename quantization structs

### DIFF
--- a/examples/llm/models/llama/model.zig
+++ b/examples/llm/models/llama/model.zig
@@ -97,7 +97,7 @@ pub const LoadedModel = struct {
     }
 
     pub fn unloadBuffers(_: *const LoadedModel, buffers: *Buffers, allocator: std.mem.Allocator) void {
-        if (buffers.lm_head) |*lm_head| lm_head.weight.deinit();
+        if (buffers.lm_head) |*lm_head| zml.nn.Linear.unloadBuffers(lm_head);
         Llama.unloadBuffers(&buffers.model, allocator);
     }
 
@@ -189,7 +189,7 @@ pub const Model = struct {
     }
 
     pub fn unloadBuffers(self: *zml.Bufferized(Model), allocator: std.mem.Allocator) void {
-        if (self.lm_head) |*lm_head| lm_head.weight.deinit();
+        if (self.lm_head) |*lm_head| zml.nn.Linear.unloadBuffers(lm_head);
         Llama.unloadBuffers(&self.model, allocator);
     }
 
@@ -480,12 +480,7 @@ const Mlp = struct {
     }
 
     pub fn unloadBuffers(self: *zml.Bufferized(Mlp)) void {
-        self.up_proj.weight.deinit();
-        if (self.up_proj.bias) |*bias| bias.deinit();
-        self.gate_proj.weight.deinit();
-        if (self.gate_proj.bias) |*bias| bias.deinit();
-        self.down_proj.weight.deinit();
-        if (self.down_proj.bias) |*bias| bias.deinit();
+        zml.Buffer.deinitAll(Mlp, self);
     }
 
     pub fn forward(self: Mlp, x: zml.Tensor) zml.Tensor {
@@ -530,17 +525,7 @@ const SelfAttn = struct {
     }
 
     pub fn unloadBuffers(self: *zml.Bufferized(SelfAttn)) void {
-        self.q_proj.weight.deinit();
-        if (self.q_proj.bias) |*bias| bias.deinit();
-        self.k_proj.weight.deinit();
-        if (self.k_proj.bias) |*bias| bias.deinit();
-        self.v_proj.weight.deinit();
-        if (self.v_proj.bias) |*bias| bias.deinit();
-        self.o_proj.weight.deinit();
-        if (self.o_proj.bias) |*bias| bias.deinit();
-
-        if (self.q_norm) |*q_norm| RmsNorm.unloadBuffers(q_norm);
-        if (self.k_norm) |*k_norm| RmsNorm.unloadBuffers(k_norm);
+        zml.Buffer.deinitAll(SelfAttn, self);
     }
 
     /// Self zml.attention.

--- a/examples/llm/models/qwen3_5/model.zig
+++ b/examples/llm/models/qwen3_5/model.zig
@@ -111,7 +111,7 @@ pub const LoadedModel = struct {
     pub fn unloadBuffers(self: *const LoadedModel, buffers: *Buffers, allocator: std.mem.Allocator) void {
         _ = self;
         TextModel.unloadBuffers(&buffers.text_model, allocator);
-        buffers.lm_head.weight.deinit();
+        zml.nn.Linear.unloadBuffers(&buffers.lm_head);
     }
 
     pub fn compile(
@@ -209,7 +209,7 @@ pub const Model = struct {
 
     pub fn unloadBuffers(self: *zml.Bufferized(Model), allocator: std.mem.Allocator) void {
         TextModel.unloadBuffers(&self.text_model, allocator);
-        self.lm_head.weight.deinit();
+        zml.nn.Linear.unloadBuffers(&self.lm_head);
     }
     pub fn forward(
         self: Model,
@@ -517,12 +517,7 @@ pub const Mlp = struct {
     }
 
     pub fn unloadBuffers(self: *zml.Bufferized(Mlp)) void {
-        self.up_proj.weight.deinit();
-        if (self.up_proj.bias) |*bias| bias.deinit();
-        self.gate_proj.weight.deinit();
-        if (self.gate_proj.bias) |*bias| bias.deinit();
-        self.down_proj.weight.deinit();
-        if (self.down_proj.bias) |*bias| bias.deinit();
+        zml.Buffer.deinitAll(Mlp, self);
     }
 
     pub fn forward(self: Mlp, x: zml.Tensor) zml.Tensor {
@@ -577,16 +572,7 @@ pub const SelfAttn = struct {
     }
 
     pub fn unloadBuffers(self: *zml.Bufferized(SelfAttn)) void {
-        self.q_proj.weight.deinit();
-        if (self.q_proj.bias) |*bias| bias.deinit();
-        self.k_proj.weight.deinit();
-        if (self.k_proj.bias) |*bias| bias.deinit();
-        self.v_proj.weight.deinit();
-        if (self.v_proj.bias) |*bias| bias.deinit();
-        self.o_proj.weight.deinit();
-        if (self.o_proj.bias) |*bias| bias.deinit();
-        RmsNorm.unloadBuffers(&self.q_norm);
-        RmsNorm.unloadBuffers(&self.k_norm);
+        zml.Buffer.deinitAll(SelfAttn, self);
     }
 
     fn projectQAndGate(self: SelfAttn, x: zml.Tensor) struct { zml.Tensor, zml.Tensor } {
@@ -810,15 +796,7 @@ pub const GatedDeltaNet = struct {
     }
 
     pub fn unloadBuffers(self: *zml.Bufferized(GatedDeltaNet)) void {
-        self.in_proj_qkv.weight.deinit();
-        self.in_proj_z.weight.deinit();
-        self.in_proj_b.weight.deinit();
-        self.in_proj_a.weight.deinit();
-        self.out_proj.weight.deinit();
-        self.conv1d_weight.deinit();
-        self.dt_bias.deinit();
-        self.aLog.deinit();
-        RmsNormGated.unloadBuffers(&self.norm);
+        zml.Buffer.deinitAll(GatedDeltaNet, self);
     }
 
     fn recurrentGatedDeltaRule(

--- a/examples/llm/models/qwen3_5_moe/model.zig
+++ b/examples/llm/models/qwen3_5_moe/model.zig
@@ -150,7 +150,7 @@ pub const LoadedModel = struct {
         progress: *std.Progress.Node,
     ) !inference.CompiledModel {
         _ = backend;
-        const moe_dtype = self.inner.text_model.layers[0].moe.gate_up_proj.dtype();
+        const moe_dtype = self.inner.text_model.layers[0].moe.gate_up_proj.weight.dtype();
         log.info("Moe dtype : {}", .{moe_dtype});
         const moe_backend = try zml.moe.Backend.auto(platform, moe_dtype);
         const params = inference.CompilationParameters.init(self.inner, self.parsed_config.value, @intCast(seqlen), moe_backend, shardings);
@@ -336,7 +336,7 @@ pub const TextModel = struct {
         }
         allocator.free(self.layers);
         RmsNorm.unloadBuffers(&self.norm);
-        self.lm_head.weight.deinit();
+        zml.nn.Linear.unloadBuffers(&self.lm_head);
     }
 
     pub fn sampler(self: TextModel) Sampler {
@@ -581,20 +581,7 @@ pub const SelfAttn = struct {
     }
 
     pub fn unloadBuffers(self: *zml.Bufferized(SelfAttn)) void {
-        self.q_proj.weight.deinit();
-        if (self.q_proj.bias) |*bias| bias.deinit();
-        if (self.q_proj_scale) |*scale| scale.deinit();
-        self.k_proj.weight.deinit();
-        if (self.k_proj.bias) |*bias| bias.deinit();
-        if (self.k_proj_scale) |*scale| scale.deinit();
-        self.v_proj.weight.deinit();
-        if (self.v_proj.bias) |*bias| bias.deinit();
-        if (self.v_proj_scale) |*scale| scale.deinit();
-        self.o_proj.weight.deinit();
-        if (self.o_proj.bias) |*bias| bias.deinit();
-        if (self.o_proj_scale) |*scale| scale.deinit();
-        RmsNorm.unloadBuffers(&self.q_norm);
-        RmsNorm.unloadBuffers(&self.k_norm);
+        zml.Buffer.deinitAll(SelfAttn, self);
     }
 
     fn projectQAndGate(self: SelfAttn, x: zml.Tensor) struct { zml.Tensor, zml.Tensor } {
@@ -703,15 +690,7 @@ pub const Mlp = struct {
     }
 
     pub fn unloadBuffers(self: *zml.Bufferized(Mlp)) void {
-        self.up_proj.weight.deinit();
-        if (self.up_proj.bias) |*bias| bias.deinit();
-        if (self.up_proj_scale) |*scale| scale.deinit();
-        self.gate_proj.weight.deinit();
-        if (self.gate_proj.bias) |*bias| bias.deinit();
-        if (self.gate_proj_scale) |*scale| scale.deinit();
-        self.down_proj.weight.deinit();
-        if (self.down_proj.bias) |*bias| bias.deinit();
-        if (self.down_proj_scale) |*scale| scale.deinit();
+        zml.Buffer.deinitAll(Mlp, self);
     }
 
     pub fn forward(self: Mlp, x: zml.Tensor) zml.Tensor {
@@ -740,8 +719,7 @@ const Router = struct {
     }
 
     pub fn unloadBuffers(self: *zml.Bufferized(Router)) void {
-        self.router.weight.deinit();
-        if (self.router.bias) |*bias| bias.deinit();
+        zml.Buffer.deinitAll(Router, self);
     }
 
     pub fn forward(self: Router, x: zml.Tensor) struct { zml.Tensor, zml.Tensor } {
@@ -756,8 +734,8 @@ const Router = struct {
 pub const Moe = struct {
     shared_expert: Mlp,
     shared_expert_gate: zml.nn.Linear,
-    gate_up_proj: zml.Tensor,
-    down_proj: zml.Tensor,
+    gate_up_proj: zml.nn.Linear,
+    down_proj: zml.nn.Linear,
     router: Router,
 
     pub fn init(allocator: std.mem.Allocator, store: zml.io.TensorStore.View, config: Config) !Moe {
@@ -781,8 +759,8 @@ pub const Moe = struct {
                 store.withPrefix("shared_expert_gate").maybeCreateTensor("bias", .{.dout}, .{ .dout = .replicated }),
                 .d,
             ),
-            .gate_up_proj = gate_up_proj_tensor,
-            .down_proj = down_proj_tensor,
+            .gate_up_proj = .init(gate_up_proj_tensor, null, .d),
+            .down_proj = .init(down_proj_tensor, null, .dout),
             .router = Router.init(store.withPrefix("gate"), config.text_config.num_experts_per_tok),
         };
     }
@@ -800,13 +778,7 @@ pub const Moe = struct {
             topk_ids,
             routing_scores,
             self.gate_up_proj,
-            null,
-            null,
             self.down_proj,
-            null,
-            null,
-            null,
-            null,
             .{},
             moe_metadata,
             moe_parameters,
@@ -824,12 +796,7 @@ pub const Moe = struct {
 
     pub fn unloadBuffers(self: *zml.Bufferized(Moe), allocator: std.mem.Allocator) void {
         _ = allocator;
-        Mlp.unloadBuffers(&self.shared_expert);
-        self.shared_expert_gate.weight.deinit();
-        if (self.shared_expert_gate.bias) |*bias| bias.deinit();
-        self.gate_up_proj.deinit();
-        self.down_proj.deinit();
-        Router.unloadBuffers(&self.router);
+        zml.Buffer.deinitAll(Moe, self);
     }
 };
 
@@ -957,18 +924,7 @@ pub const GatedDeltaNet = struct {
     }
 
     pub fn unloadBuffers(self: *zml.Bufferized(GatedDeltaNet)) void {
-        self.in_proj_qkv.weight.deinit();
-        if (self.in_proj_qkv_scale) |*scale| scale.deinit();
-        self.in_proj_z.weight.deinit();
-        if (self.in_proj_z_scale) |*scale| scale.deinit();
-        self.in_proj_b.weight.deinit();
-        self.in_proj_a.weight.deinit();
-        self.out_proj.weight.deinit();
-        if (self.out_proj_scale) |*scale| scale.deinit();
-        self.conv1d_weight.deinit();
-        self.dt_bias.deinit();
-        self.aLog.deinit();
-        RmsNormGated.unloadBuffers(&self.norm);
+        zml.Buffer.deinitAll(GatedDeltaNet, self);
     }
 
     fn recurrentGatedDeltaRule(query: zml.Tensor, key: zml.Tensor, value: zml.Tensor, g: zml.Tensor, beta: zml.Tensor, initial_state: ?zml.Tensor) struct { zml.Tensor, zml.Tensor } {

--- a/zml/BUILD.bazel
+++ b/zml/BUILD.bazel
@@ -114,6 +114,7 @@ zig_library(
         "platform.zig",
         "profiling/profiler.zig",
         "profiling/tracer.zig",
+        "quantization.zig",
         "safetensors.zig",
         "shape.zig",
         "slice.zig",

--- a/zml/moe/metal.zig
+++ b/zml/moe/metal.zig
@@ -189,25 +189,22 @@ pub fn fusedExpertsImpl(
     const expert_ids = topk_ids.reshape(.{ .token = num_tokens, .top_expert = top_expert }).withTags(.{ .token, .top_expert })
         .merge(.{ .r = .{ .token, .top_expert } }).convert(.i32);
 
-    const gate_up_w = if (gate_up.dtype() == .u8) zml.nn.unpackFp4(gate_up, .d) else gate_up;
-    const down_w = if (down.dtype() == .u8) zml.nn.unpackFp4(down, .dout) else down;
-
     const gate_up_out = try applyGateUpGlobalScale(moeGemm(
         x_rows,
-        gate_up_w,
+        gate_up,
         opts.w1_scale,
         expert_ids,
-        zml.Shape.init(.{ .r = num_routes, .out = gate_up_w.dim(.dout) }, act_dtype),
+        zml.Shape.init(.{ .r = num_routes, .out = gate_up.dim(.dout) }, act_dtype),
         mode,
     ), opts.w1_global_scale, expert_ids);
     const activated = applyActivation(gate_up_out, opts.activation);
 
     const down_out = try applyDownGlobalScale(moeGemm(
         activated,
-        down_w,
+        down,
         opts.w2_scale,
         expert_ids,
-        zml.Shape.init(.{ .r = num_routes, .d = down_w.dim(.d) }, act_dtype),
+        zml.Shape.init(.{ .r = num_routes, .d = down.dim(.d) }, act_dtype),
         mode,
     ), opts.w2_global_scale, expert_ids);
 

--- a/zml/moe/moe.zig
+++ b/zml/moe/moe.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 
 const platforms = @import("platforms");
+
 const zml = @import("../zml.zig");
 const stdx = zml.stdx;
 pub const cutlass_flashinfer = @import("cutlass_flashinfer.zig");
@@ -189,25 +190,28 @@ pub const Metadata = union(Backend) {
 
 pub const Options = struct {
     activation_threshold: ?f32 = null,
-    quant_scheme: ?zml.nn.QuantScheme = null,
 };
 
 pub fn forwardMoe(
     input: zml.Tensor,
     topk_ids: zml.Tensor,
     topk_weights: zml.Tensor,
-    weights_gate_up: zml.Tensor,
-    scales_gate_up: ?zml.Tensor,
-    bias_gate_up: ?zml.Tensor,
-    weights_down: zml.Tensor,
-    scales_down: ?zml.Tensor,
-    bias_down: ?zml.Tensor,
-    w1_global_scale: ?zml.Tensor,
-    w2_global_scale: ?zml.Tensor,
+    gate_up: zml.nn.Linear,
+    down: zml.nn.Linear,
     opts: Options,
     metadata: Metadata,
     parameters: Parameters,
 ) !zml.Tensor {
+    const gate_up_scheme: ?zml.Quantization.Scheme = if (gate_up.quantization) |q| q.scheme else null;
+    const down_scheme: ?zml.Quantization.Scheme = if (down.quantization) |q| q.scheme else null;
+    if (gate_up_scheme != down_scheme) return error.UnsupportedQuantization;
+
+    const gate_up_scales: ?zml.Tensor = if (gate_up.quantization) |q| q.scales else null;
+    const down_scales: ?zml.Tensor = if (down.quantization) |q| q.scales else null;
+    const gate_up_global_scale: ?zml.Tensor = if (gate_up.quantization) |q| (if (q.global_scale) |scale| scale.asMultiplier() else null) else null;
+    const down_global_scale: ?zml.Tensor = if (down.quantization) |q| (if (q.global_scale) |scale| scale.asMultiplier() else null) else null;
+    const quant_scheme: ?zml.Quantization.Scheme = if (gate_up.quantization) |q| q.scheme else null;
+
     return switch (parameters) {
         .flashinfer_cutlass => b: {
             if (comptime !platforms.isEnabled(.cuda)) {
@@ -217,17 +221,16 @@ pub fn forwardMoe(
                 .flashinfer_cutlass => |v| v,
                 else => return error.InvalidMetadata,
             };
-            if (scales_gate_up != null or scales_down != null) {
-                return error.UnsupportedQuantization;
-            }
-            if (bias_gate_up != null or bias_down != null) {
+            if (gate_up.bias != null or down.bias != null) {
                 return error.UnsupportedBias;
             }
 
             const runner_options = try parameters.flashinfer_cutlass.runnerOptions();
-            const expert_partition = weights_gate_up.shape().partition(.expert);
+            const expert_partition = gate_up.weight.shape().partition(.expert);
 
             if (flashinfer_metadata.variant == .nvfp4xnvfp4) {
+                const gate_up_weight_unpacked = unpackedWeight(gate_up);
+                const down_weight_unpacked = unpackedWeight(down);
                 const nvfp4 = flashinfer_metadata.nvfp4_scales orelse
                     return error.MissingNvfp4Scales;
                 if (expert_partition.eql(.init(.experts))) {
@@ -236,8 +239,8 @@ pub fn forwardMoe(
                             input,
                             topk_ids,
                             topk_weights,
-                            weights_gate_up,
-                            weights_down,
+                            gate_up_weight_unpacked,
+                            down_weight_unpacked,
                             nvfp4.fc1_act_global,
                             nvfp4.fc1_weight_block,
                             nvfp4.fc1_global,
@@ -313,8 +316,8 @@ pub fn forwardMoe(
 
                 break :b try cutlass_flashinfer.fusedExpertsNvfp4(
                     input,
-                    weights_gate_up,
-                    weights_down,
+                    gate_up_weight_unpacked,
+                    down_weight_unpacked,
                     topk_weights,
                     topk_ids,
                     nvfp4,
@@ -327,7 +330,7 @@ pub fn forwardMoe(
 
             if (expert_partition.eql(.init(.experts))) {
                 break :b zml.ops.manualComputation(
-                    .{ input, topk_ids, topk_weights, weights_gate_up, weights_down },
+                    .{ input, topk_ids, topk_weights, gate_up.weight, down.weight },
                     input.shape(),
                     .{
                         .activation = runner_options.activation,
@@ -388,8 +391,8 @@ pub fn forwardMoe(
 
             break :b try cutlass_flashinfer.fusedExpertsBf16(
                 input,
-                weights_gate_up,
-                weights_down,
+                gate_up.weight,
+                down.weight,
                 topk_weights,
                 topk_ids,
                 runner_options,
@@ -401,25 +404,25 @@ pub fn forwardMoe(
                 else => return error.InvalidMetadata,
             };
 
-            const global_num_experts = weights_gate_up.dim(.expert);
-            const expert_partition = weights_gate_up.shape().partition(.expert);
+            const global_num_experts = gate_up.weight.dim(.expert);
+            const expert_partition = gate_up.weight.shape().partition(.expert);
 
             if (!expert_partition.eql(.init(.experts))) {
                 break :b try triton.fusedExpertsImpl(
                     input,
-                    weights_gate_up,
-                    weights_down,
+                    gate_up.weight,
+                    down.weight,
                     topk_weights,
                     topk_ids,
                     triton_metadata,
                     .{
                         .activation = parameters.triton.activation,
                         .global_num_experts = global_num_experts,
-                        .w1_scale = scales_gate_up,
-                        .w2_scale = scales_down,
-                        .w1_bias = bias_gate_up,
-                        .w2_bias = bias_down,
-                        .quant_scheme = opts.quant_scheme,
+                        .w1_scale = gate_up_scales,
+                        .w2_scale = down_scales,
+                        .w1_bias = gate_up.bias,
+                        .w2_bias = down.bias,
+                        .quant_scheme = quant_scheme,
                         .activation_threshold = opts.activation_threshold,
                     },
                 );
@@ -430,19 +433,19 @@ pub fn forwardMoe(
                     input,
                     topk_ids,
                     topk_weights,
-                    weights_gate_up,
-                    weights_down,
+                    gate_up.weight,
+                    down.weight,
                 },
                 input.shape(),
                 .{
                     .activation = parameters.triton.activation,
                     .global_num_experts = global_num_experts,
-                    .bias_gate_up = bias_gate_up,
-                    .bias_down = bias_down,
-                    .quant_scheme = opts.quant_scheme,
+                    .bias_gate_up = gate_up.bias,
+                    .bias_down = down.bias,
+                    .quant_scheme = quant_scheme,
                     .activation_threshold = opts.activation_threshold,
-                    .scales_gate_up = scales_gate_up,
-                    .scales_down = scales_down,
+                    .scales_gate_up = gate_up_scales,
+                    .scales_down = down_scales,
                 },
                 (struct {
                     fn body(ctx: anytype, _: std.mem.Allocator, sharded_inputs: []const zml.Tensor, _: zml.Shape) zml.Tensor {
@@ -491,20 +494,20 @@ pub fn forwardMoe(
                 else => return error.InvalidMetadata,
             };
 
-            const expert_partition = weights_gate_up.shape().partition(.expert);
+            const expert_partition = gate_up.weight.shape().partition(.expert);
 
             if (expert_partition.eql(.init(.experts))) {
-                const global_num_experts = weights_down.dim(.expert);
+                const global_num_experts = down.weight.dim(.expert);
                 const partial_output = zml.ops.manualComputation(
-                    .{ input, topk_ids, topk_weights, weights_gate_up, weights_down },
+                    .{ input, topk_ids, topk_weights, gate_up.weight, down.weight },
                     input.shape(),
                     .{
                         .activation = parameters.mosaic_tpu.activation,
                         .global_num_experts = global_num_experts,
-                        .scales_gate_up = scales_gate_up,
-                        .bias_gate_up = bias_gate_up,
-                        .scales_down = scales_down,
-                        .bias_down = bias_down,
+                        .gate_up_scales = gate_up_scales,
+                        .bias_gate_up = gate_up.bias,
+                        .down_scales = down_scales,
+                        .bias_down = down.bias,
                     },
                     (struct {
                         fn body(ctx: anytype, _: std.mem.Allocator, sharded_inputs: []const zml.Tensor, _: zml.Shape) zml.Tensor {
@@ -530,8 +533,8 @@ pub fn forwardMoe(
                                     .activation = ctx.activation,
                                     .global_num_experts = ctx.global_num_experts,
                                     .expert_map = expert_map,
-                                    .w1_scale = ctx.scales_gate_up,
-                                    .w2_scale = ctx.scales_down,
+                                    .w1_scale = ctx.gate_up_scales,
+                                    .w2_scale = ctx.down_scales,
                                     .w1_bias = ctx.bias_gate_up,
                                     .w2_bias = ctx.bias_down,
                                 },
@@ -545,22 +548,24 @@ pub fn forwardMoe(
 
             break :b try mosaic_tpu.fusedExpertsImpl(
                 input,
-                weights_gate_up,
-                weights_down,
+                gate_up.weight,
+                down.weight,
                 topk_weights,
                 topk_ids,
                 tpu_metadata,
                 .{
                     .activation = parameters.mosaic_tpu.activation,
-                    .global_num_experts = weights_gate_up.dim(.expert),
-                    .w1_scale = scales_gate_up,
-                    .w2_scale = scales_down,
-                    .w1_bias = bias_gate_up,
-                    .w2_bias = bias_down,
+                    .global_num_experts = gate_up.weight.dim(.expert),
+                    .w1_scale = gate_up_scales,
+                    .w2_scale = down_scales,
+                    .w1_bias = gate_up.bias,
+                    .w2_bias = down.bias,
                 },
             );
         },
         .metal => b: {
+            const gate_up_weight_unpacked = unpackedWeight(gate_up);
+            const down_weight_unpacked = unpackedWeight(down);
             const metal_metadata = switch (metadata) {
                 .metal => |v| v,
                 else => return error.InvalidMetadata,
@@ -568,22 +573,30 @@ pub fn forwardMoe(
 
             break :b try metal.fusedExpertsImpl(
                 input,
-                weights_gate_up,
-                weights_down,
+                gate_up_weight_unpacked,
+                down_weight_unpacked,
                 topk_weights,
                 topk_ids,
                 metal_metadata,
                 .{
                     .activation = parameters.metal.activation,
-                    .global_num_experts = weights_gate_up.dim(.expert),
-                    .w1_scale = scales_gate_up,
-                    .w2_scale = scales_down,
-                    .w1_global_scale = w1_global_scale,
-                    .w2_global_scale = w2_global_scale,
-                    .w1_bias = bias_gate_up,
-                    .w2_bias = bias_down,
+                    .global_num_experts = gate_up_weight_unpacked.dim(.expert),
+                    .w1_scale = gate_up_scales,
+                    .w2_scale = down_scales,
+                    .w1_global_scale = gate_up_global_scale,
+                    .w2_global_scale = down_global_scale,
+                    .w1_bias = gate_up.bias,
+                    .w2_bias = down.bias,
                 },
             );
         },
     };
+}
+
+fn unpackedWeight(linear: zml.nn.Linear) zml.Tensor {
+    const quantization = linear.quantization orelse return linear.weight;
+    return if (zml.nn.isPackedFp4(quantization.scheme, linear.weight.dtype()))
+        zml.nn.unpackFp4(linear.weight, linear.tag)
+    else
+        linear.weight;
 }

--- a/zml/moe/triton.zig
+++ b/zml/moe/triton.zig
@@ -28,7 +28,7 @@ pub const Options = struct {
     inplace: bool = false,
     activation: Parameters.ActivationMode = .silu,
     apply_router_weight_on_input: bool = false,
-    quant_scheme: ?zml.nn.QuantScheme = null,
+    quant_scheme: ?zml.Quantization.Scheme = null,
     global_num_experts: i64 = -1,
     expert_map: ?Tensor = null,
     w1_scale: ?Tensor = null,
@@ -125,7 +125,7 @@ fn applyActivation(x: Tensor, mode: Parameters.ActivationMode) Tensor {
 // Top-level entry point
 // =============================================================================
 
-fn isMxFp8(quant_scheme: ?zml.nn.QuantScheme) bool {
+fn isMxFp8(quant_scheme: ?zml.Quantization.Scheme) bool {
     return quant_scheme != null and quant_scheme.? == .mxfp8;
 }
 

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -8,6 +8,8 @@ const constants = @import("constants.zig");
 const DataType = @import("dtype.zig").DataType;
 const meta = @import("meta.zig");
 const ops = @import("ops.zig");
+const quantization = @import("quantization.zig");
+pub const Quantization = quantization.Quantization;
 const Shape = @import("shape.zig").Shape;
 const Slice = @import("slice.zig").Slice;
 const Tensor = @import("tensor.zig").Tensor;
@@ -19,32 +21,7 @@ pub const Linear = struct {
     weight: Tensor,
     bias: ?Tensor = null,
     tag: Shape.Tag,
-    quant: ?Quant = null,
-
-    pub const Quant = struct {
-        scheme: QuantScheme, // decided when the checkpoint is read
-        scales: Tensor,
-        weight_scale: ?TensorScale = null,
-        input_scale: ?TensorScale = null,
-    };
-
-    /// A per-tensor scale and the polarity its producer wrote it in
-    pub const TensorScale = struct {
-        value: Tensor,
-        direction: Direction,
-
-        pub const Direction = enum { multiplier, divisor };
-
-        pub fn asMultiplier(self: TensorScale) Tensor {
-            const s = self.value.convert(.f32);
-            const flat = if (s.shape().count() == 1) s.asScalar() else s; // essentially normalization
-
-            return switch (self.direction) {
-                .multiplier => flat,
-                .divisor => Tensor.scalar(1.0, .f32).broad(flat.shape()).div(flat),
-            };
-        }
-    };
+    quantization: ?Quantization = null,
 
     pub fn init(weight: Tensor, bias: ?Tensor, tag: anytype) Linear {
         return .{
@@ -64,10 +41,9 @@ pub const Linear = struct {
     }
 
     fn forwardWeight(self: Linear, x: Tensor) Tensor {
-        const q = self.quant orelse return x.dot(self.weight, self.tag);
+        const q = self.quantization orelse return x.dot(self.weight, self.tag);
 
-        const wgs: ?Tensor = if (q.weight_scale) |s| s.asMultiplier() else null;
-        const igs: ?Tensor = if (q.input_scale) |s| s.asMultiplier() else null;
+        const weight_global_scale: ?Tensor = if (q.global_scale) |s| s.asMultiplier() else null;
 
         const weight = if (isPackedFp4(q.scheme, self.weight.dtype())) unpackFp4(self.weight, self.tag) else self.weight;
         const scales = if (q.scheme.isMx() and q.scales.dtype() == .u8)
@@ -77,233 +53,22 @@ pub const Linear = struct {
 
         var lhs = x.convert(.bf16);
         var lhs_scale: ?Tensor = null;
-        var undo: ?Tensor = null;
+        var undo_input_scale: ?Tensor = null;
 
         const platform = zml.Compiler.current().platform;
-        if (q.scheme.activationQuant()) |aq| {
-            if (aq.supportedOn(platform)) {
-                const quantized = aq.apply(lhs, igs, self.tag);
-                lhs = quantized.values;
-                lhs_scale = quantized.scales;
-                undo = igs;
-            }
+        if (quantization.quantizeInput(q, lhs, self.tag, platform)) |quantized_input| {
+            lhs = quantized_input.values;
+            lhs_scale = quantized_input.scales;
+            undo_input_scale = quantized_input.global_scale;
         }
 
         const acc = scaledDot(lhs, weight, lhs_scale, scales, self.tag);
-        return applyGlobalScale(acc, undo, wgs).convert(x.dtype());
+        return applyGlobalScale(acc, undo_input_scale, weight_global_scale).convert(x.dtype());
     }
 };
 
-const nvfp4_block_size = 16;
-const mx_block_size = 32;
-
-pub const QuantScheme = enum {
-    /// f4e2m1 values (`u8`-packed or native), f8e4m3fn scale per 16 contracted values.
-    /// Emitted by llm-compressor and by NVIDIA's ModelOpt.
-    nvfp4,
-    /// f8e4m3fn values, one e8m0 (power-of-two) scale per 32 contracted values
-    mxfp8,
-    /// f4e2m1 values (`u8`-packed or native), e8m0 scale per 32 contracted values.
-    // GPT-OSS like
-    mxfp4,
-    /// f8e4m3fn values, one bf16 or f32 scale per output channel, constant along the contraction.
-    /// Emitted by llm-compressor, including for the layers an NVFP4 recipe leaves in FP8.
-    fp8_per_channel,
-    /// f8e4m3fn values, one bf16 scale per 128x128 tile. The DeepSeek-style FP8 that model
-    /// vendors publish themselves, under `weight_scale_inv`.
-    fp8_block128,
-    /// f8e4m3fn values, one scale for the whole tensor. Spelled `[1, 1]` rather than as a
-    /// scalar: XLA's composite rewriter requires the scale to have the operand's rank.
-    fp8_per_tensor,
-
-    pub fn accepts(self: QuantScheme, weight: Shape, scale: Shape) bool {
-        if (weight.rank() != 2) return false;
-
-        const n = weight.dim(0);
-        const k = if (isPackedFp4(self, weight.dtype())) 2 * weight.dim(1) else weight.dim(1);
-
-        return switch (self) {
-            .nvfp4 => (weight.dtype() == .u8 or weight.dtype() == .f4e2m1) and
-                scale.dtype() == .f8e4m3fn and scale.rank() == 2 and
-                scale.dim(0) == n and scale.dim(1) * nvfp4_block_size == k,
-            .mxfp8 => weight.dtype() == .f8e4m3fn and isMxScale(scale) and
-                scale.dim(0) == n and scale.dim(1) * mx_block_size == k,
-            .mxfp4 => (weight.dtype() == .u8 or weight.dtype() == .i8 or weight.dtype() == .f4e2m1) and
-                isMxScale(scale) and
-                scale.dim(0) == n and scale.dim(1) * mx_block_size == k,
-            .fp8_per_tensor => weight.dtype() == .f8e4m3fn and scale.count() == 1,
-            .fp8_per_channel => weight.dtype() == .f8e4m3fn and
-                (scale.dtype() == .bf16 or scale.dtype() == .f32) and
-                scale.count() > 1 and scale.rank() == 2 and
-                scale.dim(0) == n and scale.dim(1) == 1,
-            .fp8_block128 => weight.dtype() == .f8e4m3fn and scale.dtype() == .bf16 and
-                scale.count() > 1 and scale.rank() == 2 and
-                @rem(n, 128) == 0 and @rem(k, 128) == 0 and
-                scale.dim(0) == @divExact(n, 128) and scale.dim(1) == @divExact(k, 128),
-        };
-    }
-
-    pub fn classify(weight: Shape, scale: Shape) ?QuantScheme {
-        for (std.enums.values(QuantScheme)) |scheme| {
-            if (scheme.accepts(weight, scale)) return scheme;
-        }
-
-        return null;
-    }
-
-    pub fn activationQuant(self: QuantScheme) ?ActivationQuant {
-        return switch (self) {
-            .nvfp4 => .nvfp4,
-            .mxfp8, .mxfp4, .fp8_per_channel, .fp8_block128, .fp8_per_tensor => null,
-        };
-    }
-
-    pub fn isMx(self: QuantScheme) bool {
-        return self == .mxfp8 or self == .mxfp4;
-    }
-};
-
-pub const ActivationQuant = enum {
-    nvfp4,
-
-    fn supportedOn(self: ActivationQuant, platform: *const zml.Platform) bool {
-        return switch (self) {
-            .nvfp4 => supportsNvfp4ActivationQuant(platform),
-        };
-    }
-
-    fn apply(self: ActivationQuant, x: Tensor, global_scale: ?Tensor, axis: Shape.Tag) QuantizedActivations {
-        return switch (self) {
-            .nvfp4 => quantizeNvfp4(x, global_scale, axis),
-        };
-    }
-};
-
-pub fn isPackedFp4(scheme: ?QuantScheme, weight_dtype: DataType) bool {
+pub fn isPackedFp4(scheme: ?Quantization.Scheme, weight_dtype: DataType) bool {
     return (scheme == .nvfp4 or scheme == .mxfp4) and (weight_dtype == .u8 or weight_dtype == .i8);
-}
-
-fn isMxScale(scale: Shape) bool {
-    return scale.rank() == 2 and (scale.dtype() == .f8e8m0 or scale.dtype() == .u8);
-}
-
-// Note: this test will evolve as we support more (INT4/8 and FP8 block-128 as a
-// scaled-dot are still open; see the scaledDot doc comment).
-test "QuantScheme.classify" {
-    const expect = std.testing.expectEqual;
-
-    // unsloth/Qwen3.6-27B-NVFP4: compressed-tensors, carrying both of its schemes under
-    // `weight_scale` -- NVFP4 on the MLPs of layers 0-55, FP8 per-channel everywhere else.
-    const nvfp4_packed: Shape = .init(.{ .dout = 17408, .kw = 2560 }, .u8);
-    try expect(@as(?QuantScheme, .nvfp4), QuantScheme.classify(nvfp4_packed, .init(.{ .dout = 17408, .sc = 320 }, .f8e4m3fn)));
-    try expect(@as(?QuantScheme, .fp8_per_channel), QuantScheme.classify(
-        .init(.{ .dout = 17408, .d = 5120 }, .f8e4m3fn),
-        .init(.{ .dout = 17408, .sc = 1 }, .bf16),
-    ));
-
-    // nvidia/Gemma-4-31B-IT-NVFP4: ModelOpt, packed values under the plain `weight` name.
-    try expect(@as(?QuantScheme, .nvfp4), QuantScheme.classify(
-        .init(.{ .dout = 21504, .kw = 2688 }, .u8),
-        .init(.{ .dout = 21504, .sc = 336 }, .f8e4m3fn),
-    ));
-
-    // Native (unpacked) f4e2m1, with K no longer doubled.
-    try expect(@as(?QuantScheme, .nvfp4), QuantScheme.classify(
-        .init(.{ .dout = 17408, .d = 5120 }, .f4e2m1),
-        .init(.{ .dout = 17408, .sc = 320 }, .f8e4m3fn),
-    ));
-
-    // Qwen/Qwen3.6-27B-FP8: block 128, spelled `weight_scale_inv`.
-    try expect(@as(?QuantScheme, .fp8_block128), QuantScheme.classify(
-        .init(.{ .dout = 17408, .d = 5120 }, .f8e4m3fn),
-        .init(.{ .dout = 136, .sc = 40 }, .bf16),
-    ));
-    try expect(@as(?QuantScheme, .fp8_block128), QuantScheme.classify(
-        .init(.{ .dout = 5120, .d = 6144 }, .f8e4m3fn),
-        .init(.{ .dout = 40, .sc = 48 }, .bf16),
-    ));
-
-    // Mistral's per-tensor FP8: one scale for the whole tensor, rank 0 or [1].
-    try expect(@as(?QuantScheme, .fp8_per_tensor), QuantScheme.classify(.init(.{ .dout = 4096, .d = 4096 }, .f8e4m3fn), .init(.{}, .f32)));
-    try expect(@as(?QuantScheme, .fp8_per_tensor), QuantScheme.classify(.init(.{ .dout = 4096, .d = 4096 }, .f8e4m3fn), .init(.{ .g = 1 }, .f32)));
-
-    // RadixArk/Muse-Glimmer-NVFP4: ModelOpt's MIXED_PRECISION recipe, whose MXFP8 half
-    // lands on down_proj and lm_head. safetensors has no e8m0 dtype, so the scale arrives
-    // as u8 under `weight_scale_inv` -- the shape below is verbatim from the checkpoint.
-    try expect(@as(?QuantScheme, .mxfp8), QuantScheme.classify(
-        .init(.{ .dout = 6656, .d = 19968 }, .f8e4m3fn),
-        .init(.{ .dout = 6656, .sc = 624 }, .u8),
-    ));
-    try expect(@as(?QuantScheme, .mxfp8), QuantScheme.classify(
-        .init(.{ .dout = 202048, .d = 6656 }, .f8e4m3fn),
-        .init(.{ .dout = 202048, .sc = 208 }, .u8),
-    ));
-    // The same tensor from a store that types the scale natively.
-    try expect(@as(?QuantScheme, .mxfp8), QuantScheme.classify(
-        .init(.{ .dout = 6656, .d = 19968 }, .f8e4m3fn),
-        .init(.{ .dout = 6656, .sc = 624 }, .f8e8m0),
-    ));
-    // MXFP8 rejects any group but 32: 19968 / 16 = 1248, / 64 = 312.
-    try expect(@as(?QuantScheme, null), QuantScheme.classify(
-        .init(.{ .dout = 6656, .d = 19968 }, .f8e4m3fn),
-        .init(.{ .dout = 6656, .sc = 1248 }, .u8),
-    ));
-    try expect(@as(?QuantScheme, null), QuantScheme.classify(
-        .init(.{ .dout = 6656, .d = 19968 }, .f8e4m3fn),
-        .init(.{ .dout = 6656, .sc = 312 }, .u8),
-    ));
-
-    // MXFP4: the same u8 packing as NVFP4 (two nibbles per byte, K halved on disk), with
-    // an e8m0 scale per 32 -- so K = 2 * 2560 = 5120 and 5120 / 32 = 160.
-    try expect(@as(?QuantScheme, .mxfp4), QuantScheme.classify(nvfp4_packed, .init(.{ .dout = 17408, .sc = 160 }, .u8)));
-    try expect(@as(?QuantScheme, .mxfp4), QuantScheme.classify(nvfp4_packed, .init(.{ .dout = 17408, .sc = 160 }, .f8e8m0)));
-    // DeepSeek V4 stores the same packed FP4 bits in signed bytes.
-    try expect(@as(?QuantScheme, .mxfp4), QuantScheme.classify(
-        .init(.{ .dout = 2048, .kw = 2048 }, .i8),
-        .init(.{ .dout = 2048, .sc = 128 }, .f8e8m0),
-    ));
-    // Native (unpacked) f4e2m1, K no longer halved.
-    try expect(@as(?QuantScheme, .mxfp4), QuantScheme.classify(
-        .init(.{ .dout = 17408, .d = 5120 }, .f4e2m1),
-        .init(.{ .dout = 17408, .sc = 160 }, .f8e8m0),
-    ));
-    // An e8m0 scale never turns a non-fp4/fp8 weight into MX.
-    try expect(@as(?QuantScheme, null), QuantScheme.classify(
-        .init(.{ .dout = 17408, .d = 5120 }, .bf16),
-        .init(.{ .dout = 17408, .sc = 160 }, .f8e8m0),
-    ));
-
-    // Rejected: everything no backend here can express.
-    const fp8: Shape = .init(.{ .dout = 10240, .d = 5120 }, .f8e4m3fn);
-    // Group 32 with an e4m3 scale: neither NVFP4 (wrong group) nor MX (wrong scale type).
-    try expect(@as(?QuantScheme, null), QuantScheme.classify(nvfp4_packed, .init(.{ .dout = 17408, .sc = 160 }, .f8e4m3fn)));
-    // Group 16 with an e8m0 scale: the mirror image, and equally unclaimed.
-    try expect(@as(?QuantScheme, null), QuantScheme.classify(nvfp4_packed, .init(.{ .dout = 17408, .sc = 320 }, .f8e8m0)));
-    // Per-channel in f32: what fusing per-tensor projections produces. The Metal
-    // per-channel kernels have f32 entries, so this is a real scheme, not a decline.
-    try expect(@as(?QuantScheme, .fp8_per_channel), QuantScheme.classify(fp8, .init(.{ .dout = 10240, .sc = 1 }, .f32)));
-    // A block grid that is neither per-channel nor 128x128.
-    try expect(@as(?QuantScheme, null), QuantScheme.classify(fp8, .init(.{ .dout = 160, .sc = 80 }, .bf16)));
-    // Stacked MoE weights are rank 3 and go through the MoE path, not this one.
-    try expect(@as(?QuantScheme, null), QuantScheme.classify(
-        .init(.{ .expert = 128, .dout = 1408, .kw = 1408 }, .u8),
-        .init(.{ .expert = 128, .dout = 1408, .sc = 176 }, .f8e4m3fn),
-    ));
-
-    // `fp8_per_tensor` never checks the scale dtype, so a [1, 1] u8 scale on a [1, 32]
-    // weight satisfies it as well as `mxfp8`. Declaration order is what decides, and
-    // `mxfp8` is declared first
-    try expect(@as(?QuantScheme, .mxfp8), QuantScheme.classify(
-        .init(.{ .dout = 1, .d = 32 }, .f8e4m3fn),
-        .init(.{ .dout = 1, .sc = 1 }, .u8),
-    ));
-
-    // A one-tile block grid is indistinguishable from a per-tensor scale by shape alone; the
-    // `count() > 1` guard on the grids is what makes per-tensor win.
-    try expect(@as(?QuantScheme, .fp8_per_tensor), QuantScheme.classify(
-        .init(.{ .dout = 128, .d = 128 }, .f8e4m3fn),
-        .init(.{ .dout = 1, .sc = 1 }, .bf16),
-    ));
 }
 
 /// Unpacks two f4e2m1 values per byte. `w` must be tagged with `.kw` on the packed axis,
@@ -314,46 +79,6 @@ pub fn unpackFp4(w: Tensor, k_tag: anytype) Tensor {
     return w.bitCast(.f4e2m1) // bitcast inserts a tag (it respects shlo), but maybe we should simplify it
         .merge(.{ .kb = .{ .kw, .bitcast } })
         .renameTag(.kb, Shape.toTag(k_tag));
-}
-
-pub const QuantizedActivations = struct {
-    values: Tensor,
-    scales: Tensor,
-};
-
-pub fn quantizeNvfp4(x: Tensor, input_global_scale: ?Tensor, axis: anytype) QuantizedActivations {
-    const block_size = nvfp4_block_size;
-    const value_max = 6.0;
-    const scale_min_normal = 0x1p-6;
-    const scale_max = DataType.f8e4m3fn.maxValue().as(f32);
-
-    stdx.debug.assert(x.shape().hasTag(axis) != null, "quantizeNvfp4 expects x to have {any} tag, got {f}", .{ axis, x.shape() });
-    stdx.debug.assert(@rem(x.dim(axis), block_size) == 0, "quantizeNvfp4 expects {any} to be a multiple of {}, got {f}", .{ axis, block_size, x.shape() });
-
-    const dt = x.dtype();
-    const scaled = if (input_global_scale) |igs|
-        x.div(igs.convert(dt).broad(x.shape()))
-    else
-        x;
-    const grouped = scaled.splitAxis(axis, .{ .sc = -1, .blk = block_size });
-    const amax = grouped.abs().max(.blk);
-
-    const scales = amax.scale(1.0 / value_max)
-        .clamp(.scalar(scale_min_normal, dt), .scalar(scale_max, dt))
-        .convert(.f8e4m3fn);
-
-    const divisor = scales.convert(dt)
-        .maximum(.scalar(scale_min_normal, dt))
-        .broad(grouped.shape());
-
-    const values = grouped.div(divisor)
-        .convert(.f4e2m1)
-        .reshape(x.shape().withDtype(.f4e2m1));
-
-    return .{
-        .values = values,
-        .scales = scales.squeeze(.blk),
-    };
 }
 
 /// Scaled matrix multiply (`xla.scaled_dot`): `acc = (lhs * lhs_scale) @ (rhs * rhs_scale)`.
@@ -473,18 +198,6 @@ fn scaledDotReference(in: []const Tensor, out_shape: Shape) Tensor {
         {},
         .{ .has_side_effect = false },
     );
-}
-
-fn supportsNvfp4ActivationQuant(platform: *const zml.Platform) bool {
-    if (platform.target != .cuda) {
-        return false;
-    }
-
-    const device = platform.pjrt_client.devices(platform.pjrt_api)[0];
-    const capability = zml.platform.cuda.tryGetComputeCapabilities(platform, device) orelse return false;
-    const major = std.fmt.parseInt(u8, std.mem.sliceTo(capability, '.'), 10) catch return false;
-
-    return major >= 10;
 }
 
 fn applyGlobalScale(acc: Tensor, igs: ?Tensor, wgs: ?Tensor) Tensor {

--- a/zml/quantization.zig
+++ b/zml/quantization.zig
@@ -1,0 +1,282 @@
+//! Quantization metadata and scheme classification.
+const std = @import("std");
+const stdx = @import("stdx");
+
+const DataType = @import("dtype.zig").DataType;
+const platform_mod = @import("platform.zig");
+const Platform = platform_mod.Platform;
+const Shape = @import("shape.zig").Shape;
+const Tensor = @import("tensor.zig").Tensor;
+
+pub const nvfp4_block_size = 16;
+pub const mx_block_size = 32;
+
+pub const Quantization = struct {
+    scheme: Scheme, // decided when the checkpoint is read
+    scales: Tensor,
+    global_scale: ?GlobalScale = null,
+    input_scale: ?GlobalScale = null,
+
+    /// A per-tensor scale and the polarity its producer wrote it in
+    pub const GlobalScale = struct {
+        value: Tensor,
+        operation: Operation,
+
+        pub const Operation = enum { multiply, divide };
+
+        pub fn asMultiplier(self: GlobalScale) Tensor {
+            const s = self.value.convert(.f32);
+            const flat = if (s.shape().count() == 1) s.asScalar() else s; // essentially normalization
+
+            return switch (self.operation) {
+                .multiply => flat,
+                .divide => Tensor.scalar(1.0, .f32).broad(flat.shape()).div(flat),
+            };
+        }
+    };
+
+    pub const Scheme = enum {
+        /// f4e2m1 values (`u8`-packed or native), f8e4m3fn scale per 16 contracted values.
+        /// Emitted by llm-compressor and by NVIDIA's ModelOpt.
+        nvfp4,
+        /// f8e4m3fn values, one e8m0 (power-of-two) scale per 32 contracted values
+        mxfp8,
+        /// f4e2m1 values (`u8`-packed or native), e8m0 scale per 32 contracted values.
+        // GPT-OSS like
+        mxfp4,
+        /// f8e4m3fn values, one bf16 or f32 scale per output channel, constant along the contraction.
+        /// Emitted by llm-compressor, including for the layers an NVFP4 recipe leaves in FP8.
+        fp8_per_channel,
+        /// f8e4m3fn values, one bf16 scale per 128x128 tile. The DeepSeek-style FP8 that model
+        /// vendors publish themselves, under `weight_scale_inv`.
+        fp8_block128,
+        /// f8e4m3fn values, one scale for the whole tensor. Spelled `[1, 1]` rather than as a
+        /// scalar: XLA's composite rewriter requires the scale to have the operand's rank.
+        fp8_per_tensor,
+
+        pub fn accepts(self: Scheme, weight: Shape, scale: Shape) bool {
+            if (weight.rank() != 2) return false;
+
+            const n = weight.dim(0);
+            const k = if (isPackedFp4(self, weight.dtype())) 2 * weight.dim(1) else weight.dim(1);
+
+            return switch (self) {
+                .nvfp4 => (weight.dtype() == .u8 or weight.dtype() == .f4e2m1) and
+                    scale.dtype() == .f8e4m3fn and scale.rank() == 2 and
+                    scale.dim(0) == n and scale.dim(1) * nvfp4_block_size == k,
+                .mxfp8 => weight.dtype() == .f8e4m3fn and isMxScale(scale) and
+                    scale.dim(0) == n and scale.dim(1) * mx_block_size == k,
+                .mxfp4 => (weight.dtype() == .u8 or weight.dtype() == .i8 or weight.dtype() == .f4e2m1) and
+                    isMxScale(scale) and
+                    scale.dim(0) == n and scale.dim(1) * mx_block_size == k,
+                .fp8_per_tensor => weight.dtype() == .f8e4m3fn and scale.count() == 1,
+                .fp8_per_channel => weight.dtype() == .f8e4m3fn and
+                    (scale.dtype() == .bf16 or scale.dtype() == .f32) and
+                    scale.count() > 1 and scale.rank() == 2 and
+                    scale.dim(0) == n and scale.dim(1) == 1,
+                .fp8_block128 => weight.dtype() == .f8e4m3fn and scale.dtype() == .bf16 and
+                    scale.count() > 1 and scale.rank() == 2 and
+                    @rem(n, 128) == 0 and @rem(k, 128) == 0 and
+                    scale.dim(0) == @divExact(n, 128) and scale.dim(1) == @divExact(k, 128),
+            };
+        }
+
+        pub fn classify(weight: Shape, scale: Shape) ?Scheme {
+            for (std.enums.values(Scheme)) |scheme| {
+                if (scheme.accepts(weight, scale)) return scheme;
+            }
+
+            return null;
+        }
+
+        pub fn isMx(self: Scheme) bool {
+            return self == .mxfp8 or self == .mxfp4;
+        }
+    };
+};
+
+pub const QuantizedInput = struct {
+    values: Tensor,
+    scales: Tensor,
+    global_scale: ?Tensor,
+};
+
+pub fn quantizeInput(quantization: Quantization, input: Tensor, axis: Shape.Tag, platform: *const Platform) ?QuantizedInput {
+    const global_scale: ?Tensor = if (quantization.input_scale) |scale| scale.asMultiplier() else null;
+    return switch (quantization.scheme) {
+        .nvfp4 => if (supportsNvfp4InputQuantization(platform)) quantizeNvfp4(input, global_scale, axis) else null,
+        .mxfp8, .mxfp4, .fp8_per_channel, .fp8_block128, .fp8_per_tensor => null,
+    };
+}
+
+pub fn quantizeNvfp4(x: Tensor, input_global_scale: ?Tensor, axis: anytype) QuantizedInput {
+    const value_max = 6.0;
+    const scale_min_normal = 0x1p-6;
+    const scale_max = DataType.f8e4m3fn.maxValue().as(f32);
+
+    stdx.debug.assert(x.shape().hasTag(axis) != null, "quantizeNvfp4 expects x to have {any} tag, got {f}", .{ axis, x.shape() });
+    stdx.debug.assert(@rem(x.dim(axis), nvfp4_block_size) == 0, "quantizeNvfp4 expects {any} to be a multiple of {}, got {f}", .{ axis, nvfp4_block_size, x.shape() });
+
+    const dt = x.dtype();
+    const scaled = if (input_global_scale) |igs|
+        x.div(igs.convert(dt).broad(x.shape()))
+    else
+        x;
+    const grouped = scaled.splitAxis(axis, .{ .sc = -1, .blk = nvfp4_block_size });
+    const amax = grouped.abs().max(.blk);
+
+    const scales = amax.scale(1.0 / value_max)
+        .clamp(.scalar(scale_min_normal, dt), .scalar(scale_max, dt))
+        .convert(.f8e4m3fn);
+
+    const divisor = scales.convert(dt)
+        .maximum(.scalar(scale_min_normal, dt))
+        .broad(grouped.shape());
+
+    const values = grouped.div(divisor)
+        .convert(.f4e2m1)
+        .reshape(x.shape().withDtype(.f4e2m1));
+
+    return .{
+        .values = values,
+        .scales = scales.squeeze(.blk),
+        .global_scale = input_global_scale,
+    };
+}
+
+fn supportsNvfp4InputQuantization(platform: *const Platform) bool {
+    if (platform.target != .cuda) return false;
+
+    const device = platform.pjrt_client.devices(platform.pjrt_api)[0];
+    const capability = platform_mod.cuda.tryGetComputeCapabilities(platform, device) orelse return false;
+    const major = std.fmt.parseInt(u8, std.mem.sliceTo(capability, '.'), 10) catch return false;
+
+    return major >= 10;
+}
+
+fn isPackedFp4(scheme: ?Quantization.Scheme, weight_dtype: DataType) bool {
+    return (scheme == .nvfp4 or scheme == .mxfp4) and (weight_dtype == .u8 or weight_dtype == .i8);
+}
+
+fn isMxScale(scale: Shape) bool {
+    return scale.rank() == 2 and (scale.dtype() == .f8e8m0 or scale.dtype() == .u8);
+}
+
+// Note: this test will evolve as we support more (INT4/8 and FP8 block-128 as a
+// scaled-dot are still open; see the scaledDot doc comment).
+test "Quantization.Scheme.classify" {
+    const expect = std.testing.expectEqual;
+
+    // unsloth/Qwen3.6-27B-NVFP4: compressed-tensors, carrying both of its schemes under
+    // `weight_scale` -- NVFP4 on the MLPs of layers 0-55, FP8 per-channel everywhere else.
+    const nvfp4_packed: Shape = .init(.{ .dout = 17408, .kw = 2560 }, .u8);
+    try expect(@as(?Quantization.Scheme, .nvfp4), Quantization.Scheme.classify(nvfp4_packed, .init(.{ .dout = 17408, .sc = 320 }, .f8e4m3fn)));
+    try expect(@as(?Quantization.Scheme, .fp8_per_channel), Quantization.Scheme.classify(
+        .init(.{ .dout = 17408, .d = 5120 }, .f8e4m3fn),
+        .init(.{ .dout = 17408, .sc = 1 }, .bf16),
+    ));
+
+    // nvidia/Gemma-4-31B-IT-NVFP4: ModelOpt, packed values under the plain `weight` name.
+    try expect(@as(?Quantization.Scheme, .nvfp4), Quantization.Scheme.classify(
+        .init(.{ .dout = 21504, .kw = 2688 }, .u8),
+        .init(.{ .dout = 21504, .sc = 336 }, .f8e4m3fn),
+    ));
+
+    // Native (unpacked) f4e2m1, with K no longer doubled.
+    try expect(@as(?Quantization.Scheme, .nvfp4), Quantization.Scheme.classify(
+        .init(.{ .dout = 17408, .d = 5120 }, .f4e2m1),
+        .init(.{ .dout = 17408, .sc = 320 }, .f8e4m3fn),
+    ));
+
+    // Qwen/Qwen3.6-27B-FP8: block 128, spelled `weight_scale_inv`.
+    try expect(@as(?Quantization.Scheme, .fp8_block128), Quantization.Scheme.classify(
+        .init(.{ .dout = 17408, .d = 5120 }, .f8e4m3fn),
+        .init(.{ .dout = 136, .sc = 40 }, .bf16),
+    ));
+    try expect(@as(?Quantization.Scheme, .fp8_block128), Quantization.Scheme.classify(
+        .init(.{ .dout = 5120, .d = 6144 }, .f8e4m3fn),
+        .init(.{ .dout = 40, .sc = 48 }, .bf16),
+    ));
+
+    // Mistral's per-tensor FP8: one scale for the whole tensor, rank 0 or [1].
+    try expect(@as(?Quantization.Scheme, .fp8_per_tensor), Quantization.Scheme.classify(.init(.{ .dout = 4096, .d = 4096 }, .f8e4m3fn), .init(.{}, .f32)));
+    try expect(@as(?Quantization.Scheme, .fp8_per_tensor), Quantization.Scheme.classify(.init(.{ .dout = 4096, .d = 4096 }, .f8e4m3fn), .init(.{ .g = 1 }, .f32)));
+
+    // RadixArk/Muse-Glimmer-NVFP4: ModelOpt's MIXED_PRECISION recipe, whose MXFP8 half
+    // lands on down_proj and lm_head. safetensors has no e8m0 dtype, so the scale arrives
+    // as u8 under `weight_scale_inv` -- the shape below is verbatim from the checkpoint.
+    try expect(@as(?Quantization.Scheme, .mxfp8), Quantization.Scheme.classify(
+        .init(.{ .dout = 6656, .d = 19968 }, .f8e4m3fn),
+        .init(.{ .dout = 6656, .sc = 624 }, .u8),
+    ));
+    try expect(@as(?Quantization.Scheme, .mxfp8), Quantization.Scheme.classify(
+        .init(.{ .dout = 202048, .d = 6656 }, .f8e4m3fn),
+        .init(.{ .dout = 202048, .sc = 208 }, .u8),
+    ));
+    // The same tensor from a store that types the scale natively.
+    try expect(@as(?Quantization.Scheme, .mxfp8), Quantization.Scheme.classify(
+        .init(.{ .dout = 6656, .d = 19968 }, .f8e4m3fn),
+        .init(.{ .dout = 6656, .sc = 624 }, .f8e8m0),
+    ));
+    // MXFP8 rejects any group but 32: 19968 / 16 = 1248, / 64 = 312.
+    try expect(@as(?Quantization.Scheme, null), Quantization.Scheme.classify(
+        .init(.{ .dout = 6656, .d = 19968 }, .f8e4m3fn),
+        .init(.{ .dout = 6656, .sc = 1248 }, .u8),
+    ));
+    try expect(@as(?Quantization.Scheme, null), Quantization.Scheme.classify(
+        .init(.{ .dout = 6656, .d = 19968 }, .f8e4m3fn),
+        .init(.{ .dout = 6656, .sc = 312 }, .u8),
+    ));
+
+    // MXFP4: the same u8 packing as NVFP4 (two nibbles per byte, K halved on disk), with
+    // an e8m0 scale per 32 -- so K = 2 * 2560 = 5120 and 5120 / 32 = 160.
+    try expect(@as(?Quantization.Scheme, .mxfp4), Quantization.Scheme.classify(nvfp4_packed, .init(.{ .dout = 17408, .sc = 160 }, .u8)));
+    try expect(@as(?Quantization.Scheme, .mxfp4), Quantization.Scheme.classify(nvfp4_packed, .init(.{ .dout = 17408, .sc = 160 }, .f8e8m0)));
+    // DeepSeek V4 stores the same packed FP4 bits in signed bytes.
+    try expect(@as(?Quantization.Scheme, .mxfp4), Quantization.Scheme.classify(
+        .init(.{ .dout = 2048, .kw = 2048 }, .i8),
+        .init(.{ .dout = 2048, .sc = 128 }, .f8e8m0),
+    ));
+    // Native (unpacked) f4e2m1, K no longer halved.
+    try expect(@as(?Quantization.Scheme, .mxfp4), Quantization.Scheme.classify(
+        .init(.{ .dout = 17408, .d = 5120 }, .f4e2m1),
+        .init(.{ .dout = 17408, .sc = 160 }, .f8e8m0),
+    ));
+    // An e8m0 scale never turns a non-fp4/fp8 weight into MX.
+    try expect(@as(?Quantization.Scheme, null), Quantization.Scheme.classify(
+        .init(.{ .dout = 17408, .d = 5120 }, .bf16),
+        .init(.{ .dout = 17408, .sc = 160 }, .f8e8m0),
+    ));
+
+    // Rejected: everything no backend here can express.
+    const fp8: Shape = .init(.{ .dout = 10240, .d = 5120 }, .f8e4m3fn);
+    // Group 32 with an e4m3 scale: neither NVFP4 (wrong group) nor MX (wrong scale type).
+    try expect(@as(?Quantization.Scheme, null), Quantization.Scheme.classify(nvfp4_packed, .init(.{ .dout = 17408, .sc = 160 }, .f8e4m3fn)));
+    // Group 16 with an e8m0 scale: the mirror image, and equally unclaimed.
+    try expect(@as(?Quantization.Scheme, null), Quantization.Scheme.classify(nvfp4_packed, .init(.{ .dout = 17408, .sc = 320 }, .f8e8m0)));
+    // Per-channel in f32: what fusing per-tensor projections produces. The Metal
+    // per-channel kernels have f32 entries, so this is a real scheme, not a decline.
+    try expect(@as(?Quantization.Scheme, .fp8_per_channel), Quantization.Scheme.classify(fp8, .init(.{ .dout = 10240, .sc = 1 }, .f32)));
+    // A block grid that is neither per-channel nor 128x128.
+    try expect(@as(?Quantization.Scheme, null), Quantization.Scheme.classify(fp8, .init(.{ .dout = 160, .sc = 80 }, .bf16)));
+    // Stacked MoE weights are rank 3 and go through the MoE path, not this one.
+    try expect(@as(?Quantization.Scheme, null), Quantization.Scheme.classify(
+        .init(.{ .expert = 128, .dout = 1408, .kw = 1408 }, .u8),
+        .init(.{ .expert = 128, .dout = 1408, .sc = 176 }, .f8e4m3fn),
+    ));
+
+    // `fp8_per_tensor` never checks the scale dtype, so a [1, 1] u8 scale on a [1, 32]
+    // weight satisfies it as well as `mxfp8`. Declaration order is what decides, and
+    // `mxfp8` is declared first
+    try expect(@as(?Quantization.Scheme, .mxfp8), Quantization.Scheme.classify(
+        .init(.{ .dout = 1, .d = 32 }, .f8e4m3fn),
+        .init(.{ .dout = 1, .sc = 1 }, .u8),
+    ));
+
+    // A one-tile block grid is indistinguishable from a per-tensor scale by shape alone; the
+    // `count() > 1` guard on the grids is what makes per-tensor win.
+    try expect(@as(?Quantization.Scheme, .fp8_per_tensor), Quantization.Scheme.classify(
+        .init(.{ .dout = 128, .d = 128 }, .f8e4m3fn),
+        .init(.{ .dout = 1, .sc = 1 }, .bf16),
+    ));
+}

--- a/zml/zml.zig
+++ b/zml/zml.zig
@@ -33,6 +33,7 @@ pub const meta = @import("meta.zig");
 pub const mlir = @import("mlirx.zig");
 pub const moe = @import("moe/moe.zig");
 pub const nn = @import("nn.zig");
+pub const Quantization = @import("quantization.zig").Quantization;
 pub const ops = @import("ops.zig");
 pub const pjrtx = @import("pjrtx.zig");
 pub const platform = @import("platform.zig");


### PR DESCRIPTION
`forwardMoe` is effectively consuming a `gate_up` and `down` linear MLP, it "just" only applies parts of it.
I've renamed:
```
Quant -> Quantization
QuantSchem -> Quantization.Scheme
TensorScale -> Quantization.GlobalScale
Direction { multiplier, divisor } -> Operation { multiply, divide }
```
and moved it outside of zml.nn.Linear

This makes it easier in LLMD to just load zml.nn.Linear