### PR TITLE
zml: refactor slice API

### DIFF
--- a/examples/llm/models/lfm2/model.zig
+++ b/examples/llm/models/lfm2/model.zig
@@ -471,7 +471,7 @@ pub const ShortConv = struct {
                 const sh = tokens_position_offset.shape().insert(.last, .{ .seq = self.config.conv_L_cache });
                 break :lkp zml.Tensor.iota(sh, .seq).convert(.u32).add(left_pad.convert(.u32).broad(sh)).broad(sh);
             };
-            const scatter_data = Bx.dynamicSlice(.{ .seq = @as(zml.Tensor.DynSlice, .{ .start = start.convert(.u32), .len = @intCast(self.config.conv_L_cache) }) });
+            const scatter_data = Bx.slice(.seq, .dyn(start, self.config.conv_L_cache));
             cache.state = cache.state.scatterSlices(.{ .layer = cache_index, .seq = cache_seq_indices }, scatter_data, .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override }).reuseBuffer(cache.state);
             const padding = self.config.conv_L_cache - 1;
             const conv_out_ = zml.Tensor.conv1d(Bx, self.kernel, .{
@@ -487,12 +487,12 @@ pub const ShortConv = struct {
                 .output_spatial_dimensions = Bx.axis(.seq),
                 .feature_group_count = Bx.dim(.d),
             });
-            break :b conv_out_.slice1d(.seq, .{ .end = Bx.dim(.seq) });
+            break :b conv_out_.slice(.seq, .{ .end = Bx.dim(.seq) });
         } else b: {
             cache.state = cache.state.rollRight1d(.seq, -1).scatterSlices(.{ .layer = cache_index, .seq = tokens_position_offset.convert(.u32).clamp(.scalar(@as(u32, 0), .u32), .scalar(self.config.conv_L_cache - 1, .u32)) }, Bx, .{ .indices_are_sorted = true, .update_fn = zml.Tensor.ScatterOpts.override }).reuseBuffer(cache.state);
             const kernel = self.kernel.squeeze(.in).rename(.{ .out = .d, .kernel_size = .seq });
             const sh = kernel.shape().insert(.last, .{ .batch = tokens_position_offset.dim(.batch) });
-            break :b cache.state.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = cache_index, .len = 1 } }).squeeze(.layer).mul(kernel.broad(sh).transpose(.{ .batch, .seq, .d })).sum(.seq);
+            break :b cache.state.slice(.layer, .dynSingle(cache_index)).mul(kernel.broad(sh).transpose(.{ .batch, .seq, .d })).sum(.seq);
         };
 
         const y = C.mul(conv_out);
@@ -669,11 +669,11 @@ pub const KvCache = struct {
     }
 
     pub fn keys(self: KvCache, cache_index: zml.Tensor) zml.Tensor {
-        return self.k.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = cache_index, .len = 1 } }).squeeze(.layer);
+        return self.k.slice(.layer, .dynSingle(cache_index));
     }
 
     pub fn values(self: KvCache, cache_index: zml.Tensor) zml.Tensor {
-        return self.v.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = cache_index, .len = 1 } }).squeeze(.layer);
+        return self.v.slice(.layer, .dynSingle(cache_index));
     }
 
     pub fn update(self: KvCache, new_k: zml.Tensor, new_v: zml.Tensor, token_position: zml.Tensor, cache_index: zml.Tensor) KvCache {

--- a/examples/llm/models/llama/model.zig
+++ b/examples/llm/models/llama/model.zig
@@ -646,11 +646,11 @@ pub const KvCache = struct {
     }
 
     pub fn keysAt(kv: KvCache, layer_index: zml.Tensor) zml.Tensor {
-        return kv.k.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = layer_index, .len = 1 } }).squeeze(.layer);
+        return kv.k.slice(.layer, .dynSingle(layer_index));
     }
 
     pub fn valuesAt(kv: KvCache, layer_index: zml.Tensor) zml.Tensor {
-        return kv.v.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = layer_index, .len = 1 } }).squeeze(.layer);
+        return kv.v.slice(.layer, .dynSingle(layer_index));
     }
 
     pub fn updateAt(kv: KvCache, new_k: zml.Tensor, new_v: zml.Tensor, token_index: zml.Tensor, layer_index: zml.Tensor) KvCache {

--- a/examples/llm/models/qwen3_5/model.zig
+++ b/examples/llm/models/qwen3_5/model.zig
@@ -747,14 +747,14 @@ pub const TextRotaryEmbedding = struct {
 
     fn rotateHalf(x: zml.Tensor) zml.Tensor {
         const half_dim = @divExact(x.dim(-1), 2);
-        const x1 = x.slice1d(-1, .{ .start = 0, .end = half_dim });
-        const x2 = x.slice1d(-1, .{ .start = half_dim, .end = x.dim(-1) });
+        const x1 = x.slice(-1, .{ .start = 0, .end = half_dim });
+        const x2 = x.slice(-1, .{ .start = half_dim, .end = x.dim(-1) });
         return zml.Tensor.concatenate(&.{ x2.negate(), x1 }, -1);
     }
 
     pub fn applyRope(self: TextRotaryEmbedding, x: zml.Tensor, cos: zml.Tensor, sin: zml.Tensor) zml.Tensor {
-        const x_rot = x.slice1d(-1, .{ .start = 0, .end = self.rotary_dim });
-        const x_pass = x.slice1d(-1, .{ .start = self.rotary_dim, .end = x.dim(-1) });
+        const x_rot = x.slice(-1, .{ .start = 0, .end = self.rotary_dim });
+        const x_pass = x.slice(-1, .{ .start = self.rotary_dim, .end = x.dim(-1) });
 
         const cos_x = cos.insertAxes(.hd, .{.h}).broad(x_rot.shape());
         const sin_x = sin.insertAxes(.hd, .{.h}).broad(x_rot.shape());
@@ -871,7 +871,7 @@ pub const GatedDeltaNet = struct {
 
     fn buildUpdatedConvState(input: zml.Tensor, left_pad: i64) zml.Tensor {
         const copy_len = @min(input.dim(.s), left_pad);
-        const tail = input.slice1d(.s, .{ .start = input.dim(.s) - copy_len, .end = input.dim(.s) });
+        const tail = input.slice(.s, .{ .start = input.dim(.s) - copy_len, .end = input.dim(.s) });
         if (copy_len == left_pad) return tail;
 
         const padding_shape = zml.Shape.init(.{ .b = input.dim(.b), .s = left_pad - copy_len, .mix = input.dim(.mix) }, input.dtype());
@@ -916,7 +916,7 @@ pub const GatedDeltaNet = struct {
             .silu();
 
         if (use_cached_state) {
-            mixed_qkv = mixed_qkv.slice1d(.s, .{ .start = mixed_qkv.dim(.s) - 1, .end = mixed_qkv.dim(.s) });
+            mixed_qkv = mixed_qkv.slice(.s, .{ .start = mixed_qkv.dim(.s) - 1, .end = mixed_qkv.dim(.s) });
         }
         mixed_qkv = mixed_qkv.withPartitioning(.{ .s = .replicated, .mix = .model });
 
@@ -926,13 +926,13 @@ pub const GatedDeltaNet = struct {
         const a = self.in_proj_a.forward(x_in).rename(.{ .dout = .vh });
 
         const query = mixed_qkv
-            .slice1d(.mix, .{ .start = 0, .end = key_dim })
+            .slice(.mix, .{ .start = 0, .end = key_dim })
             .splitAxis(.mix, .{ .kh = self.num_k_heads, .khd = self.head_k_dim });
         const key = mixed_qkv
-            .slice1d(.mix, .{ .start = key_dim, .end = 2 * key_dim })
+            .slice(.mix, .{ .start = key_dim, .end = 2 * key_dim })
             .splitAxis(.mix, .{ .kh = self.num_k_heads, .khd = self.head_k_dim });
         const value = mixed_qkv
-            .slice1d(.mix, .{ .start = 2 * key_dim, .end = 2 * key_dim + value_dim })
+            .slice(.mix, .{ .start = 2 * key_dim, .end = 2 * key_dim + value_dim })
             .splitAxis(.mix, .{ .vh = self.num_v_heads, .vhd = self.head_v_dim });
 
         const beta = b.sigmoid();
@@ -1072,11 +1072,11 @@ pub const KvCache = struct {
         }
 
         pub fn keys(kv: SelfAttnCache) zml.Tensor {
-            return kv.k.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = kv.layer_index, .len = 1 } }).squeeze(.layer);
+            return kv.k.slice(.layer, .dynSingle(kv.layer_index));
         }
 
         pub fn values(kv: SelfAttnCache) zml.Tensor {
-            return kv.v.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = kv.layer_index, .len = 1 } }).squeeze(.layer);
+            return kv.v.slice(.layer, .dynSingle(kv.layer_index));
         }
 
         pub fn update(kv: SelfAttnCache, new_k: zml.Tensor, new_v: zml.Tensor, token_index: ?zml.Tensor) SelfAttnCache {
@@ -1179,11 +1179,11 @@ pub const KvCache = struct {
         }
 
         pub fn convState(self: GatedDeltaNetCache) zml.Tensor {
-            return self.conv_state.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = self.layer_index, .len = 1 } }).squeeze(.layer);
+            return self.conv_state.slice(.layer, .dynSingle(self.layer_index));
         }
 
         pub fn recurrentState(self: GatedDeltaNetCache) zml.Tensor {
-            return self.recurrent_state.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = self.layer_index, .len = 1 } }).squeeze(.layer);
+            return self.recurrent_state.slice(.layer, .dynSingle(self.layer_index));
         }
 
         pub fn update(self: GatedDeltaNetCache, new_conv_state: ?zml.Tensor, new_recurrent_state: ?zml.Tensor) GatedDeltaNetCache {

--- a/examples/llm/models/qwen3_5_moe/model.zig
+++ b/examples/llm/models/qwen3_5_moe/model.zig
@@ -887,14 +887,14 @@ pub const TextRotaryEmbedding = struct {
 
     fn rotateHalf(x: zml.Tensor) zml.Tensor {
         const half_dim = @divExact(x.dim(-1), 2);
-        const x1 = x.slice1d(-1, .{ .start = 0, .end = half_dim });
-        const x2 = x.slice1d(-1, .{ .start = half_dim, .end = x.dim(-1) });
+        const x1 = x.slice(-1, .{ .start = 0, .end = half_dim });
+        const x2 = x.slice(-1, .{ .start = half_dim, .end = x.dim(-1) });
         return zml.Tensor.concatenate(&.{ x2.negate(), x1 }, -1);
     }
 
     pub fn applyRope(self: TextRotaryEmbedding, x: zml.Tensor, cos: zml.Tensor, sin: zml.Tensor) zml.Tensor {
-        const x_rot = x.slice1d(-1, .{ .start = 0, .end = self.rotary_dim });
-        const x_pass = x.slice1d(-1, .{ .start = self.rotary_dim, .end = x.dim(-1) });
+        const x_rot = x.slice(-1, .{ .start = 0, .end = self.rotary_dim });
+        const x_pass = x.slice(-1, .{ .start = self.rotary_dim, .end = x.dim(-1) });
 
         const cos_x = cos.insertAxes(.hd, .{.h}).broad(x_rot.shape());
         const sin_x = sin.insertAxes(.hd, .{.h}).broad(x_rot.shape());
@@ -1010,7 +1010,7 @@ pub const GatedDeltaNet = struct {
 
     fn buildUpdatedConvState(input: zml.Tensor, left_pad: i64) zml.Tensor {
         const copy_len = @min(input.dim(.s), left_pad);
-        const tail = input.slice1d(.s, .{ .start = input.dim(.s) - copy_len, .end = input.dim(.s) });
+        const tail = input.slice(.s, .{ .start = input.dim(.s) - copy_len, .end = input.dim(.s) });
         if (copy_len == left_pad) return tail;
 
         const padding_shape = zml.Shape.init(.{ .b = input.dim(.b), .s = left_pad - copy_len, .mix = input.dim(.mix) }, input.dtype());
@@ -1020,7 +1020,7 @@ pub const GatedDeltaNet = struct {
 
     fn buildUpdatedConvStateFromPrefix(input: zml.Tensor, left_pad: i64, valid_len: zml.Tensor) zml.Tensor {
         const start = valid_len.convert(.i64).addConstant(-left_pad).maximum(zml.Tensor.scalar(0, .i64));
-        return input.dynamicSlice1d(input.axis(.s), .{ .start = start, .len = left_pad });
+        return input.slice(.s, .dyn(start, left_pad));
     }
 
     fn setPaddingToZero(input: zml.Tensor, valid_mask: zml.Tensor) zml.Tensor {
@@ -1063,7 +1063,7 @@ pub const GatedDeltaNet = struct {
             .silu();
 
         if (use_cached_state) {
-            mixed_qkv = mixed_qkv.slice1d(.s, .{ .start = mixed_qkv.dim(.s) - 1, .end = mixed_qkv.dim(.s) });
+            mixed_qkv = mixed_qkv.slice(.s, .{ .start = mixed_qkv.dim(.s) - 1, .end = mixed_qkv.dim(.s) });
         }
         mixed_qkv = mixed_qkv.withPartitioning(.{ .s = .replicated, .mix = .model });
 
@@ -1074,15 +1074,15 @@ pub const GatedDeltaNet = struct {
         const a = self.in_proj_a.forward(x_in).rename(.{ .dout = .vh }).withPartitioning(.{ .s = .replicated, .vh = .model });
 
         const query = mixed_qkv
-            .slice1d(.mix, .{ .start = 0, .end = key_dim })
+            .slice(.mix, .{ .start = 0, .end = key_dim })
             .splitAxis(.mix, .{ .kh = self.num_k_heads, .khd = self.head_k_dim })
             .withPartitioning(.{ .s = .replicated, .kh = .model, .khd = .replicated });
         const key = mixed_qkv
-            .slice1d(.mix, .{ .start = key_dim, .end = 2 * key_dim })
+            .slice(.mix, .{ .start = key_dim, .end = 2 * key_dim })
             .splitAxis(.mix, .{ .kh = self.num_k_heads, .khd = self.head_k_dim })
             .withPartitioning(.{ .s = .replicated, .kh = .model, .khd = .replicated });
         const value = mixed_qkv
-            .slice1d(.mix, .{ .start = 2 * key_dim, .end = 2 * key_dim + value_dim })
+            .slice(.mix, .{ .start = 2 * key_dim, .end = 2 * key_dim + value_dim })
             .splitAxis(.mix, .{ .vh = self.num_v_heads, .vhd = self.head_v_dim })
             .withPartitioning(.{ .s = .replicated, .vh = .model, .vhd = .replicated });
 
@@ -1221,11 +1221,11 @@ pub const KvCache = struct {
         }
 
         pub fn keys(self: SelfAttnCache) zml.Tensor {
-            return self.k.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = self.layer_index, .len = 1 } }).squeeze(.layer);
+            return self.k.slice(.layer, .dynSingle(self.layer_index));
         }
 
         pub fn values(self: SelfAttnCache) zml.Tensor {
-            return self.v.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = self.layer_index, .len = 1 } }).squeeze(.layer);
+            return self.v.slice(.layer, .dynSingle(self.layer_index));
         }
 
         pub fn update(self: SelfAttnCache, new_k: zml.Tensor, new_v: zml.Tensor, token_index: ?zml.Tensor) SelfAttnCache {
@@ -1322,11 +1322,11 @@ pub const KvCache = struct {
         }
 
         pub fn convState(self: GatedDeltaNetCache) zml.Tensor {
-            return self.conv_state.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = self.layer_index, .len = 1 } }).squeeze(.layer);
+            return self.conv_state.slice(.layer, .dynSingle(self.layer_index));
         }
 
         pub fn recurrentState(self: GatedDeltaNetCache) zml.Tensor {
-            return self.recurrent_state.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = self.layer_index, .len = 1 } }).squeeze(.layer);
+            return self.recurrent_state.slice(.layer, .dynSingle(self.layer_index));
         }
 
         pub fn update(self: GatedDeltaNetCache, new_conv_state: ?zml.Tensor, new_recurrent_state: ?zml.Tensor) GatedDeltaNetCache {

--- a/zml/attention/attnd.zig
+++ b/zml/attention/attnd.zig
@@ -147,8 +147,8 @@ pub fn causalAttention(q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, token_offset
         .{ k, v }
     else
         .{
-            k.dynamicSlice(.{ .k = zml.Tensor.DynSlice{ .start = token_offset, .len = 1 } }),
-            v.dynamicSlice(.{ .k = zml.Tensor.DynSlice{ .start = token_offset, .len = 1 } }),
+            k.slice(.k, .dynSingle(token_offset)),
+            v.slice(.k, .dynSingle(token_offset)),
         };
 
     // Concatenate q/k/v and metadata into a single byte buffer on the GPU.

--- a/zml/attention/flashattn.zig
+++ b/zml/attention/flashattn.zig
@@ -1078,7 +1078,7 @@ pub const paged_fa2 = struct {
                     .b = batch_dim_decode,
                 }, .f32)).withPartitioning(.{ .hkv = .model });
                 const dummy_cu_seqlens_k_decode = zml.Tensor.zeroes(cu_seqlens_q_decode.shape());
-                var q_decode = q.dynamicSlice1d(0, .{ .start = mixed_parameters.metadata.decode_offset, .len = batch_dim_decode });
+                var q_decode = q.slice(0, .dyn(mixed_parameters.metadata.decode_offset, batch_dim_decode));
 
                 if (seqlenq_ngroups_swapped) {
                     q_decode = q_decode.transpose(.{ .b, .hg, .hkv, .hd }).merge(.{ .b = .{ .b, .hg } }).withPartitioning(.{ .hkv = .model });
@@ -1676,7 +1676,7 @@ pub const paged_fa3 = struct {
                     .hg = num_head_groups,
                 }, .f32));
                 const scheduler_metadata_decode = zml.Tensor.zeroes(.init(.{ .b = batch_size_decode + 1 }, .i32));
-                var q_decode = q.dynamicSlice1d(0, .{ .start = mixed_parameters.metadata.decode_offset, .len = batch_size_decode }).withPartitioning(.{ .hkv = .model });
+                var q_decode = q.slice(0, .dyn(mixed_parameters.metadata.decode_offset, batch_size_decode)).withPartitioning(.{ .hkv = .model });
 
                 q_decode = q_decode.merge(.{ .h = .{ .hkv, .hg } }).withPartitioning(.{ .h = .model });
 

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -269,8 +269,8 @@ pub const KvCache = union(enum) {
     ) [2]zml.Tensor {
         return switch (self) {
             .split => |split| .{
-                split.k.dynamicSlice1d(split.k.axis(.page), .{ .start = page_index, .len = 1 }).squeeze(.page),
-                split.v.dynamicSlice1d(split.k.axis(.page), .{ .start = page_index, .len = 1 }).squeeze(.page),
+                split.k.slice(split.k.axis(.page), .dynSingle(page_index)),
+                split.v.slice(split.k.axis(.page), .dynSingle(page_index)),
             },
             .dense, .latent => @panic("TODO"),
         };
@@ -600,15 +600,15 @@ const AttentionLoop = struct {
 
     pub fn cond(self: While, state: State) zml.Tensor {
         const has_more_sequences = state.seq_id.cmp(.LT, .scalar(self.parameters.seq_lens.count(), .i32));
-        const query_start = self.parameters.query_start_len.dynamicSlice1d(0, .{ .start = state.seq_id, .len = 1 });
-        const query_end = self.parameters.query_start_len.dynamicSlice1d(0, .{ .start = state.seq_id.addConstant(1), .len = 1 });
+        const query_start = self.parameters.query_start_len.slice(0, .dynSingle(state.seq_id));
+        const query_end = self.parameters.query_start_len.slice(0, .dynSingle(state.seq_id.addConstant(1)));
         const has_queries = query_start.cmp(.LT, query_end).asScalar();
         return has_more_sequences.logical(.AND, has_queries);
     }
 
     pub fn body(self: While, state_: State) State {
-        const query_start = self.parameters.query_start_len.dynamicSlice1d(0, .{ .start = state_.seq_id, .len = 1 });
-        const query_end = self.parameters.query_start_len.dynamicSlice1d(0, .{ .start = state_.seq_id.addConstant(1), .len = 1 });
+        const query_start = self.parameters.query_start_len.slice(0, .dynSingle(state_.seq_id));
+        const query_end = self.parameters.query_start_len.slice(0, .dynSingle(state_.seq_id.addConstant(1)));
         const seq_num_queries_: zml.Tensor = .asScalar(.sub(query_end, query_start));
         const page_size_: u32 = @intCast(self.kv_cache.split.k.dim(.k_chunk));
 
@@ -628,7 +628,7 @@ const AttentionLoop = struct {
                     const num_slots: u32 = page_size;
 
                     // seq_lens includes the current queries; subtracting their count gives the context length.
-                    const seq_len = while_body.parameters.seq_lens.dynamicSlice1d(0, .{ .start = state.seq_id, .len = 1 }).asScalar();
+                    const seq_len = while_body.parameters.seq_lens.slice(0, .dynSingle(state.seq_id));
                     const q_offset = seq_len.sub(if_ctx.seq_num_queries).add(state.q_page_idx.scale(page_size));
                     const next_k_offset = state.k_page_idx.addConstant(1).scale(page_size);
 
@@ -649,7 +649,7 @@ const AttentionLoop = struct {
                     const num_slots: u32 = 1;
 
                     // A decode query is the final token in seq_len, so its zero-based offset is seq_len - 1.
-                    const seq_len = while_body.parameters.seq_lens.dynamicSlice1d(0, .{ .start = state.seq_id, .len = 1 }).asScalar();
+                    const seq_len = while_body.parameters.seq_lens.slice(0, .dynSingle(state.seq_id)).asScalar();
                     const q_offset = seq_len.sub(if_ctx.seq_num_queries);
                     const next_k_offset = state.k_page_idx.addConstant(1).scale(page_size);
 
@@ -672,12 +672,12 @@ const AttentionLoop = struct {
 
     pub fn attentionOnePage(self: While, state: State, q_offset: zml.Tensor, q_chunk: u32, page_size: u32) PartialSoftmax {
         const k_offset = state.k_page_idx.scale(page_size);
-        const active_q = self.q.dynamicSlice1d(self.q.axis(.b), .{ .start = state.slot_id, .len = q_chunk });
+        const active_q = self.q.slice(self.q.axis(.b), .dyn(state.slot_id, q_chunk));
 
-        const active_k_page_id = self.parameters.block_table.dynamicSlice(.{
-            .b = zml.Tensor.DynSlice{ .start = state.seq_id, .len = 1 },
-            .p = zml.Tensor.DynSlice{ .start = state.k_page_idx, .len = 1 },
-        }).asScalar();
+        const active_k_page_id = self.parameters.block_table.slices(
+            .{ .b, .p },
+            &.{ .dynSingle(state.seq_id), .dynSingle(state.k_page_idx) },
+        );
         const active_k, const active_v = self.kv_cache.getPage(active_k_page_id);
 
         const dtype = self.q.dtype();
@@ -831,11 +831,7 @@ pub const Mla = struct {
         const scores_sink = zml.Tensor.concatenate(&.{ scores, sink_.convert(scores.dtype()) }, .kv);
 
         const attn_weights = scores_sink.softmax(.kv);
-        const attn_weights_non_sink = attn_weights.slice(&.{
-            .{},
-            .{},
-            .{ .end = topk.dim(.topk) },
-        });
+        const attn_weights_non_sink = attn_weights.slice(-1, .{ .end = topk.dim(.topk) });
         return attn_weights_non_sink.dot(selected_kv, .kv).convert(q.dtype());
     }
 

--- a/zml/attention/tpu_attention.zig
+++ b/zml/attention/tpu_attention.zig
@@ -118,8 +118,8 @@ pub const mosaic_tpu = struct {
     }
 
     fn activeSequenceCount(query_start_len: zml.Tensor) zml.Tensor {
-        const start = query_start_len.slice1d(.b, .{ .end = query_start_len.dim(.b) - 1 });
-        const end = query_start_len.slice1d(.b, .{ .start = 1 });
+        const start = query_start_len.slice(.b, .{ .end = query_start_len.dim(.b) - 1 });
+        const end = query_start_len.slice(.b, .{ .start = 1 });
         const query_lens = end.sub(start);
         return query_lens
             .cmp(.GT, .zeroes(query_lens.shape()))
@@ -144,7 +144,7 @@ pub const mosaic_tpu = struct {
             "mosaic_tpu ragged paged attention cannot restore output from head_dim {} to {}",
             .{ restored.dim(.hd), q_template.dim(.hd) },
         );
-        return restored.slice1d(.hd, .{ .end = q_template.dim(.hd) });
+        return restored.slice(.hd, .{ .end = q_template.dim(.hd) });
     }
 
     inline fn alignQueryHeadDimForKernel(q: zml.Tensor, target_head_dim: i64) zml.Tensor {

--- a/zml/attention/triton_attention.zig
+++ b/zml/attention/triton_attention.zig
@@ -846,8 +846,8 @@ pub const paged = struct {
 
     fn tokenToSequence(query_start_len: zml.Tensor, query_count: i64) zml.Tensor {
         const sequence_count = query_start_len.dim(.b) - 1;
-        const starts = query_start_len.slice1d(.b, .{ .end = sequence_count }).rename(.{ .b = .seq });
-        const ends = query_start_len.slice1d(.b, .{ .start = 1 }).rename(.{ .b = .seq });
+        const starts = query_start_len.slice(.b, .{ .end = sequence_count }).rename(.{ .b = .seq });
+        const ends = query_start_len.slice(.b, .{ .start = 1 }).rename(.{ .b = .seq });
         const query_x_sequence_shape = zml.Shape.init(.{ .q = query_count, .seq = sequence_count }, .i32);
         const query = zml.Tensor.iota(query_x_sequence_shape, .q).convert(.i32);
         const in_range = query.cmp(.GE, starts.broad(query_x_sequence_shape)).convert(.i32)
@@ -865,7 +865,7 @@ pub const paged = struct {
         stdx.debug.assert(tokens_pos.shape().hasTags(.{.q}), "paged MLA token positions must have a .q axis, got {f}", .{tokens_pos.shape()});
 
         const query_to_sequence = tokenToSequence(parameters.query_start_len, topk_i32.dim(.q));
-        const sequence_ends = parameters.query_start_len.slice1d(.b, .{ .start = 1 }).rename(.{ .b = .seq });
+        const sequence_ends = parameters.query_start_len.slice(.b, .{ .start = 1 }).rename(.{ .b = .seq });
         const last_query = sequence_ends.gather(.{ .seq = query_to_sequence }, .{}).sub(.scalar(1, .i32));
         const last_token_pos = tokens_pos
             .gather(.{ .q = last_query.rename(.{ .q = .lookup }) }, .{})

--- a/zml/moe/metal.zig
+++ b/zml/moe/metal.zig
@@ -78,8 +78,8 @@ fn requireScalePair(opts: Options, dtype: zml.DataType) !void {
 
 fn applyActivation(x: Tensor, mode: ActivationMode) Tensor {
     const mid = @divFloor(x.dim(.out), 2);
-    const gate = x.slice1d(.out, .{ .end = mid });
-    const up = x.slice1d(.out, .{ .start = mid });
+    const gate = x.slice(.out, .{ .end = mid });
+    const up = x.slice(.out, .{ .start = mid });
 
     const act = switch (mode) {
         .silu => gate.silu().mul(up),

--- a/zml/moe/mosaic_tpu.zig
+++ b/zml/moe/mosaic_tpu.zig
@@ -150,14 +150,14 @@ fn alignSortedRowsByGroup(rows: Tensor, expert_ids_sorted: Tensor, group_sizes: 
     const group_ends = group_sizes.cumulativeSum(.expert);
     const group_starts = Tensor.concatenate(&.{
         Tensor.zeroes(.init(.{ .expert = 1 }, .i32)),
-        group_ends.slice1d(.expert, .{ .end = num_groups - 1 }),
+        group_ends.slice(.expert, .{ .end = num_groups - 1 }),
     }, .expert);
 
     const padded_group_sizes = group_sizes.addConstant(tile_m - 1).divByConst(tile_m).mul(Tensor.scalar(tile_m, .i32));
     const padded_group_ends = padded_group_sizes.cumulativeSum(.expert);
     const padded_group_starts = Tensor.concatenate(&.{
         Tensor.zeroes(.init(.{ .expert = 1 }, .i32)),
-        padded_group_ends.slice1d(.expert, .{ .end = num_groups - 1 }),
+        padded_group_ends.slice(.expert, .{ .end = num_groups - 1 }),
     }, .expert);
 
     const logical_positions = Tensor.arange(.{ .end = rows.dim(.token) }, .i32).withTags(.{.token});
@@ -261,13 +261,13 @@ pub fn callGmmEp(
         },
     ).out;
 
-    return out.slice1d(.out, .{ .end = out_n });
+    return out.slice(.out, .{ .end = out_n });
 }
 
 fn applyActivation(x: Tensor, mode: ActivationMode) Tensor {
     const mid = @divFloor(x.dim(.out), 2);
-    const gate = x.slice1d(.out, .{ .end = mid });
-    const up = x.slice1d(.out, .{ .start = mid });
+    const gate = x.slice(.out, .{ .end = mid });
+    const up = x.slice(.out, .{ .start = mid });
 
     return switch (mode) {
         .silu => gate.silu().mul(up),

--- a/zml/moe/triton.zig
+++ b/zml/moe/triton.zig
@@ -111,8 +111,8 @@ fn initZeroBiasBuffer(io: std.Io, platform: *const zml.Platform, sharding: zml.S
 
 fn applyActivation(x: Tensor, mode: Parameters.ActivationMode) Tensor {
     const mid = @divFloor(x.dim(.out), 2);
-    const gate = x.slice1d(.out, .{ .end = mid });
-    const up = x.slice1d(.out, .{ .start = mid });
+    const gate = x.slice(.out, .{ .end = mid });
+    const up = x.slice(.out, .{ .start = mid });
     return switch (mode) {
         .silu => gate.silu().mul(up),
         .relu => x.relu().powByConst(2),

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -1584,7 +1584,7 @@ pub fn resizeBilinear(image: Tensor, resized_axes: anytype, opt: ResizeOpts) Ten
     for (new_size.constSlice(), tags_.constSlice()) |d, t| {
         const ax = image.shape().axis(t);
         const child_opt: ResizeOpts = .{
-            .original_len = if (opt.original_len) |o| o.choose1d(0, ax) else null,
+            .original_len = if (opt.original_len) |o| o.slice(0, .single(ax)) else null,
         };
         out = resizeLinear1d(out, ax, d, child_opt);
     }
@@ -1651,7 +1651,7 @@ pub fn resizeBicubic(image: Tensor, resized_axes: anytype, opt: ResizeOpts) Tens
     for (new_size.constSlice(), tags_.constSlice()) |d, t| {
         const ax = image.shape().axis(t);
         const child_opt: ResizeOpts = .{
-            .original_len = if (opt.original_len) |o| o.choose1d(0, ax) else null,
+            .original_len = if (opt.original_len) |o| o.slice(0, .single(ax)) else null,
         };
         out = resizeCubic1d(out, ax, d, child_opt);
     }

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -798,12 +798,12 @@ pub fn splitRealImg(x: Tensor, layout: RopeOpts.Layout) [2]Tensor {
 
     return switch (layout) {
         .real_im_pass, .real_pass_im_pass => .{
-            x.slice1d(-1, .{ .end = @divExact(n, 2) }),
-            x.slice1d(-1, .{ .start = @divExact(n, 2), .end = n }),
+            x.slice(-1, .{ .end = @divExact(n, 2) }),
+            x.slice(-1, .{ .start = @divExact(n, 2), .end = n }),
         },
         .interleaved => .{
-            x.slice1d(-1, .{ .start = 0, .step = 2 }),
-            x.slice1d(-1, .{ .start = 1, .step = 2 }),
+            x.slice(-1, .{ .start = 0, .step = 2 }),
+            x.slice(-1, .{ .start = 1, .step = 2 }),
         },
     };
 }
@@ -826,22 +826,22 @@ pub fn splitRealImgPass(x: Tensor, layout: RopeOpts.Layout, rotary_dim: u32) str
     const half_rotary = @divExact(rotary_dim, 2);
     return switch (layout) {
         .real_im_pass => .{
-            x.slice1d(ax, .{ .end = half_rotary }),
-            x.slice1d(ax, .{ .start = half_rotary, .end = rotary_dim }),
-            .{ .real_im_pass = x.slice1d(ax, .{ .start = rotary_dim }) },
+            x.slice(ax, .{ .end = half_rotary }),
+            x.slice(ax, .{ .start = half_rotary, .end = rotary_dim }),
+            .{ .real_im_pass = x.slice(ax, .{ .start = rotary_dim }) },
         },
         .real_pass_im_pass => .{
-            x.slice1d(ax, .{ .end = half_rotary }),
-            x.slice1d(ax, .{ .start = half, .end = half + half_rotary }),
+            x.slice(ax, .{ .end = half_rotary }),
+            x.slice(ax, .{ .start = half, .end = half + half_rotary }),
             .{ .real_pass_im_pass = .{
-                x.slice1d(ax, .{ .start = half_rotary, .end = half }),
-                x.slice1d(ax, .{ .start = half + half_rotary }),
+                x.slice(ax, .{ .start = half_rotary, .end = half }),
+                x.slice(ax, .{ .start = half + half_rotary }),
             } },
         },
         .interleaved => .{
-            x.slice1d(ax, .{ .start = 0, .end = rotary_dim, .step = 2 }),
-            x.slice1d(ax, .{ .start = 1, .end = rotary_dim, .step = 2 }),
-            .{ .interleaved = x.slice1d(ax, .{ .start = rotary_dim }) },
+            x.slice(ax, .{ .start = 0, .end = rotary_dim, .step = 2 }),
+            x.slice(ax, .{ .start = 1, .end = rotary_dim, .step = 2 }),
+            .{ .interleaved = x.slice(ax, .{ .start = rotary_dim }) },
         },
     };
 }
@@ -1890,7 +1890,7 @@ pub const GatedDeltaNet = struct {
     }
 
     fn sliceStep(input: Tensor, step_: Tensor) Tensor {
-        return input.dynamicSlice(.{ .s = Tensor.DynSlice{ .start = step_, .len = 1 } }).squeeze(.s);
+        return input.slice(.s, .dynSingle(step_));
     }
 
     fn validateInitialState(gdn: GatedDeltaNet, state: State) void {
@@ -2233,7 +2233,7 @@ fn fixupLogits(logits: Tensor, opts: DynamicSamplingStrategy) [2]Tensor {
     // this propagate to probs_sum and probs_max.
     const probs = x.softmax(.topk);
     const probs_sum = probs.cumulativeSum(.topk);
-    const probs_max = probs.slice1d(.topk, .{ .start = 0, .end = 1 });
+    const probs_max = probs.slice(.topk, .{ .start = 0, .end = 1 });
 
     const top_p = opts.top_p.convert(x.dtype()).broad(x.shape());
     const min_p = opts.min_p.convert(x.dtype()).broad(probs_max.shape()).mul(probs_max).broad(x.shape());

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -1510,7 +1510,7 @@ pub fn gather(self: Tensor, idx_axes: []const u3, idx_per_axis: []const Tensor, 
     // So let us handle that.
     if (indices_shape.count() == 1 and idx_axes.len == 1) {
         return self
-            .dynamicSlice1d(idx_axes[0], .{ .start = indices_per_axis.get(0).asScalar(), .len = 1 })
+            .slice(idx_axes[0], .dyn(indices_per_axis.get(0).asScalar(), 1))
             // Keep downstream resharding after the slice. SPMD engines like Neuron otherwise
             // may hoist an all-gather before the slice and materialize the full tensor.
             .optimizationBarrier()

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1848,14 +1848,29 @@ pub const Tensor = struct {
 
     pub const Slice = struct {
         start: i64 = 0,
+        dyn_start: ?Tensor = null,
+        len: i64 = to_the_end,
         end: i64 = to_the_end,
         step: i32 = 1,
         singleton: bool = false,
 
-        const full: Slice = .{ .start = 0, .end = to_the_end, .step = 1 };
+        /// Select the full slice
+        pub const full: Slice = .{ .start = 0, .end = to_the_end, .step = 1 };
 
+        /// Select a single element and drop the corresponding axis (to keep the axis use .{ .start = off, .len =1 })
         pub fn single(offset: i64) Slice {
             return .{ .start = offset, .end = offset + 1, .singleton = true };
+        }
+
+        /// Select a single element and drop the corresponding axis (to keep the axis use .{ .start = off, .len =1 })
+        pub fn dyn(start: Tensor, len: i64) Slice {
+            stdx.debug.assert(start.rank() == 0, "Slice.dyn expects scalar input, got {f}", .{start});
+            return .{ .dyn_start = start, .len = len };
+        }
+
+        pub fn dynSingle(start: Tensor) Slice {
+            stdx.debug.assert(start.rank() == 0, "Slice.dynSingle expects scalar input, got {f}", .{start});
+            return .{ .dyn_start = start, .len = 1, .singleton = true };
         }
 
         pub fn absolute(s: Slice, d: i64) Slice {
@@ -1866,6 +1881,8 @@ pub const Tensor = struct {
                 d
             else if (s.end < 0)
                 d + s.end
+            else if (s.len != to_the_end)
+                start + s.len
             else
                 s.end;
             const res: Slice = .{ .start = start, .end = end, .step = s.step, .singleton = s.singleton };
@@ -1876,37 +1893,98 @@ pub const Tensor = struct {
 
         const to_the_end = std.math.maxInt(i64);
 
-        pub fn format(self: Slice, writer: *std.Io.Writer) !void {
-            // if (self.singleton) {
-            //     try writer.print("[{d}]", .{self.start});
-            // } else
-            if (self.end == to_the_end and self.step == 1) {
-                try writer.print("[{d}..]", .{self.start});
-            } else if (self.step == 1) {
-                try writer.print("[{d}..{d}]", .{ self.start, self.end });
+        pub fn format(s: Slice, writer: *std.Io.Writer) !void {
+            const end = if (s.len != to_the_end) s.start +| s.len else s.end;
+            if (s.dyn_start) |_| {
+                if (s.singleton)
+                    try writer.writeAll("[x]")
+                else
+                    try writer.print("[x..x+{}]", .{s.len});
+            } else if (s.singleton) {
+                try writer.print("[{d}]", .{s.start});
+            } else if (end == to_the_end and s.step == 1) {
+                try writer.print("[{d}..]", .{s.start});
+            } else if (s.step == 1) {
+                try writer.print("[{d}..{d}]", .{ s.start, end });
             } else {
-                try writer.print("[{d}..{d}:{d}]", .{ self.start, self.end, self.step });
+                try writer.print("[{d}..{d}:{d}]", .{ s.start, end, s.step });
             }
         }
     };
 
-    /// Slices the input Tensor over the given axis using the given parameters.
-    pub fn slice1d(self: Tensor, axis_: anytype, s: Slice) Tensor {
-        var slices: [constants.MAX_RANK]Slice = @splat(.{});
-        slices[self.axis(axis_)] = s;
-        return self.slice(slices[0..self.rank()]);
+    /// Slice a Tensor across a specific axes.
+    ///
+    /// Due to the nature of stablehlo, the length of the slices need to be known when compiling the IR.
+    /// Examples:
+    /// ```
+    /// Tensor(.{.a=20,.b=30,.c=40 }).slice(.a, .{ .start = 5, .len = 11});
+    /// Tensor(.{.a=20,.b=30,.c=40 }).slice(0, .single(5));
+    /// ```
+    pub fn slice(self: Tensor, axis_: anytype, slice_: Slice) Tensor {
+        return self.slices(@as([]const ResolvedAxis, &.{self.axis(axis_)}), &.{slice_});
     }
 
-    /// Slices the input Tensor using the given parameters.
-    pub fn slice(self: Tensor, slices: []const Slice) Tensor {
-        var start_indices: [constants.MAX_RANK]i64 = undefined;
-        var strides: [constants.MAX_RANK]i64 = undefined;
-        var limit_indices: [constants.MAX_RANK]i64 = undefined;
+    /// Slices a Tensor across many axes.
+    ///
+    /// ```
+    /// Tensor(.{.a=20,.b=30,.c=40 }).slices(.{ .a, .b }, &.{ .start = 5, .end = 11}, .dyn(x) });
+    /// Tensor(.{.a=20,.b=30,.c=40 }).slices(.{
+    ///     .a = .{ .start = a_off, .len = 11 },
+    ///     .b = .{ .start = b_off, .len = 12 },
+    ///   });
+    /// Tensor(.{ 20,30,40}).slices(.{ 0, 2 }, .{.dyn(a_off, .len = 20), .{ .start = 8, .len = 12 }});
+    /// ```
+    pub fn slices(self: Tensor, axes_: anytype, slices_: []const Slice) Tensor {
+        // Note: with typed slices, the callsites are less akwards.
+        if (@TypeOf(axes_) != []const ResolvedAxis) {
+            const resolved_axes: []const ResolvedAxis = self._shape.parseAxes(axes_)[0].slice();
+            return self.slices(resolved_axes, slices_);
+        }
+
+        const rk = self.rank();
+        any_dyn: {
+            for (slices_) |s| {
+                if (s.dyn_start) |_| break :any_dyn;
+            }
+            return self.staticSlices(axes_, slices_);
+        }
+
+        const zero = scalar(0, .i64).value();
+        var start_indices: [constants.MAX_RANK]*const mlir.Value = @splat(zero);
+        var new_shape: Shape = self._shape;
+        var to_remove: Shape.AxesArray = .empty;
+
+        for (axes_, slices_) |a, s| {
+            stdx.debug.assert(s.step == 1, "Tensor.slices doesn't support mixing strided and dynamic slices, got {f}", .{stdx.fmt.slice(slices_)});
+            new_shape._dims.buffer[a] = s.len;
+            start_indices[a] = if (s.dyn_start) |dyn|
+                dyn.convert(.i64).value()
+            else
+                scalar(s.start, .i64).value();
+            if (s.singleton) to_remove.appendAssumeCapacity(@intCast(a));
+        }
+
+        const op = dialects.stablehlo.dynamic_slice(
+            mlirCtx(),
+            self.value(),
+            new_shape.dims(),
+            start_indices[0..rk],
+            .unknown(mlirCtx()),
+        ).appendTo(currentBlock());
+
+        const res = _result(new_shape, op.result(0));
+        return res.reshape(new_shape.removeMany(to_remove.constSlice()));
+    }
+
+    fn staticSlices(self: Tensor, axes_: []const ResolvedAxis, slices_: []const Slice) Tensor {
+        var start_indices: [constants.MAX_RANK]i64 = @splat(0);
+        var strides: [constants.MAX_RANK]i64 = @splat(1);
+        var limit_indices: [constants.MAX_RANK]i64 = self._shape._dims.buffer;
         var res_shape: Shape = self._shape;
 
-        for (slices, 0..) |s, a| {
-            stdx.debug.assert(s.step > 0, "slice expects 'step' to be positive, got {} at index {}", .{ s.step, a });
-            stdx.debug.assert(s.step > 0, "slice expects 'step' to be positive, got {} at index {}", .{ s.step, a });
+        for (axes_, slices_) |a, s| {
+            stdx.debug.assert(s.step > 0, "slice expects 'step' to be positive, got {} on axis {}", .{ s.step, a });
+            stdx.debug.assert(s.step > 0, "slice expects 'step' to be positive, got {} on axis {}", .{ s.step, a });
 
             const args: Slice = s.absolute(self.dim(a));
             start_indices[a] = args.start;
@@ -1928,8 +2006,8 @@ pub const Tensor = struct {
 
         var res = _result(res_shape, slice_op.result(0));
         var to_remove: Shape.AxesArray = .empty;
-        for (slices, 0..) |s, a| {
-            if (s.singleton) to_remove.appendAssumeCapacity(@intCast(a));
+        for (axes_, slices_) |a, s| {
+            if (s.singleton) to_remove.appendAssumeCapacity(a);
         }
         return res.reshape(res_shape.removeMany(to_remove.constSlice()));
     }
@@ -1943,10 +2021,11 @@ pub const Tensor = struct {
         var x_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, x.shape(), .replicated, std.mem.sliceAsBytes(&[_]f32{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }));
         defer x_buffer.deinit();
 
-        // Wrap slice1d to hide the anytype in the signature.
+        // Wrap slice to hide the anytype in the signature.
+        // TODO(wzk): stdx.meta.specifyFn (waiting 0.17 for SoA meta programming)
         const Local = struct {
-            pub fn _slice1dAxis(input: Tensor, ax: i8, slice_: Tensor.Slice) Tensor {
-                return input.slice1d(ax, slice_);
+            fn _slice1dAxis(input: Tensor, ax: i8, slice_: Tensor.Slice) Tensor {
+                return input.slice(ax, slice_);
             }
         };
 
@@ -1966,7 +2045,40 @@ pub const Tensor = struct {
             );
             defer exe.deinit();
 
-            var res = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Local._slice1dAxis, .{x_buffer});
+            var res = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Local._slice1dAxis, .{ x_buffer, .{} });
+            defer res.deinit();
+
+            try std.testing.expectEqual(expectation, try res.getValue(@TypeOf(expectation), std.testing.io));
+        }
+    }
+
+    test "dynamic slices" {
+        const zml = @import("zml.zig");
+        const platform = zml.testing.env();
+
+        const Local = struct {
+            fn dynSliceResolved(x: Tensor, ax: ResolvedAxis, dyn_slice: Slice) Tensor {
+                return x.slice(ax, dyn_slice);
+            }
+        };
+
+        inline for (.{
+            .{ [10]f32{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }, Shape.init(.{10}, .f32), [2]f32{ 4, 5 }, 4, 0 },
+            .{ [2][5]f32{ .{ 0, 1, 2, 3, 4 }, .{ 5, 6, 7, 8, 9 } }, Shape.init(.{ 2, 5 }, .f32), [4]f32{ 3, 4, 8, 9 }, 3, 1 },
+        }) |testcase| {
+            const x_data, const x_shape, const expectation, const z_value: i32, const ax = testcase;
+            const x: Tensor = .fromShape(x_shape);
+            const z: Tensor = .init(.{}, .i32);
+
+            var exe = try zml.module.compile(std.testing.allocator, std.testing.io, Local.dynSliceResolved, .{ x, ax, .dyn(z, 2) }, platform, .{});
+            defer exe.deinit();
+
+            var x_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, x.shape(), .replicated, std.mem.sliceAsBytes(&x_data));
+            defer x_buffer.deinit();
+            var z_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, z.shape(), .replicated, std.mem.asBytes(&z_value));
+            defer z_buffer.deinit();
+
+            var res = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Local.dynSliceResolved, .{ x_buffer, .{ .dyn_start = z_buffer } });
             defer res.deinit();
 
             try std.testing.expectEqual(expectation, try res.getValue(@TypeOf(expectation), std.testing.io));
@@ -1978,17 +2090,17 @@ pub const Tensor = struct {
     }
 
     pub fn choose1d(self: Tensor, axis_: anytype, i: i64) Tensor {
-        return self.slice1d(axis_, .single(i));
+        return self.slice(axis_, .single(i));
     }
 
     pub fn choose(self: Tensor, offsets: anytype) Tensor {
         const off, const tags = Shape.parseDimensions(offsets);
-        var slices: [constants.MAX_RANK]Slice = @splat(.full);
+        var singleton_slices: [constants.MAX_RANK]Slice = @splat(.full);
         for (off.constSlice(), tags.constSlice()) |o, t| {
             const ax = self.axis(t);
-            slices[ax] = .single(o);
+            singleton_slices[ax] = .single(o);
         }
-        return self.slice(slices[0..self.rank()]);
+        return self.slices(singleton_slices[0..self.rank()]);
     }
 
     /// Concatenates the input Tensors along the given axis.
@@ -3443,8 +3555,8 @@ pub const Tensor = struct {
             },
             .cpu, .cuda, .rocm, .tpu, .oneapi, .metal => blk: {
                 var sorted = self.sort(a, .{ .descending = opts.descending });
-                sorted.values = sorted.values.slice1d(a, .{ .end = k });
-                sorted.indices = sorted.indices.slice1d(a, .{ .end = k });
+                sorted.values = sorted.values.slice(a, .{ .end = k });
+                sorted.indices = sorted.indices.slice(a, .{ .end = k });
                 break :blk sorted;
             },
         };
@@ -3555,7 +3667,7 @@ pub const Tensor = struct {
         var chunks: [n_chunks]Tensor = undefined;
         for (0..n_chunks) |i| {
             const start: i64 = @as(i64, @intCast(i)) * chunk_size;
-            chunks[i] = self.slice1d(a, .{ .start = start, .end = start + chunk_size });
+            chunks[i] = self.slice(a, .{ .start = start, .end = start + chunk_size });
         }
         return chunks;
     }
@@ -3608,7 +3720,7 @@ pub const Tensor = struct {
 
         for (0.., chunks) |i, *chunk| {
             const start: i64 = @as(i64, @intCast(i)) * chunk_size;
-            chunk.* = self.slice1d(a, .{ .start = start, .end = @min(start + chunk_size, d) });
+            chunk.* = self.slice(a, .{ .start = start, .end = @min(start + chunk_size, d) });
         }
         return chunks;
     }
@@ -3665,7 +3777,7 @@ pub const Tensor = struct {
 
         var start: i64 = 0;
         for (split_sizes, 0..) |n, i| {
-            res[i] = self.slice1d(a, .{ .start = start, .end = start + n });
+            res[i] = self.slice(a, .{ .start = start, .end = start + n });
             start += n;
         }
         return res;
@@ -3712,156 +3824,6 @@ pub const Tensor = struct {
             inline for (expectation, 0..) |expected, i| {
                 try std.testing.expectEqual(expected, try res[i].getValue(@TypeOf(expected), std.testing.io));
             }
-        }
-    }
-
-    pub const DynSlice = struct { start: Tensor, len: i64 };
-
-    /// Slices the input Tensor along a specific axis, with a start offset known at runtime.
-    pub fn dynamicSlice1d(self: Tensor, axis_: anytype, slice_: DynSlice) Tensor {
-        return self.slice2(axis_, .{ .start = .{ .dynamic = slice_.start }, .len = slice_.len });
-    }
-
-    pub fn slice2(self: Tensor, axis_: anytype, slice_: DynSlice2) Tensor {
-        return self.slices2(@as([]const ResolvedAxis, &.{self.axis(axis_)}), &.{slice_});
-    }
-
-    /// The fact that slices_ is now typed make for slightly less akward calls.
-    pub fn slices2(self: Tensor, axes_: anytype, slices_: []const DynSlice2) Tensor {
-        if (@TypeOf(axes_) != []const ResolvedAxis) return self.slices2(self._shape.parseAxes(axes_)[0].slice(), slices_);
-
-        const zero = scalar(0, .i64).value();
-        var start_indices: [constants.MAX_RANK]*const mlir.Value = @splat(zero);
-        var new_shape: Shape = self._shape;
-
-        for (axes_, slices_) |a, s| {
-            new_shape._dims.buffer[a] = s.len;
-            start_indices[a] = switch (s.start) {
-                .dynamic => |dyn| dyn.convert(.i64).value(),
-                .fixed => |fixed| scalar(fixed, .i64).value(),
-            };
-        }
-
-        const op = dialects.stablehlo.dynamic_slice(
-            mlirCtx(),
-            self.value(),
-            new_shape.dims(),
-            start_indices[0..self.rank()],
-            .unknown(mlirCtx()),
-        ).appendTo(currentBlock());
-
-        const res = _result(new_shape, op.result(0));
-        for (axes_, slices_) |a, s| {
-            if (s.singleton) new_shape = new_shape.drop(a);
-        }
-        return res.reshape(new_shape);
-    }
-
-    pub const DynSlice2 = struct {
-        start: union(enum) { dynamic: Tensor, fixed: i64 },
-        len: i64,
-        singleton: bool = false,
-
-        pub fn dyn(start: Tensor, len: i64) DynSlice2 {
-            stdx.debug.assert(start.rank() == 0, "DynSlice2.dyn expects scalar input, got {f}", .{start});
-            return .{ .start = .{ .dynamic = start }, .len = len };
-        }
-
-        pub fn single(start: Tensor) DynSlice2 {
-            stdx.debug.assert(start.rank() == 0, "DynSlice2.single expects scalar input, got {f}", .{start});
-            return .{ .start = .{ .dynamic = start }, .len = 1, .singleton = true };
-        }
-
-        pub fn static(start: i64, len: i64) DynSlice2 {
-            return .{ .start = .{ .fixed = start }, .len = len };
-        }
-
-        pub fn singleStatic(start: i64) DynSlice2 {
-            return .{ .start = .{ .fixed = start }, .len = 1, .singleton = true };
-        }
-    };
-
-    /// Slices a Tensor across many axes, with runtime known offsets.
-    ///
-    /// Due to the nature of stablehlo, the length of the slices need to be known when compiling the IR.
-    /// When using the tagged API it is allowed to not specify some axes.
-    /// But with the non-tagged API all slices need to be specified.
-    /// Examples:
-    /// ```
-    /// Tensor(.{.a=20,.b=30,.c=40 }).dynamicSlice(.{ .a = .{ .start = a_off, .len = 11});
-    /// Tensor(.{.a=20,.b=30,.c=40 }).dynamicSlice(.{
-    ///     .a = .{ .start = a_off, .len = 11 },
-    ///     .b = .{ .start = b_off, .len = 12 },
-    ///   });
-    /// Tensor(.{ 20,30,40}).dynamicSlice(.{.{ .start = scalar(0, .i32), .len = 20 }, .{ .start = b_off, .len = 12 }, .{ .start = scalar(0, .i32), .len = 40 }});
-    /// ```
-    pub fn dynamicSlice(self: Tensor, slices_: anytype) Tensor {
-        // TODO: the untagged api is a bit verbose. Should I allow: `Tensor(.{ 20,30,40}).dynamicSlice(.{.{}, .{ .start = b_off, .len = 12 }, .{}});` ??
-        //
-        const slices, const slices_tags = Shape.parseStruct(DynSlice, slices_);
-
-        // TODO use slices and slices_tags for the format.
-        // Currently this prints: "dynSlice(struct{q: struct{start: tensor.Tensor, comptime len: comptime_int = 1}}{ .q = struct{start: tensor.Tensor, comptime len: comptime_int = 1}{ .start = Tensor({1,10}, dtype=.i64), .len = 1 } })"
-        // which is kinda ugly.
-
-        const idx_dtype = if (slices.len > 0) slices.get(0).start.dtype() else .i32;
-        const zero = Tensor.scalar(0, idx_dtype).value();
-        var offset_values: [constants.MAX_RANK]*const mlir.Value = @splat(zero);
-        var res_shape = self._shape;
-        for (slices.constSlice(), 0..) |slice_, i| {
-            const offset = slice_.start;
-            const len = slice_.len;
-            if (slices_tags.len == 0) {
-                stdx.debug.assert(self.rank() == slices.len, "dynamicSlice expects tensor rank and 'slices_' length to be equal, got {d} and {d}", .{ self.rank(), slices.len });
-
-                offset_values[i] = offset.value();
-                res_shape._dims.set(i, len);
-
-                stdx.debug.assert(len <= self.dim(i), "dynamicSlice expects slices 'len' to be less than or equal to their corresponding dimension in input tensor, got {d} and {d} for index {d}", .{ len, self.dim(i), i });
-            } else {
-                const t = slices_tags.get(i);
-                const a = res_shape.hasTag(t) orelse stdx.debug.panic("dynamicSlice expects input tensor to have tags used in 'slices_' but {s} is missing (input shape is {f})", .{ t, self._shape });
-
-                stdx.debug.assert(len <= self.dim(a), "dynamicSlice expects slices 'len' to be less than their corresponding dimension in input tensor, got {d} and {d} for axis {s}", .{ len, self.dim(a), t });
-
-                offset_values[a] = offset.value();
-                res_shape._dims.set(a, len);
-            }
-        }
-        const op = dialects.stablehlo.dynamic_slice(mlirCtx(), self.value(), res_shape.dims(), offset_values[0..self.rank()], .unknown(mlirCtx())).appendTo(currentBlock());
-        return _result(res_shape, op.result(0));
-    }
-
-    test dynamicSlice {
-        const zml = @import("zml.zig");
-        const platform = zml.testing.env();
-
-        const Local = struct {
-            fn dynSliceResolved(x: Tensor, ax: ResolvedAxis, dyn_slice: DynSlice) Tensor {
-                return x.dynamicSlice1d(ax, dyn_slice);
-            }
-        };
-
-        inline for (.{
-            .{ [10]f32{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }, Shape.init(.{10}, .f32), [2]f32{ 4, 5 }, 4, 0 },
-            .{ [2][5]f32{ .{ 0, 1, 2, 3, 4 }, .{ 5, 6, 7, 8, 9 } }, Shape.init(.{ 2, 5 }, .f32), [4]f32{ 3, 4, 8, 9 }, 3, 1 },
-        }) |testcase| {
-            const x_data, const x_shape, const expectation, const z_value: i32, const ax = testcase;
-            const x: Tensor = .fromShape(x_shape);
-            const z: Tensor = .init(.{}, .i32);
-
-            var exe = try zml.module.compile(std.testing.allocator, std.testing.io, Local.dynSliceResolved, .{ x, ax, .{ .len = 2, .start = z } }, platform, .{});
-            defer exe.deinit();
-
-            var x_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, x.shape(), .replicated, std.mem.sliceAsBytes(&x_data));
-            defer x_buffer.deinit();
-            var z_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, z.shape(), .replicated, std.mem.asBytes(&z_value));
-            defer z_buffer.deinit();
-
-            var res = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Local.dynSliceResolved, .{ x_buffer, .{ .start = z_buffer } });
-            defer res.deinit();
-
-            try std.testing.expectEqual(expectation, try res.getValue(@TypeOf(expectation), std.testing.io));
         }
     }
 
@@ -4445,8 +4407,8 @@ pub const Tensor = struct {
         const k = @mod(shift, n); // normalize shift to [0, n)
         if (k == 0) return self;
         return Tensor.concatenate(&.{
-            self.slice1d(a, .{ .start = n - k, .end = n }),
-            self.slice1d(a, .{ .start = 0, .end = n - k }),
+            self.slice(a, .{ .start = n - k, .end = n }),
+            self.slice(a, .{ .start = 0, .end = n - k }),
         }, a);
     }
 

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -2089,20 +2089,6 @@ pub const Tensor = struct {
         return if (idx < 0) self.dim(axis_) + idx else idx;
     }
 
-    pub fn choose1d(self: Tensor, axis_: anytype, i: i64) Tensor {
-        return self.slice(axis_, .single(i));
-    }
-
-    pub fn choose(self: Tensor, offsets: anytype) Tensor {
-        const off, const tags = Shape.parseDimensions(offsets);
-        var singleton_slices: [constants.MAX_RANK]Slice = @splat(.full);
-        for (off.constSlice(), tags.constSlice()) |o, t| {
-            const ax = self.axis(t);
-            singleton_slices[ax] = .single(o);
-        }
-        return self.slices(singleton_slices[0..self.rank()]);
-    }
-
     /// Concatenates the input Tensors along the given axis.
     pub fn concatenate(tensors: []const Tensor, axis_: anytype) Tensor {
         if (tensors.len == 1) return tensors[0];
@@ -3125,7 +3111,7 @@ pub const Tensor = struct {
 
             pub fn _scatterCB(self: Tensor, coords: Tensor, updates: Tensor) Tensor {
                 return self.scatterSlices(
-                    .{ .c = coords.choose1d(.coord, 0), .b = coords.choose1d(.coord, 1) },
+                    .{ .c = coords.slice(.coord, .single(0)), .b = coords.slice(.coord, .single(1)) },
                     updates,
                     .{ .update_fn = ScatterOpts.increment },
                 );

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -30,6 +30,8 @@ pub const Tensor = struct {
     _shape: Shape,
     _value: ?*const mlir.Value = null,
 
+    const ResolvedAxis = u3;
+
     pub fn init(shape_like: anytype, dt: DataType) Tensor {
         return .fromShape(.init(shape_like, dt));
     }
@@ -120,14 +122,14 @@ pub const Tensor = struct {
     /// Returns the index of axis 'axis_'.
     ///
     /// 'axis_' can be an integer or a tag.
-    pub fn axis(self: Tensor, axis_: anytype) u3 {
+    pub fn axis(self: Tensor, axis_: anytype) ResolvedAxis {
         return self._shape.axis(axis_);
     }
 
     /// Returns the indices of each of the given axes.
     ///
     /// 'axis_' can be an integer or a tag.
-    pub fn axes(self: Tensor, axes_: anytype) stdx.BoundedArray(u3, constants.MAX_RANK) {
+    pub fn axes(self: Tensor, axes_: anytype) stdx.BoundedArray(ResolvedAxis, constants.MAX_RANK) {
         return self._shape.axes(axes_);
     }
 
@@ -1850,7 +1852,7 @@ pub const Tensor = struct {
         step: i32 = 1,
         singleton: bool = false,
 
-        const full = .{ .start = 0, .end = to_the_end, .step = 1 };
+        const full: Slice = .{ .start = 0, .end = to_the_end, .step = 1 };
 
         pub fn single(offset: i64) Slice {
             return .{ .start = offset, .end = offset + 1, .singleton = true };
@@ -1858,7 +1860,14 @@ pub const Tensor = struct {
 
         pub fn absolute(s: Slice, d: i64) Slice {
             const start = if (s.start < 0) d + s.start else s.start;
-            const end = if (s.end == to_the_end) d else if (s.end < 0) d + s.end else s.end;
+            const end = if (s.singleton)
+                start + 1
+            else if (s.end == to_the_end)
+                d
+            else if (s.end < 0)
+                d + s.end
+            else
+                s.end;
             const res: Slice = .{ .start = start, .end = end, .step = s.step, .singleton = s.singleton };
             stdx.debug.assert(start < end, "Slice {f} is invalid for axis of dimension {d} (resolved to {f})", .{ s, d, res });
             stdx.debug.assert(end <= d, "Slice {f} is invalid for axis of dimension {d} (resolved to {f})", .{ s, d, res });
@@ -1868,9 +1877,10 @@ pub const Tensor = struct {
         const to_the_end = std.math.maxInt(i64);
 
         pub fn format(self: Slice, writer: *std.Io.Writer) !void {
-            if (self.singleton) {
-                try writer.print("[{d}]", .{self.start});
-            } else if (self.end == to_the_end and self.step == 1) {
+            // if (self.singleton) {
+            //     try writer.print("[{d}]", .{self.start});
+            // } else
+            if (self.end == to_the_end and self.step == 1) {
                 try writer.print("[{d}..]", .{self.start});
             } else if (self.step == 1) {
                 try writer.print("[{d}..{d}]", .{ self.start, self.end });
@@ -1973,7 +1983,7 @@ pub const Tensor = struct {
 
     pub fn choose(self: Tensor, offsets: anytype) Tensor {
         const off, const tags = Shape.parseDimensions(offsets);
-        var slices: [constants.MAX_RANK]Slice = @splat(.{});
+        var slices: [constants.MAX_RANK]Slice = @splat(.full);
         for (off.constSlice(), tags.constSlice()) |o, t| {
             const ax = self.axis(t);
             slices[ax] = .single(o);
@@ -3705,17 +3715,32 @@ pub const Tensor = struct {
         }
     }
 
+    pub const DynSlice = struct { start: Tensor, len: i64 };
+
     /// Slices the input Tensor along a specific axis, with a start offset known at runtime.
-    /// Note: this doesn't support tagging, if you have tags,
-    /// you should use `dynamicSlice` directly.
-    pub fn dynamicSlice1d(self: Tensor, axis_: i8, slice_: DynSlice) Tensor {
-        stdx.debug.assert(slice_.start.rank() == 0, "dynamicSlice1d expects 'slice_.start' tensor rank to be a scalar, got {f}", .{slice_.start});
+    pub fn dynamicSlice1d(self: Tensor, axis_: anytype, slice_: DynSlice) Tensor {
+        return self.slice2(axis_, .{ .start = .{ .dynamic = slice_.start }, .len = slice_.len });
+    }
 
-        const a = self.axis(axis_);
-        const new_shape = self._shape.set(a, slice_.len);
+    pub fn slice2(self: Tensor, axis_: anytype, slice_: DynSlice2) Tensor {
+        return self.slices2(@as([]const ResolvedAxis, &.{self.axis(axis_)}), &.{slice_});
+    }
 
-        var start_indices: [constants.MAX_RANK]*const mlir.Value = @splat(constant(slice_.start.dtype().zero()).value());
-        start_indices[a] = slice_.start.value();
+    /// The fact that slices_ is now typed make for slightly less akward calls.
+    pub fn slices2(self: Tensor, axes_: anytype, slices_: []const DynSlice2) Tensor {
+        if (@TypeOf(axes_) != []const ResolvedAxis) return self.slices2(self._shape.parseAxes(axes_)[0].slice(), slices_);
+
+        const zero = scalar(0, .i64).value();
+        var start_indices: [constants.MAX_RANK]*const mlir.Value = @splat(zero);
+        var new_shape: Shape = self._shape;
+
+        for (axes_, slices_) |a, s| {
+            new_shape._dims.buffer[a] = s.len;
+            start_indices[a] = switch (s.start) {
+                .dynamic => |dyn| dyn.convert(.i64).value(),
+                .fixed => |fixed| scalar(fixed, .i64).value(),
+            };
+        }
 
         const op = dialects.stablehlo.dynamic_slice(
             mlirCtx(),
@@ -3725,10 +3750,36 @@ pub const Tensor = struct {
             .unknown(mlirCtx()),
         ).appendTo(currentBlock());
 
-        return _result(new_shape, op.result(0));
+        const res = _result(new_shape, op.result(0));
+        for (axes_, slices_) |a, s| {
+            if (s.singleton) new_shape = new_shape.drop(a);
+        }
+        return res.reshape(new_shape);
     }
 
-    pub const DynSlice = struct { start: Tensor, len: i64 };
+    pub const DynSlice2 = struct {
+        start: union(enum) { dynamic: Tensor, fixed: i64 },
+        len: i64,
+        singleton: bool = false,
+
+        pub fn dyn(start: Tensor, len: i64) DynSlice2 {
+            stdx.debug.assert(start.rank() == 0, "DynSlice2.dyn expects scalar input, got {f}", .{start});
+            return .{ .start = .{ .dynamic = start }, .len = len };
+        }
+
+        pub fn single(start: Tensor) DynSlice2 {
+            stdx.debug.assert(start.rank() == 0, "DynSlice2.single expects scalar input, got {f}", .{start});
+            return .{ .start = .{ .dynamic = start }, .len = 1, .singleton = true };
+        }
+
+        pub fn static(start: i64, len: i64) DynSlice2 {
+            return .{ .start = .{ .fixed = start }, .len = len };
+        }
+
+        pub fn singleStatic(start: i64) DynSlice2 {
+            return .{ .start = .{ .fixed = start }, .len = 1, .singleton = true };
+        }
+    };
 
     /// Slices a Tensor across many axes, with runtime known offsets.
     ///
@@ -3785,6 +3836,12 @@ pub const Tensor = struct {
         const zml = @import("zml.zig");
         const platform = zml.testing.env();
 
+        const Local = struct {
+            fn dynSliceResolved(x: Tensor, ax: ResolvedAxis, dyn_slice: DynSlice) Tensor {
+                return x.dynamicSlice1d(ax, dyn_slice);
+            }
+        };
+
         inline for (.{
             .{ [10]f32{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }, Shape.init(.{10}, .f32), [2]f32{ 4, 5 }, 4, 0 },
             .{ [2][5]f32{ .{ 0, 1, 2, 3, 4 }, .{ 5, 6, 7, 8, 9 } }, Shape.init(.{ 2, 5 }, .f32), [4]f32{ 3, 4, 8, 9 }, 3, 1 },
@@ -3793,7 +3850,7 @@ pub const Tensor = struct {
             const x: Tensor = .fromShape(x_shape);
             const z: Tensor = .init(.{}, .i32);
 
-            var exe = try zml.module.compile(std.testing.allocator, std.testing.io, Tensor.dynamicSlice1d, .{ x, ax, .{ .len = 2, .start = z } }, platform, .{});
+            var exe = try zml.module.compile(std.testing.allocator, std.testing.io, Local.dynSliceResolved, .{ x, ax, .{ .len = 2, .start = z } }, platform, .{});
             defer exe.deinit();
 
             var x_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, x.shape(), .replicated, std.mem.sliceAsBytes(&x_data));
@@ -3801,7 +3858,7 @@ pub const Tensor = struct {
             var z_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, z.shape(), .replicated, std.mem.asBytes(&z_value));
             defer z_buffer.deinit();
 
-            var res = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Tensor.dynamicSlice1d, .{ x_buffer, .{ .start = z_buffer } });
+            var res = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Local.dynSliceResolved, .{ x_buffer, .{ .start = z_buffer } });
             defer res.deinit();
 
             try std.testing.expectEqual(expectation, try res.getValue(@TypeOf(expectation), std.testing.io));


### PR DESCRIPTION
## Overview

* merge `dynamicSlice` and `slice` into `slices`
* merge `dynamicSlice1d` and `slice1d` into `slice` 
* drop `choose`, `choose1d`
* handle singleton for dynamic slices too
* typed API so that it's easier to specify arguments

## Migration guide:

```diff
// new .slice accepts all old .slice1d inputs 
- const x1 = x.slice1d(-1, .{ .start = 0, .end = half_dim });
+ const x1 = x.slice(-1, .{ .start = 0, .end = half_dim });

- k.dynamicSlice(.{ .layer = zml.Tensor.DynSlice{ .start = cache_index, .len = 1 } }).squeeze(.layer);
+ k.slice(.layer, .dynSingle(cache_index));

- k.dynamicSlice(.{
-    .layer = zml.Tensor.DynSlice{ .start = cache_index, .len = 1 }, 
- }).squeeze(.layer).choose1d(.k, kv_head);
+ k.slice(.{ .layer, .k }, &.{ .dynSingle(cache_index), .single(kv_head) });

- o.choose1d(ax, 5),
+ o.slice(ax, .single(5))
```

Now the `Tensor.Slice` struct is bigger and now as a Tensor in it, which may break user code if your model was storing a `Slice` inside it, because now `zml.Bufferize(Model)` will contain one more `?Buffer`. You can either pass an extra `null` to the `zml.Exe` or refactor to remove `Slice` out of `Model`. I haven't seen this happen so far. The idea is that `Slice` will mostly be a stack only struct, only created to call `slice` 