### PR TITLE
zml: refactor `module.zig` into `Compiler.zig`

### DIFF
--- a/docs/learn/concepts.md
+++ b/docs/learn/concepts.md
@@ -138,7 +138,7 @@ corresponding types.
 5. Load some user inputs (custom struct), encode them into arrays of numbers
    (`zml.Slice`), and copy them to the accelerator (`zml.Buffer`).
 
-6. Call the executable on the user inputs. `module.call` accepts `zml.Buffer`
+6. Call the executable on the user inputs. `exe.call` accepts `zml.Buffer`
    arguments and returns `zml.Buffer`
 
 7. Return the model output (`zml.Buffer`) to the host (`zml.Slice`),

--- a/examples/llm/models/qwen3_5/model.zig
+++ b/examples/llm/models/qwen3_5/model.zig
@@ -639,7 +639,7 @@ pub const SelfAttn = struct {
 
         var q, var gate = self.projectQAndGate(x_qkv);
         var k, var v = self.projectKV(x_qkv);
-        const kv_head_sharding = zml.module.CompilationContext.current().partitioning.shardableDim(
+        const kv_head_sharding = zml.Compiler.current().partitioning.shardableDim(
             k.shape().withPartitioning(.{ .h = .model }),
             .h,
             q.dim(.h),

--- a/examples/llm/models/qwen3_5_moe/model.zig
+++ b/examples/llm/models/qwen3_5_moe/model.zig
@@ -623,7 +623,7 @@ pub const SelfAttn = struct {
         const x_qkv = x.withPartitioning(.{ .d = .replicated });
         var q, var gate = self.projectQAndGate(x_qkv);
         var k, var v = self.projectKV(x_qkv);
-        const kv_head_sharding = zml.module.CompilationContext.current().partitioning.shardableDim(
+        const kv_head_sharding = zml.Compiler.current().partitioning.shardableDim(
             k.shape().withPartitioning(.{ .h = .model }),
             .h,
             q.dim(.h),

--- a/examples/sharding/main.zig
+++ b/examples/sharding/main.zig
@@ -7,7 +7,7 @@ const log = std.log.scoped(.sharding);
 pub const std_options: std.Options = .{
     .log_level = .info,
     .log_scope_levels = &.{
-        .{ .scope = .@"zml/module", .level = .debug },
+        .{ .scope = .@"zml/compiler", .level = .debug },
     },
 };
 

--- a/kernels/mosaic_tpu/README.md
+++ b/kernels/mosaic_tpu/README.md
@@ -20,7 +20,7 @@ Two layers define the surface:
   for the final IR string. Pass `Builder.open` / `Builder.init` a
   `zml.kernel.mosaic_tpu.newContext()` (a throwaway context with the dialects
   the DSL emits), `defer ctx.deinit()` once you have the string — not a
-  `CompilationContext`'s `mlir_ctx`. (`Builder.buildOpts(...)` is a convenience
+  `Compilation`'s `mlir_ctx`. (`Builder.buildOpts(...)` is a convenience
   that bundles `open + declareArgs` into one call and returns a heap-allocated
   `*Built(Spec)`; reach for it in escape-hatch code that drives the lifecycle manually.)
 - **High layer** — `zml.kernel.mosaic_tpu.Kernel(Config, spec)`: the

--- a/kernels/mosaic_tpu/builder.zig
+++ b/kernels/mosaic_tpu/builder.zig
@@ -2209,7 +2209,7 @@ pub const Builder = struct {
             defer pm.deinit();
             // `canonicalize` folds `x * 1`, `x + 0`, etc.; `cse` then
             // dedupes identical constants and subexpressions. Same
-            // pipeline `zml/module.zig` runs on every compiled module.
+            // pipeline `zml/Compiler.zig` runs on every compiled module.
             const opm = pm.asOpPassManager();
             inline for (.{ "canonicalize", "cse", "canonicalize" }) |pass| {
                 try opm.addPipeline(pass);

--- a/kernels/triton/README.md
+++ b/kernels/triton/README.md
@@ -196,7 +196,7 @@ pub fn forward(self: Model, x: zml.Tensor, y: zml.Tensor) zml.Tensor {
 
 `call` is a thin wrapper over `Kernel.emit(...)` + `zml.ops.triton(...)`.
 It must be called from inside a `Compilation` (i.e., during
-`zml.module.compile(...)`) — `emit` builds the TTIR string in its own
+`zml.Compiler.compile(...)`) — `emit` builds the TTIR string in its own
 throwaway context; `zml.ops.triton(...)` drops the `stablehlo.custom_call`
 into the model's context. For offline tools, `Kernel.emit(allocator, cfg)`
 gives you just the TTIR string.

--- a/kernels/triton/README.md
+++ b/kernels/triton/README.md
@@ -13,7 +13,7 @@ Two layers define the surface:
   `Builder.open` / `Builder.init` take an `*mlir.Context` — pass them a
   `zml.kernel.triton.newContext()` (a throwaway context with the dialects the
   DSL emits), `defer ctx.deinit()` once you have the IR string. Not a
-  `CompilationContext`'s `mlir_ctx`: that one carries only `func`/`stablehlo`/`sdy`
+  `Compilation`'s `mlir_ctx`: that one carries only `func`/`stablehlo`/`sdy`
   (a registered `llvm` dialect makes XLA:TPU choke).
 - **High layer** — `zml.kernel.triton.Kernel(Config, spec)`: the declarative
   kernel form. Bundles a config type, a typed spec literal (name + named
@@ -195,7 +195,7 @@ pub fn forward(self: Model, x: zml.Tensor, y: zml.Tensor) zml.Tensor {
 ```
 
 `call` is a thin wrapper over `Kernel.emit(...)` + `zml.ops.triton(...)`.
-It must be called from inside a `CompilationContext` (i.e., during
+It must be called from inside a `Compilation` (i.e., during
 `zml.module.compile(...)`) — `emit` builds the TTIR string in its own
 throwaway context; `zml.ops.triton(...)` drops the `stablehlo.custom_call`
 into the model's context. For offline tools, `Kernel.emit(allocator, cfg)`
@@ -1010,7 +1010,7 @@ builder and call `b.declareArgs(spec)` mid-stream — that's exactly what
 `zml.kernel.triton.Kernel(...)` does internally.
 
 Pass these constructors a `zml.kernel.triton.newContext()`, not a
-`CompilationContext`'s `mlir_ctx`; `defer ctx.deinit()` once you have the IR
+`Compilation`'s `mlir_ctx`; `defer ctx.deinit()` once you have the IR
 string. `Kernel.emit` does this for you, which is why it takes no context.
 
 Prefer `zml.kernel.triton.Kernel(Config, spec)` for the common case.

--- a/kernels/triton/README.md
+++ b/kernels/triton/README.md
@@ -13,7 +13,7 @@ Two layers define the surface:
   `Builder.open` / `Builder.init` take an `*mlir.Context` — pass them a
   `zml.kernel.triton.newContext()` (a throwaway context with the dialects the
   DSL emits), `defer ctx.deinit()` once you have the IR string. Not a
-  `Compilation`'s `mlir_ctx`: that one carries only `func`/`stablehlo`/`sdy`
+  `zml.Compiler`'s `mlir_ctx`: that one carries only `func`/`stablehlo`/`sdy`
   (a registered `llvm` dialect makes XLA:TPU choke).
 - **High layer** — `zml.kernel.triton.Kernel(Config, spec)`: the declarative
   kernel form. Bundles a config type, a typed spec literal (name + named

--- a/zml/BUILD.bazel
+++ b/zml/BUILD.bazel
@@ -99,7 +99,7 @@ zig_library(
         "mem.zig",
         "meta.zig",
         "mlirx.zig",
-        "module.zig",
+        "Compiler.zig",
         "moe/cutlass_flashinfer.zig",
         "moe/metal.zig",
         "moe/moe.zig",

--- a/zml/Compiler.zig
+++ b/zml/Compiler.zig
@@ -22,9 +22,29 @@ const Sharding = @import("Sharding.zig");
 const Partitioning = Sharding.Partitioning;
 const Tensor = @import("tensor.zig").Tensor;
 
-const zml_module = @This();
-const log = std.log.scoped(.@"zml/module");
+const Compiler = @This();
+const log = std.log.scoped(.@"zml/compiler");
 
+allocator: std.mem.Allocator,
+io: std.Io,
+arena: std.heap.ArenaAllocator,
+
+mlir_registry: *mlir.DialectRegistry,
+mlir_ctx: *mlir.Context,
+mlir_pass_manager: *mlir.PassManager,
+module: *mlir.Module,
+platform: *const Platform,
+partitioning: Sharding.Partitioning,
+
+mlir_known_types: std.enums.EnumArray(DataType, *const mlir.Type),
+
+scopes: stdx.BoundedArray(Scope, 16) = .empty,
+manual_computation_depth: usize = 0,
+
+channel_id: i64 = 0,
+composite_id: i64 = 0,
+
+threadlocal var _current: ?*Compiler = null;
 var mlir_global_init_mutex: std.Io.Mutex = .init;
 var mlir_global_registry: ?*mlir.DialectRegistry = null;
 
@@ -46,7 +66,8 @@ fn mlirRegistry(io: std.Io) *mlir.DialectRegistry {
 
     return mlir_global_registry.?;
 }
-pub const CompilationOptions = struct {
+
+pub const Options = struct {
     shardings: []const Sharding = &.{},
     // If null, will be initialized from the target
     partitioner: ?Sharding.Partitioner = null,
@@ -59,7 +80,7 @@ pub const CompilationOptions = struct {
 };
 
 /// Errors surfaced while lowering and compiling a ZML program.
-pub const CompileError = std.mem.Allocator.Error ||
+pub const Error = std.mem.Allocator.Error ||
     std.Io.Writer.Error ||
     mlir.Error ||
     upb.SerializeError ||
@@ -68,199 +89,175 @@ pub const CompileError = std.mem.Allocator.Error ||
 
 const AttributeList = stdx.BoundedArray(mlir.NamedAttribute, 3);
 
-pub const CompilationContext = struct {
-    pub const Scope = struct {
-        block: *mlir.Block,
-        id_to_argument: std.AutoArrayHashMapUnmanaged(usize, usize),
-        id_to_donation: std.AutoArrayHashMapUnmanaged(usize, usize),
-        id_to_output_memory_kind: std.AutoArrayHashMapUnmanaged(usize, Memory.Kind),
-        id_to_input_memory_kind: std.AutoArrayHashMapUnmanaged(usize, Memory.Kind),
-        arena: std.heap.ArenaAllocator,
-
-        pub fn initFromBlock(allocator: std.mem.Allocator, block: *mlir.Block) Scope {
-            const arena: std.heap.ArenaAllocator = .init(allocator);
-            return .{
-                .block = block,
-                .id_to_argument = .empty,
-                .id_to_donation = .empty,
-                .id_to_output_memory_kind = .empty,
-                .id_to_input_memory_kind = .empty,
-                .arena = arena,
-            };
-        }
-
-        pub fn deinit(self: *Scope) void {
-            self.arena.deinit();
-        }
-    };
-
-    allocator: std.mem.Allocator,
-    io: std.Io,
+pub const Scope = struct {
+    block: *mlir.Block,
+    id_to_argument: std.AutoArrayHashMapUnmanaged(usize, usize),
+    id_to_donation: std.AutoArrayHashMapUnmanaged(usize, usize),
+    id_to_output_memory_kind: std.AutoArrayHashMapUnmanaged(usize, Memory.Kind),
+    id_to_input_memory_kind: std.AutoArrayHashMapUnmanaged(usize, Memory.Kind),
     arena: std.heap.ArenaAllocator,
 
-    mlir_registry: *mlir.DialectRegistry,
-    mlir_ctx: *mlir.Context,
-    mlir_pass_manager: *mlir.PassManager,
-    module: *mlir.Module,
-    platform: *const Platform,
-    partitioning: Sharding.Partitioning,
-
-    mlir_known_types: std.enums.EnumArray(DataType, *const mlir.Type),
-
-    scopes: stdx.BoundedArray(Scope, 16) = .empty,
-    manual_computation_depth: usize = 0,
-
-    channel_id: i64 = 0,
-
-    composite_id: i64 = 0,
-
-    threadlocal var _current: ?*CompilationContext = null;
-
-    pub fn init(allocator: std.mem.Allocator, io: std.Io, platform: *const Platform, opts: CompilationOptions) CompilationContext {
-        var arena = std.heap.ArenaAllocator.init(allocator);
-        const mlir_registry = mlirRegistry(io);
-        var mlir_ctx = mlir.Context.init(.{ .registry = mlir_registry, .threading = false }) catch unreachable;
-        mlir_ctx.loadAllAvailableDialects();
-
-        const module = mlir.Module.init(.unknown(mlir_ctx));
-        module.operation().setAttributeByName("sym_name", .string(mlir_ctx, opts.program_name));
-
-        const pass_manager = mlir.PassManager.init(mlir_ctx);
-        {
-            var opm = pass_manager.asOpPassManager();
-            const passes: []const []const u8 = &.{
-                "canonicalize",
-                "cse",
-                "canonicalize",
-            };
-            for (passes) |pass| {
-                opm.addPipeline(pass) catch unreachable;
-            }
-        }
-
-        var mlir_known_types: std.enums.EnumArray(DataType, *const mlir.Type) = .initUndefined();
-        {
-            for (0.., &mlir_known_types.values) |i, *mlir_type| {
-                mlir_type.* = mlirx.Type.fromDType(mlir_ctx, @enumFromInt(i));
-            }
-        }
-
-        // Ensure replicated sharding is always included as a fallback option.
-        var shardings = std.ArrayList(Sharding).initCapacity(arena.allocator(), opts.shardings.len + 1) catch @panic("OOM");
-        var needs_replicated: bool = true;
-        for (opts.shardings) |sharding| {
-            if (sharding.data == platform.replicated_sharding.data) needs_replicated = false;
-            shardings.appendAssumeCapacity(sharding.resolve(platform));
-        }
-        if (needs_replicated) shardings.appendAssumeCapacity(platform.replicated_sharding);
-
-        const partitioning = Sharding.Partitioning.init(opts.partitioner orelse .fromTarget(platform.target), shardings.items) catch @panic("OOM");
-
+    pub fn initFromBlock(allocator: std.mem.Allocator, block: *mlir.Block) Scope {
+        const arena: std.heap.ArenaAllocator = .init(allocator);
         return .{
-            .allocator = allocator,
-            .io = io,
+            .block = block,
+            .id_to_argument = .empty,
+            .id_to_donation = .empty,
+            .id_to_output_memory_kind = .empty,
+            .id_to_input_memory_kind = .empty,
             .arena = arena,
-            .mlir_registry = mlir_registry,
-            .mlir_ctx = mlir_ctx,
-            .mlir_pass_manager = pass_manager,
-            .mlir_known_types = mlir_known_types,
-            .module = module,
-            .platform = platform,
-            .partitioning = partitioning,
         };
     }
 
-    pub fn deinit(self: *CompilationContext) void {
-        if (_current == self) _current = null;
-        for (self.scopes.slice()) |*scope| {
-            scope.deinit();
-        }
-        self.mlir_pass_manager.deinit();
-        self.module.deinit();
-        self.mlir_ctx.deinit();
+    pub fn deinit(self: *Scope) void {
         self.arena.deinit();
-    }
-
-    pub fn activate(self: *CompilationContext) void {
-        std.debug.assert(_current == null);
-        _current = self;
-    }
-
-    pub fn deactivate(self: *CompilationContext) void {
-        _ = self;
-        _current = null;
-    }
-
-    pub fn current() *CompilationContext {
-        return _current.?;
-    }
-
-    pub fn currentOrNull() ?*CompilationContext {
-        return _current;
-    }
-
-    pub fn currentScope(self: *CompilationContext) *Scope {
-        return &self.scopes.slice()[self.scopes.len - 1];
-    }
-
-    pub fn pushBlock(self: *CompilationContext, block: *mlir.Block) void {
-        const scope = Scope.initFromBlock(self.allocator, block);
-        self.scopes.appendAssumeCapacity(scope);
-    }
-
-    pub fn popBlock(self: *CompilationContext) void {
-        var maybe_popped_scope = self.scopes.pop();
-        if (maybe_popped_scope) |*popped| {
-            popped.deinit();
-        }
-    }
-
-    pub fn nextChannelId(self: *CompilationContext) i64 {
-        self.channel_id += 1;
-        return self.channel_id;
-    }
-
-    pub fn nextCompositeId(self: *CompilationContext) i64 {
-        self.composite_id += 1;
-        return self.composite_id;
-    }
-
-    pub fn mlirType(self: *const CompilationContext, dt: DataType) *const mlir.Type {
-        return self.mlir_known_types.get(dt);
-    }
-
-    pub fn dtype(self: *const CompilationContext, mlir_type: *const mlir.Type) DataType {
-        @setRuntimeSafety(false);
-        for (0.., &self.mlir_known_types.values) |i, known_type| {
-            if (known_type == mlir_type) return @enumFromInt(i);
-        }
-        std.debug.panic("Can't convert unknown mlir type to dtype: {f}", .{mlir_type});
-    }
-
-    pub fn abortOOM(self: *CompilationContext) noreturn {
-        _ = self;
-        @panic("OOM");
-    }
-
-    pub fn alloc(self: *CompilationContext, T: type, n: usize) []T {
-        return self.arena.allocator().alloc(T, n) catch self.abortOOM();
-    }
-
-    pub fn allocPrint(self: *CompilationContext, comptime fmt: []const u8, args: anytype) []u8 {
-        return std.fmt.allocPrint(self.arena.allocator(), fmt, args) catch self.abortOOM();
     }
 };
 
-pub fn Compiler(comptime func: anytype) type {
+pub fn init(allocator: std.mem.Allocator, io: std.Io, platform: *const Platform, opts: Options) Compiler {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    const mlir_registry = mlirRegistry(io);
+    var mlir_ctx = mlir.Context.init(.{ .registry = mlir_registry, .threading = false }) catch unreachable;
+    mlir_ctx.loadAllAvailableDialects();
+
+    const module = mlir.Module.init(.unknown(mlir_ctx));
+    module.operation().setAttributeByName("sym_name", .string(mlir_ctx, opts.program_name));
+
+    const pass_manager = mlir.PassManager.init(mlir_ctx);
+    {
+        var opm = pass_manager.asOpPassManager();
+        const passes: []const []const u8 = &.{
+            "canonicalize",
+            "cse",
+            "canonicalize",
+        };
+        for (passes) |pass| {
+            opm.addPipeline(pass) catch unreachable;
+        }
+    }
+
+    var mlir_known_types: std.enums.EnumArray(DataType, *const mlir.Type) = .initUndefined();
+    {
+        for (0.., &mlir_known_types.values) |i, *mlir_type| {
+            mlir_type.* = mlirx.Type.fromDType(mlir_ctx, @enumFromInt(i));
+        }
+    }
+
+    // Ensure replicated sharding is always included as a fallback option.
+    var shardings = std.ArrayList(Sharding).initCapacity(arena.allocator(), opts.shardings.len + 1) catch @panic("OOM");
+    var needs_replicated: bool = true;
+    for (opts.shardings) |sharding| {
+        if (sharding.data == platform.replicated_sharding.data) needs_replicated = false;
+        shardings.appendAssumeCapacity(sharding.resolve(platform));
+    }
+    if (needs_replicated) shardings.appendAssumeCapacity(platform.replicated_sharding);
+
+    const partitioning = Sharding.Partitioning.init(opts.partitioner orelse .fromTarget(platform.target), shardings.items) catch @panic("OOM");
+
+    return .{
+        .allocator = allocator,
+        .io = io,
+        .arena = arena,
+        .mlir_registry = mlir_registry,
+        .mlir_ctx = mlir_ctx,
+        .mlir_pass_manager = pass_manager,
+        .mlir_known_types = mlir_known_types,
+        .module = module,
+        .platform = platform,
+        .partitioning = partitioning,
+    };
+}
+
+pub fn deinit(self: *Compiler) void {
+    if (_current == self) _current = null;
+    for (self.scopes.slice()) |*scope| {
+        scope.deinit();
+    }
+    self.mlir_pass_manager.deinit();
+    self.module.deinit();
+    self.mlir_ctx.deinit();
+    self.arena.deinit();
+}
+
+pub fn activate(self: *Compiler) void {
+    std.debug.assert(_current == null);
+    _current = self;
+}
+
+pub fn deactivate(self: *Compiler) void {
+    _ = self;
+    _current = null;
+}
+
+pub fn current() *Compiler {
+    return _current.?;
+}
+
+pub fn currentOrNull() ?*Compiler {
+    return _current;
+}
+
+pub fn currentScope(self: *Compiler) *Scope {
+    return &self.scopes.slice()[self.scopes.len - 1];
+}
+
+pub fn pushBlock(self: *Compiler, block: *mlir.Block) void {
+    const scope = Scope.initFromBlock(self.allocator, block);
+    self.scopes.appendAssumeCapacity(scope);
+}
+
+pub fn popBlock(self: *Compiler) void {
+    var maybe_popped_scope = self.scopes.pop();
+    if (maybe_popped_scope) |*popped| {
+        popped.deinit();
+    }
+}
+
+pub fn nextChannelId(self: *Compiler) i64 {
+    self.channel_id += 1;
+    return self.channel_id;
+}
+
+pub fn nextCompositeId(self: *Compiler) i64 {
+    self.composite_id += 1;
+    return self.composite_id;
+}
+
+pub fn mlirType(self: *const Compiler, dt: DataType) *const mlir.Type {
+    return self.mlir_known_types.get(dt);
+}
+
+pub fn dtype(self: *const Compiler, mlir_type: *const mlir.Type) DataType {
+    @setRuntimeSafety(false);
+    for (0.., &self.mlir_known_types.values) |i, known_type| {
+        if (known_type == mlir_type) return @enumFromInt(i);
+    }
+    std.debug.panic("Can't convert unknown mlir type to dtype: {f}", .{mlir_type});
+}
+
+pub fn abortOOM(self: *Compiler) noreturn {
+    _ = self;
+    @panic("OOM");
+}
+
+pub fn alloc(self: *Compiler, T: type, n: usize) []T {
+    return self.arena.allocator().alloc(T, n) catch self.abortOOM();
+}
+
+pub fn allocPrint(self: *Compiler, comptime fmt: []const u8, args: anytype) []u8 {
+    return std.fmt.allocPrint(self.arena.allocator(), fmt, args) catch self.abortOOM();
+}
+
+pub fn Typed(comptime func: anytype) type {
     return struct {
         pub fn compile(
             allocator: std.mem.Allocator,
             io: std.Io,
             platform: *const Platform,
-            opts: CompilationOptions,
+            opts: Options,
             args: std.meta.ArgsTuple(@TypeOf(func)),
-        ) CompileError!Exe {
-            return zml_module.compile(allocator, io, func, args, platform, opts);
+        ) Error!Exe {
+            return Compiler.compile(allocator, io, func, args, platform, opts);
         }
     };
 }
@@ -271,10 +268,10 @@ pub fn compile(
     comptime func: anytype,
     args: std.meta.ArgsTuple(@TypeOf(func)),
     platform: *const Platform,
-    opts: CompilationOptions,
-) CompileError!Exe {
+    opts: Options,
+) Error!Exe {
     // TODO: Here we have somewhat of a requirement
-    // Emitting MLIR requires to have the compilation context available at all times using `CompilationContext.current()`.
+    // Emitting MLIR requires to have the compiler context available at all times using `Compiler.current()`.
     // If in the future, we inject an Io that is not thread-based, we might have some surprises.
     //
     // I think the correct implementation would be to dispatch `emitMlir` to a thread pool, then wait for the result
@@ -292,36 +289,36 @@ pub fn compile(
     var span = tracer.Span.start(span_name);
     defer span.end();
 
-    var compilation_context: CompilationContext = .init(allocator, st_io.io(), platform, opts);
-    defer compilation_context.deinit();
+    var compiler: Compiler = .init(allocator, st_io.io(), platform, opts);
+    defer compiler.deinit();
 
-    const result = emitMlir(&compilation_context, func, args) catch |err| switch (err) {
+    const result = emitMlir(&compiler, func, args) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         else => unreachable,
     };
-    defer result.output_info.deinit(compilation_context.allocator);
-    defer result.input_info.deinit(compilation_context.allocator);
+    defer result.output_info.deinit(compiler.allocator);
+    defer result.input_info.deinit(compiler.allocator);
 
-    try addPartitionerOperations(&compilation_context);
+    try addPartitionerOperations(&compiler);
 
-    _ = result.func.appendTo(compilation_context.module.body());
+    _ = result.func.appendTo(compiler.module.body());
 
-    const num_partitions = compilation_context.partitioning.numPartitions();
-    const num_replicas = compilation_context.partitioning.numReplicas();
-    const num_devices = compilation_context.partitioning.numDevices();
+    const num_partitions = compiler.partitioning.numPartitions();
+    const num_replicas = compiler.partitioning.numReplicas();
+    const num_devices = compiler.partitioning.numDevices();
 
-    compilation_context.module.operation().setAttributeByName(
+    compiler.module.operation().setAttributeByName(
         "mhlo.num_partitions",
-        .int(compilation_context.mlir_ctx, .i32, num_partitions),
+        .int(compiler.mlir_ctx, .i32, num_partitions),
     );
-    compilation_context.module.operation().setAttributeByName(
+    compiler.module.operation().setAttributeByName(
         "mhlo.num_replicas",
-        .int(compilation_context.mlir_ctx, .i32, num_replicas),
+        .int(compiler.mlir_ctx, .i32, num_replicas),
     );
 
-    compilation_context.mlir_pass_manager.runOnOp(compilation_context.module.operation()) catch |err| switch (err) {
+    compiler.mlir_pass_manager.runOnOp(compiler.module.operation()) catch |err| switch (err) {
         error.MlirUnexpected => {
-            std.log.err("Failed to canonicalize invalid mlir: \n {f} \n ", .{compilation_context.module.operation()});
+            std.log.err("Failed to canonicalize invalid mlir: \n {f} \n ", .{compiler.module.operation()});
             @panic("ZML generated invalid mlir. Please open a bug report");
         },
     };
@@ -329,8 +326,8 @@ pub fn compile(
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
 
-    const loaded_executable = try compileModuleToPjrtExecutable(arena.allocator(), st_io.io(), platform, compilation_context.module, compilation_context.partitioning, opts);
-    log.debug("\n******** ZML generated MLIR ********\n{f}", .{compilation_context.module.operation()});
+    const loaded_executable = try compileModuleToPjrtExecutable(arena.allocator(), st_io.io(), platform, compiler.module, compiler.partitioning, opts);
+    log.debug("\n******** ZML generated MLIR ********\n{f}", .{compiler.module.operation()});
 
     const exe = try Exe.init(
         allocator,
@@ -348,7 +345,7 @@ pub fn compile(
     return exe;
 }
 
-fn addPartitionerOperations(ctx: *CompilationContext) !void {
+fn addPartitionerOperations(ctx: *Compiler) !void {
     const allocator = ctx.arena.allocator();
     const mlir_ctx = ctx.mlir_ctx;
     const module = ctx.module;
@@ -509,31 +506,31 @@ fn finalizeAttributeList(allocator_: std.mem.Allocator, mlir_ctx: *mlir.Context,
     return res;
 }
 
-fn emitMlir(compilation_context: *CompilationContext, comptime func: anytype, args: std.meta.ArgsTuple(@TypeOf(func))) !EmitMlirResult {
-    var arena = std.heap.ArenaAllocator.init(compilation_context.allocator);
+fn emitMlir(compiler: *Compiler, comptime func: anytype, args: std.meta.ArgsTuple(@TypeOf(func))) !EmitMlirResult {
+    var arena = std.heap.ArenaAllocator.init(compiler.allocator);
     defer arena.deinit();
 
-    const module = mlir.Module.init(.unknown(compilation_context.mlir_ctx));
+    const module = mlir.Module.init(.unknown(compiler.mlir_ctx));
     errdefer module.deinit();
 
     const block = mlir.Block.init(&.{}, &.{});
     errdefer block.deinit();
 
-    compilation_context.pushBlock(block);
-    defer compilation_context.popBlock();
+    compiler.pushBlock(block);
+    defer compiler.popBlock();
 
     const LocalContext = struct {
-        compilation_context: *CompilationContext,
+        compiler: *Compiler,
         current_argument_id: usize = 0,
     };
     var context: LocalContext = .{
-        .compilation_context = compilation_context,
+        .compiler = compiler,
     };
     meta.visit(struct {
         fn cb(ctx_: *LocalContext, tensor: *const Tensor) void {
-            const mlir_type = mlirx.Type.rankedTensor(ctx_.compilation_context.mlir_ctx, tensor.shape());
-            _ = ctx_.compilation_context.currentScope().block.addArgument(mlir_type, .unknown(ctx_.compilation_context.mlir_ctx));
-            const gop = ctx_.compilation_context.currentScope().id_to_argument.getOrPut(ctx_.compilation_context.currentScope().arena.allocator(), tensor.id) catch unreachable;
+            const mlir_type = mlirx.Type.rankedTensor(ctx_.compiler.mlir_ctx, tensor.shape());
+            _ = ctx_.compiler.currentScope().block.addArgument(mlir_type, .unknown(ctx_.compiler.mlir_ctx));
+            const gop = ctx_.compiler.currentScope().id_to_argument.getOrPut(ctx_.compiler.currentScope().arena.allocator(), tensor.id) catch unreachable;
             if (gop.found_existing) std.debug.panic("Tensor with id {} has already been used once as an argument", .{tensor.id});
             gop.value_ptr.* = ctx_.current_argument_id;
             ctx_.current_argument_id += 1;
@@ -541,21 +538,21 @@ fn emitMlir(compilation_context: *CompilationContext, comptime func: anytype, ar
     }.cb, &context, &args);
 
     const output_info, const input_info = b: {
-        compilation_context.activate();
-        defer compilation_context.deactivate();
+        compiler.activate();
+        defer compiler.deactivate();
 
         const result = @call(.auto, func, args);
 
-        const input_info = try collectInputInfo(compilation_context.allocator, compilation_context.partitioning, &args);
-        errdefer input_info.deinit(compilation_context.allocator);
+        const input_info = try collectInputInfo(compiler.allocator, compiler.partitioning, &args);
+        errdefer input_info.deinit(compiler.allocator);
 
-        const output_info = try collectOutputInfo(compilation_context.allocator, compilation_context.partitioning, &result);
-        errdefer output_info.deinit(compilation_context.allocator);
+        const output_info = try collectOutputInfo(compiler.allocator, compiler.partitioning, &result);
+        errdefer output_info.deinit(compiler.allocator);
 
         break :b .{ output_info, input_info };
     };
-    errdefer input_info.deinit(compilation_context.allocator);
-    errdefer output_info.deinit(compilation_context.allocator);
+    errdefer input_info.deinit(compiler.allocator);
+    errdefer output_info.deinit(compiler.allocator);
 
     const input_attributes = try arena.allocator().alloc(AttributeList, input_info.shapes.len);
     @memset(input_attributes, .empty);
@@ -564,59 +561,59 @@ fn emitMlir(compilation_context: *CompilationContext, comptime func: anytype, ar
     @memset(output_attributes, .empty);
 
     for (output_info.donations, 0..) |donation, index| if (donation) |argument_index| {
-        input_attributes[argument_index].appendAssumeCapacity(.named(compilation_context.mlir_ctx, "tf.aliasing_output", .int(compilation_context.mlir_ctx, .i32, index)));
+        input_attributes[argument_index].appendAssumeCapacity(.named(compiler.mlir_ctx, "tf.aliasing_output", .int(compiler.mlir_ctx, .i32, index)));
     };
     for (output_info.output_memory_kinds, 0..) |output_memory_kind, index| {
         if (output_memory_kind == .device) continue;
         output_attributes[index].appendAssumeCapacity(.named(
-            compilation_context.mlir_ctx,
+            compiler.mlir_ctx,
             "mhlo.memory_kind",
             .string(
-                compilation_context.mlir_ctx,
-                compilation_context.platform.memoryKind(output_memory_kind),
+                compiler.mlir_ctx,
+                compiler.platform.memoryKind(output_memory_kind),
             ),
         ));
     }
-    _ = dialects.func.returns(compilation_context.mlir_ctx, output_info.values, .unknown(compilation_context.mlir_ctx)).appendTo(compilation_context.currentScope().block);
+    _ = dialects.func.returns(compiler.mlir_ctx, output_info.values, .unknown(compiler.mlir_ctx)).appendTo(compiler.currentScope().block);
 
     for (input_info.shapes, input_info.shardings, input_info.memory_kinds, 0..) |shape, sharding, maybe_memory_kind, i| {
-        const attr = try compilation_context.partitioning.tensorShardingAttr(compilation_context.arena.allocator(), compilation_context.mlir_ctx, shape, sharding);
-        const name = switch (compilation_context.partitioning.partitioner) {
+        const attr = try compiler.partitioning.tensorShardingAttr(compiler.arena.allocator(), compiler.mlir_ctx, shape, sharding);
+        const name = switch (compiler.partitioning.partitioner) {
             .gspmd => "mhlo.sharding",
             .shardy => "sdy.sharding",
         };
 
-        input_attributes[i].appendAssumeCapacity(.named(compilation_context.mlir_ctx, name, attr));
+        input_attributes[i].appendAssumeCapacity(.named(compiler.mlir_ctx, name, attr));
 
         if (maybe_memory_kind) |memory_kind| {
             if (memory_kind == .device) continue;
             input_attributes[i].appendAssumeCapacity(.named(
-                compilation_context.mlir_ctx,
+                compiler.mlir_ctx,
                 "mhlo.memory_kind",
                 .string(
-                    compilation_context.mlir_ctx,
-                    compilation_context.platform.memoryKind(memory_kind),
+                    compiler.mlir_ctx,
+                    compiler.platform.memoryKind(memory_kind),
                 ),
             ));
         }
     }
 
     for (output_info.shapes, output_info.shardings, 0..) |shape, sharding, i| {
-        const attr = try compilation_context.partitioning.tensorShardingAttr(compilation_context.arena.allocator(), compilation_context.mlir_ctx, shape, sharding);
-        const name = switch (compilation_context.partitioning.partitioner) {
+        const attr = try compiler.partitioning.tensorShardingAttr(compiler.arena.allocator(), compiler.mlir_ctx, shape, sharding);
+        const name = switch (compiler.partitioning.partitioner) {
             .gspmd => "mhlo.sharding",
             .shardy => "sdy.sharding",
         };
 
-        output_attributes[i].appendAssumeCapacity(.named(compilation_context.mlir_ctx, name, attr));
+        output_attributes[i].appendAssumeCapacity(.named(compiler.mlir_ctx, name, attr));
     }
 
-    const mlir_func = dialects.func.func(compilation_context.mlir_ctx, .{
+    const mlir_func = dialects.func.func(compiler.mlir_ctx, .{
         .name = "main",
-        .block = compilation_context.currentScope().block,
-        .location = .unknown(compilation_context.mlir_ctx),
-        .args_attributes = try finalizeAttributeList(arena.allocator(), compilation_context.mlir_ctx, input_attributes),
-        .results_attributes = try finalizeAttributeList(arena.allocator(), compilation_context.mlir_ctx, output_attributes),
+        .block = compiler.currentScope().block,
+        .location = .unknown(compiler.mlir_ctx),
+        .args_attributes = try finalizeAttributeList(arena.allocator(), compiler.mlir_ctx, input_attributes),
+        .results_attributes = try finalizeAttributeList(arena.allocator(), compiler.mlir_ctx, output_attributes),
         .verify = false,
     });
 
@@ -649,7 +646,7 @@ fn setXlaOverrideFlag(map: *c.upb_Map, flag: []const u8, value: anytype, upb_are
     }
 }
 
-fn compileModuleToPjrtExecutable(arena: std.mem.Allocator, io: std.Io, platform: *const Platform, module: *const mlir.Module, partitioning: Partitioning, opts: CompilationOptions) !*pjrt.LoadedExecutable {
+fn compileModuleToPjrtExecutable(arena: std.mem.Allocator, io: std.Io, platform: *const Platform, module: *const mlir.Module, partitioning: Partitioning, opts: Options) !*pjrt.LoadedExecutable {
     var upb_alloc: upb.Allocator = .init(arena);
     const upb_arena = c.upb_Arena_Init(null, 0, upb_alloc.inner());
     defer c.upb_Arena_Free(upb_arena);

--- a/zml/Compiler.zig
+++ b/zml/Compiler.zig
@@ -257,7 +257,7 @@ pub fn Typed(comptime func: anytype) type {
             opts: Options,
             args: std.meta.ArgsTuple(@TypeOf(func)),
         ) Error!Exe {
-            return Compiler.compile(allocator, io, func, args, platform, opts);
+            return Compiler.compile(io, allocator, platform, func, args, opts);
         }
     };
 }

--- a/zml/Compiler.zig
+++ b/zml/Compiler.zig
@@ -251,20 +251,20 @@ pub fn allocPrint(self: *Compiler, comptime fmt: []const u8, args: anytype) []u8
 pub fn Typed(comptime func: anytype) type {
     return struct {
         pub fn compile(
-            io: std.Io,
             allocator: std.mem.Allocator,
+            io: std.Io,
             platform: *const Platform,
             opts: Options,
             args: std.meta.ArgsTuple(@TypeOf(func)),
         ) Error!Exe {
-            return Compiler.compile(io, allocator, platform, func, args, opts);
+            return Compiler.compile(allocator, io, platform, func, args, opts);
         }
     };
 }
 
 pub fn compile(
-    io: std.Io,
     allocator: std.mem.Allocator,
+    io: std.Io,
     platform: *const Platform,
     comptime func: anytype,
     args: std.meta.ArgsTuple(@TypeOf(func)),

--- a/zml/Compiler.zig
+++ b/zml/Compiler.zig
@@ -251,8 +251,8 @@ pub fn allocPrint(self: *Compiler, comptime fmt: []const u8, args: anytype) []u8
 pub fn Typed(comptime func: anytype) type {
     return struct {
         pub fn compile(
-            allocator: std.mem.Allocator,
             io: std.Io,
+            allocator: std.mem.Allocator,
             platform: *const Platform,
             opts: Options,
             args: std.meta.ArgsTuple(@TypeOf(func)),
@@ -263,11 +263,11 @@ pub fn Typed(comptime func: anytype) type {
 }
 
 pub fn compile(
-    allocator: std.mem.Allocator,
     io: std.Io,
+    allocator: std.mem.Allocator,
+    platform: *const Platform,
     comptime func: anytype,
     args: std.meta.ArgsTuple(@TypeOf(func)),
-    platform: *const Platform,
     opts: Options,
 ) Error!Exe {
     // TODO: Here we have somewhat of a requirement

--- a/zml/attention/attnd.zig
+++ b/zml/attention/attnd.zig
@@ -140,7 +140,7 @@ const Context = struct {
 };
 
 pub fn causalAttention(q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, token_offset: zml.Tensor, metadata: Metadata, parameters: Parameters) zml.Tensor {
-    const ctx = zml.module.CompilationContext.current();
+    const ctx = zml.Compiler.current();
     const num_partitions = ctx.partitioning.numPartitionsForLogicalAxis(q.shape(), .model) catch unreachable;
 
     const actual_k, const actual_v = if (parameters.is_prefill)

--- a/zml/attention/flashattn.zig
+++ b/zml/attention/flashattn.zig
@@ -4,7 +4,6 @@ const flashattn = @import("platforms/cuda/flashattn");
 const platforms = @import("platforms");
 const stdx = @import("stdx");
 
-const CompilationContext = @import("../module.zig").CompilationContext;
 const zml = @import("../zml.zig");
 const ffi = zml.pjrt.ffi;
 const AttentionOptions = @import("paged_attention.zig").AttentionOptions;
@@ -268,7 +267,7 @@ pub const fa2 = struct {
     };
 
     pub fn attention(q_: zml.Tensor, k_: zml.Tensor, v_: zml.Tensor, token_index_: zml.Tensor, metadata: Metadata, parameters: Parameters) zml.Tensor {
-        const ctx = CompilationContext.current();
+        const ctx = zml.Compiler.current();
 
         var bs: i64 = 1;
         var q = q_;
@@ -900,7 +899,7 @@ pub const paged_fa2 = struct {
         stdx.debug.assert(q.shape().hasTags(.{ .b, .hg, .hkv, .hd }), "Expected q to have tags .b, .h, .hd", .{});
         stdx.debug.assert(k_cache.shape().hasTags(.{ .page, .k_chunk, .hkv, .hd }), "Expected paged_k to have tags .page, .k_chunk, .h, .hd, got {}", .{k_cache.shape()});
         stdx.debug.assert(v_cache.shape().hasTags(.{ .page, .k_chunk, .hkv, .hd }), "Expected paged_v to have tags .page, .k_chunk, .h, .hd. got {}", .{v_cache.shape()});
-        const ctx = CompilationContext.current();
+        const ctx = zml.Compiler.current();
 
         const num_head_groups = q.dim(.hg);
         const num_kv_heads = q.dim(.hkv);

--- a/zml/attention/tpu_attention.zig
+++ b/zml/attention/tpu_attention.zig
@@ -4,7 +4,7 @@ const mlir = @import("mlir");
 const ragged_paged = @import("platforms/tpu/ragged_paged");
 const stdx = @import("stdx");
 
-const CompilationContext = @import("../module.zig").CompilationContext;
+const Compilation = @import("../Compiler.zig").Compilation;
 const zml = @import("../zml.zig");
 const AttentionOptions = @import("paged_attention.zig").AttentionOptions;
 const ragged_attention = @import("mosaic_tpu_kernels/ragged_attention.zig");
@@ -89,7 +89,7 @@ pub const mosaic_tpu = struct {
         num_seqs: zml.Tensor,
         cfg: ragged_paged.Cfg,
     ) zml.Tensor {
-        const mlir_ctx = CompilationContext.current().mlir_ctx;
+        const mlir_ctx = Compilation.current().mlir_ctx;
         const out = ragged_attention.Kernel.call(
             .{
                 .kv_lens = seq_lens,

--- a/zml/attention/tpu_attention.zig
+++ b/zml/attention/tpu_attention.zig
@@ -4,7 +4,7 @@ const mlir = @import("mlir");
 const ragged_paged = @import("platforms/tpu/ragged_paged");
 const stdx = @import("stdx");
 
-const Compilation = @import("../Compiler.zig").Compilation;
+const Compiler = @import("../Compiler.zig");
 const zml = @import("../zml.zig");
 const AttentionOptions = @import("paged_attention.zig").AttentionOptions;
 const ragged_attention = @import("mosaic_tpu_kernels/ragged_attention.zig");
@@ -89,7 +89,7 @@ pub const mosaic_tpu = struct {
         num_seqs: zml.Tensor,
         cfg: ragged_paged.Cfg,
     ) zml.Tensor {
-        const mlir_ctx = Compilation.current().mlir_ctx;
+        const mlir_ctx = Compiler.current().mlir_ctx;
         const out = ragged_attention.Kernel.call(
             .{
                 .kv_lens = seq_lens,

--- a/zml/attention/triton_attention.zig
+++ b/zml/attention/triton_attention.zig
@@ -13,7 +13,7 @@ const mla_kernels = @import("triton_kernels/unified_sparse_mla.zig");
 const log = std.log.scoped(.@"zml/attention/triton");
 
 fn isOneapiTarget() bool {
-    return zml.module.CompilationContext.current().platform.target == .oneapi;
+    return zml.Compiler.current().platform.target == .oneapi;
 }
 
 fn use2dKernel(all_decode: bool, batch_size: usize, num_kv_heads: usize) bool {
@@ -204,7 +204,7 @@ fn select3dConfig(options: paged.PagedAttentionOptions) Config3D {
 }
 
 fn getCuCount() usize {
-    const platform = zml.module.CompilationContext.current().platform;
+    const platform = zml.Compiler.current().platform;
     if (platform.devices.len == 0) return 1;
     const attribute = platform.devices[0].pjrt_desc.attribute(platform.pjrt_api, "core_count") orelse return 1;
     if (attribute.int64 <= 0) return 1;
@@ -988,7 +988,7 @@ test "sparse MLA launch selection honors valid explicit splits" {
 
 test "sparse MLA emits 2D and 3D Triton kernels" {
     const platform = zml.testing.env();
-    var compilation = zml.module.CompilationContext.init(std.testing.allocator, std.testing.io, platform, .{});
+    var compilation = zml.Compiler.init(std.testing.allocator, std.testing.io, platform, .{});
     defer compilation.deinit();
     compilation.activate();
     defer compilation.deactivate();

--- a/zml/attention/triton_kernels/unified_attention.zig
+++ b/zml/attention/triton_kernels/unified_attention.zig
@@ -349,7 +349,7 @@ pub const ReduceSegmentsPtr = struct {
 // ============================================================================
 
 fn ctx() *mlir.Context {
-    return zml.module.CompilationContext.current().mlir_ctx;
+    return zml.Compiler.current().mlir_ctx;
 }
 
 fn isFp8(dt: DType) bool {

--- a/zml/exe.zig
+++ b/zml/exe.zig
@@ -4,9 +4,9 @@ const pjrt = @import("pjrt");
 const stdx = @import("stdx");
 
 const Buffer = @import("buffer.zig").Buffer;
+const Compiler = @import("Compiler.zig");
 const mem = @import("mem.zig");
 const meta = @import("meta.zig");
-const module = @import("module.zig");
 const Platform = @import("platform.zig").Platform;
 const tracer = @import("profiling/tracer.zig");
 const Shape = @import("shape.zig").Shape;
@@ -319,7 +319,7 @@ pub const Exe = struct {
             .results = results_.flat_buffers.buffers,
             .events = events_slice,
             // this allows to tell a specific buffer shouldn't be donated,
-            // even if it has been marked as "can be donated" during compilation.
+            // even if it has been marked as "can be donated" during compiler.
             // TODO: expose it ?
             .non_donatable_input_indices = &.{},
             .context = self.context,
@@ -408,10 +408,10 @@ pub fn FnExe(comptime function_: anytype) type {
             allocator: std.mem.Allocator,
             io: std.Io,
             platform: *const Platform,
-            opts: module.CompilationOptions,
+            opts: Compiler.Options,
             args: std.meta.ArgsTuple(@TypeOf(function_)),
-        ) module.CompileError!Self {
-            return .{ .raw = try module.Compiler(function_).compile(allocator, io, platform, opts, args) };
+        ) Compiler.Error!Self {
+            return .{ .raw = try Compiler.Typed(function_).compile(allocator, io, platform, opts, args) };
         }
 
         pub fn deinit(self: *const Self) void {

--- a/zml/exe.zig
+++ b/zml/exe.zig
@@ -411,7 +411,7 @@ pub fn FnExe(comptime function_: anytype) type {
             opts: Compiler.Options,
             args: std.meta.ArgsTuple(@TypeOf(function_)),
         ) Compiler.Error!Self {
-            return .{ .raw = try Compiler.Typed(function_).compile(allocator, io, platform, opts, args) };
+            return .{ .raw = try Compiler.Typed(function_).compile(io, allocator, platform, opts, args) };
         }
 
         pub fn deinit(self: *const Self) void {

--- a/zml/exe.zig
+++ b/zml/exe.zig
@@ -411,7 +411,7 @@ pub fn FnExe(comptime function_: anytype) type {
             opts: Compiler.Options,
             args: std.meta.ArgsTuple(@TypeOf(function_)),
         ) Compiler.Error!Self {
-            return .{ .raw = try Compiler.Typed(function_).compile(io, allocator, platform, opts, args) };
+            return .{ .raw = try Compiler.Typed(function_).compile(allocator, io, platform, opts, args) };
         }
 
         pub fn deinit(self: *const Self) void {

--- a/zml/kernel.zig
+++ b/zml/kernel.zig
@@ -7,7 +7,7 @@ const mosaic_tpu_builder = @import("kernels/mosaic_tpu/builder");
 const tpu_dialect = @import("mlir/dialects/mosaic_tpu");
 const triton_builder = @import("kernels/triton/builder");
 
-const CompilationContext = @import("module.zig").CompilationContext;
+const Compiler = @import("Compiler.zig");
 const DataType = @import("dtype.zig").DataType;
 const mlirx = @import("mlirx.zig");
 const ops = @import("ops.zig");
@@ -126,7 +126,7 @@ pub const triton = struct {
             }
 
             pub fn call(inputs: Inputs, outputs: Outputs, opts: CallOpts) Results {
-                const cur = CompilationContext.current();
+                const cur = Compiler.current();
 
                 const ttir = emit(cur.allocator, opts.cfg) catch |err|
                     std.debug.panic("zml.kernel.triton.Kernel({s}).call: emit failed: {}", .{ name, err });
@@ -232,7 +232,7 @@ pub const mosaic_tpu = struct {
             }
 
             pub fn call(inputs: Inputs, outputs: Outputs, opts: CallOpts) Results {
-                const cur = CompilationContext.current();
+                const cur = Compiler.current();
 
                 const ir = emit(cur.allocator, opts.cfg) catch |err|
                     std.debug.panic("zml.kernel.mosaic_tpu.Kernel({s}).call: emit failed: {}", .{ name, err });
@@ -365,7 +365,7 @@ pub const mosaic_tpu = struct {
     };
 
     fn callTpuCustomCall(args: TpuCustomCallArgs) *mlir.Operation {
-        const cur = CompilationContext.current();
+        const cur = Compiler.current();
 
         var all_inputs: stdx.BoundedArray(*const mlir.Value, dialects.stablehlo.CustomCallOpts.MAX_OPERANDS) = .empty;
         for (args.dynamic_grid_bounds) |t| all_inputs.appendAssumeCapacity(t.value());

--- a/zml/moe/cutlass_flashinfer.zig
+++ b/zml/moe/cutlass_flashinfer.zig
@@ -240,7 +240,7 @@ fn runnersFromAttributes(attributes: Attributes) !*Runners {
 }
 
 fn currentRunners() !*Runners {
-    const platform = zml.module.CompilationContext.current().platform;
+    const platform = zml.Compiler.current().platform;
     const runners = platform.state.cuda.fi_cutlass_moe_runners;
     return runners orelse error.RunnersNotLoaded;
 }

--- a/zml/moe/triton.zig
+++ b/zml/moe/triton.zig
@@ -643,7 +643,7 @@ fn applyJsonTokenConfig(opts: Options, num_tokens: i64) !Options {
     var out = opts;
     if (!opts.dynamic_launch_by_num_tokens) return out;
 
-    const compilation_context = zml.module.CompilationContext.current();
+    const compilation_context = zml.Compiler.current();
     const io = compilation_context.io;
     const allocator = compilation_context.allocator;
 
@@ -1243,8 +1243,8 @@ fn runGemm(
 }
 
 fn applySwiGlu(input: zml.Tensor, activation_limit: ?f32) zml.Tensor {
-    var gate = input.slice1d(.dout, .{ .start = 0, .step = 2 });
-    var up = input.slice1d(.dout, .{ .start = 1, .step = 2 });
+    var gate = input.slice(.dout, .{ .start = 0, .step = 2 });
+    var up = input.slice(.dout, .{ .start = 1, .step = 2 });
 
     if (activation_limit) |limit| {
         const threshold = zml.Tensor.scalar(limit, .f32);

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -79,7 +79,7 @@ pub const Linear = struct {
         var lhs_scale: ?Tensor = null;
         var undo: ?Tensor = null;
 
-        const platform = zml.module.CompilationContext.current().platform;
+        const platform = zml.Compiler.current().platform;
         if (q.scheme.activationQuant()) |aq| {
             if (aq.supportedOn(platform)) {
                 const quantized = aq.apply(lhs, igs, self.tag);
@@ -434,7 +434,7 @@ pub fn scaledDot(
     else
         rhs_scale;
 
-    const mlir_ctx = zml.module.CompilationContext.current().mlir_ctx;
+    const mlir_ctx = zml.Compiler.current().mlir_ctx;
     const dnums = mlir.Attribute.array(mlir_ctx, &.{
         .array(mlir_ctx, &.{
             .intArray(mlir_ctx, i64, lhs_contracting_axes.constSlice()),
@@ -873,7 +873,7 @@ pub fn mergeRealImgPass(x_real: Tensor, x_imag: Tensor, x_pass: ?Pass, layout: R
 
 /// {exp( - n * ln(10_000) / N ) | n in [0..N] }
 pub fn invFreq(N: i64, opts: RopeOpts) Tensor {
-    const allocator = zml.module.CompilationContext.current().allocator;
+    const allocator = zml.Compiler.current().allocator;
     const N_half: u32 = @intCast(@divExact(N, 2));
     const num_freqs: u32 = opts.scaling.partialRotaryDim(N_half);
 
@@ -1595,7 +1595,7 @@ test resizeBilinear {
     const platform = zml.testing.env();
 
     // Only test shapes
-    var comp = zml.module.CompilationContext.init(std.testing.allocator, std.testing.io, platform, .{});
+    var comp = zml.Compiler.init(std.testing.allocator, std.testing.io, platform, .{});
     defer comp.deinit();
     comp.activate();
     defer comp.deactivate();
@@ -1662,7 +1662,7 @@ test resizeBicubic {
     const platform = zml.testing.env();
 
     // Only test shapes
-    var comp = zml.module.CompilationContext.init(std.testing.allocator, std.testing.io, platform, .{});
+    var comp = zml.Compiler.init(std.testing.allocator, std.testing.io, platform, .{});
     defer comp.deinit();
     comp.activate();
     defer comp.deactivate();

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -598,7 +598,7 @@ test normalizeL2 {
 
     const input: zml.Tensor = .init(.{ 2, 2 }, .f32);
 
-    var exe = try zml.module.compile(std.testing.allocator, std.testing.io, normalizeL2, .{ input, 1e-12 }, platform, .{});
+    var exe = try platform.compileFn(std.testing.allocator, std.testing.io, normalizeL2, .{ input, 1e-12 }, .{});
     defer exe.deinit();
 
     var input_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, input.shape(), .replicated, std.mem.sliceAsBytes(&[_]f32{ -0.9686, -1.0058, -1.7808, 0.6698 }));
@@ -1121,7 +1121,7 @@ test "real/img" {
         }
     };
     {
-        var exe = try zml.module.compile(std.testing.allocator, std.testing.io, Fns.testSplitMergeIsId, .{.interleaved}, platform, .{});
+        var exe = try platform.compileFn(std.testing.allocator, std.testing.io, Fns.testSplitMergeIsId, .{.interleaved}, .{});
         defer exe.deinit();
 
         var d_interleaved = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Fns.testSplitMergeIsId, {});
@@ -1129,7 +1129,7 @@ test "real/img" {
         try std.testing.expectEqual(20, try d_interleaved.getValue(i32, std.testing.io));
     }
     {
-        var exe = try zml.module.compile(std.testing.allocator, std.testing.io, Fns.testSplitMergeIsId, .{.real_im_pass}, platform, .{});
+        var exe = try platform.compileFn(std.testing.allocator, std.testing.io, Fns.testSplitMergeIsId, .{.real_im_pass}, .{});
         defer exe.deinit();
 
         var d_sequential = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Fns.testSplitMergeIsId, {});
@@ -1139,7 +1139,7 @@ test "real/img" {
 
     // test the function that accepts 1 void argument
     {
-        var exe = try zml.module.compile(std.testing.allocator, std.testing.io, Fns.testSplitSeqVoid, .{{}}, platform, .{});
+        var exe = try platform.compileFn(std.testing.allocator, std.testing.io, Fns.testSplitSeqVoid, .{{}}, .{});
         defer exe.deinit();
 
         var d_split_seq_void = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Fns.testSplitSeqVoid, {});
@@ -1149,7 +1149,7 @@ test "real/img" {
 
     // test the function that takes NO arguments
     {
-        var exe = try zml.module.compile(std.testing.allocator, std.testing.io, Fns.testSplitSeq, .{}, platform, .{});
+        var exe = try platform.compileFn(std.testing.allocator, std.testing.io, Fns.testSplitSeq, .{}, .{});
         defer exe.deinit();
 
         var d_split_seq = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Fns.testSplitSeq, {});
@@ -1158,7 +1158,7 @@ test "real/img" {
     }
 
     {
-        var exe = try zml.module.compile(std.testing.allocator, std.testing.io, Fns.testSplitInterleaved, .{}, platform, .{});
+        var exe = try platform.compileFn(std.testing.allocator, std.testing.io, Fns.testSplitInterleaved, .{}, .{});
         defer exe.deinit();
 
         var d_split_seq = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, Fns.testSplitInterleaved, {});
@@ -1192,10 +1192,10 @@ test rope {
     // x is made such as the interleaved and sequential reps are the same.
     // So the two implementations should give the same results.
     const x: zml.Tensor = .init(.{ .b = 1, .s = 5, .hd = 4 }, .f32);
-    var exe_interleaved = try zml.module.compile(std.testing.allocator, std.testing.io, Local._fwd, .{ x, RopeOpts{ .layout = .interleaved } }, platform, .{});
+    var exe_interleaved = try platform.compileFn(std.testing.allocator, std.testing.io, Local._fwd, .{ x, RopeOpts{ .layout = .interleaved } }, .{});
     defer exe_interleaved.deinit();
 
-    var exe_sequential = try zml.module.compile(std.testing.allocator, std.testing.io, Local._fwd, .{ x, RopeOpts{ .layout = .real_im_pass } }, platform, .{});
+    var exe_sequential = try platform.compileFn(std.testing.allocator, std.testing.io, Local._fwd, .{ x, RopeOpts{ .layout = .real_im_pass } }, .{});
     defer exe_sequential.deinit();
 
     const x_values: [5][4]f32 = @splat(.{ 1.0, 0.1, -1.0, -0.5 });
@@ -1216,7 +1216,7 @@ test "rope: Proportional" {
     const platform = zml.testing.env();
 
     const x: zml.Tensor = .init(.{ .s = 5, .hd = 16 }, .f32);
-    var exe = try zml.module.compile(
+    var exe = try platform.compileFn(
         allocator,
         io,
         rope,
@@ -1228,7 +1228,6 @@ test "rope: Proportional" {
                 .scaling = .{ .proportional = .{ .partial_rotary_factor = 0.25 } },
             },
         },
-        platform,
         .{},
     );
     defer exe.deinit();
@@ -1261,7 +1260,7 @@ test "rope: Yarn with partial_rotary_factor" {
     const platform = zml.testing.env();
 
     const x: zml.Tensor = .init(.{ .s = 5, .hd = 16 }, .f32);
-    var exe = try zml.module.compile(
+    var exe = try platform.compileFn(
         allocator,
         io,
         rope,
@@ -1281,7 +1280,6 @@ test "rope: Yarn with partial_rotary_factor" {
                 } },
             },
         },
-        platform,
         .{},
     );
     defer exe.deinit();
@@ -1370,12 +1368,11 @@ test nearest {
     // 3D Tensor (basic)
     {
         const input_3d_basic: zml.Tensor = .init(.{ 1, 1, 2 }, .i32);
-        var exe = try zml.module.compile(
+        var exe = try platform.compileFn(
             std.testing.allocator,
             std.testing.io,
             upsample,
             .{ input_3d_basic, .{ .scale_factor = &.{3}, .mode = .nearest } },
-            platform,
             .{},
         );
         defer exe.deinit();
@@ -1400,12 +1397,11 @@ test nearest {
     // 3D Tensor (advanced)
     {
         const input_3d_advanced: zml.Tensor = .init(.{ 2, 3, 4 }, .i32);
-        var exe = try zml.module.compile(
+        var exe = try platform.compileFn(
             std.testing.allocator,
             std.testing.io,
             upsample,
             .{ input_3d_advanced, .{ .scale_factor = &.{2}, .mode = .nearest } },
-            platform,
             .{},
         );
         defer exe.deinit();
@@ -1438,12 +1434,11 @@ test nearest {
     // 4D Tensor (basic)
     {
         const input_4d_basic: zml.Tensor = .init(.{ 1, 1, 2, 2 }, .i32);
-        var exe = try zml.module.compile(
+        var exe = try platform.compileFn(
             std.testing.allocator,
             std.testing.io,
             upsample,
             .{ input_4d_basic, .{ .scale_factor = &.{ 3, 3 }, .mode = .nearest } },
-            platform,
             .{},
         );
         defer exe.deinit();
@@ -1468,12 +1463,11 @@ test nearest {
     // 4D Tensor (advanced)
     {
         const input_4d_advanced: zml.Tensor = .init(.{ 2, 2, 2, 2 }, .i32);
-        var exe = try zml.module.compile(
+        var exe = try platform.compileFn(
             std.testing.allocator,
             std.testing.io,
             upsample,
             .{ input_4d_advanced, .{ .scale_factor = &.{ 2, 2 }, .mode = .nearest } },
-            platform,
             .{},
         );
         defer exe.deinit();
@@ -1526,12 +1520,11 @@ test nearest {
     // 5D Tensor (basic)
     {
         const input_5d: zml.Tensor = .init(.{ 1, 1, 1, 2, 2 }, .i32);
-        var exe = try zml.module.compile(
+        var exe = try platform.compileFn(
             std.testing.allocator,
             std.testing.io,
             upsample,
             .{ input_5d, .{ .scale_factor = &.{2}, .mode = .nearest } },
-            platform,
             .{},
         );
         defer exe.deinit();
@@ -1962,12 +1955,11 @@ test "gated delta net" {
     const betas: zml.Tensor = .init(.{ .s = 2, .h = 2 }, .f32);
     const initial_s: zml.Tensor = .init(.{ .h = 2, .v = 2, .k = 2 }, .f32);
 
-    var exe = try zml.module.compile(
+    var exe = try platform.compileFn(
         std.testing.allocator,
         std.testing.io,
         GatedDeltaNet.forward,
         .{ queries, keys, values, alphas, betas, .{ .s = initial_s } },
-        platform,
         .{},
     );
     defer exe.deinit();
@@ -2117,7 +2109,7 @@ test sampleTokens {
     const rng: zml.Tensor.Rng = .init();
     const activations: zml.Tensor = .init(.{ .voc = 4 }, .f32);
 
-    var exe = try zml.module.compile(std.testing.allocator, std.testing.io, sampleTokens, .{ activations, .{ .topk = 4, .temperature = 2.0 }, rng }, platform, .{});
+    var exe = try platform.compileFn(std.testing.allocator, std.testing.io, sampleTokens, .{ activations, .{ .topk = 4, .temperature = 2.0 }, rng }, .{});
     defer exe.deinit();
 
     var rng_buffer = try zml.Tensor.Rng.initBuffer(std.testing.io, platform, .replicated, 0xdeadbeef);
@@ -2259,7 +2251,7 @@ test sampleTokensDynamic {
     const logits: zml.Tensor = .init(.{ .voc = logits_data.len }, .f32);
     const dynamic_sampling_strategy = DynamicSamplingStrategy.init(.f32, 0);
 
-    var exe = try zml.module.compile(std.testing.allocator, std.testing.io, fixupLogits, .{ logits, dynamic_sampling_strategy }, platform, .{});
+    var exe = try platform.compileFn(std.testing.allocator, std.testing.io, fixupLogits, .{ logits, dynamic_sampling_strategy }, .{});
     defer exe.deinit();
 
     var logits_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, logits.shape(), .replicated, std.mem.sliceAsBytes(&logits_data));
@@ -2296,7 +2288,7 @@ test sampleTokensDynamic {
 
         const logits_bf16: zml.Tensor = .init(.{ .voc = logits_data.len }, .bf16);
         const dynamic_sampling_strategy_bf16 = DynamicSamplingStrategy.init(.bf16, 0);
-        var exe_bf16 = try zml.module.compile(std.testing.allocator, std.testing.io, fixupLogits, .{ logits_bf16, dynamic_sampling_strategy_bf16 }, platform, .{});
+        var exe_bf16 = try platform.compileFn(std.testing.allocator, std.testing.io, fixupLogits, .{ logits_bf16, dynamic_sampling_strategy_bf16 }, .{});
         defer exe_bf16.deinit();
 
         const boost = bf16.inf;

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -9,7 +9,7 @@ const stdx = @import("stdx");
 
 const Buffer = @import("buffer.zig").Buffer;
 const Bufferized = @import("mem.zig").Bufferized;
-const CompilationContext = @import("module.zig").CompilationContext;
+const Compiler = @import("Compiler.zig");
 const constants = @import("constants.zig");
 const CustomCallBuffer = @import("pjrtx.zig").CustomCallBuffer;
 const DataType = @import("dtype.zig").DataType;
@@ -22,7 +22,7 @@ const Tensor = @import("tensor.zig").Tensor;
 pub const TensorToCustomCallBuffer = @import("pjrtx.zig").TensorToCustomCallBuffer;
 
 pub fn allReduce(inputs: anytype, comptime func: anytype) AllReduceReturnType(@TypeOf(inputs)) {
-    const ctx = CompilationContext.current();
+    const ctx = Compiler.current();
     const mlir_ctx = ctx.mlir_ctx;
 
     const InputsT = @TypeOf(inputs);
@@ -194,7 +194,7 @@ fn AllReduceReturnType(comptime InputsT: type) type {
 }
 
 pub fn partitionId() Tensor {
-    const ctx = CompilationContext.current();
+    const ctx = Compiler.current();
     const op = mlir.Operation.make(ctx.mlir_ctx, "stablehlo.partition_id", .{
         .results = .{ .flat = &.{mlirx.Type.rankedTensor(ctx.mlir_ctx, Shape.scalar(.u32))} },
         .location = .unknown(ctx.mlir_ctx),
@@ -208,10 +208,10 @@ pub const ReduceArgs = struct {
 };
 
 pub fn reduce(inputs: anytype, inits: anytype, axes_: []const i64, comptime func: anytype, context: anytype) stdx.meta.FnReturn(func) {
-    var arena = std.heap.ArenaAllocator.init(CompilationContext.current().allocator);
+    var arena = std.heap.ArenaAllocator.init(Compiler.current().allocator);
     defer arena.deinit();
 
-    const mlir_ctx = CompilationContext.current().mlir_ctx;
+    const mlir_ctx = Compiler.current().mlir_ctx;
 
     const reduce_block, var result = b: {
         const ArgsTypes: [inits.len]type = @splat(ReduceArgs);
@@ -231,10 +231,10 @@ pub fn reduce(inputs: anytype, inits: anytype, axes_: []const i64, comptime func
         const reduce_block = mlir.Block.init(&block_types, &block_locs);
         errdefer reduce_block.deinit();
 
-        CompilationContext.current().pushBlock(reduce_block);
-        defer CompilationContext.current().popBlock();
+        Compiler.current().pushBlock(reduce_block);
+        defer Compiler.current().popBlock();
 
-        const scope = CompilationContext.current().currentScope();
+        const scope = Compiler.current().currentScope();
         inline for (0..inits.len) |i| {
             scope.id_to_argument.put(scope.arena.allocator(), args[i].left.id, i) catch unreachable;
             scope.id_to_argument.put(scope.arena.allocator(), args[i].right.id, i + inits.len) catch unreachable;
@@ -267,7 +267,7 @@ pub fn reduce(inputs: anytype, inits: anytype, axes_: []const i64, comptime func
         },
         .verify = true,
         .location = .unknown(mlir_ctx),
-    }).appendTo(CompilationContext.current().currentScope().block);
+    }).appendTo(Compiler.current().currentScope().block);
 
     // `stablehlo.reduce` drops axes. We want to avoid that to propagate tags.
     // So we need to broadcast the output of `stablehlo.reduce` to the input shapes.
@@ -293,7 +293,7 @@ pub fn reduce(inputs: anytype, inits: anytype, axes_: []const i64, comptime func
             broadcasting_axes.slice()[0 .. reduced_shape.rank() - axes_.len],
             mlirx.Type.rankedTensor(mlir_ctx, reduced_shape),
             .unknown(mlir_ctx),
-        ).appendTo(CompilationContext.current().currentScope().block);
+        ).appendTo(Compiler.current().currentScope().block);
 
         result[i] = Tensor._result(reduced_shape, broad_op.result(0));
     }
@@ -320,10 +320,10 @@ pub fn ReduceWindowFn(N: comptime_int) type {
 }
 
 pub fn reduceWindow(N: comptime_int, inputs: [N]Tensor, inits: [N]Tensor, opts: ReduceWindowOpts, func: *const ReduceWindowFn(N)) [N]Tensor {
-    var arena = std.heap.ArenaAllocator.init(CompilationContext.current().allocator);
+    var arena = std.heap.ArenaAllocator.init(Compiler.current().allocator);
     defer arena.deinit();
 
-    const mlir_ctx = CompilationContext.current().mlir_ctx;
+    const mlir_ctx = Compiler.current().mlir_ctx;
 
     const reduce_block, var result = b: {
         const Args = @Tuple(&@as([N]type, @splat(ReduceArgs)));
@@ -342,10 +342,10 @@ pub fn reduceWindow(N: comptime_int, inputs: [N]Tensor, inits: [N]Tensor, opts: 
         const reduce_block = mlir.Block.init(&block_types, &block_locs);
         errdefer reduce_block.deinit();
 
-        CompilationContext.current().pushBlock(reduce_block);
-        defer CompilationContext.current().popBlock();
+        Compiler.current().pushBlock(reduce_block);
+        defer Compiler.current().popBlock();
 
-        const scope = CompilationContext.current().currentScope();
+        const scope = Compiler.current().currentScope();
         inline for (0..N) |i| {
             scope.id_to_argument.put(scope.arena.allocator(), args[i].left.id, i) catch unreachable;
             scope.id_to_argument.put(scope.arena.allocator(), args[i].right.id, i + N) catch unreachable;
@@ -386,7 +386,7 @@ pub fn reduceWindow(N: comptime_int, inputs: [N]Tensor, inits: [N]Tensor, opts: 
         },
         .verify = true,
         .location = .unknown(mlir_ctx),
-    }).appendTo(CompilationContext.current().currentScope().block);
+    }).appendTo(Compiler.current().currentScope().block);
 
     inline for (0..result.len) |i| {
         result[i] = Tensor.fromMlirValue(reduce_op.result(i)).withTags(inputs[i].shape());
@@ -401,10 +401,10 @@ pub const SortArgs = struct {
 };
 
 pub fn sort(inputs: anytype, axis_: i64, comptime func: anytype, context: anytype, is_stable: bool) [inputs.len]Tensor {
-    var arena = std.heap.ArenaAllocator.init(CompilationContext.current().allocator);
+    var arena = std.heap.ArenaAllocator.init(Compiler.current().allocator);
     defer arena.deinit();
 
-    const mlir_ctx = CompilationContext.current().mlir_ctx;
+    const mlir_ctx = Compiler.current().mlir_ctx;
 
     const sort_block = b: {
         const ArgsTypes: [inputs.len]type = @splat(SortArgs);
@@ -424,10 +424,10 @@ pub fn sort(inputs: anytype, axis_: i64, comptime func: anytype, context: anytyp
         const sort_block = mlir.Block.init(&block_types, &block_locs);
         errdefer sort_block.deinit();
 
-        CompilationContext.current().pushBlock(sort_block);
-        defer CompilationContext.current().popBlock();
+        Compiler.current().pushBlock(sort_block);
+        defer Compiler.current().popBlock();
 
-        const scope = CompilationContext.current().currentScope();
+        const scope = Compiler.current().currentScope();
         inline for (0..inputs.len) |i| {
             scope.id_to_argument.put(scope.arena.allocator(), args[i].left.id, 2 * i) catch unreachable;
             scope.id_to_argument.put(scope.arena.allocator(), args[i].right.id, 2 * i + 1) catch unreachable;
@@ -454,7 +454,7 @@ pub fn sort(inputs: anytype, axis_: i64, comptime func: anytype, context: anytyp
         },
         .verify = true,
         .location = .unknown(mlir_ctx),
-    }).appendTo(CompilationContext.current().currentScope().block);
+    }).appendTo(Compiler.current().currentScope().block);
 
     var result: [inputs.len]Tensor = undefined;
     inline for (0..inputs.len) |i| {
@@ -475,7 +475,7 @@ pub fn @"while"(
     context: While,
     initial_state: While.State,
 ) While.State {
-    const comp = CompilationContext.current();
+    const comp = Compiler.current();
 
     var arena = std.heap.ArenaAllocator.init(comp.allocator);
     defer arena.deinit();
@@ -676,7 +676,7 @@ pub fn @"if"(
 
     stdx.debug.assert(pred.dtype() == .bool and pred.count() == 1, "zml.ops.if expects the condition to have exactly one element of dtype .bool, got {f}", .{pred});
 
-    var arena = std.heap.ArenaAllocator.init(CompilationContext.current().allocator);
+    var arena = std.heap.ArenaAllocator.init(Compiler.current().allocator);
     defer arena.deinit();
 
     const allocator = arena.allocator();
@@ -689,15 +689,15 @@ pub fn @"if"(
         }
     }.capture, arena.allocator(), {}, if_captures, &blkctx) catch unreachable;
 
-    const mlir_ctx = CompilationContext.current().mlir_ctx;
+    const mlir_ctx = Compiler.current().mlir_ctx;
     const loc: *const mlir.Location = .unknown(mlir_ctx);
 
     const true_branch, const true_branch_block = b: {
         const block = mlir.Block.init(&.{}, &.{});
         errdefer block.deinit();
 
-        CompilationContext.current().pushBlock(block);
-        defer CompilationContext.current().popBlock();
+        Compiler.current().pushBlock(block);
+        defer Compiler.current().popBlock();
 
         const result = blkctx.onTrue();
         const result_values = meta.collectAlloc(Tensor.value, {}, allocator, &result) catch @panic("OOM");
@@ -710,8 +710,8 @@ pub fn @"if"(
         const block = mlir.Block.init(&.{}, &.{});
         errdefer block.deinit();
 
-        CompilationContext.current().pushBlock(block);
-        defer CompilationContext.current().popBlock();
+        Compiler.current().pushBlock(block);
+        defer Compiler.current().popBlock();
 
         const result = blkctx.onFalse();
         const result_values = meta.collectAlloc(Tensor.value, {}, allocator, &result) catch @panic("OOM");
@@ -730,7 +730,7 @@ pub fn @"if"(
         .verify = false,
         .location = loc,
     });
-    _ = op.appendTo(CompilationContext.current().currentScope().block);
+    _ = op.appendTo(Compiler.current().currentScope().block);
 
     return fromMlirOperationWithTags(op, true_branch);
 }
@@ -775,12 +775,12 @@ pub fn if2(
 ) @TypeOf(on_true) {
     stdx.debug.assert(pred.dtype() == .bool and pred.count() == 1, "zml.ops.if expects the condition to have exactly one element of dtype .bool, got {f}", .{pred});
 
-    var arena = std.heap.ArenaAllocator.init(CompilationContext.current().allocator);
+    var arena = std.heap.ArenaAllocator.init(Compiler.current().allocator);
     defer arena.deinit();
 
     const allocator = arena.allocator();
 
-    const mlir_ctx = CompilationContext.current().mlir_ctx;
+    const mlir_ctx = Compiler.current().mlir_ctx;
     const loc: *const mlir.Location = .unknown(mlir_ctx);
 
     const true_values = meta.collectAlloc(Tensor.value, {}, allocator, &on_true) catch @panic("OOM");
@@ -789,8 +789,8 @@ pub fn if2(
         const block = mlir.Block.init(&.{}, &.{});
         errdefer block.deinit();
 
-        CompilationContext.current().pushBlock(block);
-        defer CompilationContext.current().popBlock();
+        Compiler.current().pushBlock(block);
+        defer Compiler.current().popBlock();
         _ = dialects.stablehlo.returns(mlir_ctx, true_values, loc).appendTo(block);
         break :b block;
     };
@@ -801,8 +801,8 @@ pub fn if2(
         const block = mlir.Block.init(&.{}, &.{});
         errdefer block.deinit();
 
-        CompilationContext.current().pushBlock(block);
-        defer CompilationContext.current().popBlock();
+        Compiler.current().pushBlock(block);
+        defer Compiler.current().popBlock();
 
         _ = dialects.stablehlo.returns(mlir_ctx, false_values, loc).appendTo(block);
         break :b block;
@@ -815,7 +815,7 @@ pub fn if2(
         .location = loc,
         .verify = false,
     });
-    _ = op.appendTo(CompilationContext.current().currentScope().block);
+    _ = op.appendTo(Compiler.current().currentScope().block);
 
     return fromMlirOperationWithTags(op, on_true);
 }
@@ -881,8 +881,8 @@ pub const TritonOps = struct {
 
 /// Generate an MLIR call to the given member function with the given tensors.
 pub fn triton(inputs: anytype, outputs: anytype, opts: TritonOps) [outputs.len]Tensor {
-    const mlir_ctx = CompilationContext.current().mlir_ctx;
-    var arena = std.heap.ArenaAllocator.init(CompilationContext.current().allocator);
+    const mlir_ctx = Compiler.current().mlir_ctx;
+    var arena = std.heap.ArenaAllocator.init(Compiler.current().allocator);
     defer arena.deinit();
 
     var values: [inputs.len]*const mlir.Value = undefined;
@@ -928,7 +928,7 @@ pub fn triton(inputs: anytype, outputs: anytype, opts: TritonOps) [outputs.len]T
             .output_operand_aliases = opts.output_operand_aliases,
         },
         .unknown(mlir_ctx),
-    ).appendTo(CompilationContext.current().currentScope().block);
+    ).appendTo(Compiler.current().currentScope().block);
 
     var outputs_: [outputs.len]Tensor = undefined;
     inline for (outputs, 0..) |output, i| {
@@ -952,7 +952,7 @@ pub const NeuronNkiOps = struct {
 /// This API is Neuron-only: the source is compiled to an
 /// `AwsNeuronCustomNativeKernel` backend config while emitting the graph.
 pub fn neuronNki(inputs: anytype, outputs: anytype, opts: NeuronNkiOps) [outputs.len]Tensor {
-    const ctx = CompilationContext.current();
+    const ctx = Compiler.current();
     switch (ctx.platform.target) {
         .neuron => {},
         .cpu, .cuda, .rocm, .tpu, .oneapi, .metal => {
@@ -1123,10 +1123,10 @@ pub fn scatter(
     context: anytype,
     opts: Tensor.ScatterOpts,
 ) stdx.meta.FnReturn(func) {
-    var arena = std.heap.ArenaAllocator.init(CompilationContext.current().allocator);
+    var arena = std.heap.ArenaAllocator.init(Compiler.current().allocator);
     defer arena.deinit();
 
-    const mlir_ctx = CompilationContext.current().mlir_ctx;
+    const mlir_ctx = Compiler.current().mlir_ctx;
 
     const update_block, var result = b: {
         const ArgsTypes: [inputs.len]type = @splat(ScatterArgs);
@@ -1146,10 +1146,10 @@ pub fn scatter(
         const update_block = mlir.Block.init(&block_types, &block_locs);
         errdefer update_block.deinit();
 
-        CompilationContext.current().pushBlock(update_block);
-        defer CompilationContext.current().popBlock();
+        Compiler.current().pushBlock(update_block);
+        defer Compiler.current().popBlock();
 
-        const scope = CompilationContext.current().currentScope();
+        const scope = Compiler.current().currentScope();
         inline for (0..inputs.len) |i| {
             scope.id_to_argument.put(scope.arena.allocator(), args[i].input.id, i) catch unreachable;
             scope.id_to_argument.put(scope.arena.allocator(), args[i].update.id, i + inputs.len) catch unreachable;
@@ -1231,7 +1231,7 @@ pub fn scatter(
             .unique_indices = opts.indices_are_unique,
         },
         .unknown(mlir_ctx),
-    ).appendTo(CompilationContext.current().currentScope().block);
+    ).appendTo(Compiler.current().currentScope().block);
 
     inline for (0..result.len) |i| {
         result[i] = Tensor._result(inputs[i].shape(), op.result(i));
@@ -1343,7 +1343,7 @@ test scatterConfig {
     const zml = @import("zml.zig");
     const platform = zml.testing.env();
 
-    var comp = zml.module.CompilationContext.init(std.testing.allocator, std.testing.io, platform, .{});
+    var comp = zml.module.Compiler.init(std.testing.allocator, std.testing.io, platform, .{});
     defer comp.deinit();
     comp.activate();
     defer comp.deactivate();
@@ -1437,7 +1437,7 @@ pub const GatherAxisKind = enum { batching, offset, collapsed, indices };
 pub const GatherOpts = struct { indices_are_sorted: bool = false };
 
 pub fn gather(self: Tensor, idx_axes: []const u3, idx_per_axis: []const Tensor, opts: GatherOpts) Tensor {
-    const mlir_ctx = CompilationContext.current().mlir_ctx;
+    const mlir_ctx = Compiler.current().mlir_ctx;
 
     stdx.debug.assert(idx_axes.len > 0, "gather expects 1 or more axes to operate one, received none. Example: `x.gather(.a, indices, .{{}})`", .{});
     for (idx_axes, 0..) |a, i| {
@@ -1544,7 +1544,7 @@ pub fn gather(self: Tensor, idx_axes: []const u3, idx_per_axis: []const Tensor, 
             .indices_are_sorted = opts.indices_are_sorted,
         },
         .unknown(mlir_ctx),
-    ).appendTo(CompilationContext.current().currentScope().block);
+    ).appendTo(Compiler.current().currentScope().block);
 
     const mlir_shape = Tensor.fromMlirValue(gather_op.result(0)).shape();
     stdx.debug.assert(mlir_shape.eql(res_shape), "gather expects that batching indices appear in the same order in 'self' and 'indices', got: self={f}, indices={f}. You should transpose one or the other.", .{ self, indices });
@@ -1565,7 +1565,7 @@ pub const LoweringCompatibility = struct {
     /// splats too early, which can perturb later indexed-update lowering. A
     /// scalar optimization barrier preserves the source-level broadcast shape.
     pub fn preserveIntegerScalarBroadcast(self: Tensor, output_shape: Shape) ?Tensor {
-        switch (CompilationContext.current().platform.target) {
+        switch (Compiler.current().platform.target) {
             .neuron => {},
             .cpu, .cuda, .rocm, .tpu, .oneapi, .metal => return null,
         }
@@ -1584,7 +1584,7 @@ pub const LoweringCompatibility = struct {
     /// keeping the active rows unchanged. Related upstream Neuron report:
     /// https://github.com/aws-neuron/aws-neuron-sdk/issues/1335.
     pub fn preserveGatherFillSemantics(indices: []Tensor) void {
-        switch (CompilationContext.current().platform.target) {
+        switch (Compiler.current().platform.target) {
             .neuron => {},
             .cpu, .cuda, .rocm, .tpu, .oneapi, .metal => return,
         }
@@ -1596,7 +1596,7 @@ pub const LoweringCompatibility = struct {
     /// Preserve scatter drop semantics before backend indirect-memory lowering.
     /// Same as above but for scatter drop semantics.
     pub fn preserveScatterDropSemantics(indices: []Tensor, updates: anytype, opts: Tensor.ScatterOpts, update_values: *[updates.len]*const mlir.Value) void {
-        const active_lanes: ?Tensor = switch (CompilationContext.current().platform.target) {
+        const active_lanes: ?Tensor = switch (Compiler.current().platform.target) {
             .neuron => if (opts.update_fn == Tensor.ScatterOpts.increment) activeLanesForFillDropIndices(indices) else null,
             .cpu, .cuda, .rocm, .tpu, .oneapi, .metal => null,
         };
@@ -1704,7 +1704,7 @@ pub const CustomCallOptions = struct {
     compute_on_host: bool = false,
 };
 
-fn customCallAdditionalAttributes(ctx: *CompilationContext, opts: CustomCallOptions) []const mlir.NamedAttribute {
+fn customCallAdditionalAttributes(ctx: *Compiler, opts: CustomCallOptions) []const mlir.NamedAttribute {
     if (!opts.compute_on_host or ctx.platform.target == .cpu) return &.{};
 
     const frontend_attributes = mlir.Attribute.dict(ctx.mlir_ctx, &.{
@@ -1760,7 +1760,7 @@ pub fn composite(
     context: anytype,
     opts: CompositeOpts,
 ) []Tensor {
-    const ctx = CompilationContext.current();
+    const ctx = Compiler.current();
     const mlir_ctx = ctx.mlir_ctx;
 
     const decomp_name = ctx.allocPrint("{s}.impl_{d}", .{ name, ctx.nextCompositeId() });
@@ -1989,7 +1989,7 @@ fn manualComputationInternal(
     const BodyInputsT = stdx.meta.FnParam(body_fn, 2);
     const BodyOutputShapesT = stdx.meta.FnParam(body_fn, 3);
 
-    const ctx = CompilationContext.current();
+    const ctx = Compiler.current();
     const allocator = ctx.arena.allocator();
 
     const input_shapes = allocator.alloc(Shape, inputs.len) catch unreachable;
@@ -2464,7 +2464,7 @@ pub fn typedCustomCall(
     const Output = @TypeOf(output);
     const Attributes = @TypeOf(attributes);
 
-    const ctx = CompilationContext.current();
+    const ctx = Compiler.current();
     const allocator = ctx.arena.allocator();
 
     stdx.debug.assert(!opts.has_side_effect or ctx.manual_computation_depth > 0, "side-effect customCall '{s}' must be emitted inside manualComputation", .{target_name});
@@ -2622,7 +2622,7 @@ test customCall {
     const zml = @import("zml.zig");
     const platform = zml.testing.env();
 
-    var comp = zml.module.CompilationContext.init(std.testing.allocator, std.testing.io, platform, .{});
+    var comp = zml.module.Compiler.init(std.testing.allocator, std.testing.io, platform, .{});
     defer comp.deinit();
     comp.activate();
     defer comp.deactivate();

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -1343,7 +1343,7 @@ test scatterConfig {
     const zml = @import("zml.zig");
     const platform = zml.testing.env();
 
-    var comp = zml.module.Compiler.init(std.testing.allocator, std.testing.io, platform, .{});
+    var comp: zml.Compiler = .init(std.testing.allocator, std.testing.io, platform, .{});
     defer comp.deinit();
     comp.activate();
     defer comp.deactivate();
@@ -2622,7 +2622,7 @@ test customCall {
     const zml = @import("zml.zig");
     const platform = zml.testing.env();
 
-    var comp = zml.module.Compiler.init(std.testing.allocator, std.testing.io, platform, .{});
+    var comp: zml.Compiler = .init(std.testing.allocator, std.testing.io, platform, .{});
     defer comp.deinit();
     comp.activate();
     defer comp.deactivate();

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -576,7 +576,7 @@ pub const Platform = struct {
         args: std.meta.ArgsTuple(@TypeOf(func)),
         opts: zml.Compiler.Options,
     ) !Exe {
-        return zml.Compiler.compile(allocator, io, func, args, self, opts);
+        return zml.Compiler.compile(io, allocator, self, func, args, opts);
     }
 
     pub fn format(self: *const Platform, writer: *std.Io.Writer) std.Io.Writer.Error!void {

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -576,7 +576,7 @@ pub const Platform = struct {
         args: std.meta.ArgsTuple(@TypeOf(func)),
         opts: zml.Compiler.Options,
     ) !Exe {
-        return zml.Compiler.compile(io, allocator, self, func, args, opts);
+        return zml.Compiler.compile(allocator, io, self, func, args, opts);
     }
 
     pub fn format(self: *const Platform, writer: *std.Io.Writer) std.Io.Writer.Error!void {

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -545,7 +545,7 @@ pub const Platform = struct {
         args: stdx.meta.Tail(
             std.meta.ArgsTuple(@TypeOf(@field(@TypeOf(model_), @tagName(func)))),
         ),
-        opts: zml.module.CompilationOptions,
+        opts: zml.Compiler.Options,
     ) !Exe {
         return self.compileFn(
             allocator,
@@ -563,7 +563,7 @@ pub const Platform = struct {
         comptime func: anytype,
         model: stdx.meta.Head(std.meta.ArgsTuple(@TypeOf(func))),
         args: stdx.meta.Tail(std.meta.ArgsTuple(@TypeOf(func))),
-        opts: zml.module.CompilationOptions,
+        opts: zml.Compiler.Options,
     ) !Exe {
         return self.compileFn(allocator, io, func, .{model} ++ args, opts);
     }
@@ -574,9 +574,9 @@ pub const Platform = struct {
         io: std.Io,
         comptime func: anytype,
         args: std.meta.ArgsTuple(@TypeOf(func)),
-        opts: zml.module.CompilationOptions,
+        opts: zml.Compiler.Options,
     ) !Exe {
-        return zml.module.compile(allocator, io, func, args, self, opts);
+        return zml.Compiler.compile(allocator, io, func, args, self, opts);
     }
 
     pub fn format(self: *const Platform, writer: *std.Io.Writer) std.Io.Writer.Error!void {

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -2748,7 +2748,7 @@ pub const Tensor = struct {
 
         {
             // Only test shapes
-            var comp = zml.module.Compiler.init(std.testing.allocator, std.testing.io, platform, .{});
+            var comp: zml.Compiler = .init(std.testing.allocator, std.testing.io, platform, .{});
             defer comp.deinit();
             comp.activate();
             defer comp.deactivate();
@@ -2900,7 +2900,7 @@ pub const Tensor = struct {
 
         {
             // Only test shapes
-            var comp = zml.module.Compiler.init(std.testing.allocator, std.testing.io, platform, .{});
+            var comp: zml.Compiler = .init(std.testing.allocator, std.testing.io, platform, .{});
             defer comp.deinit();
             comp.activate();
             defer comp.deactivate();
@@ -3125,7 +3125,7 @@ pub const Tensor = struct {
 
         {
             // Only test shapes
-            var comp = zml.module.Compiler.init(std.testing.allocator, std.testing.io, platform, .{});
+            var comp: zml.Compiler = .init(std.testing.allocator, std.testing.io, platform, .{});
             defer comp.deinit();
             comp.activate();
             defer comp.deactivate();
@@ -3664,7 +3664,7 @@ pub const Tensor = struct {
         const platform = zml.testing.env();
 
         // Only test shapes
-        var comp = zml.module.Compiler.init(std.testing.allocator, std.testing.io, platform, .{});
+        var comp: zml.Compiler = .init(std.testing.allocator, std.testing.io, platform, .{});
         defer comp.deinit();
         comp.activate();
         defer comp.deactivate();
@@ -3717,7 +3717,7 @@ pub const Tensor = struct {
         const platform = zml.testing.env();
 
         // Only test shapes
-        var comp = zml.module.Compiler.init(std.testing.allocator, std.testing.io, platform, .{});
+        var comp: zml.Compiler = .init(std.testing.allocator, std.testing.io, platform, .{});
         defer comp.deinit();
         comp.activate();
         defer comp.deactivate();

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -5,7 +5,7 @@ const dialects = @import("mlir/dialects");
 const mlir = @import("mlir");
 const stdx = @import("stdx");
 
-const CompilationContext = @import("module.zig").CompilationContext;
+const Compiler = @import("Compiler.zig");
 const constants = @import("constants.zig");
 const DataType = @import("dtype.zig").DataType;
 const mem = @import("mem.zig");
@@ -92,7 +92,7 @@ pub const Tensor = struct {
     ///
     /// The shape is derived from the type of the mlir.Value.
     pub fn fromMlirValue(val: *const mlir.Value) Tensor {
-        const ctx = CompilationContext.current();
+        const ctx = Compiler.current();
         const ranked_tensor = val.type_().isA(mlir.RankedTensorType).?;
         const n = ranked_tensor.rank();
 
@@ -153,7 +153,7 @@ pub const Tensor = struct {
     pub fn withPartitioning(self: Tensor, axes_: anytype) Tensor {
         const partitioned_shape = self._shape.withPartitioning(axes_);
 
-        const ctx = CompilationContext.currentOrNull() orelse {
+        const ctx = Compiler.currentOrNull() orelse {
             var res = self;
             res._shape = partitioned_shape;
             return res;
@@ -203,7 +203,7 @@ pub const Tensor = struct {
 
     /// Copy the given tensor to the specified memory.
     pub fn toMemory(self: Tensor, kind: Memory.Kind) Tensor {
-        const ctx = CompilationContext.current();
+        const ctx = Compiler.current();
         switch (ctx.platform.target) {
             .cpu, .neuron, .metal => return self,
             .cuda, .rocm, .tpu, .oneapi => {},
@@ -240,7 +240,7 @@ pub const Tensor = struct {
     /// Copy all the given tensor to the specified memory.
     /// The input struct is copied on the stack, so it must be a simple flat struct without pointers.
     pub fn toMemoryAll(flat_tensors: anytype, kind: Memory.Kind) @TypeOf(flat_tensors) {
-        const ctx = CompilationContext.current();
+        const ctx = Compiler.current();
         switch (ctx.platform.target) {
             .cpu, .neuron, .metal => return flat_tensors,
             .cuda, .rocm, .tpu, .oneapi => {},
@@ -258,7 +258,7 @@ pub const Tensor = struct {
     /// Mark the given input tensor as being physically located on a specific memory.
     /// Has no effect if the input tensor is not an executable input.
     pub fn onMemory(self: Tensor, kind: Memory.Kind) Tensor {
-        const ctx = CompilationContext.current();
+        const ctx = Compiler.current();
         switch (ctx.platform.target) {
             .cpu, .neuron, .metal => return self,
             .cuda, .rocm, .tpu, .oneapi => {},
@@ -276,7 +276,7 @@ pub const Tensor = struct {
     /// Mark all the given input tensors as being physically located on a specific memory
     /// see `zml.Tensor.onMemory`
     pub fn onMemoryAll(tensors: anytype, kind: Memory.Kind) void {
-        const ctx = CompilationContext.current();
+        const ctx = Compiler.current();
         switch (ctx.platform.target) {
             // Only one memory kind on those platform
             .cpu, .neuron, .metal => return,
@@ -311,10 +311,10 @@ pub const Tensor = struct {
 
     /// Returns the mlir.Value associated with the Tensor.
     ///
-    /// This will fail if used outside of a compilation context.
+    /// This will fail if used outside of a Compiler context.
     pub fn value(self: Tensor) *const mlir.Value {
-        if (CompilationContext.current().currentScope().id_to_argument.get(self.id)) |argument_index| {
-            return CompilationContext.current().currentScope().block.argument(argument_index);
+        if (Compiler.current().currentScope().id_to_argument.get(self.id)) |argument_index| {
+            return Compiler.current().currentScope().block.argument(argument_index);
         } else if (self._value) |v| {
             return v;
         } else @panic("Something went really wrong, tensor is not an argument nor has an mlir.Value");
@@ -328,7 +328,7 @@ pub const Tensor = struct {
     /// is not allowed to reuse the donated input buffer after the call.
     /// For `reuseBuffer` to be effective, it needs to propagate all the way through the output.
     pub fn reuseBuffer(self: Tensor, origin: Tensor) Tensor {
-        const compilation_context = CompilationContext.current();
+        const compilation_context = Compiler.current();
         const scope = compilation_context.currentScope();
         if (scope.id_to_argument.get(origin.id)) |argument_index| {
             const gop = scope.id_to_donation.getOrPut(scope.arena.allocator(), self.id) catch unreachable;
@@ -2093,7 +2093,7 @@ pub const Tensor = struct {
     /// Concatenates the input Tensors along the given axis.
     pub fn concatenate(tensors: []const Tensor, axis_: anytype) Tensor {
         if (tensors.len == 1) return tensors[0];
-        const ctx = CompilationContext.current();
+        const ctx = Compiler.current();
         var buffer = ctx.alloc(*const mlir.Value, tensors.len);
         std.debug.assert(tensors.len <= buffer.len);
         std.debug.assert(tensors.len > 0);
@@ -2125,7 +2125,7 @@ pub const Tensor = struct {
             stdx.debug.assert(shape0.eqlWithTags(tensor._shape), "stack expects tensor shapes to match, got {f} and {f}", .{ shape0, tensor._shape });
         }
 
-        const ctx = CompilationContext.current();
+        const ctx = Compiler.current();
         var reshaped = ctx.alloc(Tensor, tensors.len);
         for (tensors, 0..) |tensor, i| {
             reshaped[i] = tensor.reshape(res_shape);
@@ -2476,7 +2476,7 @@ pub const Tensor = struct {
     }
 
     pub fn uninitialized(sh: Shape) Tensor {
-        const ctx = CompilationContext.current();
+        const ctx = Compiler.current();
         const buffer_type = mlir.Type.memRef(
             mlirx.Type.fromDType(ctx.mlir_ctx, sh.dtype()),
             sh.dims(),
@@ -2584,7 +2584,7 @@ pub const Tensor = struct {
     }
 
     pub fn optimizationBarrier(self: Tensor) Tensor {
-        const ctx = CompilationContext.current();
+        const ctx = Compiler.current();
 
         const op = dialects.stablehlo.optimizationBarrier(
             ctx.mlir_ctx,
@@ -2748,7 +2748,7 @@ pub const Tensor = struct {
 
         {
             // Only test shapes
-            var comp = zml.module.CompilationContext.init(std.testing.allocator, std.testing.io, platform, .{});
+            var comp = zml.module.Compiler.init(std.testing.allocator, std.testing.io, platform, .{});
             defer comp.deinit();
             comp.activate();
             defer comp.deactivate();
@@ -2900,7 +2900,7 @@ pub const Tensor = struct {
 
         {
             // Only test shapes
-            var comp = zml.module.CompilationContext.init(std.testing.allocator, std.testing.io, platform, .{});
+            var comp = zml.module.Compiler.init(std.testing.allocator, std.testing.io, platform, .{});
             defer comp.deinit();
             comp.activate();
             defer comp.deactivate();
@@ -3125,7 +3125,7 @@ pub const Tensor = struct {
 
         {
             // Only test shapes
-            var comp = zml.module.CompilationContext.init(std.testing.allocator, std.testing.io, platform, .{});
+            var comp = zml.module.Compiler.init(std.testing.allocator, std.testing.io, platform, .{});
             defer comp.deinit();
             comp.activate();
             defer comp.deactivate();
@@ -3500,7 +3500,7 @@ pub const Tensor = struct {
             },
             else => stdx.debug.compileError(err_msg, .{}),
         };
-        const ctx = CompilationContext.current();
+        const ctx = Compiler.current();
         var result: SortRes = switch (ctx.platform.target) {
             // Work around https://github.com/aws-neuron/aws-neuron-sdk/issues/1339 until Neuron's sort+slice rewrite uses the slice size as k.
             .neuron => blk: {
@@ -3664,7 +3664,7 @@ pub const Tensor = struct {
         const platform = zml.testing.env();
 
         // Only test shapes
-        var comp = zml.module.CompilationContext.init(std.testing.allocator, std.testing.io, platform, .{});
+        var comp = zml.module.Compiler.init(std.testing.allocator, std.testing.io, platform, .{});
         defer comp.deinit();
         comp.activate();
         defer comp.deactivate();
@@ -3703,7 +3703,7 @@ pub const Tensor = struct {
         const tail_chunk_size: i64 = @rem(d, chunk_size);
 
         const len: usize = if (tail_chunk_size == 0) n_chunks else n_chunks + 1;
-        const chunks = CompilationContext.current().alloc(Tensor, len);
+        const chunks = Compiler.current().alloc(Tensor, len);
 
         for (0.., chunks) |i, *chunk| {
             const start: i64 = @as(i64, @intCast(i)) * chunk_size;
@@ -3717,7 +3717,7 @@ pub const Tensor = struct {
         const platform = zml.testing.env();
 
         // Only test shapes
-        var comp = zml.module.CompilationContext.init(std.testing.allocator, std.testing.io, platform, .{});
+        var comp = zml.module.Compiler.init(std.testing.allocator, std.testing.io, platform, .{});
         defer comp.deinit();
         comp.activate();
         defer comp.deactivate();
@@ -3760,7 +3760,7 @@ pub const Tensor = struct {
         for (split_sizes) |n| split_sum += n;
         stdx.debug.assert(split_sum == d, "split expects sum of 'split_sizes' values and axis dimension to be equal, got {} and {}", .{ split_sum, d });
 
-        const res = CompilationContext.current().alloc(Tensor, split_sizes.len);
+        const res = Compiler.current().alloc(Tensor, split_sizes.len);
 
         var start: i64 = 0;
         for (split_sizes, 0..) |n, i| {
@@ -4485,7 +4485,7 @@ pub const Tensor = struct {
     /// Only for debug purpose, it inserts device to host synchronization
     /// so it will slow down the program execution.
     pub fn print(input: Tensor, name: []const u8) void {
-        const ctx = CompilationContext.current();
+        const ctx = Compiler.current();
         const full_name = std.fmt.allocPrint(ctx.arena.allocator(), "{s}: {f}", .{ name, input.shape() }) catch @panic("OOM");
         defer ctx.arena.allocator().free(full_name);
         switch (ctx.platform.target) {
@@ -4501,25 +4501,25 @@ pub const Tensor = struct {
     }
 
     fn mlirCtx() *mlir.Context {
-        return CompilationContext.current().mlir_ctx;
+        return Compiler.current().mlir_ctx;
     }
 
     fn currentBlock() *mlir.Block {
-        return CompilationContext.current().currentScope().block;
+        return Compiler.current().currentScope().block;
     }
 
     /// Returns the donation data of the tensor.
     pub fn donation(self: Tensor) ?usize {
-        return CompilationContext.current().currentScope().id_to_donation.get(self.id);
+        return Compiler.current().currentScope().id_to_donation.get(self.id);
     }
 
     /// Returns the output memory kind of the tensor.
     pub fn outputMemoryKind(self: Tensor) Memory.Kind {
-        return CompilationContext.current().currentScope().id_to_output_memory_kind.get(self.id) orelse .device;
+        return Compiler.current().currentScope().id_to_output_memory_kind.get(self.id) orelse .device;
     }
 
     pub fn inputMemoryKind(self: Tensor) ?Memory.Kind {
-        return CompilationContext.current().currentScope().id_to_input_memory_kind.get(self.id);
+        return Compiler.current().currentScope().id_to_input_memory_kind.get(self.id);
     }
 };
 

--- a/zml/zml.zig
+++ b/zml/zml.zig
@@ -65,7 +65,7 @@ pub const module = struct {
         platform_: *const Platform,
         opts: Compiler.Options,
     ) Compiler.Error!Exe {
-        return Compiler.compile(io_, allocator, platform_, func, args, opts);
+        return Compiler.compile(allocator, io_, platform_, func, args, opts);
     }
 };
 

--- a/zml/zml.zig
+++ b/zml/zml.zig
@@ -15,6 +15,7 @@ pub const tokenizer = @import("zml/tokenizer");
 
 pub const attention = @import("attention.zig");
 pub const Buffer = @import("buffer.zig").Buffer;
+pub const Compiler = @import("Compiler.zig");
 pub const constants = @import("constants.zig");
 pub const dtype = @import("dtype.zig");
 pub const Data = dtype.Data;
@@ -30,9 +31,6 @@ pub const mem = @import("mem.zig");
 pub const Bufferized = mem.Bufferized;
 pub const meta = @import("meta.zig");
 pub const mlir = @import("mlirx.zig");
-pub const module = @import("module.zig");
-pub const CompilationOptions = module.CompilationOptions;
-pub const Compiler = module.Compiler;
 pub const moe = @import("moe/moe.zig");
 pub const nn = @import("nn.zig");
 pub const ops = @import("ops.zig");

--- a/zml/zml.zig
+++ b/zml/zml.zig
@@ -50,6 +50,20 @@ pub const tensor = @import("tensor.zig");
 pub const Tensor = tensor.Tensor;
 pub const testing = @import("testing.zig");
 
+pub const module = struct {
+    /// Deprecated, use `platform.compile` or `zml.Compiler.compile`
+    pub fn compile(
+        allocator: std.mem.Allocator,
+        io_: std.Io,
+        comptime func: anytype,
+        args: std.meta.ArgsTuple(@TypeOf(func)),
+        platform_: *const Platform,
+        opts: Compiler.Options,
+    ) Compiler.Error!Exe {
+        return Compiler.compile(io_, allocator, platform_, func, args, opts);
+    }
+};
+
 test "zml" {
     std.testing.refAllDecls(@This());
 }

--- a/zml/zml.zig
+++ b/zml/zml.zig
@@ -56,7 +56,7 @@ pub const module = struct {
     pub const CompileError = Compiler.Error;
     pub const CompilationOptions = Compiler.Options;
 
-    /// Deprecated, use `platform.compile` or `zml.Compiler.compile`
+    /// Deprecated, use `platform.compileFn` or `zml.Compiler.compile`
     pub fn compile(
         allocator: std.mem.Allocator,
         io_: std.Io,

--- a/zml/zml.zig
+++ b/zml/zml.zig
@@ -50,7 +50,12 @@ pub const tensor = @import("tensor.zig");
 pub const Tensor = tensor.Tensor;
 pub const testing = @import("testing.zig");
 
+/// Deprecated, use `zml.Compiler` instead
 pub const module = struct {
+    pub const CompilationContext = Compiler;
+    pub const CompileError = Compiler.Error;
+    pub const CompilationOptions = Compiler.Options;
+
     /// Deprecated, use `platform.compile` or `zml.Compiler.compile`
     pub fn compile(
         allocator: std.mem.Allocator,


### PR DESCRIPTION
Migration instructions:

zml.module.CompilationContext -> zml.Compiler
zml.module.CompileError -> zml.Compiler.Error
zml.module.CompilationOptions -> zml.Compiler.Options
zml.module.compile -> zml.Platform.compiler or zml.Compiler.compile

Breaking changes: none, I've kept a small compatibility layer at the top level, with upgrade instructions.

We can remove it in a second time.