### PR TITLE
zml/attention: optimize sparse MLA value accumulation

### DIFF
--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -801,8 +801,9 @@ pub fn partialSoftmax(self: zml.Tensor, axis: anytype) PartialSoftmax {
 pub const Mla = struct {
     pub const Options = struct {
         rope_rank: i64,
+        value_rank: i64,
         scale: ?f32 = null,
-        /// null selects automatically; 1 forces the 2D kernel; other values must be powers of two up to 16.
+        /// null selects automatically; 1 forces the 2D kernel; other values must be powers of two up to 128.
         num_kv_splits: ?u8 = null,
     };
 
@@ -833,9 +834,12 @@ pub const Mla = struct {
 
         const attn_weights = scores_sink.softmax(.kv);
         const attn_weights_non_sink = attn_weights.slice(-1, .{ .end = topk.dim(.topk) });
-        return attn_weights_non_sink.dot(selected_kv, .kv).convert(q.dtype());
+        const selected_values = selected_kv.slice(.hd, .{ .end = opts.value_rank });
+        return attn_weights_non_sink.dot(selected_values, .kv).convert(q.dtype());
     }
 
+    /// Computes sparse MLA scores over the complete cached key and returns
+    /// `opts.value_rank` output dimensions per head.
     pub fn pagedSparseAttention(parameters: Parameters, q: zml.Tensor, kv_cache: KvCache, sink: ?zml.Tensor, topk: zml.Tensor, tokens_pos: zml.Tensor, opts: Mla.Options) zml.Tensor {
         const latent_kv = switch (kv_cache) {
             .latent => |latent_kv| latent_kv,
@@ -844,6 +848,8 @@ pub const Mla = struct {
 
         stdx.debug.assert(q.shape().hasTags(.{ .q, .h, .hd }), "expected q to have tags .q, .h, .hd after flattening, got {f}", .{q.shape()});
         stdx.debug.assert(q.dim(.hd) > opts.rope_rank, "expected q head dim ({}) to include a rope tail of {}", .{ q.dim(.hd), opts.rope_rank });
+        stdx.debug.assert(opts.value_rank > 0, "expected MLA value rank to be positive, got {}", .{opts.value_rank});
+        stdx.debug.assert(opts.value_rank == q.dim(.hd) or opts.value_rank + opts.rope_rank == q.dim(.hd), "expected MLA value rank ({}) to cover either the complete qk head ({}) or its non-RoPE prefix ({})", .{ opts.value_rank, q.dim(.hd), q.dim(.hd) - opts.rope_rank });
         stdx.debug.assert(latent_kv.shape().hasTags(.{ .page, .k_chunk, .hkv, .hd }), "expected paged latent KV cache to have tags .page, .k_chunk, .hkv, .hd, got {f}", .{latent_kv.shape()});
         stdx.debug.assert(latent_kv.dim(.hd) == q.dim(.hd), "expected q and kv cache head dims to match, got q={} kv={}", .{ q.dim(.hd), latent_kv.dim(.hd) });
 
@@ -861,7 +867,7 @@ pub const Mla = struct {
     }
 };
 
-test "use mla kernel" {
+test "Triton sparse MLA value ranks and padded queries" {
     const platform = zml.testing.env();
     if (!Backend.triton.isAvailable(platform)) return error.SkipZigTest;
 
@@ -871,40 +877,45 @@ test "use mla kernel" {
         .batch_size = 1,
         .seq_len = 32,
         .max_num_pages = 2,
-        .max_token_count = 1,
+        .max_token_count = 2,
         .num_heads = 16,
         .num_kv_heads = 1,
         .head_dim = 128,
-        .max_seqlen_q = 1,
+        .max_seqlen_q = 2,
     }));
-    const q_shape = zml.Shape.init(.{ .q = 1, .h = 16, .hd = 128 }, .f32);
+    const q_shape = zml.Shape.init(.{ .q = 2, .h = 16, .hd = 128 }, .f32);
     const kv_shape = zml.Shape.init(.{ .page = 2, .k_chunk = 16, .hkv = 1, .hd = 128 }, .f32);
     const sink_shape = zml.Shape.init(.{ .h = 16 }, .f32);
-    const topk_shape = zml.Shape.init(.{ .q = 1, .topk = 32 }, .i32);
-    const tokens_pos_shape = zml.Shape.init(.{ .q = 1 }, .i32);
+    const topk_shape = zml.Shape.init(.{ .q = 2, .topk = 32 }, .i32);
+    const tokens_pos_shape = zml.Shape.init(.{ .q = 2 }, .i32);
 
-    var q_data: [1][16][128]f32 = undefined;
+    var q_data: [2][16][128]f32 = undefined;
     @memset(std.mem.sliceAsBytes(&q_data), 0);
+    for (&q_data[0]) |*head| head[64] = 1;
     var kv_data: [2][16][1][128]f32 = undefined;
     @memset(std.mem.sliceAsBytes(&kv_data), 0);
-    for (&kv_data[1][0][0]) |*value| value.* = 10;
-    for (&kv_data[1][1][0]) |*value| value.* = 11;
+    @memset(kv_data[1][0][0][0..64], 10);
+    @memset(kv_data[1][1][0][0..64], 20);
+    kv_data[1][0][0][64] = 0;
+    kv_data[1][1][0][64] = 2;
     var sink_data: [16]f32 = undefined;
     for (&sink_data) |*value| value.* = -std.math.inf(f32);
-    var topk_data: [1][32]i32 = undefined;
+    var topk_data: [2][32]i32 = undefined;
     @memset(&topk_data[0], -1);
+    @memset(&topk_data[1], -1);
     topk_data[0][0] = 0;
     topk_data[0][1] = 1;
-    const tokens_pos_data: [1]i32 = .{31};
+    const tokens_pos_data: [2]i32 = .{ 31, 31 };
     const block_table: [1][2]i32 = .{.{ 1, 0 }};
     const seq_lens: [1]i32 = .{32};
+    // Only the first of the two statically allocated query rows is active.
     const query_start_len: [2]i32 = .{ 0, 1 };
 
     const q = zml.Tensor.init(q_shape, .f32);
     const kv: KvCache = .{ .latent = zml.Tensor.init(kv_shape, .f32) };
     const sink = zml.Tensor.init(sink_shape, .f32);
     const topk = zml.Tensor.init(topk_shape, .i32);
-    const tokens_pos = zml.Tensor.init(.{ .q = 1 }, .i32);
+    const tokens_pos = zml.Tensor.init(tokens_pos_shape, .i32);
 
     var parameters_d: zml.Bufferized(Parameters) = .{ .triton = .{
         .block_table = try .fromBytes(std.testing.io, platform, parameters.triton.block_table.shape(), .replicated, std.mem.sliceAsBytes(&block_table)),
@@ -923,23 +934,59 @@ test "use mla kernel" {
     var tokens_pos_d = try zml.Buffer.fromBytes(std.testing.io, platform, tokens_pos_shape, .replicated, std.mem.sliceAsBytes(&tokens_pos_data));
     defer tokens_pos_d.deinit();
 
-    const exe = try platform.compileFn(
-        std.testing.allocator,
-        std.testing.io,
-        Mla.pagedSparseAttention,
-        .{ parameters, q, kv, sink, topk, tokens_pos, .{ .rope_rank = 64, .num_kv_splits = 2 } },
-        .{},
-    );
-    defer exe.deinit();
+    const TestCase = struct {
+        num_kv_splits: u8,
+        value_rank: i64,
+    };
+    inline for ([_]TestCase{
+        .{ .num_kv_splits = 2, .value_rank = 64 },
+        .{ .num_kv_splits = 1, .value_rank = 128 },
+    }) |case| {
+        var exe = try platform.compileFn(
+            std.testing.allocator,
+            std.testing.io,
+            Mla.pagedSparseAttention,
+            .{ parameters, q, kv, sink, topk, tokens_pos, .{
+                .rope_rank = 64,
+                .value_rank = case.value_rank,
+                .scale = 1,
+                .num_kv_splits = case.num_kv_splits,
+            } },
+            .{},
+        );
+        defer exe.deinit();
 
-    var output_d = try zml.testing.autoCall(
-        std.testing.allocator,
-        std.testing.io,
-        &exe,
-        Mla.pagedSparseAttention,
-        .{ parameters_d, q_d, kv_d, sink_d, topk_d, tokens_pos_d },
-    );
-    defer zml.Buffer.deinitAll(zml.Tensor, &output_d);
+        var output_d = try zml.testing.autoCall(
+            std.testing.allocator,
+            std.testing.io,
+            &exe,
+            Mla.pagedSparseAttention,
+            .{ parameters_d, q_d, kv_d, sink_d, topk_d, tokens_pos_d },
+        );
+        defer output_d.deinit();
+        try std.testing.expect(output_d.shape().eql(q_shape.set(.hd, case.value_rank)));
+
+        var output = try output_d.toSliceAlloc(std.testing.allocator, std.testing.io);
+        defer output.free(std.testing.allocator);
+        const active_output = output.subSlice(output.shape.axis(.q), 0, 1);
+
+        const expected_shape = q_shape.set(.q, 1).set(.hd, case.value_rank);
+        const expected_data = try std.testing.allocator.alloc(f32, expected_shape.count());
+        defer std.testing.allocator.free(expected_data);
+        const exp_two = @exp(@as(f32, 2));
+        const second_weight = exp_two / (1 + exp_two);
+        for (expected_data, 0..) |*value, i| {
+            const dim = i % @as(usize, @intCast(case.value_rank));
+            value.* = if (dim < 64)
+                10 + 10 * second_weight
+            else if (dim == 64)
+                2 * second_weight
+            else
+                0;
+        }
+        const expected = zml.Slice.init(expected_shape, std.mem.sliceAsBytes(expected_data));
+        try zml.testing.expectClose(std.testing.io, expected, active_output, .{ .absolute_tolerance = 0.001, .relative_tolerance = 0.001 });
+    }
 }
 
 test "execute stablehlo mla kernel" {
@@ -965,10 +1012,13 @@ test "execute stablehlo mla kernel" {
 
     var q_data: [1][16][128]f32 = undefined;
     @memset(std.mem.sliceAsBytes(&q_data), 0);
+    for (&q_data[0]) |*head| head[64] = 1;
     var kv_data: [2][16][1][128]f32 = undefined;
     @memset(std.mem.sliceAsBytes(&kv_data), 0);
-    for (&kv_data[1][0][0]) |*value| value.* = 10;
-    for (&kv_data[1][1][0]) |*value| value.* = 11;
+    @memset(kv_data[1][0][0][0..64], 10);
+    @memset(kv_data[1][1][0][0..64], 20);
+    kv_data[1][0][0][64] = 0;
+    kv_data[1][1][0][64] = 2;
     var sink_data: [16]f32 = undefined;
     for (&sink_data) |*value| value.* = -std.math.inf(f32);
     const topk_data: [1][2]i32 = .{.{ 0, 1 }};
@@ -1004,7 +1054,11 @@ test "execute stablehlo mla kernel" {
         std.testing.allocator,
         std.testing.io,
         Mla.pagedSparseAttention,
-        .{ parameters, q, kv, sink, topk, tokens_pos, .{ .rope_rank = 64 } },
+        .{ parameters, q, kv, sink, topk, tokens_pos, .{
+            .rope_rank = 64,
+            .value_rank = 64,
+            .scale = 1,
+        } },
         .{},
     );
     defer exe.deinit();
@@ -1017,4 +1071,12 @@ test "execute stablehlo mla kernel" {
         .{ parameters_d, q_d, kv_d, sink_d, topk_d, tokens_pos_d },
     );
     defer zml.Buffer.deinitAll(zml.Tensor, &output_d);
+
+    const output_shape = q_shape.set(.hd, 64);
+    var expected_data: [1][16][64]f32 = undefined;
+    const exp_two = @exp(@as(f32, 2));
+    const expected_value = (10 + 20 * exp_two) / (1 + exp_two);
+    for (&expected_data[0]) |*head| @memset(head, expected_value);
+    const expected = zml.Slice.init(output_shape, std.mem.sliceAsBytes(&expected_data));
+    try zml.testing.expectClose(std.testing.io, expected, output_d, .{ .absolute_tolerance = 0.001, .relative_tolerance = 0.001 });
 }

--- a/zml/attention/triton_attention.zig
+++ b/zml/attention/triton_attention.zig
@@ -38,74 +38,98 @@ pub const Config2D = struct {
     total_q_blocks: usize,
 };
 
-const SparseMlaLaunchConfig = struct {
+const SparseMlaConfig = struct {
     block_m: usize,
     tile_size: usize,
-    num_tiles: usize,
     num_splits: usize,
     direct_programs: usize,
+    main_num_warps: usize = 4,
+    main_num_stages: usize = 2,
+    grouped_reduce_threshold: usize = 32,
+    splits_per_group: usize = 16,
+    grouped_reduce_num_warps: usize = 1,
+    parallel_reduce_min_splits: usize = std.math.maxInt(usize),
+    parallel_reduce_num_warps: usize = 1,
 };
 
-fn selectSparseMlaLaunchConfig(
-    query_count: usize,
-    num_heads: usize,
-    topk_count: usize,
-    cu_count_: usize,
-    requested_splits: ?u8,
-) SparseMlaLaunchConfig {
-    stdx.debug.assert(query_count > 0, "sparse MLA requires at least one query", .{});
-    stdx.debug.assert(num_heads > 0, "sparse MLA requires at least one query head", .{});
+fn isCudaComputeCapability(expected: []const u8) bool {
+    const platform = zml.module.CompilationContext.current().platform;
+    if (platform.target != .cuda) return false;
+    const devices = platform.pjrt_client.devices(platform.pjrt_api);
+    if (devices.len == 0) return false;
+    const actual = zml.platform.cuda.tryGetComputeCapabilities(platform, devices[0]) orelse return false;
+    return std.mem.eql(u8, actual, expected);
+}
+
+fn sparseMlaConfig(paged_opts: paged.PagedSparseMlaOptions, topk_count: usize, cu_count_: usize) SparseMlaConfig {
+    stdx.debug.assert(paged_opts.total_q_blocks > 0, "sparse MLA requires at least one query", .{});
+    stdx.debug.assert(paged_opts.num_heads > 0, "sparse MLA requires at least one query head", .{});
     stdx.debug.assert(topk_count > 0, "sparse MLA requires at least one top-k entry", .{});
 
-    const block_m = @min(num_heads, 16);
-    stdx.debug.assert(@mod(num_heads, block_m) == 0, "expected q heads ({}) to be divisible by block_m ({})", .{ num_heads, block_m });
+    const padded_heads = std.math.ceilPowerOfTwoAssert(usize, paged_opts.num_heads);
+    const padded_topk = std.math.ceilPowerOfTwoAssert(usize, topk_count);
+    var config: SparseMlaConfig = .{
+        .block_m = @min(padded_heads, 16),
+        .tile_size = @min(padded_topk, 16),
+        .num_splits = 1,
+        .direct_programs = undefined,
+    };
+    const is_sm103 = isCudaComputeCapability("10.3");
 
-    const topk_padded = std.math.ceilPowerOfTwoAssert(usize, topk_count);
-    const tile_size = @min(topk_padded, 16);
-    const num_tiles = std.math.divCeil(usize, topk_count, tile_size) catch unreachable;
-    const direct_programs = query_count * @divExact(num_heads, block_m);
-    const cu_count = @max(cu_count_, 1);
-
-    var max_splits: usize = 1;
-    while (max_splits * 2 <= @min(num_tiles, 16)) max_splits *= 2;
-
-    if (requested_splits) |requested| {
-        const num_splits: usize = requested;
-        stdx.debug.assert(std.math.isPowerOfTwo(num_splits), "MLA num_kv_splits ({}) must be a power of two", .{num_splits});
-        stdx.debug.assert(num_splits <= 16, "MLA num_kv_splits ({}) must not exceed 16", .{num_splits});
-        stdx.debug.assert(num_splits <= num_tiles, "MLA num_kv_splits ({}) must not exceed sparse tile count ({})", .{ num_splits, num_tiles });
-        return .{
-            .block_m = block_m,
-            .tile_size = tile_size,
-            .num_tiles = num_tiles,
-            .num_splits = num_splits,
-            .direct_programs = direct_programs,
-        };
+    // GB300 (sm_103): a single wide query benefits from more head blocks and
+    // wider sparse tiles. The split selection below still derives each layer's
+    // split count from query/head/top-k shapes (16 for DSV4 CSA/HCA and 4 for
+    // its 128-entry full-attention layers).
+    if (is_sm103 and
+        paged_opts.all_decode and
+        paged_opts.total_q_blocks == 1 and
+        paged_opts.value_rank >= 512)
+    {
+        config.block_m = @min(padded_heads, 8);
+        config.tile_size = @min(padded_topk, 32);
+        config.parallel_reduce_min_splits = 16;
+        config.parallel_reduce_num_warps = 2;
+    }
+    // Full 256-query prefill chunks already expose enough query parallelism.
+    // Retain BLOCK_M=16 and the generic split model, but process wider sparse
+    // tiles. The predicate uses the post-sharding flattened query shape.
+    if (is_sm103 and
+        !paged_opts.all_decode and
+        paged_opts.total_q_blocks >= 256 and
+        paged_opts.value_rank >= 512)
+    {
+        config.tile_size = @min(padded_topk, 32);
     }
 
-    var best_splits: usize = 1;
-    var best_cost: usize = std.math.maxInt(usize);
-    const candidates = [_]usize{ 1, 2, 4, 8, 16 };
-    for (candidates) |num_splits| {
-        if (num_splits > max_splits) break;
-        const programs = direct_programs * num_splits;
-        const rounds = std.math.divCeil(usize, programs, cu_count) catch unreachable;
-        const tiles_per_program = std.math.divCeil(usize, num_tiles, num_splits) catch unreachable;
-        const cost = rounds * tiles_per_program;
-        // Candidates are ordered by split count, so ties retain 2D or the lower-overhead 3D launch.
-        if (cost < best_cost) {
-            best_cost = cost;
-            best_splits = num_splits;
+    const num_tiles = std.math.divCeil(usize, topk_count, config.tile_size) catch unreachable;
+    const head_blocks = std.math.divCeil(usize, paged_opts.num_heads, config.block_m) catch unreachable;
+    config.direct_programs = paged_opts.total_q_blocks * head_blocks;
+    const cu_count = @max(cu_count_, 1);
+
+    if (paged_opts.num_kv_splits) |requested| {
+        const num_splits: usize = requested;
+        stdx.debug.assert(std.math.isPowerOfTwo(num_splits), "MLA num_kv_splits ({}) must be a power of two", .{num_splits});
+        stdx.debug.assert(num_splits <= 128, "MLA num_kv_splits ({}) must not exceed 128", .{num_splits});
+        stdx.debug.assert(num_splits <= num_tiles, "MLA num_kv_splits ({}) must not exceed sparse tile count ({})", .{ num_splits, num_tiles });
+        config.num_splits = num_splits;
+    } else {
+        var best_cost: usize = std.math.maxInt(usize);
+        const candidates = [_]usize{ 1, 2, 4, 8, 16, 32, 64, 128 };
+        for (candidates) |num_splits| {
+            if (num_splits > num_tiles) break;
+            const programs = config.direct_programs * num_splits;
+            const rounds = std.math.divCeil(usize, programs, cu_count) catch unreachable;
+            const tiles_per_program = std.math.divCeil(usize, num_tiles, num_splits) catch unreachable;
+            const cost = rounds * tiles_per_program;
+            // Candidates are ordered by split count, so ties retain 2D or the lower-overhead 3D launch.
+            if (cost < best_cost) {
+                best_cost = cost;
+                config.num_splits = num_splits;
+            }
         }
     }
 
-    return .{
-        .block_m = block_m,
-        .tile_size = tile_size,
-        .num_tiles = num_tiles,
-        .num_splits = best_splits,
-        .direct_programs = direct_programs,
-    };
+    return config;
 }
 
 fn select2dConfig(options: paged.PagedAttentionOptions) Config2D {
@@ -697,12 +721,14 @@ pub const paged = struct {
         return output.output;
     }
 
-    fn pagedSparseMlaKernel(q: zml.Tensor, kv_cache: zml.Tensor, sink: ?zml.Tensor, topk: zml.Tensor, parameters: Parameters, paged_opts: PagedSparseMlaOptions) zml.Tensor {
-        const rope_rank: i64 = @intCast(paged_opts.rope_rank);
-        const nope_rank: i64 = @intCast(paged_opts.head_dim - paged_opts.rope_rank);
-        const kv_lora_rank: i64 = @intCast(std.math.ceilPowerOfTwoAssert(usize, @intCast(nope_rank)));
+    fn pagedSparseMlaKernel(q: zml.Tensor, kv_cache: zml.Tensor, sink: ?zml.Tensor, topk: zml.Tensor, active_query_count: zml.Tensor, paged_opts: PagedSparseMlaOptions) zml.Tensor {
+        const value_rank: i64 = @intCast(paged_opts.value_rank);
+        const rope_rank: i64 = if (paged_opts.value_rank == paged_opts.qk_rank) 0 else @intCast(paged_opts.rope_rank);
+        stdx.debug.assert(std.math.isPowerOfTwo(paged_opts.value_rank), "sparse MLA value rank ({}) must be a power of two", .{paged_opts.value_rank});
+        stdx.debug.assert(rope_rank == 0 or std.math.isPowerOfTwo(@as(usize, @intCast(rope_rank))), "sparse MLA separate RoPE rank ({}) must be a power of two", .{rope_rank});
+        stdx.debug.assert(value_rank + rope_rank == paged_opts.qk_rank, "sparse MLA expects either a full-width value or adjacent value/RoPE regions, got qk={} value={} rope={}", .{ paged_opts.qk_rank, value_rank, rope_rank });
 
-        const out_shape = q.shape();
+        const out_shape = q.shape().set(.hd, value_rank);
 
         const q_strides = q.shape().computeElementStrides().constSlice();
         const out_strides = out_shape.computeElementStrides().constSlice();
@@ -710,15 +736,9 @@ pub const paged = struct {
 
         const sink_: zml.Tensor = sink orelse .scalar(0, .i8);
         const use_sink = sink != null;
-        const sm_scale: f32 = paged_opts.scale orelse @floatCast(1.0 / @sqrt(@as(f64, @floatFromInt(paged_opts.head_dim))));
+        const sm_scale: f32 = paged_opts.scale orelse @floatCast(1.0 / @sqrt(@as(f64, @floatFromInt(paged_opts.qk_rank))));
 
-        const launch = selectSparseMlaLaunchConfig(
-            paged_opts.total_q_blocks,
-            paged_opts.num_heads,
-            @intCast(topk.dim(.topk)),
-            getCuCount(),
-            paged_opts.num_kv_splits,
-        );
+        const config = sparseMlaConfig(paged_opts, @intCast(topk.dim(.topk)), getCuCount());
 
         const kernel_config: mla_kernels.Config = .{
             .q_dtype = triton.from(q.dtype()),
@@ -726,102 +746,115 @@ pub const paged = struct {
             .sink_dtype = triton.from(sink_.dtype()),
             .o_dtype = triton.from(q.dtype()),
             .num_query_heads = @intCast(paged_opts.num_heads),
-            .num_queries_per_kv = @intCast(paged_opts.num_heads),
             .block_size = @intCast(paged_opts.block_size),
-            .block_m = @intCast(launch.block_m),
+            .block_m = @intCast(config.block_m),
             .topk_count = topk.dim(.topk),
             .rope_rank = rope_rank,
-            .qk_lora_rank = nope_rank,
-            .kv_lora_rank = kv_lora_rank,
-            .rope_offset = nope_rank,
-            .value_rank = @intCast(paged_opts.head_dim),
-            .tile_size = @intCast(launch.tile_size),
-            .num_splits = @intCast(launch.num_splits),
+            .value_rank = value_rank,
+            .rope_offset = value_rank,
+            .tile_size = @intCast(config.tile_size),
+            .num_splits = @intCast(config.num_splits),
             .use_attn_sink = use_sink,
-            .all_decode = !parameters.options_.is_prefill,
+            .all_decode = paged_opts.all_decode,
         };
-        log.debug("pagedSparseMla launch: {any}, kernel: {any}", .{ launch, kernel_config });
+        log.debug("pagedSparseMla config: {any}, kernel: {any}", .{ config, kernel_config });
 
         const kernel_inputs: mla_kernels.Kernel2D.Inputs = .{
             .query_ptr = q,
-            .key_cache_ptr = kv_cache,
-            .value_cache_ptr = kv_cache,
+            .kv_cache_ptr = kv_cache,
             .attn_sink_ptr = sink_,
-            .block_tables_ptr = parameters.block_table,
             .topk_indices_ptr = topk,
-            .seq_lens_ptr = parameters.seq_lens,
+            .active_query_count_ptr = active_query_count,
             .scale_ptr = zml.Tensor.constant(zml.DataType.f32.constant(sm_scale)),
-            .block_table_stride_ptr = zml.Tensor.constant(zml.DataType.i64.constant(parameters.block_table.dim(.p))),
             .query_stride_0_ptr = zml.Tensor.constant(zml.DataType.i64.constant(q_strides[0])),
             .query_stride_1_ptr = zml.Tensor.constant(zml.DataType.i64.constant(q_strides[1])),
             .output_stride_0_ptr = zml.Tensor.constant(zml.DataType.i64.constant(out_strides[0])),
             .output_stride_1_ptr = zml.Tensor.constant(zml.DataType.i64.constant(out_strides[1])),
-            .stride_k_cache_0_ptr = zml.Tensor.constant(zml.DataType.i64.constant(kv_strides[kv_cache.shape().axis(.page)])),
-            .stride_k_cache_1_ptr = zml.Tensor.constant(zml.DataType.i64.constant(kv_strides[kv_cache.shape().axis(.k_chunk)])),
-            .stride_k_cache_2_ptr = zml.Tensor.constant(zml.DataType.i64.constant(kv_strides[kv_cache.shape().axis(.hkv)])),
-            .stride_v_cache_0_ptr = zml.Tensor.constant(zml.DataType.i64.constant(kv_strides[kv_cache.shape().axis(.page)])),
-            .stride_v_cache_1_ptr = zml.Tensor.constant(zml.DataType.i64.constant(kv_strides[kv_cache.shape().axis(.k_chunk)])),
-            .stride_v_cache_2_ptr = zml.Tensor.constant(zml.DataType.i64.constant(kv_strides[kv_cache.shape().axis(.hkv)])),
-            .query_start_len_ptr = parameters.query_start_len,
-            .num_seqs_ptr = zml.Tensor.constant(.{ .i32 = @as(i32, @intCast(parameters.block_table.dim(.b))) }).reshape(.{1}),
+            .stride_cache_0_ptr = zml.Tensor.constant(zml.DataType.i64.constant(kv_strides[kv_cache.shape().axis(.page)])),
+            .stride_cache_1_ptr = zml.Tensor.constant(zml.DataType.i64.constant(kv_strides[kv_cache.shape().axis(.k_chunk)])),
         };
 
-        if (launch.num_splits == 1) {
+        if (config.num_splits == 1) {
             const out = mla_kernels.Kernel2D.call(
                 kernel_inputs,
                 .{ .output = out_shape },
                 .{
                     .cfg = kernel_config,
-                    .grid = .{ @intCast(launch.direct_programs), 1, 1 },
-                    .num_warps = 4,
-                    .num_stages = 2,
+                    .grid = .{ @intCast(config.direct_programs), 1, 1 },
+                    .num_warps = @intCast(config.main_num_warps),
+                    .num_stages = @intCast(config.main_num_stages),
                 },
             );
-            return out.output.reshape(q.shape());
+            return out.output.reshape(out_shape);
         }
 
-        const num_splits: i64 = @intCast(launch.num_splits);
+        const num_splits: i64 = @intCast(config.num_splits);
         const kernel_3d_inputs: mla_kernels.Kernel3D.Inputs = .{
             .query_ptr = kernel_inputs.query_ptr,
-            .key_cache_ptr = kernel_inputs.key_cache_ptr,
-            .value_cache_ptr = kernel_inputs.value_cache_ptr,
+            .kv_cache_ptr = kernel_inputs.kv_cache_ptr,
             .attn_sink_ptr = kernel_inputs.attn_sink_ptr,
-            .block_tables_ptr = kernel_inputs.block_tables_ptr,
             .topk_indices_ptr = kernel_inputs.topk_indices_ptr,
-            .seq_lens_ptr = kernel_inputs.seq_lens_ptr,
+            .active_query_count_ptr = kernel_inputs.active_query_count_ptr,
             .scale_ptr = kernel_inputs.scale_ptr,
-            .block_table_stride_ptr = kernel_inputs.block_table_stride_ptr,
             .query_stride_0_ptr = kernel_inputs.query_stride_0_ptr,
             .query_stride_1_ptr = kernel_inputs.query_stride_1_ptr,
             .output_stride_0_ptr = kernel_inputs.output_stride_0_ptr,
             .output_stride_1_ptr = kernel_inputs.output_stride_1_ptr,
-            .stride_k_cache_0_ptr = kernel_inputs.stride_k_cache_0_ptr,
-            .stride_k_cache_1_ptr = kernel_inputs.stride_k_cache_1_ptr,
-            .stride_k_cache_2_ptr = kernel_inputs.stride_k_cache_2_ptr,
-            .stride_v_cache_0_ptr = kernel_inputs.stride_v_cache_0_ptr,
-            .stride_v_cache_1_ptr = kernel_inputs.stride_v_cache_1_ptr,
-            .stride_v_cache_2_ptr = kernel_inputs.stride_v_cache_2_ptr,
-            .query_start_len_ptr = kernel_inputs.query_start_len_ptr,
-            .num_seqs_ptr = kernel_inputs.num_seqs_ptr,
+            .stride_cache_0_ptr = kernel_inputs.stride_cache_0_ptr,
+            .stride_cache_1_ptr = kernel_inputs.stride_cache_1_ptr,
         };
         const partials = mla_kernels.Kernel3D.call(
             kernel_3d_inputs,
             .{
-                .partial_output = zml.Shape.init(.{ q.dim(.q), @as(i64, @intCast(paged_opts.num_heads)), num_splits, @as(i64, @intCast(paged_opts.head_dim)) }, .f32),
+                .partial_output = zml.Shape.init(.{ q.dim(.q), @as(i64, @intCast(paged_opts.num_heads)), num_splits, value_rank }, .f32),
                 .partial_lse = zml.Shape.init(.{ q.dim(.q), @as(i64, @intCast(paged_opts.num_heads)), num_splits }, .f32),
             },
             .{
                 .cfg = kernel_config,
-                .grid = .{ @intCast(launch.direct_programs), @intCast(launch.num_splits), 1 },
-                .num_warps = 4,
-                .num_stages = 2,
+                .grid = .{ @intCast(config.direct_programs), @intCast(config.num_splits), 1 },
+                .num_warps = @intCast(config.main_num_warps),
+                .num_stages = @intCast(config.main_num_stages),
             },
         );
+        var reduce_partial_output = partials.partial_output;
+        var reduce_partial_lse = partials.partial_lse;
+        var reduce_num_splits = num_splits;
+        if (num_splits > config.grouped_reduce_threshold) {
+            const grouped_splits: i64 = @divExact(num_splits, @as(i64, @intCast(config.splits_per_group)));
+            const grouped = mla_kernels.Reduce3DPartials.call(
+                .{
+                    .input = partials.partial_output,
+                    .input_lse = partials.partial_lse,
+                    .active_query_count_ptr = active_query_count,
+                },
+                .{
+                    .partial_output = zml.Shape.init(.{ q.dim(.q), @as(i64, @intCast(paged_opts.num_heads)), grouped_splits, value_rank }, .f32),
+                    .partial_lse = zml.Shape.init(.{ q.dim(.q), @as(i64, @intCast(paged_opts.num_heads)), grouped_splits }, .f32),
+                },
+                .{
+                    .cfg = .{
+                        .num_query_heads = @intCast(paged_opts.num_heads),
+                        .value_rank = value_rank,
+                        .num_input_splits = num_splits,
+                        .num_output_splits = grouped_splits,
+                        .all_decode = paged_opts.all_decode,
+                    },
+                    .grid = .{ @intCast(q.dim(.q)), @intCast(paged_opts.num_heads * @as(usize, @intCast(grouped_splits))), 1 },
+                    .num_warps = @intCast(config.grouped_reduce_num_warps),
+                    .num_stages = 1,
+                },
+            );
+            reduce_partial_output = grouped.partial_output;
+            reduce_partial_lse = grouped.partial_lse;
+            reduce_num_splits = grouped_splits;
+        }
+
         const out = mla_kernels.Reduce3D.call(
             .{
-                .partial_output_ptr = partials.partial_output,
-                .partial_lse_ptr = partials.partial_lse,
+                .partial_output_ptr = reduce_partial_output,
+                .partial_lse_ptr = reduce_partial_lse,
                 .attn_sink_ptr = sink_,
+                .active_query_count_ptr = active_query_count,
                 .output_stride_0_ptr = zml.Tensor.constant(zml.DataType.i64.constant(out_strides[0])),
                 .output_stride_1_ptr = zml.Tensor.constant(zml.DataType.i64.constant(out_strides[1])),
             },
@@ -831,17 +864,21 @@ pub const paged = struct {
                     .sink_dtype = triton.from(sink_.dtype()),
                     .o_dtype = triton.from(q.dtype()),
                     .num_query_heads = @intCast(paged_opts.num_heads),
-                    .value_rank = @intCast(paged_opts.head_dim),
-                    .num_splits = num_splits,
+                    .value_rank = value_rank,
+                    .num_splits = reduce_num_splits,
                     .use_attn_sink = use_sink,
+                    .all_decode = paged_opts.all_decode,
                 },
                 .grid = .{ @intCast(q.dim(.q)), @intCast(paged_opts.num_heads), 1 },
-                .num_warps = 1,
+                .num_warps = @intCast(if (reduce_num_splits >= config.parallel_reduce_min_splits)
+                    config.parallel_reduce_num_warps
+                else
+                    1),
                 .num_stages = 1,
             },
         );
 
-        return out.output.reshape(q.shape());
+        return out.output.reshape(out_shape);
     }
 
     fn tokenToSequence(query_start_len: zml.Tensor, query_count: i64) zml.Tensor {
@@ -895,16 +932,19 @@ pub const paged = struct {
     }
 
     pub const PagedSparseMlaOptions = struct {
-        head_dim: usize,
+        qk_rank: usize,
+        value_rank: usize,
         num_heads: usize,
         block_size: usize,
         rope_rank: usize,
         scale: ?f32,
         total_q_blocks: usize,
         num_kv_splits: ?u8,
+        all_decode: bool,
     };
 
     pub fn pagedSparseMla(parameters: Parameters, q: zml.Tensor, kv_cache: zml.Tensor, sink: ?zml.Tensor, topk: zml.Tensor, tokens_pos: zml.Tensor, opts: MlaOptions) zml.Tensor {
+        const output_shape = q.shape().set(.hd, opts.value_rank);
         return zml.ops.manualComputation(
             .{
                 q,
@@ -916,7 +956,7 @@ pub const paged = struct {
                 parameters.seq_lens,
                 parameters.query_start_len,
             },
-            q.shape(),
+            output_shape,
             .{
                 .opts = opts,
                 .options = parameters.options_,
@@ -936,17 +976,22 @@ pub const paged = struct {
                     };
 
                     const topk_final = topkToPhysical(parameters_, sharded_inputs[3], sharded_inputs[4], block_size);
+                    const active_query_count = sharded_inputs[7]
+                        .slice(.b, .{ .start = sharded_inputs[7].dim(.b) - 1 })
+                        .squeeze(.b);
                     stdx.debug.assert(topk_final.dim(.q) == q_.dim(.q), "expected topk q dim ({}) to match q dim ({})", .{ topk_final.dim(.q), q_.dim(.q) });
 
                     const num_heads: usize = @intCast(q_.dim(.h));
                     const paged_opts: PagedSparseMlaOptions = .{
-                        .head_dim = @intCast(q_.dim(.hd)),
+                        .qk_rank = @intCast(q_.dim(.hd)),
+                        .value_rank = @intCast(ctx_.opts.value_rank),
                         .num_heads = num_heads,
                         .block_size = @intCast(kv_cache_.dim(.k_chunk)),
                         .rope_rank = @intCast(ctx_.opts.rope_rank),
                         .scale = ctx_.opts.scale,
                         .total_q_blocks = @intCast(q_.dim(.q)),
                         .num_kv_splits = ctx_.opts.num_kv_splits,
+                        .all_decode = !ctx_.options.is_prefill,
                     };
 
                     return pagedSparseMlaKernel(
@@ -954,7 +999,7 @@ pub const paged = struct {
                         kv_cache_,
                         sharded_inputs[2],
                         topk_final,
-                        parameters_,
+                        active_query_count,
                         paged_opts,
                     );
                 }
@@ -962,29 +1007,6 @@ pub const paged = struct {
         );
     }
 };
-
-test "sparse MLA launch selection balances occupancy and split overhead" {
-    const saturated = selectSparseMlaLaunchConfig(120, 16, 512, 120, null);
-    try std.testing.expectEqual(@as(usize, 1), saturated.num_splits);
-
-    const under_occupied = selectSparseMlaLaunchConfig(1, 16, 512, 120, null);
-    try std.testing.expectEqual(@as(usize, 16), under_occupied.num_splits);
-
-    const tile_limited = selectSparseMlaLaunchConfig(1, 16, 32, 120, null);
-    try std.testing.expectEqual(@as(usize, 2), tile_limited.num_splits);
-
-    const missing_cu_count = selectSparseMlaLaunchConfig(1, 16, 512, 0, null);
-    try std.testing.expectEqual(@as(usize, 1), missing_cu_count.num_splits);
-}
-
-test "sparse MLA launch selection honors valid explicit splits" {
-    const forced = selectSparseMlaLaunchConfig(1, 16, 64, 120, 4);
-    try std.testing.expectEqual(@as(usize, 4), forced.num_splits);
-
-    const one_tile = selectSparseMlaLaunchConfig(1, 16, 5, 120, null);
-    try std.testing.expectEqual(@as(usize, 8), one_tile.tile_size);
-    try std.testing.expectEqual(@as(usize, 1), one_tile.num_splits);
-}
 
 test "sparse MLA emits 2D and 3D Triton kernels" {
     const platform = zml.testing.env();
@@ -997,38 +1019,47 @@ test "sparse MLA emits 2D and 3D Triton kernels" {
     compilation.pushBlock(block);
     defer compilation.popBlock();
 
-    const q = zml.Tensor.zeroes(zml.Shape.init(.{ .q = 1, .h = 16, .hd = 128 }, .bf16));
-    const kv = zml.Tensor.zeroes(zml.Shape.init(.{ .page = 32, .k_chunk = 1, .hkv = 1, .hd = 128 }, .bf16));
-    const sink = zml.Tensor.zeroes(zml.Shape.init(.{ .h = 16 }, .bf16));
+    const q = zml.Tensor.zeroes(zml.Shape.init(.{ .q = 1, .h = 6, .hd = 576 }, .bf16));
+    const kv = zml.Tensor.zeroes(zml.Shape.init(.{ .page = 32, .k_chunk = 1, .hkv = 1, .hd = 576 }, .bf16));
+    const sink = zml.Tensor.zeroes(zml.Shape.init(.{ .h = 6 }, .bf16));
     const topk = zml.Tensor.zeroes(zml.Shape.init(.{ .q = 1, .topk = 32 }, .i32));
-    const parameters: paged.Parameters = .{
-        .block_table = zml.Tensor.zeroes(zml.Shape.init(.{ .b = 1, .p = 1 }, .i32)),
-        .seq_lens = zml.Tensor.zeroes(zml.Shape.init(.{ .b = 1 }, .i32)),
-        .query_start_len = zml.Tensor.zeroes(zml.Shape.init(.{ .b = 2 }, .i32)),
-        .options_ = .{
-            .batch_size = 1,
-            .max_num_pages = 1,
-            .max_seqlen_q = 1,
-            .is_prefill = false,
-        },
-    };
+    const active_query_count = zml.Tensor.scalar(1, .i32);
     const two_d_opts: paged.PagedSparseMlaOptions = .{
-        .head_dim = 128,
-        .num_heads = 16,
+        .qk_rank = 576,
+        .value_rank = 512,
+        .num_heads = 6,
         .block_size = 1,
         .rope_rank = 64,
         .scale = null,
         .total_q_blocks = 1,
         .num_kv_splits = 1,
+        .all_decode = true,
     };
+    const output_shape = q.shape().set(.hd, 512);
 
-    const two_d = paged.pagedSparseMlaKernel(q, kv, sink, topk, parameters, two_d_opts);
-    try std.testing.expect(two_d.shape().eql(q.shape()));
+    const two_d = paged.pagedSparseMlaKernel(q, kv, sink, topk, active_query_count, two_d_opts);
+    try std.testing.expect(two_d.shape().eql(output_shape));
     try std.testing.expect(two_d.value().owner().verify());
 
     var three_d_opts = two_d_opts;
     three_d_opts.num_kv_splits = 2;
-    const three_d = paged.pagedSparseMlaKernel(q, kv, sink, topk, parameters, three_d_opts);
-    try std.testing.expect(three_d.shape().eql(q.shape()));
+    const three_d = paged.pagedSparseMlaKernel(q, kv, sink, topk, active_query_count, three_d_opts);
+    try std.testing.expect(three_d.shape().eql(output_shape));
     try std.testing.expect(three_d.value().owner().verify());
+
+    const dsv4_q = zml.Tensor.zeroes(zml.Shape.init(.{ .q = 1, .h = 6, .hd = 512 }, .bf16));
+    const dsv4_kv = zml.Tensor.zeroes(zml.Shape.init(.{ .page = 32, .k_chunk = 1, .hkv = 1, .hd = 512 }, .bf16));
+    var dsv4_opts = two_d_opts;
+    dsv4_opts.qk_rank = 512;
+    dsv4_opts.value_rank = 512;
+    const dsv4_output_shape = dsv4_q.shape();
+
+    const dsv4_two_d = paged.pagedSparseMlaKernel(dsv4_q, dsv4_kv, sink, topk, active_query_count, dsv4_opts);
+    try std.testing.expect(dsv4_two_d.shape().eql(dsv4_output_shape));
+    try std.testing.expect(dsv4_two_d.value().owner().verify());
+
+    dsv4_opts.num_kv_splits = 2;
+    const dsv4_three_d = paged.pagedSparseMlaKernel(dsv4_q, dsv4_kv, sink, topk, active_query_count, dsv4_opts);
+    try std.testing.expect(dsv4_three_d.shape().eql(dsv4_output_shape));
+    try std.testing.expect(dsv4_three_d.value().owner().verify());
 }

--- a/zml/attention/triton_kernels/unified_sparse_mla.zig
+++ b/zml/attention/triton_kernels/unified_sparse_mla.zig
@@ -15,17 +15,13 @@ pub const Config = struct {
     sink_dtype: DType = .f32,
     o_dtype: DType = .bf16,
     num_query_heads: i64 = 32,
-    num_queries_per_kv: i64 = 32,
     block_size: i64 = 16,
-    stride_k_cache_3: i64 = 1,
-    stride_v_cache_3: i64 = 1,
+    stride_cache_dim: i64 = 1,
     topk_count: i64 = 32,
     block_m: i64 = 16,
     rope_rank: i64 = 64,
-    qk_lora_rank: i64 = 512,
-    kv_lora_rank: i64 = 512,
-    rope_offset: i64 = 512,
     value_rank: i64 = 512,
+    rope_offset: i64 = 512,
     tile_size: i64 = 16,
     num_splits: i64 = 1,
     use_attn_sink: bool = false,
@@ -36,26 +32,17 @@ pub const Kernel2D = tri.Kernel(Config, .{
     .name = "_kernel_unified_attention_sparse_mla_2d_ptr",
     .inputs = &.{
         "query_ptr",
-        "key_cache_ptr",
-        "value_cache_ptr",
+        "kv_cache_ptr",
         "attn_sink_ptr",
-        "block_tables_ptr",
         "topk_indices_ptr",
-        "seq_lens_ptr",
+        "active_query_count_ptr",
         "scale_ptr",
-        "block_table_stride_ptr",
         "query_stride_0_ptr",
         "query_stride_1_ptr",
         "output_stride_0_ptr",
         "output_stride_1_ptr",
-        "stride_k_cache_0_ptr",
-        "stride_k_cache_1_ptr",
-        "stride_k_cache_2_ptr",
-        "stride_v_cache_0_ptr",
-        "stride_v_cache_1_ptr",
-        "stride_v_cache_2_ptr",
-        "query_start_len_ptr",
-        "num_seqs_ptr",
+        "stride_cache_0_ptr",
+        "stride_cache_1_ptr",
     },
     .outputs = &.{"output"},
     .run = run2D,
@@ -64,26 +51,17 @@ pub const Kernel2D = tri.Kernel(Config, .{
 fn run2D(b: *tri.Builder, cfg: Config) tri.FinishError!void {
     const a = try b.declareArgs(.{
         .query_ptr = .{ .ptr = cfg.q_dtype },
-        .key_cache_ptr = .{ .ptr = cfg.kv_dtype },
-        .value_cache_ptr = .{ .ptr = cfg.kv_dtype },
+        .kv_cache_ptr = .{ .ptr = cfg.kv_dtype },
         .attn_sink_ptr = .{ .ptr = cfg.sink_dtype },
-        .block_tables_ptr = .{ .ptr = .i32 },
         .topk_indices_ptr = .{ .ptr = .i32 },
-        .seq_lens_ptr = .{ .ptr = .i32 },
+        .active_query_count_ptr = .{ .ptr = .i32 },
         .scale_ptr = .{ .ptr = .f32 },
-        .block_table_stride_ptr = .{ .ptr = .i64 },
         .query_stride_0_ptr = .{ .ptr = .i64 },
         .query_stride_1_ptr = .{ .ptr = .i64 },
         .output_stride_0_ptr = .{ .ptr = .i64 },
         .output_stride_1_ptr = .{ .ptr = .i64 },
-        .stride_k_cache_0_ptr = .{ .ptr = .i64 },
-        .stride_k_cache_1_ptr = .{ .ptr = .i64 },
-        .stride_k_cache_2_ptr = .{ .ptr = .i64 },
-        .stride_v_cache_0_ptr = .{ .ptr = .i64 },
-        .stride_v_cache_1_ptr = .{ .ptr = .i64 },
-        .stride_v_cache_2_ptr = .{ .ptr = .i64 },
-        .query_start_len_ptr = .{ .ptr = .i32 },
-        .num_seqs_ptr = .{ .ptr = .i32 },
+        .stride_cache_0_ptr = .{ .ptr = .i64 },
+        .stride_cache_1_ptr = .{ .ptr = .i64 },
         .output_ptr = .{ .ptr = cfg.o_dtype },
     });
 
@@ -92,32 +70,25 @@ fn run2D(b: *tri.Builder, cfg: Config) tri.FinishError!void {
     const query_stride_1 = b.load(a.query_stride_1_ptr);
     const output_stride_0 = b.load(a.output_stride_0_ptr);
     const output_stride_1 = b.load(a.output_stride_1_ptr);
-    const stride_k_cache_0 = b.load(a.stride_k_cache_0_ptr);
-    const stride_k_cache_1 = b.load(a.stride_k_cache_1_ptr);
-    const stride_v_cache_0 = b.load(a.stride_v_cache_0_ptr);
-    const stride_v_cache_1 = b.load(a.stride_v_cache_1_ptr);
-    const num_seqs = b.load(a.num_seqs_ptr);
+    const stride_cache_0 = b.load(a.stride_cache_0_ptr);
+    const stride_cache_1 = b.load(a.stride_cache_1_ptr);
 
     kernelUnifiedAttentionSparseMla(
         b,
         a.output_ptr,
         null,
         a.query_ptr,
-        a.key_cache_ptr,
-        a.value_cache_ptr,
+        a.kv_cache_ptr,
         a.attn_sink_ptr,
         a.topk_indices_ptr,
+        a.active_query_count_ptr,
         scale,
         query_stride_0,
         query_stride_1,
         output_stride_0,
         output_stride_1,
-        stride_k_cache_0,
-        stride_k_cache_1,
-        stride_v_cache_0,
-        stride_v_cache_1,
-        a.query_start_len_ptr,
-        num_seqs,
+        stride_cache_0,
+        stride_cache_1,
         cfg,
         false,
     );
@@ -127,26 +98,17 @@ pub const Kernel3D = tri.Kernel(Config, .{
     .name = "_kernel_unified_attention_sparse_mla_3d_ptr",
     .inputs = &.{
         "query_ptr",
-        "key_cache_ptr",
-        "value_cache_ptr",
+        "kv_cache_ptr",
         "attn_sink_ptr",
-        "block_tables_ptr",
         "topk_indices_ptr",
-        "seq_lens_ptr",
+        "active_query_count_ptr",
         "scale_ptr",
-        "block_table_stride_ptr",
         "query_stride_0_ptr",
         "query_stride_1_ptr",
         "output_stride_0_ptr",
         "output_stride_1_ptr",
-        "stride_k_cache_0_ptr",
-        "stride_k_cache_1_ptr",
-        "stride_k_cache_2_ptr",
-        "stride_v_cache_0_ptr",
-        "stride_v_cache_1_ptr",
-        "stride_v_cache_2_ptr",
-        "query_start_len_ptr",
-        "num_seqs_ptr",
+        "stride_cache_0_ptr",
+        "stride_cache_1_ptr",
     },
     .outputs = &.{ "partial_output", "partial_lse" },
     .run = run3D,
@@ -155,26 +117,17 @@ pub const Kernel3D = tri.Kernel(Config, .{
 fn run3D(b: *tri.Builder, cfg: Config) tri.FinishError!void {
     const a = try b.declareArgs(.{
         .query_ptr = .{ .ptr = cfg.q_dtype },
-        .key_cache_ptr = .{ .ptr = cfg.kv_dtype },
-        .value_cache_ptr = .{ .ptr = cfg.kv_dtype },
+        .kv_cache_ptr = .{ .ptr = cfg.kv_dtype },
         .attn_sink_ptr = .{ .ptr = cfg.sink_dtype },
-        .block_tables_ptr = .{ .ptr = .i32 },
         .topk_indices_ptr = .{ .ptr = .i32 },
-        .seq_lens_ptr = .{ .ptr = .i32 },
+        .active_query_count_ptr = .{ .ptr = .i32 },
         .scale_ptr = .{ .ptr = .f32 },
-        .block_table_stride_ptr = .{ .ptr = .i64 },
         .query_stride_0_ptr = .{ .ptr = .i64 },
         .query_stride_1_ptr = .{ .ptr = .i64 },
         .output_stride_0_ptr = .{ .ptr = .i64 },
         .output_stride_1_ptr = .{ .ptr = .i64 },
-        .stride_k_cache_0_ptr = .{ .ptr = .i64 },
-        .stride_k_cache_1_ptr = .{ .ptr = .i64 },
-        .stride_k_cache_2_ptr = .{ .ptr = .i64 },
-        .stride_v_cache_0_ptr = .{ .ptr = .i64 },
-        .stride_v_cache_1_ptr = .{ .ptr = .i64 },
-        .stride_v_cache_2_ptr = .{ .ptr = .i64 },
-        .query_start_len_ptr = .{ .ptr = .i32 },
-        .num_seqs_ptr = .{ .ptr = .i32 },
+        .stride_cache_0_ptr = .{ .ptr = .i64 },
+        .stride_cache_1_ptr = .{ .ptr = .i64 },
         .partial_output_ptr = .{ .ptr = .f32 },
         .partial_lse_ptr = .{ .ptr = .f32 },
     });
@@ -184,74 +137,28 @@ fn run3D(b: *tri.Builder, cfg: Config) tri.FinishError!void {
     const query_stride_1 = b.load(a.query_stride_1_ptr);
     const output_stride_0 = b.load(a.output_stride_0_ptr);
     const output_stride_1 = b.load(a.output_stride_1_ptr);
-    const stride_k_cache_0 = b.load(a.stride_k_cache_0_ptr);
-    const stride_k_cache_1 = b.load(a.stride_k_cache_1_ptr);
-    const stride_v_cache_0 = b.load(a.stride_v_cache_0_ptr);
-    const stride_v_cache_1 = b.load(a.stride_v_cache_1_ptr);
-    const num_seqs = b.load(a.num_seqs_ptr);
+    const stride_cache_0 = b.load(a.stride_cache_0_ptr);
+    const stride_cache_1 = b.load(a.stride_cache_1_ptr);
 
     kernelUnifiedAttentionSparseMla(
         b,
         a.partial_output_ptr,
         a.partial_lse_ptr,
         a.query_ptr,
-        a.key_cache_ptr,
-        a.value_cache_ptr,
+        a.kv_cache_ptr,
         a.attn_sink_ptr,
         a.topk_indices_ptr,
+        a.active_query_count_ptr,
         scale,
         query_stride_0,
         query_stride_1,
         output_stride_0,
         output_stride_1,
-        stride_k_cache_0,
-        stride_k_cache_1,
-        stride_v_cache_0,
-        stride_v_cache_1,
-        a.query_start_len_ptr,
-        num_seqs,
+        stride_cache_0,
+        stride_cache_1,
         cfg,
         true,
     );
-}
-
-fn findSeqIdx(
-    k: *Builder,
-    query_start_len_ptr: Value,
-    target_idx: Value,
-    num_seqs: Value,
-    block_q: i64,
-    use_q_block_mode: bool,
-) Value {
-    const left_init = k.liftAs(0, .i32);
-
-    var w = k.openWhile(.{ left_init, num_seqs }, .{ k.scalarTy(.i32), k.scalarTy(.i32) });
-    {
-        const left = w.before_carried[0];
-        const right = w.before_carried[1];
-        w.yieldBefore(left.lt(right), .{ left, right });
-    }
-    {
-        const left = w.after_carried[0];
-        const right = w.after_carried[1];
-        const mid = left.add(right).div(2);
-        const val = k.load(query_start_len_ptr.addPtr(mid));
-        const mid_val = if (use_q_block_mode)
-            val.div(@as(i32, @intCast(block_q))).add(mid)
-        else
-            val;
-
-        var i = k.openIfElse(mid_val.le(target_idx), .{ k.scalarTy(.i32), k.scalarTy(.i32) });
-        {
-            i.yieldThen(.{ mid.add(1), right });
-        }
-        {
-            i.yieldElse(.{ left, mid });
-        }
-        w.yieldAfter(.{ i.results[0], i.results[1] });
-    }
-
-    return w.results[0].sub(1);
 }
 
 fn kernelUnifiedAttentionSparseMla(
@@ -259,36 +166,28 @@ fn kernelUnifiedAttentionSparseMla(
     output_ptr: Value,
     partial_lse_ptr: ?Value,
     query_ptr: Value,
-    key_cache_ptr: Value,
-    value_cache_ptr: Value,
+    kv_cache_ptr: Value,
     attn_sink_ptr: Value,
     topk_indices_ptr: Value,
+    active_query_count_ptr: Value,
     scale: Value,
     query_stride_0: Value,
     query_stride_1: Value,
     output_stride_0: Value,
     output_stride_1: Value,
-    stride_k_cache_0: Value,
-    stride_k_cache_1: Value,
-    stride_v_cache_0: Value,
-    stride_v_cache_1: Value,
-    query_start_len_ptr: Value,
-    num_seqs: Value,
+    stride_cache_0: Value,
+    stride_cache_1: Value,
     config: Config,
     comptime three_d: bool,
 ) void {
-    const BLOCK_Q: i64 = 1;
     const BLOCK_M: i64 = config.block_m;
     const BLOCK_SIZE: i64 = config.block_size;
     const ROPE_RANK: i64 = config.rope_rank;
-    const QK_LORA_RANK: i64 = config.qk_lora_rank;
-    const KV_LORA_RANK: i64 = config.kv_lora_rank;
-    const ROPE_OFFSET: i64 = config.rope_offset;
     const VALUE_RANK: i64 = config.value_rank;
+    const ROPE_OFFSET: i64 = config.rope_offset;
     const TILE_SIZE: i64 = config.tile_size;
-    const NUM_QUERIES_PER_KV: i64 = config.num_queries_per_kv;
     const NUM_QUERY_HEADS: i64 = config.num_query_heads;
-    const NUM_HEAD_BLOCKS: i64 = @divTrunc(NUM_QUERY_HEADS, BLOCK_M);
+    const NUM_HEAD_BLOCKS: i64 = @divTrunc(NUM_QUERY_HEADS + BLOCK_M - 1, BLOCK_M);
     const NUM_TILES: i64 = @divTrunc(config.topk_count + TILE_SIZE - 1, TILE_SIZE);
     const NUM_SPLITS: i64 = if (three_d) config.num_splits else 1;
     const TILES_PER_SPLIT: i64 = @divTrunc(NUM_TILES + NUM_SPLITS - 1, NUM_SPLITS);
@@ -299,45 +198,38 @@ fn kernelUnifiedAttentionSparseMla(
     const split_tile_end = split_idx.add(1).mul(@as(i32, @intCast(NUM_TILES))).div(@as(i32, @intCast(NUM_SPLITS)));
     const q_ind = q_block_global_idx.div(@as(i32, @intCast(NUM_HEAD_BLOCKS)));
     const head_ind = q_block_global_idx.rem(@as(i32, @intCast(NUM_HEAD_BLOCKS)));
-    const seq_idx = findSeqIdx(k, query_start_len_ptr, q_ind, num_seqs, BLOCK_Q, false);
-    const q_block_start_idx = k.load(query_start_len_ptr.addPtr(seq_idx));
+    if (!config.all_decode) {
+        const active_query_count = k.load(active_query_count_ptr);
+        k.returnIf(q_ind.ge(active_query_count), .{});
+    }
 
-    const q_block_local_idx = q_ind.sub(q_block_start_idx);
-    const cur_batch_in_all_start_index = k.load(query_start_len_ptr.addPtr(seq_idx));
-    const cur_batch_in_all_stop_index = k.load(query_start_len_ptr.addPtr(seq_idx).addPtr(1));
-    const cur_batch_query_len = cur_batch_in_all_stop_index.sub(cur_batch_in_all_start_index);
-
-    k.returnIf(q_block_local_idx.ge(cur_batch_query_len), .{});
-
-    const offs_m = k.arange(0, BLOCK_M, .i32).add(head_ind.mul(@as(i32, @intCast(BLOCK_M))));
-    const offs_lora = k.arange(0, KV_LORA_RANK, .i32);
-    const offs_rope = k.arange(ROPE_OFFSET, ROPE_OFFSET + ROPE_RANK, .i32);
+    const offs_h = k.arange(0, BLOCK_M, .i32).add(head_ind.mul(@as(i32, @intCast(BLOCK_M))));
     const offs_value = k.arange(0, VALUE_RANK, .i32);
+    const offs_rope: ?Value = if (ROPE_RANK > 0)
+        k.arange(ROPE_OFFSET, ROPE_OFFSET + ROPE_RANK, .i32)
+    else
+        null;
     const offs_t = k.arange(0, TILE_SIZE, .i32);
 
-    const query_pos = q_block_local_idx.add(offs_m.div(@as(i32, @intCast(NUM_QUERIES_PER_KV))));
-
-    const query_offset_0 = cur_batch_in_all_start_index.add(query_pos);
-    const query_offset_1 = offs_m.rem(@as(i32, @intCast(NUM_QUERIES_PER_KV)));
-
-    const query_mask_0 = query_pos.lt(cur_batch_query_len);
-    const query_mask_1 = query_offset_1.lt(@as(i32, @intCast(NUM_QUERY_HEADS)));
+    const query_offset_0 = k.splat(q_ind, &.{BLOCK_M});
+    const query_offset_1 = offs_h;
+    const head_mask = offs_h.lt(@as(i32, @intCast(NUM_QUERY_HEADS)));
 
     const qo0_2d = query_offset_0.expandDims(1).mul(query_stride_0);
     const qo1_2d = query_offset_1.expandDims(1).mul(query_stride_1);
-    const q_rope_offset = qo0_2d.add(qo1_2d).add(offs_rope.expandDims(0));
-    const q_mask = query_mask_0.expandDims(1).bitAnd(query_mask_1.expandDims(1));
-    const Q_rope = k.loadOpts(query_ptr.addPtr(q_rope_offset), .{
-        .mask = q_mask,
-        .other = k.zeros(&.{ BLOCK_M, ROPE_RANK }, config.q_dtype),
-        .cache_modifier = if (config.all_decode or BLOCK_M >= NUM_QUERY_HEADS) .cg else .none,
-    });
+    const Q_rope: ?Value = if (ROPE_RANK > 0) blk: {
+        const q_rope_offset = qo0_2d.add(qo1_2d).add(offs_rope.?.expandDims(0));
+        break :blk k.loadOpts(query_ptr.addPtr(q_rope_offset), .{
+            .mask = head_mask.expandDims(1),
+            .other = k.zeros(&.{ BLOCK_M, ROPE_RANK }, config.q_dtype),
+            .cache_modifier = if (config.all_decode or BLOCK_M >= NUM_QUERY_HEADS) .cg else .none,
+        });
+    } else null;
 
-    const q_lora_offset = qo0_2d.add(qo1_2d).add(offs_lora.expandDims(0));
-    const q_lora_mask = q_mask.bitAnd(offs_lora.lt(@as(i32, @intCast(QK_LORA_RANK))).expandDims(0));
-    const Q_lora = k.loadOpts(query_ptr.addPtr(q_lora_offset), .{
-        .mask = q_lora_mask,
-        .other = k.zeros(&.{ BLOCK_M, KV_LORA_RANK }, config.q_dtype),
+    const q_value_offset = qo0_2d.add(qo1_2d).add(offs_value.expandDims(0));
+    const Q_value = k.loadOpts(query_ptr.addPtr(q_value_offset), .{
+        .mask = head_mask.expandDims(1),
+        .other = k.zeros(&.{ BLOCK_M, VALUE_RANK }, config.q_dtype),
         .cache_modifier = if (config.all_decode or BLOCK_M >= NUM_QUERY_HEADS) .cg else .none,
     });
 
@@ -363,7 +255,7 @@ fn kernelUnifiedAttentionSparseMla(
             .mask = valid_t,
             .other = k.zeros(&.{TILE_SIZE}, .i32),
         });
-        valid_t = valid_t.bitAnd(topk_pos.ne(-1));
+        valid_t = valid_t.bitAnd(topk_pos.ge(0));
 
         const physical_block_idx = topk_pos.div(@as(i32, @intCast(BLOCK_SIZE)));
         const slot = topk_pos.rem(@as(i32, @intCast(BLOCK_SIZE)));
@@ -371,34 +263,34 @@ fn kernelUnifiedAttentionSparseMla(
         var S = k.zeros(&.{ BLOCK_M, TILE_SIZE }, .f32);
 
         const physical_block_idx_t = physical_block_idx.expandDims(0);
-        const key_block_offsets = physical_block_idx_t.to(.i64).mul(stride_k_cache_0);
-        const key_block_ptrs = key_cache_ptr.addPtr(key_block_offsets);
-        const k_rope_dim_offsets = offs_rope.expandDims(1).mul(@as(i32, @intCast(config.stride_k_cache_3)));
-        const k_rope_dim_ptrs = k.broadcastTo(key_block_ptrs, &.{ ROPE_RANK, TILE_SIZE })
-            .addPtr(k.broadcastTo(k_rope_dim_offsets, &.{ ROPE_RANK, TILE_SIZE }));
+        const cache_block_offsets = physical_block_idx_t.to(.i64).mul(stride_cache_0);
+        const cache_block_ptrs = kv_cache_ptr.addPtr(cache_block_offsets);
         const slot_t = slot.expandDims(0);
-        const key_slot_offsets = slot_t.to(.i64).mul(stride_k_cache_1);
-        const K_rope = k.loadOpts(k_rope_dim_ptrs.addPtr(k.broadcastTo(key_slot_offsets, &.{ ROPE_RANK, TILE_SIZE })), .{
+        const cache_slot_offsets = slot_t.to(.i64).mul(stride_cache_1);
+        if (ROPE_RANK > 0) {
+            const k_rope_dim_offsets = offs_rope.?.expandDims(1).mul(@as(i32, @intCast(config.stride_cache_dim)));
+            const k_rope_dim_ptrs = k.broadcastTo(cache_block_ptrs, &.{ ROPE_RANK, TILE_SIZE })
+                .addPtr(k.broadcastTo(k_rope_dim_offsets, &.{ ROPE_RANK, TILE_SIZE }));
+            const K_rope = k.loadOpts(k_rope_dim_ptrs.addPtr(k.broadcastTo(cache_slot_offsets, &.{ ROPE_RANK, TILE_SIZE })), .{
+                .mask = valid_t.expandDims(0),
+                .other = k.zeros(&.{ ROPE_RANK, TILE_SIZE }, config.kv_dtype),
+                .cache_modifier = if (config.all_decode) .cg else .none,
+            });
+            S = S.add(scale.mul(k.dot(Q_rope.?, K_rope, k.zeros(&.{ BLOCK_M, TILE_SIZE }, .f32))));
+        }
+
+        const k_value_dim_offsets = offs_value.expandDims(1).mul(@as(i32, @intCast(config.stride_cache_dim)));
+        const k_value_dim_ptrs = k.broadcastTo(cache_block_ptrs, &.{ VALUE_RANK, TILE_SIZE })
+            .addPtr(k.broadcastTo(k_value_dim_offsets, &.{ VALUE_RANK, TILE_SIZE }));
+        const K_value = k.loadOpts(k_value_dim_ptrs.addPtr(k.broadcastTo(cache_slot_offsets, &.{ VALUE_RANK, TILE_SIZE })), .{
             .mask = valid_t.expandDims(0),
-            .other = k.zeros(&.{ ROPE_RANK, TILE_SIZE }, config.kv_dtype),
-            .cache_modifier = if (config.all_decode) .cg else .none,
-        });
-        S = S.add(scale.mul(k.dot(Q_rope, K_rope, k.zeros(&.{ BLOCK_M, TILE_SIZE }, .f32))));
-
-        const k_lora_dim_offsets = offs_lora.expandDims(1).mul(@as(i32, @intCast(config.stride_k_cache_3)));
-        const k_lora_dim_ptrs = k.broadcastTo(key_block_ptrs, &.{ KV_LORA_RANK, TILE_SIZE })
-            .addPtr(k.broadcastTo(k_lora_dim_offsets, &.{ KV_LORA_RANK, TILE_SIZE }));
-        const k_lora_mask = valid_t.expandDims(0).bitAnd(offs_lora.lt(@as(i32, @intCast(QK_LORA_RANK))).expandDims(1));
-        const K_lora = k.loadOpts(k_lora_dim_ptrs.addPtr(k.broadcastTo(key_slot_offsets, &.{ KV_LORA_RANK, TILE_SIZE })), .{
-            .mask = k_lora_mask,
-            .other = k.zeros(&.{ KV_LORA_RANK, TILE_SIZE }, config.kv_dtype),
+            .other = k.zeros(&.{ VALUE_RANK, TILE_SIZE }, config.kv_dtype),
             .cache_modifier = if (config.all_decode) .cg else .none,
         });
 
-        S = S.add(scale.mul(k.dot(Q_lora, K_lora, k.zeros(&.{ BLOCK_M, TILE_SIZE }, .f32))));
+        S = S.add(scale.mul(k.dot(Q_value, K_value, k.zeros(&.{ BLOCK_M, TILE_SIZE }, .f32))));
 
-        const keep_mask = query_mask_1.expandDims(1)
-            .bitAnd(query_mask_0.expandDims(1))
+        const keep_mask = head_mask.expandDims(1)
             .bitAnd(valid_t.expandDims(0));
         S = k.where(keep_mask, S, k.full(&.{ BLOCK_M, TILE_SIZE }, -std.math.inf(f32), .f32));
 
@@ -411,21 +303,8 @@ fn kernelUnifiedAttentionSparseMla(
         const acc_scaled = acc.mul(alpha.expandDims(1));
         const new_L = L.mul(alpha).add(l_j);
 
-        const physical_block_idx_v = physical_block_idx.expandDims(1).to(.i64);
-        const v_block_offsets = physical_block_idx_v.mul(stride_v_cache_0);
-        const v_base_ptr = k.splat(value_cache_ptr, &.{ TILE_SIZE, 1 });
-        const slot_v = slot.expandDims(1).to(.i64);
-        const v_slot_offsets = slot_v.mul(stride_v_cache_1);
-        const v_base_offsets = v_block_offsets.add(v_slot_offsets);
-        const v_base_ptrs = v_base_ptr.addPtr(v_base_offsets);
-        const v_lora_dim_offsets = offs_value.expandDims(0).mul(@as(i32, @intCast(config.stride_v_cache_3)));
-        const V_lora = k.loadOpts(k.broadcastTo(v_base_ptrs, &.{ TILE_SIZE, VALUE_RANK }).addPtr(k.broadcastTo(v_lora_dim_offsets, &.{ TILE_SIZE, VALUE_RANK })), .{
-            .mask = valid_t.expandDims(1),
-            .other = k.zeros(&.{ TILE_SIZE, VALUE_RANK }, config.kv_dtype),
-            .cache_modifier = if (config.all_decode) .cg else .none,
-        });
-
-        const new_acc = k.dot(P.to(config.kv_dtype), V_lora, acc_scaled);
+        const V = k.trans(K_value, &.{ 1, 0 });
+        const new_acc = k.dot(P.to(config.kv_dtype), V, acc_scaled);
 
         loop.yield(.{ m_j, new_L, new_acc });
     }
@@ -435,13 +314,12 @@ fn kernelUnifiedAttentionSparseMla(
     var acc = loop.results[2];
 
     if (!three_d and config.use_attn_sink) {
-        const sink_mask = query_mask_0.bitAnd(query_mask_1);
         const sink_logits = k.loadOpts(attn_sink_ptr.addPtr(query_offset_1), .{
-            .mask = sink_mask,
+            .mask = head_mask,
             .other = k.zeros(&.{BLOCK_M}, config.sink_dtype),
         }).to(.f32);
         const sink_score = k.where(
-            sink_mask,
+            head_mask,
             sink_logits,
             k.full(&.{BLOCK_M}, -std.math.inf(f32), .f32),
         );
@@ -469,18 +347,18 @@ fn kernelUnifiedAttentionSparseMla(
         const partial_out_token_stride: i64 = NUM_QUERY_HEADS * NUM_SPLITS * VALUE_RANK;
         const partial_out_head_stride: i64 = NUM_SPLITS * VALUE_RANK;
         const partial_out_offset = q_ind.to(.i64).mul(partial_out_token_stride)
-            .add(offs_m.expandDims(1).to(.i64).mul(partial_out_head_stride))
+            .add(offs_h.expandDims(1).to(.i64).mul(partial_out_head_stride))
             .add(split_idx.to(.i64).mul(VALUE_RANK))
             .add(offs_value.expandDims(0).to(.i64));
         k.storeOpts(
             output_ptr.addPtr(partial_out_offset),
             acc,
-            .{ .mask = q_mask },
+            .{ .mask = head_mask.expandDims(1) },
         );
 
         const partial_lse_token_stride: i64 = NUM_QUERY_HEADS * NUM_SPLITS;
         const partial_lse_offset = q_ind.to(.i64).mul(partial_lse_token_stride)
-            .add(offs_m.to(.i64).mul(NUM_SPLITS))
+            .add(offs_h.to(.i64).mul(NUM_SPLITS))
             .add(split_idx.to(.i64));
         const partial_lse = k.where(
             has_value,
@@ -490,19 +368,108 @@ fn kernelUnifiedAttentionSparseMla(
         k.storeOpts(
             partial_lse_ptr.?.addPtr(partial_lse_offset),
             partial_lse,
-            .{ .mask = query_mask_0.bitAnd(query_mask_1) },
+            .{ .mask = head_mask },
         );
         return;
     }
 
-    const output_offs_lora = query_offset_0.expandDims(1).mul(output_stride_0)
+    const output_offsets = query_offset_0.expandDims(1).mul(output_stride_0)
         .add(query_offset_1.expandDims(1).mul(output_stride_1))
         .add(offs_value.expandDims(0));
     k.storeOpts(
-        output_ptr.addPtr(output_offs_lora),
+        output_ptr.addPtr(output_offsets),
         acc.to(config.o_dtype),
-        .{ .mask = q_mask },
+        .{ .mask = head_mask.expandDims(1) },
     );
+}
+
+const Reduce3DPartialsCfg = struct {
+    num_query_heads: i64,
+    value_rank: i64,
+    num_input_splits: i64,
+    num_output_splits: i64,
+    all_decode: bool,
+};
+
+/// Reduce a large split dimension in fixed-size groups before the final
+/// attention-sink reduction. Keeping the local reduction width small avoids
+/// register spilling when sparse decode uses enough splits to fill a MI300X.
+pub const Reduce3DPartials = tri.Kernel(Reduce3DPartialsCfg, .{
+    .name = "_kernel_reduce_sparse_mla_3d_partials_ptr",
+    .inputs = &.{ "input", "input_lse", "active_query_count_ptr" },
+    .outputs = &.{ "partial_output", "partial_lse" },
+    .run = runReduce3DPartials,
+});
+
+fn runReduce3DPartials(b: *tri.Builder, cfg: Reduce3DPartialsCfg) tri.FinishError!void {
+    const a = try b.declareArgs(.{
+        .input_ptr = .{ .ptr = .f32 },
+        .input_lse_ptr = .{ .ptr = .f32 },
+        .active_query_count_ptr = .{ .ptr = .i32 },
+        .partial_output_ptr = .{ .ptr = .f32 },
+        .partial_lse_ptr = .{ .ptr = .f32 },
+    });
+
+    const query_idx = b.programId(.x);
+    if (!cfg.all_decode) {
+        const active_query_count = b.load(a.active_query_count_ptr);
+        b.returnIf(query_idx.ge(active_query_count), .{});
+    }
+    const head_group_idx = b.programId(.y);
+    const head_idx = head_group_idx.div(@as(i32, @intCast(cfg.num_output_splits)));
+    const group_idx = head_group_idx.rem(@as(i32, @intCast(cfg.num_output_splits)));
+    const splits_per_group = @divExact(cfg.num_input_splits, cfg.num_output_splits);
+    const offs_s = b.arange(0, splits_per_group, .i32);
+    const offs_d = b.arange(0, cfg.value_rank, .i32);
+    const group_start = group_idx.to(.i64).mul(splits_per_group);
+
+    const input_lse_token_stride = cfg.num_query_heads * cfg.num_input_splits;
+    const input_lse_offset = query_idx.to(.i64).mul(input_lse_token_stride)
+        .add(head_idx.to(.i64).mul(cfg.num_input_splits))
+        .add(group_start)
+        .add(offs_s.to(.i64));
+    const input_lse = b.load(a.input_lse_ptr.addPtr(input_lse_offset));
+    const overall_max = b.max(input_lse);
+    const has_value = overall_max.gt(-std.math.inf(f32));
+    const safe_max = b.where(has_value, overall_max, b.liftAs(0.0, .f32));
+    const split_weights = b.exp(input_lse.sub(safe_max));
+    const denominator = b.sumOpts(split_weights, .{ .axis = 0 });
+
+    const input_output_token_stride = cfg.num_query_heads * cfg.num_input_splits * cfg.value_rank;
+    const input_output_head_stride = cfg.num_input_splits * cfg.value_rank;
+    const input_output_base = query_idx.to(.i64).mul(input_output_token_stride)
+        .add(head_idx.to(.i64).mul(input_output_head_stride))
+        .add(group_start.mul(cfg.value_rank));
+    const input_output_offset = b.broadcastTo(
+        input_output_base.add(offs_s.expandDims(1).to(.i64).mul(cfg.value_rank)),
+        &.{ splits_per_group, cfg.value_rank },
+    ).add(b.broadcastTo(offs_d.expandDims(0).to(.i64), &.{ splits_per_group, cfg.value_rank }));
+    const input_output = b.load(a.input_ptr.addPtr(input_output_offset));
+    const numerator = b.sumOpts(input_output.mul(split_weights.expandDims(1)), .{ .axis = 0 });
+    const safe_denominator = b.where(denominator.gt(0.0), denominator, b.liftAs(1.0, .f32));
+    const output = b.where(
+        has_value,
+        numerator.div(safe_denominator),
+        b.zeros(&.{cfg.value_rank}, .f32),
+    );
+
+    const output_token_stride = cfg.num_query_heads * cfg.num_output_splits * cfg.value_rank;
+    const output_head_stride = cfg.num_output_splits * cfg.value_rank;
+    const output_offset = query_idx.to(.i64).mul(output_token_stride)
+        .add(head_idx.to(.i64).mul(output_head_stride))
+        .add(group_idx.to(.i64).mul(cfg.value_rank))
+        .add(offs_d.to(.i64));
+    b.store(a.partial_output_ptr.addPtr(output_offset), output);
+
+    const output_lse_offset = query_idx.to(.i64).mul(cfg.num_query_heads * cfg.num_output_splits)
+        .add(head_idx.to(.i64).mul(cfg.num_output_splits))
+        .add(group_idx.to(.i64));
+    const output_lse = b.where(
+        has_value,
+        safe_max.add(b.log(safe_denominator)),
+        b.liftAs(-std.math.inf(f32), .f32),
+    );
+    b.store(a.partial_lse_ptr.addPtr(output_lse_offset), output_lse);
 }
 
 const Reduce3DCfg = struct {
@@ -512,6 +479,7 @@ const Reduce3DCfg = struct {
     value_rank: i64 = 512,
     num_splits: i64 = 1,
     use_attn_sink: bool = false,
+    all_decode: bool = false,
 };
 
 pub const Reduce3D = tri.Kernel(Reduce3DCfg, .{
@@ -520,6 +488,7 @@ pub const Reduce3D = tri.Kernel(Reduce3DCfg, .{
         "partial_output_ptr",
         "partial_lse_ptr",
         "attn_sink_ptr",
+        "active_query_count_ptr",
         "output_stride_0_ptr",
         "output_stride_1_ptr",
     },
@@ -532,6 +501,7 @@ fn runReduce3D(b: *tri.Builder, cfg: Reduce3DCfg) tri.FinishError!void {
         .partial_output_ptr = .{ .ptr = .f32 },
         .partial_lse_ptr = .{ .ptr = .f32 },
         .attn_sink_ptr = .{ .ptr = cfg.sink_dtype },
+        .active_query_count_ptr = .{ .ptr = .i32 },
         .output_stride_0_ptr = .{ .ptr = .i64 },
         .output_stride_1_ptr = .{ .ptr = .i64 },
         .output_ptr = .{ .ptr = cfg.o_dtype },
@@ -541,6 +511,10 @@ fn runReduce3D(b: *tri.Builder, cfg: Reduce3DCfg) tri.FinishError!void {
     const output_stride_1 = b.load(a.output_stride_1_ptr);
     const query_idx = b.programId(.x);
     const head_idx = b.programId(.y);
+    if (!cfg.all_decode) {
+        const active_query_count = b.load(a.active_query_count_ptr);
+        b.returnIf(query_idx.ge(active_query_count), .{});
+    }
     const offs_s = b.arange(0, cfg.num_splits, .i32);
     const offs_d = b.arange(0, cfg.value_rank, .i32);
 
@@ -589,8 +563,5 @@ fn runReduce3D(b: *tri.Builder, cfg: Reduce3DCfg) tri.FinishError!void {
     const output_offset = query_idx.to(.i64).mul(output_stride_0)
         .add(head_idx.to(.i64).mul(output_stride_1))
         .add(offs_d.to(.i64));
-    b.store(
-        a.output_ptr.addPtr(output_offset),
-        output.to(cfg.o_dtype),
-    );
+    b.store(a.output_ptr.addPtr(output_offset), output.to(cfg.o_dtype));
 }


### PR DESCRIPTION
GLM 5.2 represents each MLA query/key head as 512 latent dimensions
followed by 64 RoPE dimensions. All 576 dimensions participate in the
attention score, but the value is only the 512-dimensional latent prefix.

Previously, sparse MLA accumulated a 576-dimensional context and sliced
off the RoPE suffix afterward. Return the 512-dimensional value context
directly instead. This also reduces the padded value accumulator from
1024 to 512 elements.

Make the value width explicit so the same implementation also supports
models such as DeepSeek V4, where the RoPE dimensions are included in
the value.

Keys and values share the same latent cache. Remove the redundant value
pointer and strides, reuse the loaded key tile for value accumulation,
and remove paging arguments that are no longer needed after converting
top-k indices to physical cache positions.

Add a grouped partial-reduction path for the high split counts that
improve occupancy on MI300, and tune the shape-based launch selection
more aggressively for GB300.