### PR TITLE
zml.Compiler: cleanup

### DIFF
--- a/zml/Compiler.zig
+++ b/zml/Compiler.zig
@@ -374,66 +374,6 @@ fn addPartitionerOperations(ctx: *Compiler) !void {
     }
 }
 
-fn collectOutputInfo(allocator: std.mem.Allocator, partitioning: Sharding.Partitioning, v: anytype) !std.MultiArrayList(TensorInfo) {
-    const CollectOutputInfoCb = struct {
-        allocator: std.mem.Allocator,
-        partitioning: Sharding.Partitioning,
-        infos: std.MultiArrayList(TensorInfo) = .empty,
-
-        fn cb(ctx: *@This(), tensor: *const Tensor) !void {
-            try ctx.infos.append(ctx.allocator, .{
-                .shape = tensor.shape(),
-                .sharding = try ctx.partitioning.selectSharding(tensor.shape()),
-                .value = tensor.value(),
-                .donation = tensor.donation(),
-                .memory_kind = tensor.outputMemoryKind(),
-            });
-        }
-    };
-
-    var context: CollectOutputInfoCb = .{ .allocator = allocator, .partitioning = partitioning };
-    errdefer context.infos.deinit(allocator);
-
-    try meta.visit(CollectOutputInfoCb.cb, &context, v);
-    return context.infos;
-}
-
-fn collectInputInfo(compiler: *Compiler, scope: *Scope, v: anytype) !std.MultiArrayList(TensorInfo) {
-    const CollectInputInfoCb = struct {
-        compiler: *Compiler,
-        scope: *Scope,
-
-        current_argument_id: u32 = 0,
-        infos: std.MultiArrayList(TensorInfo) = .empty,
-
-        fn cb(ctx: *@This(), tensor: *const Tensor) !void {
-            const mlir_type = mlirx.Type.rankedTensor(ctx.compiler.mlir_ctx, tensor.shape());
-
-            const value = ctx.scope.block.addArgument(mlir_type, .unknown(ctx.compiler.mlir_ctx));
-            const gop = ctx.scope.id_to_argument.getOrPut(ctx.scope.arena.allocator(), tensor.id) catch unreachable;
-            if (gop.found_existing) std.debug.panic("Tensor with id {} has already been used once as an argument", .{tensor.id});
-
-            gop.value_ptr.* = ctx.current_argument_id;
-            defer ctx.current_argument_id += 1;
-
-            try ctx.infos.append(ctx.compiler.allocator, .{
-                .shape = tensor.shape(),
-                .sharding = try ctx.compiler.partitioning.selectSharding(tensor.shape()),
-                .value = value,
-                .donation = ctx.current_argument_id,
-                .memory_kind = tensor.inputMemoryKind(),
-            });
-        }
-    };
-
-    var context: CollectInputInfoCb = .{ .compiler = compiler, .scope = scope };
-    errdefer context.infos.deinit(compiler.allocator);
-
-    try meta.visit(CollectInputInfoCb.cb, &context, v);
-
-    return context.infos;
-}
-
 const EmitMlirResult = struct {
     func: *mlir.Operation,
     input_info: std.MultiArrayList(TensorInfo),
@@ -447,7 +387,7 @@ pub const TensorInfo = struct {
     donation: ?usize,
     memory_kind: ?Memory.Kind,
 
-    pub fn attributes(info: TensorInfo, arena: std.mem.Allocator, compiler: *const Compiler) !AttributeList {
+    pub fn attributes(info: TensorInfo, arena: std.mem.Allocator, compiler: *const Compiler) error{OutOfMemory}!AttributeList {
         var attrs: AttributeList = .empty;
 
         const mlir_ctx = compiler.mlir_ctx;
@@ -484,28 +424,97 @@ fn emitMlir(compiler: *Compiler, comptime func: anytype, args: std.meta.ArgsTupl
     defer compiler.popBlock();
     const fn_scope: *Scope = compiler.currentScope();
 
-    var input_info, var output_info = b: {
+    var input_info = try collectInputInfo(compiler, fn_scope, &args);
+    errdefer input_info.deinit(compiler.allocator);
+
+    var result = result: {
         compiler.activate();
         defer compiler.deactivate();
 
-        var input_info = try collectInputInfo(compiler, fn_scope, &args);
-        errdefer input_info.deinit(compiler.allocator);
-
-        const result = @call(.auto, func, args);
-
-        var output_info = try collectOutputInfo(compiler.allocator, compiler.partitioning, &result);
-        errdefer output_info.deinit(compiler.allocator);
-
-        break :b .{ input_info, output_info };
+        break :result @call(.auto, func, args);
     };
 
-    errdefer input_info.deinit(compiler.allocator);
+    var output_info = try collectOutputInfo(compiler, fn_scope, &result);
     errdefer output_info.deinit(compiler.allocator);
+
     // Finalize in a separate function that doesn't depend on `func` type.
     return try finalizeMlirFunc(compiler, fn_scope, input_info, output_info);
 }
 
-fn finalizeMlirFunc(compiler: *Compiler, fn_scope: *Scope, input_info: std.MultiArrayList(TensorInfo), output_info: std.MultiArrayList(TensorInfo)) !EmitMlirResult {
+fn collectInputInfo(compiler: *Compiler, scope: *Scope, v: anytype) error{OutOfMemory}!std.MultiArrayList(TensorInfo) {
+    const CollectInputInfoCb = struct {
+        compiler: *Compiler,
+        scope: *Scope,
+
+        current_argument_id: u32 = 0,
+        infos: std.MultiArrayList(TensorInfo) = .empty,
+
+        fn cb(ctx: *@This(), tensor: *const Tensor) error{OutOfMemory}!void {
+            const mlir_type = mlirx.Type.rankedTensor(ctx.compiler.mlir_ctx, tensor._shape);
+
+            const value = ctx.scope.block.addArgument(mlir_type, .unknown(ctx.compiler.mlir_ctx));
+            const gop = ctx.scope.id_to_argument.getOrPut(ctx.scope.arena.allocator(), tensor.id) catch unreachable;
+            if (gop.found_existing) std.debug.panic("Tensor with id {} has already been used once as an argument", .{tensor.id});
+
+            gop.value_ptr.* = ctx.current_argument_id;
+            defer ctx.current_argument_id += 1;
+
+            const input_sharding = ctx.compiler.partitioning.selectSharding(tensor._shape) catch |err| switch (err) {
+                error.NoSuitableSharding => std.debug.panic(
+                    "Failed to resolve sharding for input {f}({d}) because it's using unknown sharding. Pass more shardings to `platform.compile`. Known shardings: {f}",
+                    .{ tensor._shape, ctx.current_argument_id, stdx.fmt.slice(ctx.compiler.partitioning.shardings) },
+                ),
+            };
+            try ctx.infos.append(ctx.compiler.allocator, .{
+                .shape = tensor._shape,
+                .sharding = input_sharding,
+                .value = value,
+                .donation = ctx.current_argument_id,
+                .memory_kind = ctx.scope.id_to_input_memory_kind.get(tensor.id),
+            });
+        }
+    };
+
+    var context: CollectInputInfoCb = .{ .compiler = compiler, .scope = scope };
+    errdefer context.infos.deinit(compiler.allocator);
+
+    try meta.visit(CollectInputInfoCb.cb, &context, v);
+
+    return context.infos;
+}
+
+fn collectOutputInfo(compiler: *Compiler, scope: *Scope, v: anytype) error{OutOfMemory}!std.MultiArrayList(TensorInfo) {
+    const CollectOutputInfoCb = struct {
+        compiler: *Compiler,
+        scope: *Scope,
+
+        infos: std.MultiArrayList(TensorInfo) = .empty,
+
+        fn cb(ctx: *@This(), tensor: *const Tensor) !void {
+            const value = if (ctx.scope.id_to_argument.get(tensor.id)) |arg_id|
+                ctx.scope.block.argument(arg_id)
+            else
+                tensor._value orelse @panic("no value found for output tensor");
+
+            try ctx.infos.append(ctx.compiler.allocator, .{
+                .shape = tensor._shape,
+                // Note: the panic should have been triggered during emitMlir or collectInputInfo
+                .sharding = ctx.compiler.partitioning.selectSharding(tensor._shape) catch @panic("failed to resolve output sharding"),
+                .value = value,
+                .donation = ctx.scope.id_to_donation.get(tensor.id),
+                .memory_kind = ctx.scope.id_to_output_memory_kind.get(tensor.id) orelse .device,
+            });
+        }
+    };
+
+    var context: CollectOutputInfoCb = .{ .compiler = compiler, .scope = scope };
+    errdefer context.infos.deinit(compiler.allocator);
+
+    try meta.visit(CollectOutputInfoCb.cb, &context, v);
+    return context.infos;
+}
+
+fn finalizeMlirFunc(compiler: *Compiler, fn_scope: *Scope, input_info: std.MultiArrayList(TensorInfo), output_info: std.MultiArrayList(TensorInfo)) error{OutOfMemory}!EmitMlirResult {
     var arena_state = std.heap.ArenaAllocator.init(compiler.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -551,7 +560,7 @@ fn finalizeMlirFunc(compiler: *Compiler, fn_scope: *Scope, input_info: std.Multi
     };
 }
 
-fn finalizeAttributeList(allocator_: std.mem.Allocator, mlir_ctx: *mlir.Context, attributes: []AttributeList) ![]*const mlir.Attribute {
+fn finalizeAttributeList(allocator_: std.mem.Allocator, mlir_ctx: *mlir.Context, attributes: []AttributeList) error{OutOfMemory}![]*const mlir.Attribute {
     const res = try allocator_.alloc(*const mlir.Attribute, attributes.len);
     for (res, attributes) |*r, attr| {
         r.* = .dict(mlir_ctx, attr.constSlice());

--- a/zml/Compiler.zig
+++ b/zml/Compiler.zig
@@ -292,7 +292,7 @@ pub fn compile(
     var compiler: Compiler = .init(allocator, st_io.io(), platform, opts);
     defer compiler.deinit();
 
-    const result = emitMlir(&compiler, func, args) catch |err| switch (err) {
+    var result = emitMlir(&compiler, func, args) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         else => unreachable,
     };
@@ -335,10 +335,10 @@ pub fn compile(
         loaded_executable,
         @intCast(num_devices),
         num_partitions,
-        result.input_info.shapes,
-        result.output_info.shapes,
-        result.input_info.shardings,
-        result.output_info.shardings,
+        result.input_info.items(.shape),
+        result.output_info.items(.shape),
+        result.input_info.items(.sharding),
+        result.output_info.items(.sharding),
     );
     errdefer exe.deinit();
 
@@ -376,126 +376,73 @@ fn addPartitionerOperations(ctx: *Compiler) !void {
     }
 }
 
+pub const OutputInfos = std.MultiArrayList(OutputInfo);
 pub const OutputInfo = struct {
-    shapes: []Shape,
-    shardings: []Sharding,
-    values: []*const mlir.Value,
-    donations: []?usize,
-    output_memory_kinds: []Memory.Kind,
-
-    pub fn deinit(self: OutputInfo, allocator: std.mem.Allocator) void {
-        allocator.free(self.shapes);
-        allocator.free(self.shardings);
-        allocator.free(self.values);
-        allocator.free(self.donations);
-        allocator.free(self.output_memory_kinds);
-    }
+    shape: Shape,
+    sharding: Sharding,
+    value: *const mlir.Value,
+    donation: ?usize,
+    memory_kind: Memory.Kind,
 };
 
-fn collectOutputInfo(allocator: std.mem.Allocator, partitioning: Sharding.Partitioning, v: anytype) !OutputInfo {
-    const LocalContext = struct {
-        shape_list: *std.array_list.Managed(Shape),
-        sharding_list: *std.array_list.Managed(Sharding),
-        value_list: *std.array_list.Managed(*const mlir.Value),
-        donation_list: *std.array_list.Managed(?usize),
-        output_memory_kind_list: *std.array_list.Managed(Memory.Kind),
+fn collectOutputInfo(allocator: std.mem.Allocator, partitioning: Sharding.Partitioning, v: anytype) !OutputInfos {
+    const CollectOutputInfoCb = struct {
+        allocator: std.mem.Allocator,
         partitioning: Sharding.Partitioning,
-    };
+        infos: OutputInfos = .empty,
 
-    var shape_list = std.array_list.Managed(Shape).init(allocator);
-    errdefer shape_list.deinit();
-    var sharding_list = std.array_list.Managed(Sharding).init(allocator);
-    errdefer sharding_list.deinit();
-    var value_list = std.array_list.Managed(*const mlir.Value).init(allocator);
-    errdefer value_list.deinit();
-    var donation_list = std.array_list.Managed(?usize).init(allocator);
-    errdefer donation_list.deinit();
-    var output_memory_kind_list = std.array_list.Managed(Memory.Kind).init(allocator);
-    errdefer output_memory_kind_list.deinit();
-
-    var context: LocalContext = .{
-        .shape_list = &shape_list,
-        .sharding_list = &sharding_list,
-        .value_list = &value_list,
-        .donation_list = &donation_list,
-        .output_memory_kind_list = &output_memory_kind_list,
-        .partitioning = partitioning,
-    };
-
-    try meta.visit(struct {
-        fn cb(ctx_: *LocalContext, tensor: *const Tensor) !void {
-            try ctx_.shape_list.append(tensor.shape());
-            try ctx_.sharding_list.append(try ctx_.partitioning.selectSharding(tensor.shape()));
-            try ctx_.value_list.append(tensor.value());
-            try ctx_.donation_list.append(tensor.donation());
-            try ctx_.output_memory_kind_list.append(tensor.outputMemoryKind());
+        fn cb(ctx: *@This(), tensor: *const Tensor) !void {
+            try ctx.infos.append(ctx.allocator, .{
+                .shape = tensor.shape(),
+                .sharding = try ctx.partitioning.selectSharding(tensor.shape()),
+                .value = tensor.value(),
+                .donation = tensor.donation(),
+                .memory_kind = tensor.outputMemoryKind(),
+            });
         }
-    }.cb, &context, v);
-
-    return .{
-        .shapes = try shape_list.toOwnedSlice(),
-        .shardings = try sharding_list.toOwnedSlice(),
-        .values = try value_list.toOwnedSlice(),
-        .donations = try donation_list.toOwnedSlice(),
-        .output_memory_kinds = try output_memory_kind_list.toOwnedSlice(),
     };
+
+    var context: CollectOutputInfoCb = .{ .allocator = allocator, .partitioning = partitioning };
+    errdefer context.infos.deinit(allocator);
+
+    try meta.visit(CollectOutputInfoCb.cb, &context, v);
+    return context.infos;
 }
 
+pub const InputInfos = std.MultiArrayList(InputInfo);
 pub const InputInfo = struct {
-    shapes: []Shape,
-    shardings: []Sharding,
-    memory_kinds: []?Memory.Kind,
-
-    pub fn deinit(self: InputInfo, allocator: std.mem.Allocator) void {
-        allocator.free(self.shapes);
-        allocator.free(self.shardings);
-        allocator.free(self.memory_kinds);
-    }
+    shape: Shape,
+    sharding: Sharding,
+    memory_kind: ?Memory.Kind,
 };
 
-fn collectInputInfo(allocator: std.mem.Allocator, partitioning: Sharding.Partitioning, v: anytype) !InputInfo {
-    const LocalContext = struct {
-        shape_list: *std.array_list.Managed(Shape),
-        sharding_list: *std.array_list.Managed(Sharding),
-        memory_kind_list: *std.array_list.Managed(?Memory.Kind),
+fn collectInputInfo(allocator: std.mem.Allocator, partitioning: Sharding.Partitioning, v: anytype) !InputInfos {
+    const CollectInputInfoCb = struct {
+        allocator: std.mem.Allocator,
         partitioning: Sharding.Partitioning,
-    };
+        infos: InputInfos = .empty,
 
-    var shape_list = std.array_list.Managed(Shape).init(allocator);
-    errdefer shape_list.deinit();
-
-    var sharding_list = std.array_list.Managed(Sharding).init(allocator);
-    errdefer sharding_list.deinit();
-
-    var memory_kind_list = std.array_list.Managed(?Memory.Kind).init(allocator);
-    errdefer memory_kind_list.deinit();
-
-    var context: LocalContext = .{
-        .shape_list = &shape_list,
-        .sharding_list = &sharding_list,
-        .memory_kind_list = &memory_kind_list,
-        .partitioning = partitioning,
-    };
-
-    try meta.visit(struct {
-        fn cb(ctx_: *LocalContext, tensor: *const Tensor) !void {
-            try ctx_.shape_list.append(tensor.shape());
-            try ctx_.sharding_list.append(try ctx_.partitioning.selectSharding(tensor.shape()));
-            try ctx_.memory_kind_list.append(tensor.inputMemoryKind());
+        fn cb(ctx: *@This(), tensor: *const Tensor) !void {
+            try ctx.infos.append(ctx.allocator, .{
+                .shape = tensor.shape(),
+                .sharding = try ctx.partitioning.selectSharding(tensor.shape()),
+                .memory_kind = tensor.inputMemoryKind(),
+            });
         }
-    }.cb, &context, v);
-
-    return .{
-        .shapes = try shape_list.toOwnedSlice(),
-        .shardings = try sharding_list.toOwnedSlice(),
-        .memory_kinds = try memory_kind_list.toOwnedSlice(),
     };
+
+    var context: CollectInputInfoCb = .{ .allocator = allocator, .partitioning = partitioning };
+    errdefer context.infos.deinit(allocator);
+
+    try meta.visit(CollectInputInfoCb.cb, &context, v);
+
+    return context.infos;
 }
 
 const EmitMlirResult = struct {
     func: *mlir.Operation,
-    input_info: InputInfo,
-    output_info: OutputInfo,
+    input_info: InputInfos,
+    output_info: OutputInfos,
 };
 
 fn finalizeAttributeList(allocator_: std.mem.Allocator, mlir_ctx: *mlir.Context, attributes: []AttributeList) ![]*const mlir.Attribute {
@@ -537,16 +484,16 @@ fn emitMlir(compiler: *Compiler, comptime func: anytype, args: std.meta.ArgsTupl
         }
     }.cb, &context, &args);
 
-    const output_info, const input_info = b: {
+    var output_info, var input_info = b: {
         compiler.activate();
         defer compiler.deactivate();
 
         const result = @call(.auto, func, args);
 
-        const input_info = try collectInputInfo(compiler.allocator, compiler.partitioning, &args);
+        var input_info = try collectInputInfo(compiler.allocator, compiler.partitioning, &args);
         errdefer input_info.deinit(compiler.allocator);
 
-        const output_info = try collectOutputInfo(compiler.allocator, compiler.partitioning, &result);
+        var output_info = try collectOutputInfo(compiler.allocator, compiler.partitioning, &result);
         errdefer output_info.deinit(compiler.allocator);
 
         break :b .{ output_info, input_info };
@@ -554,16 +501,16 @@ fn emitMlir(compiler: *Compiler, comptime func: anytype, args: std.meta.ArgsTupl
     errdefer input_info.deinit(compiler.allocator);
     errdefer output_info.deinit(compiler.allocator);
 
-    const input_attributes = try arena.allocator().alloc(AttributeList, input_info.shapes.len);
+    const input_attributes = try arena.allocator().alloc(AttributeList, input_info.len);
     @memset(input_attributes, .empty);
 
-    const output_attributes = try arena.allocator().alloc(AttributeList, output_info.shapes.len);
+    const output_attributes = try arena.allocator().alloc(AttributeList, output_info.len);
     @memset(output_attributes, .empty);
 
-    for (output_info.donations, 0..) |donation, index| if (donation) |argument_index| {
+    for (output_info.items(.donation), 0..) |donation, index| if (donation) |argument_index| {
         input_attributes[argument_index].appendAssumeCapacity(.named(compiler.mlir_ctx, "tf.aliasing_output", .int(compiler.mlir_ctx, .i32, index)));
     };
-    for (output_info.output_memory_kinds, 0..) |output_memory_kind, index| {
+    for (output_info.items(.memory_kind), 0..) |output_memory_kind, index| {
         if (output_memory_kind == .device) continue;
         output_attributes[index].appendAssumeCapacity(.named(
             compiler.mlir_ctx,
@@ -574,9 +521,9 @@ fn emitMlir(compiler: *Compiler, comptime func: anytype, args: std.meta.ArgsTupl
             ),
         ));
     }
-    _ = dialects.func.returns(compiler.mlir_ctx, output_info.values, .unknown(compiler.mlir_ctx)).appendTo(compiler.currentScope().block);
+    _ = dialects.func.returns(compiler.mlir_ctx, output_info.items(.value), .unknown(compiler.mlir_ctx)).appendTo(compiler.currentScope().block);
 
-    for (input_info.shapes, input_info.shardings, input_info.memory_kinds, 0..) |shape, sharding, maybe_memory_kind, i| {
+    for (input_info.items(.shape), input_info.items(.sharding), input_info.items(.memory_kind), 0..) |shape, sharding, maybe_memory_kind, i| {
         const attr = try compiler.partitioning.tensorShardingAttr(compiler.arena.allocator(), compiler.mlir_ctx, shape, sharding);
         const name = switch (compiler.partitioning.partitioner) {
             .gspmd => "mhlo.sharding",
@@ -598,7 +545,7 @@ fn emitMlir(compiler: *Compiler, comptime func: anytype, args: std.meta.ArgsTupl
         }
     }
 
-    for (output_info.shapes, output_info.shardings, 0..) |shape, sharding, i| {
+    for (output_info.items(.shape), output_info.items(.sharding), 0..) |shape, sharding, i| {
         const attr = try compiler.partitioning.tensorShardingAttr(compiler.arena.allocator(), compiler.mlir_ctx, shape, sharding);
         const name = switch (compiler.partitioning.partitioner) {
             .gspmd => "mhlo.sharding",

--- a/zml/Compiler.zig
+++ b/zml/Compiler.zig
@@ -89,10 +89,10 @@ pub const Error = std.mem.Allocator.Error ||
 
 pub const Scope = struct {
     block: *mlir.Block,
-    id_to_argument: std.AutoArrayHashMapUnmanaged(usize, usize),
-    id_to_donation: std.AutoArrayHashMapUnmanaged(usize, usize),
-    id_to_output_memory_kind: std.AutoArrayHashMapUnmanaged(usize, Memory.Kind),
-    id_to_input_memory_kind: std.AutoArrayHashMapUnmanaged(usize, Memory.Kind),
+    id_to_argument: std.AutoArrayHashMapUnmanaged(Tensor.Id, usize),
+    id_to_donation: std.AutoArrayHashMapUnmanaged(Tensor.Id, usize),
+    id_to_output_memory_kind: std.AutoArrayHashMapUnmanaged(Tensor.Id, Memory.Kind),
+    id_to_input_memory_kind: std.AutoArrayHashMapUnmanaged(Tensor.Id, Memory.Kind),
     arena: std.heap.ArenaAllocator,
 
     pub fn initFromBlock(allocator: std.mem.Allocator, block: *mlir.Block) Scope {

--- a/zml/Compiler.zig
+++ b/zml/Compiler.zig
@@ -87,8 +87,6 @@ pub const Error = std.mem.Allocator.Error ||
     pjrtx.Client.CompileError ||
     error{MissingDeviceInTile};
 
-const AttributeList = stdx.BoundedArray(mlir.NamedAttribute, 3);
-
 pub const Scope = struct {
     block: *mlir.Block,
     id_to_argument: std.AutoArrayHashMapUnmanaged(usize, usize),
@@ -376,20 +374,11 @@ fn addPartitionerOperations(ctx: *Compiler) !void {
     }
 }
 
-pub const OutputInfos = std.MultiArrayList(OutputInfo);
-pub const OutputInfo = struct {
-    shape: Shape,
-    sharding: Sharding,
-    value: *const mlir.Value,
-    donation: ?usize,
-    memory_kind: Memory.Kind,
-};
-
-fn collectOutputInfo(allocator: std.mem.Allocator, partitioning: Sharding.Partitioning, v: anytype) !OutputInfos {
+fn collectOutputInfo(allocator: std.mem.Allocator, partitioning: Sharding.Partitioning, v: anytype) !std.MultiArrayList(TensorInfo) {
     const CollectOutputInfoCb = struct {
         allocator: std.mem.Allocator,
         partitioning: Sharding.Partitioning,
-        infos: OutputInfos = .empty,
+        infos: std.MultiArrayList(TensorInfo) = .empty,
 
         fn cb(ctx: *@This(), tensor: *const Tensor) !void {
             try ctx.infos.append(ctx.allocator, .{
@@ -409,30 +398,36 @@ fn collectOutputInfo(allocator: std.mem.Allocator, partitioning: Sharding.Partit
     return context.infos;
 }
 
-pub const InputInfos = std.MultiArrayList(InputInfo);
-pub const InputInfo = struct {
-    shape: Shape,
-    sharding: Sharding,
-    memory_kind: ?Memory.Kind,
-};
-
-fn collectInputInfo(allocator: std.mem.Allocator, partitioning: Sharding.Partitioning, v: anytype) !InputInfos {
+fn collectInputInfo(compiler: *Compiler, scope: *Scope, v: anytype) !std.MultiArrayList(TensorInfo) {
     const CollectInputInfoCb = struct {
-        allocator: std.mem.Allocator,
-        partitioning: Sharding.Partitioning,
-        infos: InputInfos = .empty,
+        compiler: *Compiler,
+        scope: *Scope,
+
+        current_argument_id: u32 = 0,
+        infos: std.MultiArrayList(TensorInfo) = .empty,
 
         fn cb(ctx: *@This(), tensor: *const Tensor) !void {
-            try ctx.infos.append(ctx.allocator, .{
+            const mlir_type = mlirx.Type.rankedTensor(ctx.compiler.mlir_ctx, tensor.shape());
+
+            const value = ctx.scope.block.addArgument(mlir_type, .unknown(ctx.compiler.mlir_ctx));
+            const gop = ctx.scope.id_to_argument.getOrPut(ctx.scope.arena.allocator(), tensor.id) catch unreachable;
+            if (gop.found_existing) std.debug.panic("Tensor with id {} has already been used once as an argument", .{tensor.id});
+
+            gop.value_ptr.* = ctx.current_argument_id;
+            defer ctx.current_argument_id += 1;
+
+            try ctx.infos.append(ctx.compiler.allocator, .{
                 .shape = tensor.shape(),
-                .sharding = try ctx.partitioning.selectSharding(tensor.shape()),
+                .sharding = try ctx.compiler.partitioning.selectSharding(tensor.shape()),
+                .value = value,
+                .donation = ctx.current_argument_id,
                 .memory_kind = tensor.inputMemoryKind(),
             });
         }
     };
 
-    var context: CollectInputInfoCb = .{ .allocator = allocator, .partitioning = partitioning };
-    errdefer context.infos.deinit(allocator);
+    var context: CollectInputInfoCb = .{ .compiler = compiler, .scope = scope };
+    errdefer context.infos.deinit(compiler.allocator);
 
     try meta.visit(CollectInputInfoCb.cb, &context, v);
 
@@ -441,22 +436,44 @@ fn collectInputInfo(allocator: std.mem.Allocator, partitioning: Sharding.Partiti
 
 const EmitMlirResult = struct {
     func: *mlir.Operation,
-    input_info: InputInfos,
-    output_info: OutputInfos,
+    input_info: std.MultiArrayList(TensorInfo),
+    output_info: std.MultiArrayList(TensorInfo),
 };
 
-fn finalizeAttributeList(allocator_: std.mem.Allocator, mlir_ctx: *mlir.Context, attributes: []AttributeList) ![]*const mlir.Attribute {
-    const res = try allocator_.alloc(*const mlir.Attribute, attributes.len);
-    for (res, attributes) |*r, attr| {
-        r.* = .dict(mlir_ctx, attr.constSlice());
+pub const TensorInfo = struct {
+    shape: Shape,
+    sharding: Sharding,
+    value: *const mlir.Value,
+    donation: ?usize,
+    memory_kind: ?Memory.Kind,
+
+    pub fn attributes(info: TensorInfo, arena: std.mem.Allocator, compiler: *const Compiler) !AttributeList {
+        var attrs: AttributeList = .empty;
+
+        const mlir_ctx = compiler.mlir_ctx;
+        const sharding_attr = try compiler.partitioning.tensorShardingAttr(arena, mlir_ctx, info.shape, info.sharding);
+        const name = switch (compiler.partitioning.partitioner) {
+            .gspmd => "mhlo.sharding",
+            .shardy => "sdy.sharding",
+        };
+        attrs.appendAssumeCapacity(.named(mlir_ctx, name, sharding_attr));
+
+        const memory_kind = info.memory_kind orelse .device;
+        if (memory_kind != .device) {
+            attrs.appendAssumeCapacity(.named(
+                mlir_ctx,
+                "mhlo.memory_kind",
+                .string(mlir_ctx, compiler.platform.memoryKind(memory_kind)),
+            ));
+        }
+
+        return attrs;
     }
-    return res;
-}
+};
+
+const AttributeList = stdx.BoundedArray(mlir.NamedAttribute, 3);
 
 fn emitMlir(compiler: *Compiler, comptime func: anytype, args: std.meta.ArgsTuple(@TypeOf(func))) !EmitMlirResult {
-    var arena = std.heap.ArenaAllocator.init(compiler.allocator);
-    defer arena.deinit();
-
     const module = mlir.Module.init(.unknown(compiler.mlir_ctx));
     errdefer module.deinit();
 
@@ -465,102 +482,65 @@ fn emitMlir(compiler: *Compiler, comptime func: anytype, args: std.meta.ArgsTupl
 
     compiler.pushBlock(block);
     defer compiler.popBlock();
+    const fn_scope: *Scope = compiler.currentScope();
 
-    const LocalContext = struct {
-        compiler: *Compiler,
-        current_argument_id: usize = 0,
-    };
-    var context: LocalContext = .{
-        .compiler = compiler,
-    };
-    meta.visit(struct {
-        fn cb(ctx_: *LocalContext, tensor: *const Tensor) void {
-            const mlir_type = mlirx.Type.rankedTensor(ctx_.compiler.mlir_ctx, tensor.shape());
-            _ = ctx_.compiler.currentScope().block.addArgument(mlir_type, .unknown(ctx_.compiler.mlir_ctx));
-            const gop = ctx_.compiler.currentScope().id_to_argument.getOrPut(ctx_.compiler.currentScope().arena.allocator(), tensor.id) catch unreachable;
-            if (gop.found_existing) std.debug.panic("Tensor with id {} has already been used once as an argument", .{tensor.id});
-            gop.value_ptr.* = ctx_.current_argument_id;
-            ctx_.current_argument_id += 1;
-        }
-    }.cb, &context, &args);
-
-    var output_info, var input_info = b: {
+    var input_info, var output_info = b: {
         compiler.activate();
         defer compiler.deactivate();
 
-        const result = @call(.auto, func, args);
-
-        var input_info = try collectInputInfo(compiler.allocator, compiler.partitioning, &args);
+        var input_info = try collectInputInfo(compiler, fn_scope, &args);
         errdefer input_info.deinit(compiler.allocator);
+
+        const result = @call(.auto, func, args);
 
         var output_info = try collectOutputInfo(compiler.allocator, compiler.partitioning, &result);
         errdefer output_info.deinit(compiler.allocator);
 
-        break :b .{ output_info, input_info };
+        break :b .{ input_info, output_info };
     };
+
     errdefer input_info.deinit(compiler.allocator);
     errdefer output_info.deinit(compiler.allocator);
+    // Finalize in a separate function that doesn't depend on `func` type.
+    return try finalizeMlirFunc(compiler, fn_scope, input_info, output_info);
+}
 
-    const input_attributes = try arena.allocator().alloc(AttributeList, input_info.len);
-    @memset(input_attributes, .empty);
+fn finalizeMlirFunc(compiler: *Compiler, fn_scope: *Scope, input_info: std.MultiArrayList(TensorInfo), output_info: std.MultiArrayList(TensorInfo)) !EmitMlirResult {
+    var arena_state = std.heap.ArenaAllocator.init(compiler.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const mlir_ctx = compiler.mlir_ctx;
 
-    const output_attributes = try arena.allocator().alloc(AttributeList, output_info.len);
-    @memset(output_attributes, .empty);
+    const fn_return = dialects.func.returns(mlir_ctx, output_info.items(.value), .unknown(mlir_ctx));
+    _ = fn_return.appendTo(fn_scope.block);
 
-    for (output_info.items(.donation), 0..) |donation, index| if (donation) |argument_index| {
-        input_attributes[argument_index].appendAssumeCapacity(.named(compiler.mlir_ctx, "tf.aliasing_output", .int(compiler.mlir_ctx, .i32, index)));
-    };
-    for (output_info.items(.memory_kind), 0..) |output_memory_kind, index| {
-        if (output_memory_kind == .device) continue;
-        output_attributes[index].appendAssumeCapacity(.named(
-            compiler.mlir_ctx,
-            "mhlo.memory_kind",
-            .string(
-                compiler.mlir_ctx,
-                compiler.platform.memoryKind(output_memory_kind),
-            ),
-        ));
+    // Input sharding/memory attributes
+    const input_attributes = try arena.alloc(AttributeList, input_info.len);
+    for (0.., input_attributes) |i, *input_attrs| {
+        input_attrs.* = try input_info.get(i).attributes(arena, compiler);
     }
-    _ = dialects.func.returns(compiler.mlir_ctx, output_info.items(.value), .unknown(compiler.mlir_ctx)).appendTo(compiler.currentScope().block);
 
-    for (input_info.items(.shape), input_info.items(.sharding), input_info.items(.memory_kind), 0..) |shape, sharding, maybe_memory_kind, i| {
-        const attr = try compiler.partitioning.tensorShardingAttr(compiler.arena.allocator(), compiler.mlir_ctx, shape, sharding);
-        const name = switch (compiler.partitioning.partitioner) {
-            .gspmd => "mhlo.sharding",
-            .shardy => "sdy.sharding",
-        };
-
-        input_attributes[i].appendAssumeCapacity(.named(compiler.mlir_ctx, name, attr));
-
-        if (maybe_memory_kind) |memory_kind| {
-            if (memory_kind == .device) continue;
-            input_attributes[i].appendAssumeCapacity(.named(
-                compiler.mlir_ctx,
-                "mhlo.memory_kind",
-                .string(
-                    compiler.mlir_ctx,
-                    compiler.platform.memoryKind(memory_kind),
-                ),
-            ));
+    // Input donation attributes
+    for (output_info.items(.donation), 0..) |donation, index| {
+        if (donation) |argument_index| {
+            input_attributes[argument_index].appendAssumeCapacity(
+                .named(mlir_ctx, "tf.aliasing_output", .int(mlir_ctx, .i32, index)),
+            );
         }
     }
 
-    for (output_info.items(.shape), output_info.items(.sharding), 0..) |shape, sharding, i| {
-        const attr = try compiler.partitioning.tensorShardingAttr(compiler.arena.allocator(), compiler.mlir_ctx, shape, sharding);
-        const name = switch (compiler.partitioning.partitioner) {
-            .gspmd => "mhlo.sharding",
-            .shardy => "sdy.sharding",
-        };
-
-        output_attributes[i].appendAssumeCapacity(.named(compiler.mlir_ctx, name, attr));
+    // Output sharding/memory attributes
+    const output_attributes = try arena.alloc(AttributeList, output_info.len);
+    for (0.., output_attributes) |i, *output_attrs| {
+        output_attrs.* = try output_info.get(i).attributes(arena, compiler);
     }
 
-    const mlir_func = dialects.func.func(compiler.mlir_ctx, .{
+    const mlir_func = dialects.func.func(mlir_ctx, .{
         .name = "main",
-        .block = compiler.currentScope().block,
-        .location = .unknown(compiler.mlir_ctx),
-        .args_attributes = try finalizeAttributeList(arena.allocator(), compiler.mlir_ctx, input_attributes),
-        .results_attributes = try finalizeAttributeList(arena.allocator(), compiler.mlir_ctx, output_attributes),
+        .block = fn_scope.block,
+        .location = .unknown(mlir_ctx),
+        .args_attributes = try finalizeAttributeList(arena, mlir_ctx, input_attributes),
+        .results_attributes = try finalizeAttributeList(arena, mlir_ctx, output_attributes),
         .verify = false,
     });
 
@@ -569,6 +549,14 @@ fn emitMlir(compiler: *Compiler, comptime func: anytype, args: std.meta.ArgsTupl
         .input_info = input_info,
         .output_info = output_info,
     };
+}
+
+fn finalizeAttributeList(allocator_: std.mem.Allocator, mlir_ctx: *mlir.Context, attributes: []AttributeList) ![]*const mlir.Attribute {
+    const res = try allocator_.alloc(*const mlir.Attribute, attributes.len);
+    for (res, attributes) |*r, attr| {
+        r.* = .dict(mlir_ctx, attr.constSlice());
+    }
+    return res;
 }
 
 fn setXlaOverrideFlag(map: *c.upb_Map, flag: []const u8, value: anytype, upb_arena: *c.upb_Arena) !void {

--- a/zml/Compiler.zig
+++ b/zml/Compiler.zig
@@ -90,10 +90,9 @@ pub const Error = std.mem.Allocator.Error ||
 pub const Scope = struct {
     compiler: *Compiler,
     block: *mlir.Block,
-    id_to_argument: std.AutoArrayHashMapUnmanaged(Tensor.Id, usize),
+    id_to_argument: std.AutoArrayHashMapUnmanaged(Tensor.Id, *const mlir.Value),
     id_to_donation: std.AutoArrayHashMapUnmanaged(Tensor.Id, usize),
-    id_to_output_memory_kind: std.AutoArrayHashMapUnmanaged(Tensor.Id, Memory.Kind),
-    id_to_input_memory_kind: std.AutoArrayHashMapUnmanaged(Tensor.Id, Memory.Kind),
+    id_to_memory: std.AutoArrayHashMapUnmanaged(Tensor.Id, Memory.Kind),
     arena: std.heap.ArenaAllocator,
 
     pub fn initFromBlock(compiler: *Compiler, block: *mlir.Block) Scope {
@@ -103,8 +102,7 @@ pub const Scope = struct {
             .block = block,
             .id_to_argument = .empty,
             .id_to_donation = .empty,
-            .id_to_output_memory_kind = .empty,
-            .id_to_input_memory_kind = .empty,
+            .id_to_memory = .empty,
             .arena = arena,
         };
     }
@@ -118,7 +116,7 @@ pub const Scope = struct {
     }
 
     pub fn registerTensorAsBlockArgument(scope: *Scope, id: Tensor.Id, arg_id: usize) void {
-        scope.id_to_argument.put(scope.arena.allocator(), id, arg_id) catch @panic("OOM");
+        scope.id_to_argument.put(scope.arena.allocator(), id, scope.block.argument(arg_id)) catch @panic("OOM");
     }
 };
 
@@ -335,6 +333,7 @@ pub fn compile(
         loaded_executable,
         @intCast(num_devices),
         num_partitions,
+        // This will get copied into exe
         result.input_info.items(.shape),
         result.output_info.items(.shape),
         result.input_info.items(.sharding),
@@ -383,13 +382,15 @@ const EmitMlirResult = struct {
 };
 
 pub const TensorInfo = struct {
+    id: Tensor.Id,
     shape: Shape,
     sharding: Sharding,
     value: *const mlir.Value,
-    donation: ?usize,
-    memory_kind: ?Memory.Kind,
 
-    pub fn attributes(info: TensorInfo, arena: std.mem.Allocator, compiler: *const Compiler) error{OutOfMemory}!AttributeList {
+    // Only used for input tensors, stores which output tensor ends up with their buffer
+    aliasing_output: ?u32 = null,
+
+    pub fn attributes(info: TensorInfo, arena: std.mem.Allocator, compiler: *const Compiler, scope: *const Scope) error{OutOfMemory}!AttributeList {
         var attrs: AttributeList = .empty;
 
         const mlir_ctx = compiler.mlir_ctx;
@@ -400,13 +401,19 @@ pub const TensorInfo = struct {
         };
         attrs.appendAssumeCapacity(.named(mlir_ctx, name, sharding_attr));
 
-        const memory_kind = info.memory_kind orelse .device;
-        if (memory_kind != .device) {
+        const memory = scope.id_to_memory.get(info.id) orelse .device;
+        if (memory != .device) {
             attrs.appendAssumeCapacity(.named(
                 mlir_ctx,
                 "mhlo.memory_kind",
-                .string(mlir_ctx, compiler.platform.memoryKind(memory_kind)),
+                .string(mlir_ctx, compiler.platform.memoryKind(memory)),
             ));
+        }
+
+        if (info.aliasing_output) |output_index| {
+            attrs.appendAssumeCapacity(
+                .named(mlir_ctx, "tf.aliasing_output", .int(mlir_ctx, .i32, output_index)),
+            );
         }
 
         return attrs;
@@ -425,7 +432,7 @@ fn emitMlir(compiler: *Compiler, comptime func: anytype, args: std.meta.ArgsTupl
     const fn_scope: *Scope = compiler.pushBlock(block);
     defer fn_scope.pop();
 
-    var input_info = try collectInputInfo(compiler, fn_scope, &args);
+    var input_info = try createBlockArguments(compiler, fn_scope, &args);
     errdefer input_info.deinit(compiler.allocator);
 
     var result = result: {
@@ -442,8 +449,8 @@ fn emitMlir(compiler: *Compiler, comptime func: anytype, args: std.meta.ArgsTupl
     return try finalizeMlirFunc(compiler, fn_scope, input_info, output_info);
 }
 
-fn collectInputInfo(compiler: *Compiler, scope: *Scope, v: anytype) error{OutOfMemory}!std.MultiArrayList(TensorInfo) {
-    const CollectInputInfoCb = struct {
+fn createBlockArguments(compiler: *Compiler, scope: *Scope, v: anytype) error{OutOfMemory}!std.MultiArrayList(TensorInfo) {
+    const CreateBlockArgumentsCb = struct {
         compiler: *Compiler,
         scope: *Scope,
 
@@ -454,10 +461,12 @@ fn collectInputInfo(compiler: *Compiler, scope: *Scope, v: anytype) error{OutOfM
             const mlir_type = mlirx.Type.rankedTensor(ctx.compiler.mlir_ctx, tensor._shape);
 
             const value = ctx.scope.block.addArgument(mlir_type, .unknown(ctx.compiler.mlir_ctx));
-            const gop = ctx.scope.id_to_argument.getOrPut(ctx.scope.arena.allocator(), tensor.id) catch unreachable;
+            const gop = ctx.scope.id_to_argument.getOrPutValue(ctx.scope.arena.allocator(), tensor.id, value) catch @panic("OOM");
             if (gop.found_existing) std.debug.panic("Tensor with id {} has already been used once as an argument", .{tensor.id});
 
-            gop.value_ptr.* = ctx.current_argument_id;
+            // Associate each input argument with their own buffer
+            ctx.scope.id_to_donation.putNoClobber(ctx.scope.arena.allocator(), tensor.id, ctx.current_argument_id) catch @panic("OOM");
+
             defer ctx.current_argument_id += 1;
 
             const input_sharding = ctx.compiler.partitioning.selectSharding(tensor._shape) catch |err| switch (err) {
@@ -467,19 +476,18 @@ fn collectInputInfo(compiler: *Compiler, scope: *Scope, v: anytype) error{OutOfM
                 ),
             };
             try ctx.infos.append(ctx.compiler.allocator, .{
+                .id = tensor.id,
                 .shape = tensor._shape,
                 .sharding = input_sharding,
                 .value = value,
-                .donation = ctx.current_argument_id,
-                .memory_kind = ctx.scope.id_to_input_memory_kind.get(tensor.id),
             });
         }
     };
 
-    var context: CollectInputInfoCb = .{ .compiler = compiler, .scope = scope };
+    var context: CreateBlockArgumentsCb = .{ .compiler = compiler, .scope = scope };
     errdefer context.infos.deinit(compiler.allocator);
 
-    try meta.visit(CollectInputInfoCb.cb, &context, v);
+    try meta.visit(CreateBlockArgumentsCb.cb, &context, v);
 
     return context.infos;
 }
@@ -492,18 +500,16 @@ fn collectOutputInfo(compiler: *Compiler, scope: *Scope, v: anytype) error{OutOf
         infos: std.MultiArrayList(TensorInfo) = .empty,
 
         fn cb(ctx: *@This(), tensor: *const Tensor) !void {
-            const value = if (ctx.scope.id_to_argument.get(tensor.id)) |arg_id|
-                ctx.scope.block.argument(arg_id)
-            else
-                tensor._value orelse @panic("no value found for output tensor");
+            const value = ctx.scope.id_to_argument.get(tensor.id) orelse
+                tensor._value orelse
+                @panic("no value found for output tensor");
 
             try ctx.infos.append(ctx.compiler.allocator, .{
+                .id = tensor.id,
                 .shape = tensor._shape,
                 // Note: the panic should have been triggered during emitMlir or collectInputInfo
                 .sharding = ctx.compiler.partitioning.selectSharding(tensor._shape) catch @panic("failed to resolve output sharding"),
                 .value = value,
-                .donation = ctx.scope.id_to_donation.get(tensor.id),
-                .memory_kind = ctx.scope.id_to_output_memory_kind.get(tensor.id) orelse .device,
             });
         }
     };
@@ -524,33 +530,38 @@ fn finalizeMlirFunc(compiler: *Compiler, fn_scope: *Scope, input_info: std.Multi
     const fn_return = dialects.func.returns(mlir_ctx, output_info.items(.value), .unknown(mlir_ctx));
     _ = fn_return.appendTo(fn_scope.block);
 
-    // Input sharding/memory attributes
-    const input_attributes = try arena.alloc(AttributeList, input_info.len);
-    for (0.., input_attributes) |i, *input_attrs| {
-        input_attrs.* = try input_info.get(i).attributes(arena, compiler);
-    }
+    // Resolve donations
+    for (output_info.items(.id), 0..) |output_id, output_index| {
+        if (fn_scope.id_to_donation.get(output_id)) |donated_input| {
+            const aliasing_output: *?u32 = &input_info.items(.aliasing_output)[donated_input];
+            if (aliasing_output.*) |previous_aliased_output| {
+                std.debug.panic("Input {d} buffer {} was reused twice with `reuseBuffer` for output {} and output {}. Expected `reuseBuffer` to be called at most once", .{ donated_input, input_info.items(.shape)[donated_input], previous_aliased_output, output_index });
+            }
 
-    // Input donation attributes
-    for (output_info.items(.donation), 0..) |donation, index| {
-        if (donation) |argument_index| {
-            input_attributes[argument_index].appendAssumeCapacity(
-                .named(mlir_ctx, "tf.aliasing_output", .int(mlir_ctx, .i32, index)),
-            );
+            aliasing_output.* = @intCast(output_index);
         }
     }
 
+    // Input sharding/memory/aliasing attributes
+    const input_attributes = try arena.alloc(*const mlir.Attribute, input_info.len);
+    for (0.., input_attributes) |i, *input_attrs| {
+        const attrs_list = try input_info.get(i).attributes(arena, compiler, fn_scope);
+        input_attrs.* = .dict(mlir_ctx, attrs_list.constSlice());
+    }
+
     // Output sharding/memory attributes
-    const output_attributes = try arena.alloc(AttributeList, output_info.len);
+    const output_attributes = try arena.alloc(*const mlir.Attribute, output_info.len);
     for (0.., output_attributes) |i, *output_attrs| {
-        output_attrs.* = try output_info.get(i).attributes(arena, compiler);
+        const attrs_list = try output_info.get(i).attributes(arena, compiler, fn_scope);
+        output_attrs.* = .dict(mlir_ctx, attrs_list.constSlice());
     }
 
     const mlir_func = dialects.func.func(mlir_ctx, .{
         .name = "main",
         .block = fn_scope.block,
         .location = .unknown(mlir_ctx),
-        .args_attributes = try finalizeAttributeList(arena, mlir_ctx, input_attributes),
-        .results_attributes = try finalizeAttributeList(arena, mlir_ctx, output_attributes),
+        .args_attributes = input_attributes,
+        .results_attributes = output_attributes,
         .verify = false,
     });
 
@@ -559,14 +570,6 @@ fn finalizeMlirFunc(compiler: *Compiler, fn_scope: *Scope, input_info: std.Multi
         .input_info = input_info,
         .output_info = output_info,
     };
-}
-
-fn finalizeAttributeList(allocator_: std.mem.Allocator, mlir_ctx: *mlir.Context, attributes: []AttributeList) error{OutOfMemory}![]*const mlir.Attribute {
-    const res = try allocator_.alloc(*const mlir.Attribute, attributes.len);
-    for (res, attributes) |*r, attr| {
-        r.* = .dict(mlir_ctx, attr.constSlice());
-    }
-    return res;
 }
 
 fn setXlaOverrideFlag(map: *c.upb_Map, flag: []const u8, value: anytype, upb_arena: *c.upb_Arena) !void {

--- a/zml/Compiler.zig
+++ b/zml/Compiler.zig
@@ -88,6 +88,7 @@ pub const Error = std.mem.Allocator.Error ||
     error{MissingDeviceInTile};
 
 pub const Scope = struct {
+    compiler: *Compiler,
     block: *mlir.Block,
     id_to_argument: std.AutoArrayHashMapUnmanaged(Tensor.Id, usize),
     id_to_donation: std.AutoArrayHashMapUnmanaged(Tensor.Id, usize),
@@ -95,9 +96,10 @@ pub const Scope = struct {
     id_to_input_memory_kind: std.AutoArrayHashMapUnmanaged(Tensor.Id, Memory.Kind),
     arena: std.heap.ArenaAllocator,
 
-    pub fn initFromBlock(allocator: std.mem.Allocator, block: *mlir.Block) Scope {
-        const arena: std.heap.ArenaAllocator = .init(allocator);
+    pub fn initFromBlock(compiler: *Compiler, block: *mlir.Block) Scope {
+        const arena: std.heap.ArenaAllocator = .init(compiler.allocator);
         return .{
+            .compiler = compiler,
             .block = block,
             .id_to_argument = .empty,
             .id_to_donation = .empty,
@@ -107,8 +109,16 @@ pub const Scope = struct {
         };
     }
 
-    pub fn deinit(self: *Scope) void {
-        self.arena.deinit();
+    pub fn pop(self: *Scope) void {
+        const compiler = self.compiler;
+        std.debug.assert(self == compiler.currentScope());
+        var arena = self.arena;
+        _ = compiler.scopes.pop();
+        arena.deinit();
+    }
+
+    pub fn registerTensorAsBlockArgument(scope: *Scope, id: Tensor.Id, arg_id: usize) void {
+        scope.id_to_argument.put(scope.arena.allocator(), id, arg_id) catch @panic("OOM");
     }
 };
 
@@ -168,9 +178,7 @@ pub fn init(allocator: std.mem.Allocator, io: std.Io, platform: *const Platform,
 
 pub fn deinit(self: *Compiler) void {
     if (_current == self) _current = null;
-    for (self.scopes.slice()) |*scope| {
-        scope.deinit();
-    }
+    std.debug.assert(self.scopes.len == 0);
     self.mlir_pass_manager.deinit();
     self.module.deinit();
     self.mlir_ctx.deinit();
@@ -199,16 +207,10 @@ pub fn currentScope(self: *Compiler) *Scope {
     return &self.scopes.slice()[self.scopes.len - 1];
 }
 
-pub fn pushBlock(self: *Compiler, block: *mlir.Block) void {
-    const scope = Scope.initFromBlock(self.allocator, block);
+pub fn pushBlock(self: *Compiler, block: *mlir.Block) *Scope {
+    const scope = Scope.initFromBlock(self, block);
     self.scopes.appendAssumeCapacity(scope);
-}
-
-pub fn popBlock(self: *Compiler) void {
-    var maybe_popped_scope = self.scopes.pop();
-    if (maybe_popped_scope) |*popped| {
-        popped.deinit();
-    }
+    return self.currentScope();
 }
 
 pub fn nextChannelId(self: *Compiler) i64 {
@@ -420,9 +422,8 @@ fn emitMlir(compiler: *Compiler, comptime func: anytype, args: std.meta.ArgsTupl
     const block = mlir.Block.init(&.{}, &.{});
     errdefer block.deinit();
 
-    compiler.pushBlock(block);
-    defer compiler.popBlock();
-    const fn_scope: *Scope = compiler.currentScope();
+    const fn_scope: *Scope = compiler.pushBlock(block);
+    defer fn_scope.pop();
 
     var input_info = try collectInputInfo(compiler, fn_scope, &args);
     errdefer input_info.deinit(compiler.allocator);

--- a/zml/Sharding.zig
+++ b/zml/Sharding.zig
@@ -99,11 +99,21 @@ pub const Partitioning = struct {
         };
     }
 
-    pub fn tensorShardingAttr(self: Partitioning, allocator: std.mem.Allocator, ctx: *mlir.Context, shape: Shape, sharding: ?Sharding) !*const mlir.Attribute {
-        const selected_sharding = sharding orelse try self.selectSharding(shape);
+    pub fn tensorShardingAttr(
+        self: Partitioning,
+        allocator: std.mem.Allocator,
+        ctx: *mlir.Context,
+        shape: Shape,
+        sharding: Sharding,
+    ) error{OutOfMemory}!*const mlir.Attribute {
         return switch (self.partitioner) {
-            .shardy => (try selected_sharding.data.sdyShardingAttrForShape(allocator, ctx, shape)).asAttr(),
-            .gspmd => try selected_sharding.data.gspmdShardingAttrForShape(allocator, ctx, shape),
+            .shardy => (try sharding.data.sdyShardingAttrForShape(allocator, ctx, shape)).asAttr(),
+            .gspmd => sharding.data.gspmdShardingAttrForShape(allocator, ctx, shape) catch |err| switch (err) {
+                error.WriteFailed => error.OutOfMemory, // We're writing to memory
+                error.OutOfMemory => error.OutOfMemory,
+                // TODO(hugomano): clarify what can trigger this and consider moving the check to the Sharding creation
+                error.MissingDeviceInTile => @panic("MissingDeviceInTile"),
+            },
         };
     }
 
@@ -128,68 +138,7 @@ pub const Partitioning = struct {
         return sharding.shardableDim(shape.dim(ax), spec.axis, must_divide);
     }
 
-    pub fn sdyPerValueShardingAttr(self: Partitioning, allocator: std.mem.Allocator, ctx: *mlir.Context, shapes: []const Shape) !*const mlir.Attribute {
-        stdx.debug.assert(self.partitioner == .shardy, "sdyPerValueShardingAttr requires shardy partitioner", .{});
-
-        const shardings = try allocator.alloc(*const dialects.shardy.TensorShardingAttribute, shapes.len);
-        for (shapes, 0..) |shape, i| {
-            const sharding = try self.selectSharding(shape);
-            shardings[i] = try sharding.data.sdyShardingAttrForShape(allocator, ctx, shape);
-        }
-        return dialects.shardy.TensorShardingPerValueAttribute.init(ctx, shardings).asAttr();
-    }
-
-    pub fn sdyManualAxesAttr(self: Partitioning, allocator: std.mem.Allocator, ctx: *mlir.Context, in_shapes: []const Shape, out_shapes: []const Shape) !*const mlir.Attribute {
-        stdx.debug.assert(self.partitioner == .shardy, "sdyManualAxesAttr requires shardy partitioner", .{});
-
-        var axis_names = std.ArrayList([]const u8).empty;
-        defer axis_names.deinit(allocator);
-
-        const Collect = struct {
-            fn appendUnique(list: *std.ArrayList([]const u8), allocator_: std.mem.Allocator, axis_name: []const u8) void {
-                for (list.items) |existing| {
-                    if (std.mem.eql(u8, existing, axis_name)) return;
-                }
-                list.append(allocator_, axis_name) catch unreachable;
-            }
-        };
-
-        for (in_shapes) |shape| {
-            const sharding = try self.selectSharding(shape);
-            const attr = try sharding.data.sdyShardingAttrForShape(allocator, ctx, shape);
-            for (0..attr.numReplicatedAxes()) |i| {
-                Collect.appendUnique(&axis_names, allocator, attr.replicatedAxis(i).name());
-            }
-            for (0..attr.numDimensions()) |i| {
-                const dim = attr.dimension(i);
-                for (0..dim.numAxes()) |j| {
-                    Collect.appendUnique(&axis_names, allocator, dim.axis(j).name());
-                }
-            }
-        }
-        for (out_shapes) |shape| {
-            const sharding = try self.selectSharding(shape);
-            const attr = try sharding.data.sdyShardingAttrForShape(allocator, ctx, shape);
-            for (0..attr.numReplicatedAxes()) |i| {
-                Collect.appendUnique(&axis_names, allocator, attr.replicatedAxis(i).name());
-            }
-            for (0..attr.numDimensions()) |i| {
-                const dim = attr.dimension(i);
-                for (0..dim.numAxes()) |j| {
-                    Collect.appendUnique(&axis_names, allocator, dim.axis(j).name());
-                }
-            }
-        }
-
-        const axes = try allocator.alloc(*const mlir.StringAttribute, axis_names.items.len);
-        for (axis_names.items, 0..) |axis_name, i| {
-            axes[i] = mlir.StringAttribute.init(ctx, axis_name);
-        }
-
-        return dialects.shardy.ManualAxesAttribute.init(ctx, axes).asAttr();
-    }
-
-    pub fn selectSharding(self: Partitioning, shape: Shape) !Sharding {
+    pub fn selectSharding(self: Partitioning, shape: Shape) error{NoSuitableSharding}!Sharding {
         return pickSharding(self.shardings, shape, .any_covering) orelse error.NoSuitableSharding;
     }
 
@@ -242,6 +191,72 @@ pub fn shardableDim(sharding: Sharding, dim: i64, logical_axis: anytype, must_di
     } else {
         return .replicated;
     }
+}
+
+pub fn sdyPerValueShardingAttr(
+    allocator: std.mem.Allocator,
+    ctx: *mlir.Context,
+    shapes: []const Shape,
+    shardings: []const Sharding,
+) error{OutOfMemory}!*const mlir.Attribute {
+    const sharding_attrs = try allocator.alloc(*const dialects.shardy.TensorShardingAttribute, shapes.len);
+    for (sharding_attrs, shapes, shardings) |*attr, shape, sharding| {
+        attr.* = try sharding.data.sdyShardingAttrForShape(allocator, ctx, shape);
+    }
+    return dialects.shardy.TensorShardingPerValueAttribute.init(ctx, sharding_attrs).asAttr();
+}
+
+pub fn sdyManualAxesAttr(
+    allocator: std.mem.Allocator,
+    ctx: *mlir.Context,
+    in_shapes: []const Shape,
+    in_shardings: []const Sharding,
+    out_shapes: []const Shape,
+    out_shardings: []const Sharding,
+) error{OutOfMemory}!*const mlir.Attribute {
+    var axis_names = std.ArrayList([]const u8).empty;
+    defer axis_names.deinit(allocator);
+
+    const Collect = struct {
+        fn appendUnique(list: *std.ArrayList([]const u8), allocator_: std.mem.Allocator, axis_name: []const u8) void {
+            for (list.items) |existing| {
+                if (std.mem.eql(u8, existing, axis_name)) return;
+            }
+            list.append(allocator_, axis_name) catch unreachable;
+        }
+    };
+
+    for (in_shapes, in_shardings) |shape, sharding| {
+        const attr = try sharding.data.sdyShardingAttrForShape(allocator, ctx, shape);
+        for (0..attr.numReplicatedAxes()) |i| {
+            Collect.appendUnique(&axis_names, allocator, attr.replicatedAxis(i).name());
+        }
+        for (0..attr.numDimensions()) |i| {
+            const dim = attr.dimension(i);
+            for (0..dim.numAxes()) |j| {
+                Collect.appendUnique(&axis_names, allocator, dim.axis(j).name());
+            }
+        }
+    }
+    for (out_shapes, out_shardings) |shape, sharding| {
+        const attr = try sharding.data.sdyShardingAttrForShape(allocator, ctx, shape);
+        for (0..attr.numReplicatedAxes()) |i| {
+            Collect.appendUnique(&axis_names, allocator, attr.replicatedAxis(i).name());
+        }
+        for (0..attr.numDimensions()) |i| {
+            const dim = attr.dimension(i);
+            for (0..dim.numAxes()) |j| {
+                Collect.appendUnique(&axis_names, allocator, dim.axis(j).name());
+            }
+        }
+    }
+
+    const axes = try allocator.alloc(*const mlir.StringAttribute, axis_names.items.len);
+    for (axis_names.items, 0..) |axis_name, i| {
+        axes[i] = mlir.StringAttribute.init(ctx, axis_name);
+    }
+
+    return dialects.shardy.ManualAxesAttribute.init(ctx, axes).asAttr();
 }
 
 /// Device as part of a PhysicalMesh.
@@ -1460,7 +1475,7 @@ pub const Data = struct {
         parent_allocator: std.mem.Allocator,
         ctx: *mlir.Context,
         shape: Shape,
-    ) !*const dialects.shardy.TensorShardingAttribute {
+    ) error{OutOfMemory}!*const dialects.shardy.TensorShardingAttribute {
         var arena = try stdx.arenaWithCapacity(parent_allocator, 1024);
         defer arena.deinit();
         const allocator = arena.allocator();

--- a/zml/attention/triton_attention.zig
+++ b/zml/attention/triton_attention.zig
@@ -1045,8 +1045,8 @@ test "sparse MLA emits 2D and 3D Triton kernels" {
     defer compilation.deactivate();
 
     const block = @import("mlir").Block.init(&.{}, &.{});
-    compilation.pushBlock(block);
-    defer compilation.popBlock();
+    const scope = compilation.pushBlock(block);
+    defer scope.pop();
 
     const q = zml.Tensor.zeroes(zml.Shape.init(.{ .q = 1, .h = 6, .hd = 576 }, .bf16));
     const kv = zml.Tensor.zeroes(zml.Shape.init(.{ .page = 32, .k_chunk = 1, .hkv = 1, .hd = 576 }, .bf16));

--- a/zml/io.zig
+++ b/zml/io.zig
@@ -25,7 +25,7 @@ const log = std.log.scoped(.@"zml/io");
 
 pub const TensorStore = struct {
     registry: *safetensors.TensorRegistry,
-    id_to_sources: std.AutoHashMapUnmanaged(usize, []*safetensors.Tensor),
+    id_to_sources: std.AutoHashMapUnmanaged(Tensor.Id, []*safetensors.Tensor),
     allocator: std.mem.Allocator,
     arena: std.heap.ArenaAllocator,
 
@@ -44,7 +44,7 @@ pub const TensorStore = struct {
         self.arena.deinit();
     }
 
-    fn putSourcesNoClobber(self: *TensorStore, id: usize, sources: []*safetensors.Tensor) std.mem.Allocator.Error!void {
+    fn putSourcesNoClobber(self: *TensorStore, id: Tensor.Id, sources: []*safetensors.Tensor) std.mem.Allocator.Error!void {
         const gop = try self.id_to_sources.getOrPut(self.allocator, id);
         if (gop.found_existing) {
             stdx.debug.panic("Id {} already has associated sources", .{id});
@@ -85,7 +85,7 @@ pub const TensorStore = struct {
         return sources[0].reader(io, buffer, .{});
     }
 
-    pub fn getSourcesById(self: *const TensorStore, id: usize) ?[]*safetensors.Tensor {
+    pub fn getSourcesById(self: *const TensorStore, id: Tensor.Id) ?[]*safetensors.Tensor {
         return self.id_to_sources.get(id);
     }
 

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -1594,8 +1594,8 @@ test resizeBilinear {
     defer comp.deactivate();
 
     const block = @import("mlir").Block.init(&.{}, &.{});
-    comp.pushBlock(block);
-    defer comp.popBlock();
+    const scope = comp.pushBlock(block);
+    defer scope.pop();
 
     inline for (.{
         .{ .{ .a = 10, .b = 10 }, .{ .a = 20 }, .{ .a = 20, .b = 10 } },
@@ -1661,8 +1661,8 @@ test resizeBicubic {
     defer comp.deactivate();
 
     const block = @import("mlir").Block.init(&.{}, &.{});
-    comp.pushBlock(block);
-    defer comp.popBlock();
+    const scope = comp.pushBlock(block);
+    defer scope.pop();
 
     inline for (.{
         .{ .{ .a = 10, .b = 10 }, .{ .a = 20 }, .{ .a = 20, .b = 10 } },

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -87,13 +87,12 @@ pub fn allReduce(inputs: anytype, comptime func: anytype) AllReduceReturnType(@T
         const block = mlir.Block.init(&block_types, &block_locs);
         errdefer block.deinit();
 
-        ctx.pushBlock(block);
-        defer ctx.popBlock();
+        const reducer_scope = ctx.pushBlock(block);
+        defer reducer_scope.pop();
 
-        const scope = ctx.currentScope();
         inline for (0..input_tensors.len) |i| {
-            scope.id_to_argument.put(scope.arena.allocator(), args[i].left.id, i) catch unreachable;
-            scope.id_to_argument.put(scope.arena.allocator(), args[i].right.id, i + input_tensors.len) catch unreachable;
+            reducer_scope.registerTensorAsBlockArgument(args[i].left.id, i);
+            reducer_scope.registerTensorAsBlockArgument(args[i].right.id, i + input_tensors.len);
         }
 
         var reduced_values: [input_tensors.len]*const mlir.Value = undefined;
@@ -103,14 +102,10 @@ pub fn allReduce(inputs: anytype, comptime func: anytype) AllReduceReturnType(@T
         } else {
             var reduced = @call(.auto, func, args);
             var reduced_tensors: [input_tensors.len]Tensor = undefined;
-            meta.collectBuf((struct {
-                pub fn cb(t: Tensor) Tensor {
-                    return t;
-                }
-            }).cb, {}, &reduced, &reduced_tensors);
+            meta.collectBuf(stdx.meta.identity, {}, &reduced, &reduced_tensors);
 
-            inline for (0..input_tensors.len) |i| {
-                reduced_values[i] = reduced_tensors[i].value();
+            for (reduced_values, reduced_tensors) |*vi, ti| {
+                vi.* = ti.value();
             }
         }
 
@@ -209,11 +204,11 @@ pub const ReduceArgs = struct {
 };
 
 pub fn reduce(inputs: anytype, inits: anytype, axes_: []const i64, comptime func: anytype, context: anytype) stdx.meta.FnReturn(func) {
-    var arena = std.heap.ArenaAllocator.init(Compiler.current().allocator);
-    defer arena.deinit();
+    const compiler = Compiler.current();
+    const caller_scope = compiler.currentScope();
+    const mlir_ctx = compiler.mlir_ctx;
 
-    const mlir_ctx = Compiler.current().mlir_ctx;
-
+    // Note: inputs and inits are infered to be tuple of ReduceArgs
     const reduce_block, var result = b: {
         const ArgsTypes: [inits.len]type = @splat(ReduceArgs);
         const ArgsType = std.meta.Tuple(&ArgsTypes);
@@ -232,13 +227,12 @@ pub fn reduce(inputs: anytype, inits: anytype, axes_: []const i64, comptime func
         const reduce_block = mlir.Block.init(&block_types, &block_locs);
         errdefer reduce_block.deinit();
 
-        Compiler.current().pushBlock(reduce_block);
-        defer Compiler.current().popBlock();
+        const reduce_scope = compiler.pushBlock(reduce_block);
+        defer reduce_scope.pop();
 
-        const scope = Compiler.current().currentScope();
         inline for (0..inits.len) |i| {
-            scope.id_to_argument.put(scope.arena.allocator(), args[i].left.id, i) catch unreachable;
-            scope.id_to_argument.put(scope.arena.allocator(), args[i].right.id, i + inits.len) catch unreachable;
+            reduce_scope.registerTensorAsBlockArgument(args[i].left.id, i);
+            reduce_scope.registerTensorAsBlockArgument(args[i].right.id, i + inits.len);
         }
 
         var result = @call(.auto, func, args ++ context);
@@ -248,13 +242,12 @@ pub fn reduce(inputs: anytype, inits: anytype, axes_: []const i64, comptime func
             result_values[i] = result[i].value();
         }
 
-        _ = dialects.stablehlo.returns(mlir_ctx, &result_values, .unknown(mlir_ctx)).appendTo(reduce_block);
+        const block_result = dialects.stablehlo.returns(mlir_ctx, &result_values, .unknown(mlir_ctx));
+        _ = block_result.appendTo(reduce_block);
         break :b .{ reduce_block, result };
     };
     var input_values: [inputs.len]*const mlir.Value = undefined;
-    inline for (0..inputs.len) |i| {
-        input_values[i] = inputs[i].value();
-    }
+    inline for (0..inputs.len) |i| input_values[i] = inputs[i].value();
 
     var init_values: [inputs.len]*const mlir.Value = undefined;
     inline for (0..inits.len) |i| init_values[i] = inits[i].value();
@@ -268,7 +261,7 @@ pub fn reduce(inputs: anytype, inits: anytype, axes_: []const i64, comptime func
         },
         .verify = true,
         .location = .unknown(mlir_ctx),
-    }).appendTo(Compiler.current().currentScope().block);
+    }).appendTo(caller_scope.block);
 
     // `stablehlo.reduce` drops axes. We want to avoid that to propagate tags.
     // So we need to broadcast the output of `stablehlo.reduce` to the input shapes.
@@ -294,7 +287,7 @@ pub fn reduce(inputs: anytype, inits: anytype, axes_: []const i64, comptime func
             broadcasting_axes.slice()[0 .. reduced_shape.rank() - axes_.len],
             mlirx.Type.rankedTensor(mlir_ctx, reduced_shape),
             .unknown(mlir_ctx),
-        ).appendTo(Compiler.current().currentScope().block);
+        ).appendTo(caller_scope.block);
 
         result[i] = Tensor._result(reduced_shape, broad_op.result(0));
     }
@@ -321,10 +314,8 @@ pub fn ReduceWindowFn(N: comptime_int) type {
 }
 
 pub fn reduceWindow(N: comptime_int, inputs: [N]Tensor, inits: [N]Tensor, opts: ReduceWindowOpts, func: *const ReduceWindowFn(N)) [N]Tensor {
-    var arena = std.heap.ArenaAllocator.init(Compiler.current().allocator);
-    defer arena.deinit();
-
-    const mlir_ctx = Compiler.current().mlir_ctx;
+    const compiler = Compiler.current();
+    const mlir_ctx = compiler.mlir_ctx;
 
     const reduce_block, var result = b: {
         const Args = @Tuple(&@as([N]type, @splat(ReduceArgs)));
@@ -343,13 +334,12 @@ pub fn reduceWindow(N: comptime_int, inputs: [N]Tensor, inits: [N]Tensor, opts: 
         const reduce_block = mlir.Block.init(&block_types, &block_locs);
         errdefer reduce_block.deinit();
 
-        Compiler.current().pushBlock(reduce_block);
-        defer Compiler.current().popBlock();
+        const reduce_scope = compiler.pushBlock(reduce_block);
+        defer reduce_scope.pop();
 
-        const scope = Compiler.current().currentScope();
         inline for (0..N) |i| {
-            scope.id_to_argument.put(scope.arena.allocator(), args[i].left.id, i) catch unreachable;
-            scope.id_to_argument.put(scope.arena.allocator(), args[i].right.id, i + N) catch unreachable;
+            reduce_scope.registerTensorAsBlockArgument(args[i].left.id, i);
+            reduce_scope.registerTensorAsBlockArgument(args[i].right.id, i + N);
         }
 
         var result = @call(.auto, func, args);
@@ -387,7 +377,7 @@ pub fn reduceWindow(N: comptime_int, inputs: [N]Tensor, inits: [N]Tensor, opts: 
         },
         .verify = true,
         .location = .unknown(mlir_ctx),
-    }).appendTo(Compiler.current().currentScope().block);
+    }).appendTo(compiler.currentScope().block);
 
     inline for (0..result.len) |i| {
         result[i] = Tensor.fromMlirValue(reduce_op.result(i)).withTags(inputs[i].shape());
@@ -402,10 +392,8 @@ pub const SortArgs = struct {
 };
 
 pub fn sort(inputs: anytype, axis_: i64, comptime func: anytype, context: anytype, is_stable: bool) [inputs.len]Tensor {
-    var arena = std.heap.ArenaAllocator.init(Compiler.current().allocator);
-    defer arena.deinit();
-
-    const mlir_ctx = Compiler.current().mlir_ctx;
+    const compiler = Compiler.current();
+    const mlir_ctx = compiler.mlir_ctx;
 
     const sort_block = b: {
         const ArgsTypes: [inputs.len]type = @splat(SortArgs);
@@ -425,13 +413,13 @@ pub fn sort(inputs: anytype, axis_: i64, comptime func: anytype, context: anytyp
         const sort_block = mlir.Block.init(&block_types, &block_locs);
         errdefer sort_block.deinit();
 
-        Compiler.current().pushBlock(sort_block);
-        defer Compiler.current().popBlock();
+        const scope = compiler.pushBlock(sort_block);
+        defer scope.pop();
 
-        const scope = Compiler.current().currentScope();
+        const arena = scope.arena.allocator();
         inline for (0..inputs.len) |i| {
-            scope.id_to_argument.put(scope.arena.allocator(), args[i].left.id, 2 * i) catch unreachable;
-            scope.id_to_argument.put(scope.arena.allocator(), args[i].right.id, 2 * i + 1) catch unreachable;
+            scope.id_to_argument.put(arena, args[i].left.id, 2 * i) catch @panic("OOM");
+            scope.id_to_argument.put(arena, args[i].right.id, 2 * i + 1) catch @panic("OOM");
         }
 
         var result = @call(.auto, func, args ++ context);
@@ -455,7 +443,7 @@ pub fn sort(inputs: anytype, axis_: i64, comptime func: anytype, context: anytyp
         },
         .verify = true,
         .location = .unknown(mlir_ctx),
-    }).appendTo(Compiler.current().currentScope().block);
+    }).appendTo(compiler.currentScope().block);
 
     var result: [inputs.len]Tensor = undefined;
     inline for (0..inputs.len) |i| {
@@ -515,11 +503,10 @@ pub fn @"while"(
         const block = mlir.Block.init(operands_info.items(.type), operands_info.items(.location));
         errdefer block.deinit();
 
-        comp.pushBlock(block);
-        defer comp.popBlock();
+        const scope = comp.pushBlock(block);
+        defer scope.pop();
 
         // Interpret initial_state as the block argument
-        const scope = comp.currentScope();
         scope.id_to_argument.ensureUnusedCapacity(scope.arena.allocator(), flat_operands.len) catch @panic("OOM");
         for (0.., flat_operands) |i, input| {
             scope.id_to_argument.putAssumeCapacity(input.id, i);
@@ -536,11 +523,10 @@ pub fn @"while"(
         const block = mlir.Block.init(operands_info.items(.type), operands_info.items(.location));
         errdefer block.deinit();
 
-        comp.pushBlock(block);
-        defer comp.popBlock();
+        const scope = comp.pushBlock(block);
+        defer scope.pop();
 
         // Interpret operands as the block argument
-        const scope = comp.currentScope();
         scope.id_to_argument.ensureUnusedCapacity(scope.arena.allocator(), flat_operands.len) catch @panic("OOM");
         for (0.., flat_operands) |i, input| {
             scope.id_to_argument.putAssumeCapacity(input.id, i);
@@ -697,8 +683,8 @@ pub fn @"if"(
         const block = mlir.Block.init(&.{}, &.{});
         errdefer block.deinit();
 
-        Compiler.current().pushBlock(block);
-        defer Compiler.current().popBlock();
+        const scope = Compiler.current().pushBlock(block);
+        defer scope.pop();
 
         const result = blkctx.onTrue();
         const result_values = meta.collectAlloc(Tensor.value, {}, allocator, &result) catch @panic("OOM");
@@ -711,8 +697,8 @@ pub fn @"if"(
         const block = mlir.Block.init(&.{}, &.{});
         errdefer block.deinit();
 
-        Compiler.current().pushBlock(block);
-        defer Compiler.current().popBlock();
+        const scope = Compiler.current().pushBlock(block);
+        defer scope.pop();
 
         const result = blkctx.onFalse();
         const result_values = meta.collectAlloc(Tensor.value, {}, allocator, &result) catch @panic("OOM");
@@ -790,8 +776,8 @@ pub fn if2(
         const block = mlir.Block.init(&.{}, &.{});
         errdefer block.deinit();
 
-        Compiler.current().pushBlock(block);
-        defer Compiler.current().popBlock();
+        const scope = Compiler.current().pushBlock(block);
+        defer scope.pop();
         _ = dialects.stablehlo.returns(mlir_ctx, true_values, loc).appendTo(block);
         break :b block;
     };
@@ -802,8 +788,8 @@ pub fn if2(
         const block = mlir.Block.init(&.{}, &.{});
         errdefer block.deinit();
 
-        Compiler.current().pushBlock(block);
-        defer Compiler.current().popBlock();
+        const scope = Compiler.current().pushBlock(block);
+        defer scope.pop();
 
         _ = dialects.stablehlo.returns(mlir_ctx, false_values, loc).appendTo(block);
         break :b block;
@@ -1147,13 +1133,12 @@ pub fn scatter(
         const update_block = mlir.Block.init(&block_types, &block_locs);
         errdefer update_block.deinit();
 
-        Compiler.current().pushBlock(update_block);
-        defer Compiler.current().popBlock();
+        const scope = Compiler.current().pushBlock(update_block);
+        defer scope.pop();
 
-        const scope = Compiler.current().currentScope();
         inline for (0..inputs.len) |i| {
-            scope.id_to_argument.put(scope.arena.allocator(), args[i].input.id, i) catch unreachable;
-            scope.id_to_argument.put(scope.arena.allocator(), args[i].update.id, i + inputs.len) catch unreachable;
+            scope.registerTensorAsBlockArgument(args[i].input.id, i);
+            scope.registerTensorAsBlockArgument(args[i].update.id, i + inputs.len);
         }
 
         var result = @call(.auto, func, args ++ context);
@@ -1350,8 +1335,8 @@ test scatterConfig {
     defer comp.deactivate();
 
     const block = mlir.Block.init(&.{}, &.{});
-    comp.pushBlock(block);
-    defer comp.popBlock();
+    const scope = comp.pushBlock(block);
+    defer scope.pop();
 
     const Local = struct {
         pub fn _idx(idx_shape: anytype) Tensor {
@@ -1777,7 +1762,7 @@ pub fn composite(
 
         const block = mlir.Block.init(block_types, block_locs);
 
-        ctx.pushBlock(block);
+        const scope = ctx.pushBlock(block);
         {
             const arg_tensors = ctx.alloc(Tensor, inputs.len);
             for (inputs, 0..) |t, i| {
@@ -1799,7 +1784,7 @@ pub fn composite(
 
             _ = dialects.func.returns(mlir_ctx, rvals, .unknown(mlir_ctx)).appendTo(block);
         }
-        ctx.popBlock();
+        scope.pop();
 
         _ = dialects.func.func(mlir_ctx, .{
             .name = decomp_name,
@@ -2049,8 +2034,8 @@ fn manualComputationInternal(
             const manual_block = mlir.Block.init(block_types, block_locs);
             errdefer manual_block.deinit();
 
-            ctx.pushBlock(manual_block);
-            defer ctx.popBlock();
+            const manual_scope = ctx.pushBlock(manual_block);
+            defer manual_scope.pop();
 
             const local_inputs = try arena.alloc(Tensor, inputs.len);
             for (0..inputs.len) |i| {
@@ -2633,8 +2618,8 @@ test customCall {
     defer comp.deactivate();
 
     const block = mlir.Block.init(&.{}, &.{});
-    comp.pushBlock(block);
-    defer comp.popBlock();
+    const scope = comp.pushBlock(block);
+    defer scope.pop();
 
     const shape = zml.Shape.init(.{128}, .bf16).withPartitioning(.{ ._0 = .x });
     const input = Tensor.constant(zml.DataType.bf16.constant(0)).broad(shape);

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -416,10 +416,9 @@ pub fn sort(inputs: anytype, axis_: i64, comptime func: anytype, context: anytyp
         const scope = compiler.pushBlock(sort_block);
         defer scope.pop();
 
-        const arena = scope.arena.allocator();
         inline for (0..inputs.len) |i| {
-            scope.id_to_argument.put(arena, args[i].left.id, 2 * i) catch @panic("OOM");
-            scope.id_to_argument.put(arena, args[i].right.id, 2 * i + 1) catch @panic("OOM");
+            scope.registerTensorAsBlockArgument(args[i].left.id, 2 * i);
+            scope.registerTensorAsBlockArgument(args[i].right.id, 2 * i + 1);
         }
 
         var result = @call(.auto, func, args ++ context);
@@ -507,9 +506,8 @@ pub fn @"while"(
         defer scope.pop();
 
         // Interpret initial_state as the block argument
-        scope.id_to_argument.ensureUnusedCapacity(scope.arena.allocator(), flat_operands.len) catch @panic("OOM");
         for (0.., flat_operands) |i, input| {
-            scope.id_to_argument.putAssumeCapacity(input.id, i);
+            scope.registerTensorAsBlockArgument(input.id, i);
         }
 
         const cond: Tensor = captured_context.cond(initial_state);
@@ -529,7 +527,7 @@ pub fn @"while"(
         // Interpret operands as the block argument
         scope.id_to_argument.ensureUnusedCapacity(scope.arena.allocator(), flat_operands.len) catch @panic("OOM");
         for (0.., flat_operands) |i, input| {
-            scope.id_to_argument.putAssumeCapacity(input.id, i);
+            scope.registerTensorAsBlockArgument(input.id, i);
         }
 
         const result: While.State = captured_context.body(initial_state);

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -17,9 +17,10 @@ const meta = @import("meta.zig");
 const mlirx = @import("mlirx.zig");
 const Platform = @import("platform.zig").Platform;
 const Shape = @import("shape.zig").Shape;
-pub const ShapeToCustomCallBuffer = @import("pjrtx.zig").ShapeToCustomCallBuffer;
+const ShapeToCustomCallBuffer = @import("pjrtx.zig").ShapeToCustomCallBuffer;
+const Sharding = @import("Sharding.zig");
 const Tensor = @import("tensor.zig").Tensor;
-pub const TensorToCustomCallBuffer = @import("pjrtx.zig").TensorToCustomCallBuffer;
+const TensorToCustomCallBuffer = @import("pjrtx.zig").TensorToCustomCallBuffer;
 
 pub fn allReduce(inputs: anytype, comptime func: anytype) AllReduceReturnType(@TypeOf(inputs)) {
     const ctx = Compiler.current();
@@ -1975,8 +1976,11 @@ pub fn manualComputation(
         else => @compileError("Unsupported manualComputation output type: " ++ @typeName(@TypeOf(outputs))),
     };
 
+    const sharded_outputs: []const Tensor = manualComputationInternal(inputs_, output_shapes, body_context, body_fn) catch |err| switch (err) {
+        error.OutOfMemory => @panic("OOM"),
+    };
     const ReturnT = manualComputationReturnType(body_fn);
-    return manualComputationSliceToReturn(ReturnT, manualComputationInternal(inputs_, output_shapes, body_context, body_fn));
+    return manualComputationSliceToReturn(ReturnT, sharded_outputs);
 }
 
 fn manualComputationInternal(
@@ -1984,53 +1988,71 @@ fn manualComputationInternal(
     outputs: []const Shape,
     body_context: anytype,
     comptime body_fn: anytype,
-) []Tensor {
+) error{OutOfMemory}![]Tensor {
     const BodyReturnT = manualComputationReturnType(body_fn);
     const BodyInputsT = stdx.meta.FnParam(body_fn, 2);
     const BodyOutputShapesT = stdx.meta.FnParam(body_fn, 3);
 
     const ctx = Compiler.current();
-    const allocator = ctx.arena.allocator();
+    const scope = ctx.currentScope();
 
-    const input_shapes = allocator.alloc(Shape, inputs.len) catch unreachable;
-    const input_values = allocator.alloc(*const mlir.Value, inputs.len) catch unreachable;
+    var arena_state: std.heap.ArenaAllocator = .init(std.heap.page_allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const input_shapes = try arena.alloc(Shape, inputs.len);
+    const input_values = try arena.alloc(*const mlir.Value, inputs.len);
 
     for (inputs, 0..) |input, i| {
         input_shapes[i] = input.shape();
         input_values[i] = input.value();
     }
+    const local_input_shapes = try arena.alloc(Shape, inputs.len);
+    const local_output_shapes = try arena.alloc(Shape, outputs.len);
+    const input_shardings = try arena.alloc(Sharding, inputs.len);
+    const output_shardings = try arena.alloc(Sharding, outputs.len);
+
+    for (input_shapes, 0..) |shape, i| {
+        const sharding = ctx.partitioning.selectSharding(shape) catch |err| switch (err) {
+            error.NoSuitableSharding => std.debug.panic(
+                "failed to shard manualComputation input {f}({d}) because it's using unknown sharding. Pass more shardings to `.compile`. Known shardings: {f}",
+                .{ shape, i, stdx.fmt.slice(ctx.partitioning.shardings) },
+            ),
+        };
+        input_shardings[i] = sharding;
+        local_input_shapes[i] = sharding.shardedShape(shape) catch std.debug.panic("can't shard {f} for {f}", .{ shape, sharding });
+    }
+    for (outputs, 0..) |shape, i| {
+        const sharding = ctx.partitioning.selectSharding(shape) catch |err| switch (err) {
+            error.NoSuitableSharding => std.debug.panic(
+                "failed to shard manualComputation output {f}({d}) because it's using unknown sharding. Pass more shardings to `.compile`. Known shardings: {f}",
+                .{ shape, i, stdx.fmt.slice(ctx.partitioning.shardings) },
+            ),
+        };
+        output_shardings[i] = sharding;
+        local_output_shapes[i] = sharding.shardedShape(shape) catch std.debug.panic("can't shard {f} for {f}", .{ shape, sharding });
+    }
 
     return switch (ctx.partitioning.partitioner) {
-        .shardy => blk: {
-            const local_input_shapes = allocator.alloc(Shape, inputs.len) catch unreachable;
-            const local_output_shapes = allocator.alloc(Shape, outputs.len) catch unreachable;
+        .shardy => {
+            const in_shardings_attr = try Sharding.sdyPerValueShardingAttr(arena, ctx.mlir_ctx, input_shapes, input_shardings);
+            const out_shardings_attr = try Sharding.sdyPerValueShardingAttr(arena, ctx.mlir_ctx, outputs, output_shardings);
+            const manual_axes_attr = try Sharding.sdyManualAxesAttr(arena, ctx.mlir_ctx, input_shapes, input_shardings, outputs, output_shardings);
 
-            for (input_shapes, 0..) |input_shape, i| {
-                local_input_shapes[i] = ctx.partitioning.localShapeForShape(input_shape) catch unreachable;
-            }
-            for (outputs, 0..) |output_shape, i| {
-                local_output_shapes[i] = ctx.partitioning.localShapeForShape(output_shape) catch unreachable;
-            }
-
-            const in_shardings_attr = ctx.partitioning.sdyPerValueShardingAttr(allocator, ctx.mlir_ctx, input_shapes) catch unreachable;
-            const out_shardings_attr = ctx.partitioning.sdyPerValueShardingAttr(allocator, ctx.mlir_ctx, outputs) catch unreachable;
-            const manual_axes_attr = ctx.partitioning.sdyManualAxesAttr(allocator, ctx.mlir_ctx, input_shapes, outputs) catch unreachable;
-
-            const block_types = allocator.alloc(*const mlir.Type, inputs.len) catch unreachable;
-            const block_locs = allocator.alloc(*const mlir.Location, inputs.len) catch unreachable;
+            const block_types = try arena.alloc(*const mlir.Type, inputs.len);
             for (local_input_shapes, 0..) |input_shape, i| {
                 block_types[i] = mlirx.Type.rankedTensor(ctx.mlir_ctx, input_shape);
-                block_locs[i] = mlir.Location.unknown(ctx.mlir_ctx);
             }
+            const block_locs = try arena.alloc(*const mlir.Location, inputs.len);
+            @memset(block_locs, mlir.Location.unknown(ctx.mlir_ctx));
 
-            const parent_block = ctx.currentScope().block;
             const manual_block = mlir.Block.init(block_types, block_locs);
             errdefer manual_block.deinit();
 
             ctx.pushBlock(manual_block);
             defer ctx.popBlock();
 
-            const local_inputs = allocator.alloc(Tensor, inputs.len) catch unreachable;
+            const local_inputs = try arena.alloc(Tensor, inputs.len);
             for (0..inputs.len) |i| {
                 local_inputs[i] = Tensor._result(local_input_shapes[i], manual_block.argument(i));
             }
@@ -2040,11 +2062,11 @@ fn manualComputationInternal(
 
             const body_inputs = manualComputationInputsArg(BodyInputsT, local_inputs);
             const body_output_shapes = manualComputationOutputShapesArg(BodyOutputShapesT, local_output_shapes);
-            const body_result = @call(.auto, body_fn, .{ body_context, allocator, body_inputs, body_output_shapes });
-            const local_outputs = manualComputationBodyToSlice(BodyReturnT, allocator, body_result);
+            const body_result = @call(.auto, body_fn, .{ body_context, arena, body_inputs, body_output_shapes });
+            const local_outputs = manualComputationBodyToSlice(BodyReturnT, arena, body_result);
             stdx.debug.assert(local_outputs.len == outputs.len, "manualComputation body returned {} values, expected {}", .{ local_outputs.len, outputs.len });
 
-            const local_output_values = allocator.alloc(*const mlir.Value, outputs.len) catch unreachable;
+            const local_output_values = try arena.alloc(*const mlir.Value, outputs.len);
             for (0..outputs.len) |i| {
                 stdx.debug.assert(local_outputs[i].shape().eql(local_output_shapes[i]), "manualComputation body returned shape {f}, expected {f}", .{ local_outputs[i].shape(), local_output_shapes[i] });
                 local_output_values[i] = local_outputs[i].value();
@@ -2056,7 +2078,7 @@ fn manualComputationInternal(
                 .location = .unknown(ctx.mlir_ctx),
             }).appendTo(manual_block);
 
-            const global_result_types = allocator.alloc(*const mlir.Type, outputs.len) catch unreachable;
+            const global_result_types = try arena.alloc(*const mlir.Type, outputs.len);
             for (outputs, 0..) |output_shape, i| {
                 global_result_types[i] = mlirx.Type.rankedTensor(ctx.mlir_ctx, output_shape);
             }
@@ -2072,29 +2094,17 @@ fn manualComputationInternal(
                 },
                 .verify = true,
                 .location = .unknown(ctx.mlir_ctx),
-            }).appendTo(parent_block);
+            }).appendTo(scope.block);
 
-            const outputs_ = allocator.alloc(Tensor, outputs.len) catch unreachable;
+            // Use the compiler allocator to return memory to the parent
+            const sharded_outputs = ctx.alloc(Tensor, outputs.len);
             for (outputs, 0..) |output, i| {
-                outputs_[i] = Tensor._result(output, op.result(i));
+                sharded_outputs[i] = Tensor._result(output, op.result(i));
             }
-            break :blk outputs_;
+            return sharded_outputs;
         },
-        .gspmd => blk: {
-            const manual_sharding = "{manual}";
-            const output_shardings = allocator.alloc(*const mlir.Attribute, outputs.len) catch unreachable;
-            const local_input_shapes = allocator.alloc(Shape, inputs.len) catch unreachable;
-            const local_output_shapes = allocator.alloc(Shape, outputs.len) catch unreachable;
-
-            for (input_shapes, 0..) |input_shape, i| {
-                local_input_shapes[i] = ctx.partitioning.localShapeForShape(input_shape) catch unreachable;
-            }
-            for (outputs, 0..) |output_shape, i| {
-                local_output_shapes[i] = ctx.partitioning.localShapeForShape(output_shape) catch unreachable;
-                output_shardings[i] = ctx.partitioning.tensorShardingAttr(allocator, ctx.mlir_ctx, output_shape, null) catch unreachable;
-            }
-
-            const local_input_values = allocator.alloc(*const mlir.Value, inputs.len) catch unreachable;
+        .gspmd => {
+            const local_input_values = try arena.alloc(*const mlir.Value, inputs.len);
             for (0..inputs.len) |i| {
                 const local_type = mlirx.Type.rankedTensor(ctx.mlir_ctx, local_input_shapes[i]);
                 const full_to_shard = dialects.stablehlo.custom_call(
@@ -2106,15 +2116,15 @@ fn manualComputationInternal(
                         .has_side_effect = false,
                         .backend_config = .{ .original = "" },
                         .additional_attributes = &.{
-                            .named(ctx.mlir_ctx, "mhlo.sharding", .string(ctx.mlir_ctx, manual_sharding)),
+                            .named(ctx.mlir_ctx, "mhlo.sharding", .string(ctx.mlir_ctx, "{manual}")),
                         },
                     },
                     .unknown(ctx.mlir_ctx),
-                ).appendTo(ctx.currentScope().block);
+                ).appendTo(scope.block);
                 local_input_values[i] = full_to_shard.result(0);
             }
 
-            const local_inputs = allocator.alloc(Tensor, inputs.len) catch unreachable;
+            const local_inputs = try arena.alloc(Tensor, inputs.len);
             for (0..inputs.len) |i| {
                 local_inputs[i] = Tensor._result(local_input_shapes[i], local_input_values[i]);
             }
@@ -2123,20 +2133,21 @@ fn manualComputationInternal(
             defer ctx.manual_computation_depth -= 1;
             const body_inputs = manualComputationInputsArg(BodyInputsT, local_inputs);
             const body_output_shapes = manualComputationOutputShapesArg(BodyOutputShapesT, local_output_shapes);
-            const body_result = @call(.auto, body_fn, .{ body_context, allocator, body_inputs, body_output_shapes });
-            const local_outputs = manualComputationBodyToSlice(BodyReturnT, allocator, body_result);
+            const body_result = @call(.auto, body_fn, .{ body_context, arena, body_inputs, body_output_shapes });
+            const local_outputs = manualComputationBodyToSlice(BodyReturnT, arena, body_result);
             stdx.debug.assert(local_outputs.len == outputs.len, "manualComputation body returned {} values, expected {}", .{ local_outputs.len, outputs.len });
             for (0..outputs.len) |i| {
                 stdx.debug.assert(local_outputs[i].shape().eql(local_output_shapes[i]), "manualComputation body returned shape {f}, expected {f}", .{ local_outputs[i].shape(), local_output_shapes[i] });
             }
 
-            if (outputs.len == 0) {
-                break :blk allocator.alloc(Tensor, 0) catch unreachable;
-            }
+            // Skip optimization barrier for custom call that don't return values
+            if (outputs.len == 0) return &.{};
 
-            const global_values = allocator.alloc(*const mlir.Value, outputs.len) catch unreachable;
-            const global_types = allocator.alloc(*const mlir.Type, outputs.len) catch unreachable;
-            for (outputs, 0..) |output_shape, i| {
+            const global_values = try arena.alloc(*const mlir.Value, outputs.len);
+            const global_types = try arena.alloc(*const mlir.Type, outputs.len);
+            for (outputs, output_shardings, 0..) |output_shape, output_sharding, i| {
+                const gspmd_attr = try ctx.partitioning.tensorShardingAttr(arena, ctx.mlir_ctx, output_shape, output_sharding);
+
                 global_types[i] = mlirx.Type.rankedTensor(ctx.mlir_ctx, output_shape);
                 const shard_to_full = dialects.stablehlo.custom_call(
                     ctx.mlir_ctx,
@@ -2147,11 +2158,11 @@ fn manualComputationInternal(
                         .has_side_effect = false,
                         .backend_config = .{ .original = "" },
                         .additional_attributes = &.{
-                            .named(ctx.mlir_ctx, "mhlo.sharding", output_shardings[i]),
+                            .named(ctx.mlir_ctx, "mhlo.sharding", gspmd_attr),
                         },
                     },
                     .unknown(ctx.mlir_ctx),
-                ).appendTo(ctx.currentScope().block);
+                ).appendTo(scope.block);
                 global_values[i] = shard_to_full.result(0);
             }
 
@@ -2160,13 +2171,13 @@ fn manualComputationInternal(
                 global_values,
                 global_types,
                 .unknown(ctx.mlir_ctx),
-            ).appendTo(ctx.currentScope().block);
+            ).appendTo(scope.block);
 
-            const outputs_ = allocator.alloc(Tensor, outputs.len) catch unreachable;
+            const sharded_outputs = ctx.alloc(Tensor, outputs.len);
             for (outputs, 0..) |output_shape, i| {
-                outputs_[i] = Tensor._result(output_shape, barrier.result(i));
+                sharded_outputs[i] = Tensor._result(output_shape, barrier.result(i));
             }
-            break :blk outputs_;
+            return sharded_outputs;
         },
     };
 }
@@ -2245,7 +2256,7 @@ fn manualComputationOutputShapesArg(comptime OutputShapesT: type, local_output_s
     };
 }
 
-fn manualComputationSliceToReturn(comptime ReturnT: type, outputs: []Tensor) ReturnT {
+fn manualComputationSliceToReturn(comptime ReturnT: type, outputs: []const Tensor) ReturnT {
     if (ReturnT == void) {
         stdx.debug.assert(outputs.len == 0, "manualComputation expected no outputs, got {}", .{outputs.len});
         return;
@@ -2433,17 +2444,11 @@ pub fn shardingAwareTypedCustomCall(
         output_shapes[i] = @field(output, field.name);
     }
 
-    const output_tensors = manualComputationInternal(&input_tensors, &output_shapes, attributes, (struct {
+    const output_tensors: []const Tensor = manualComputationInternal(&input_tensors, &output_shapes, attributes, (struct {
         fn body(attributes_: Attributes, _: std.mem.Allocator, sharded_input_tensors: []const Tensor, sharded_output_shapes: []const Shape) []const Tensor {
-            return typedCustomCall(
-                target_name,
-                opts,
-                sharded_input_tensors,
-                sharded_output_shapes,
-                attributes_,
-            );
+            return typedCustomCall(target_name, opts, sharded_input_tensors, sharded_output_shapes, attributes_);
         }
-    }).body);
+    }).body) catch @panic("OOM");
 
     // Convert the slice back to a struct
     var out: ShapeToTensor(Output) = undefined;

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -233,7 +233,7 @@ pub const Tensor = struct {
         ).appendTo(currentBlock());
 
         const res = _result(self._shape, op.result(0));
-        ctx.currentScope().id_to_output_memory_kind.put(ctx.currentScope().arena.allocator(), res.id, kind) catch unreachable;
+        ctx.currentScope().id_to_memory.putNoClobber(ctx.currentScope().arena.allocator(), res.id, kind) catch @panic("OOM");
         return res;
     }
 
@@ -248,10 +248,10 @@ pub const Tensor = struct {
 
         var copy = flat_tensors;
         meta.visitFlatStruct(struct {
-            fn onMemory(k: Memory.Kind, x: *Tensor) void {
+            fn toMemory(k: Memory.Kind, x: *Tensor) void {
                 x.* = x.toMemory(k);
             }
-        }.onMemory, kind, &copy);
+        }.toMemory, kind, &copy);
         return copy;
     }
 
@@ -268,7 +268,7 @@ pub const Tensor = struct {
             return self;
         }
 
-        ctx.currentScope().id_to_input_memory_kind.put(ctx.currentScope().arena.allocator(), self.id, kind) catch unreachable;
+        ctx.currentScope().id_to_memory.put(ctx.currentScope().arena.allocator(), self.id, kind) catch unreachable;
 
         return self;
     }
@@ -314,11 +314,9 @@ pub const Tensor = struct {
     /// This will fail if used outside of a Compiler context.
     pub fn value(self: Tensor) *const mlir.Value {
         const scope = Compiler.current().currentScope();
-        if (scope.id_to_argument.get(self.id)) |argument_index| {
-            return scope.block.argument(argument_index);
-        } else if (self._value) |v| {
-            return v;
-        } else @panic("Something went really wrong, tensor is not an argument nor has an mlir.Value");
+        return scope.id_to_argument.get(self.id) orelse
+            self._value orelse
+            @panic("Something went really wrong, tensor is not an argument nor has an mlir.Value");
     }
 
     /// Tell PJRT compiler that memory should be reuse between the two tensors.
@@ -331,10 +329,7 @@ pub const Tensor = struct {
     pub fn reuseBuffer(self: Tensor, origin: Tensor) Tensor {
         const compilation_context = Compiler.current();
         const scope = compilation_context.currentScope();
-        if (scope.id_to_argument.get(origin.id)) |argument_index| {
-            const gop = scope.id_to_donation.getOrPut(scope.arena.allocator(), self.id) catch unreachable;
-            gop.value_ptr.* = argument_index;
-        } else if (scope.id_to_donation.get(origin.id)) |origin_donation| {
+        if (scope.id_to_donation.get(origin.id)) |origin_donation| {
             const gop = scope.id_to_donation.getOrPut(scope.arena.allocator(), self.id) catch unreachable;
             gop.value_ptr.* = origin_donation;
         }
@@ -4507,20 +4502,6 @@ pub const Tensor = struct {
 
     fn currentBlock() *mlir.Block {
         return Compiler.current().currentScope().block;
-    }
-
-    /// Returns the donation data of the tensor.
-    pub fn donation(self: Tensor) ?usize {
-        return Compiler.current().currentScope().id_to_donation.get(self.id);
-    }
-
-    /// Returns the output memory kind of the tensor.
-    pub fn outputMemoryKind(self: Tensor) Memory.Kind {
-        return Compiler.current().currentScope().id_to_output_memory_kind.get(self.id) orelse .device;
-    }
-
-    pub fn inputMemoryKind(self: Tensor) ?Memory.Kind {
-        return Compiler.current().currentScope().id_to_input_memory_kind.get(self.id);
     }
 };
 

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -313,8 +313,9 @@ pub const Tensor = struct {
     ///
     /// This will fail if used outside of a Compiler context.
     pub fn value(self: Tensor) *const mlir.Value {
-        if (Compiler.current().currentScope().id_to_argument.get(self.id)) |argument_index| {
-            return Compiler.current().currentScope().block.argument(argument_index);
+        const scope = Compiler.current().currentScope();
+        if (scope.id_to_argument.get(self.id)) |argument_index| {
+            return scope.block.argument(argument_index);
         } else if (self._value) |v| {
             return v;
         } else @panic("Something went really wrong, tensor is not an argument nor has an mlir.Value");
@@ -350,7 +351,7 @@ pub const Tensor = struct {
         const right = Tensor.init(.{ 2, 6 }, .f32);
 
         const Local = struct {
-            pub fn memcopy(x: Tensor, y: Tensor) Tensor {
+            fn memcopy(x: Tensor, y: Tensor) Tensor {
                 return x.addConstant(1).reuseBuffer(y);
             }
         };
@@ -2754,8 +2755,8 @@ pub const Tensor = struct {
             defer comp.deactivate();
 
             const block = mlir.Block.init(&.{}, &.{});
-            comp.pushBlock(block);
-            defer comp.popBlock();
+            const scope = comp.pushBlock(block);
+            defer scope.pop();
 
             inline for (.{
                 .{ .{ .a = 10 }, .{ .a = idx(.{}) }, .{} },
@@ -2906,8 +2907,8 @@ pub const Tensor = struct {
             defer comp.deactivate();
 
             const block = mlir.Block.init(&.{}, &.{});
-            comp.pushBlock(block);
-            defer comp.popBlock();
+            const scope = comp.pushBlock(block);
+            defer scope.pop();
 
             inline for (.{
                 .{ .{ .a = 10 }, .{}, .{ ._ = 0 }, .{ .a = 10 } },
@@ -3132,8 +3133,8 @@ pub const Tensor = struct {
 
             const block = mlir.Block.init(&.{}, &.{});
             defer block.deinit();
-            comp.pushBlock(block);
-            defer comp.popBlock();
+            const scope = comp.pushBlock(block);
+            defer scope.pop();
 
             const idx = Local._idx;
 
@@ -3671,8 +3672,8 @@ pub const Tensor = struct {
 
         const block = mlir.Block.init(&.{}, &.{});
         defer block.deinit();
-        comp.pushBlock(block);
-        defer comp.popBlock();
+        const scope = comp.pushBlock(block);
+        defer scope.pop();
 
         inline for (.{
             .{ .{ .a = 12 }, .a, 3, .{ .a = 4 } },
@@ -3724,8 +3725,8 @@ pub const Tensor = struct {
 
         const block = mlir.Block.init(&.{}, &.{});
         defer block.deinit();
-        comp.pushBlock(block);
-        defer comp.popBlock();
+        const scope = comp.pushBlock(block);
+        defer scope.pop();
 
         inline for (.{
             .{ .{ .a = 10 }, .a, 3, .{ .a = 3 }, .{ .a = 1 } },

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -159,14 +159,13 @@ pub const Tensor = struct {
             return res;
         };
 
-        const attr = ctx.partitioning.tensorShardingAttr(ctx.allocator, ctx.mlir_ctx, partitioned_shape, null) catch |err| switch (err) {
+        const sharding = ctx.partitioning.selectSharding(partitioned_shape) catch |err| switch (err) {
             error.NoSuitableSharding => std.debug.panic(
                 "{f}.withPartitioning({f}) failed to resolve because it's using unknown sharding. Pass more shardings to `zml.compile`. Known shardings: {f}",
                 .{ self, partitioned_shape, stdx.fmt.slice(ctx.partitioning.shardings) },
             ),
-            error.OutOfMemory, error.WriteFailed => @panic("OOM"),
-            error.MissingDeviceInTile => @panic("TODO"),
         };
+        const attr = ctx.partitioning.tensorShardingAttr(ctx.allocator, ctx.mlir_ctx, partitioned_shape, sharding) catch @panic("OOM");
 
         const op_result = switch (ctx.partitioning.partitioner) {
             .shardy => blk: {

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -23,9 +23,10 @@ test {
 }
 
 pub const Tensor = struct {
-    var current_id: std.atomic.Value(usize) = .{ .raw = 1 };
+    pub const Id = enum(u64) { _ };
+    var current_id: std.atomic.Value(u64) = .init(1);
 
-    id: usize,
+    id: Tensor.Id,
     auto_broadcast: bool = false,
     _shape: Shape,
     _value: ?*const mlir.Value = null,
@@ -36,8 +37,12 @@ pub const Tensor = struct {
         return .fromShape(.init(shape_like, dt));
     }
 
+    fn nextTensorId() Id {
+        return @enumFromInt(Tensor.current_id.fetchAdd(1, .seq_cst));
+    }
+
     pub fn fromShape(shape_: Shape) Tensor {
-        return .{ .id = Tensor.current_id.fetchAdd(1, .seq_cst), ._shape = shape_ };
+        return .{ .id = nextTensorId(), ._shape = shape_ };
     }
 
     pub fn format(self: Tensor, writer: *std.Io.Writer) !void {
@@ -73,11 +78,7 @@ pub const Tensor = struct {
     ///
     /// Creates a tensor from a Shape and an mlir.Value.
     pub fn _result(sh: Shape, val: *const mlir.Value) Tensor {
-        const res: Tensor = .{
-            ._shape = sh,
-            ._value = val,
-            .id = Tensor.current_id.fetchAdd(1, .seq_cst),
-        };
+        const res: Tensor = .{ ._shape = sh, ._value = val, .id = nextTensorId() };
 
         if (builtin.mode == .Debug) {
             // Check that the MLIR value actually have the same shape.
@@ -105,7 +106,7 @@ pub const Tensor = struct {
         sh._tags.appendNTimes(Shape.TagUnknown, n) catch unreachable;
         sh._partitioning.appendNTimes(.unknown, n) catch unreachable;
 
-        return .{ ._shape = sh, ._value = val, .id = Tensor.current_id.fetchAdd(1, .seq_cst) };
+        return .{ ._shape = sh, ._value = val, .id = nextTensorId() };
     }
 
     /// Returns the dimension of axis 'axis_'.


### PR DESCRIPTION
* use multiArrayList in `emitMlirFunc` to store information about input/output tensors. 
* merge OutputInfo and InputInfo: The code is collecting same info for input/output, some code was merge.
`emitMlirFunc` is now clearly split between the function specific wrapper, and the part that works only with slices of tensor info.
* zml.Sharding: clarify error sources, added more error messages. Most `zml.Sharding` function can fail because they resolve the sharding on the fly. Changed some APIs to explicitly take a resolved sharding, leaving only OOM errors to handle. I've put a TODO for you @hugomano about GSPMD sharding that can still fails pretty late when generating the attribute. I feel this should be checked when constructing the Partitionning.
* add Tensor.Id instead of old `usize` this allows accidental confusion or operation on type id.
* improve Compiler.Scope API: `pushBlock` now returns the `scope` this remove the old pattern of `pushBlock(); const scope = currentScope();`
        