### PR TITLE
zml/moe: support Flashinfer cutlass MoE for sm 10.3 

### DIFF
--- a/platforms/cuda/flashinfer_cutlass_moe/flashinfer_cutlass_moe.zig
+++ b/platforms/cuda/flashinfer_cutlass_moe/flashinfer_cutlass_moe.zig
@@ -136,16 +136,30 @@ pub fn apiForDevice(device: i32) !*Api {
 }
 
 test "select host and GPU architecture-specific FlashInfer CUTLASS MoE library" {
-    var buffer: [160]u8 = undefined;
-    const path = try libraryRunfile(120, &buffer);
-    const expected = switch (builtin.cpu.arch) {
-        .aarch64 => "flashinfer_cutlass_moe_linux_arm64/lib/libflashinfer_cutlass_moe_sm120.so",
-        .x86_64 => "flashinfer_cutlass_moe_linux_amd64/lib/libflashinfer_cutlass_moe_sm120.so",
-        else => return,
+    const test_case = &.{
+        .{
+            .compat_version = 120,
+            .expected = switch (builtin.cpu.arch) {
+                .aarch64 => "flashinfer_cutlass_moe_linux_arm64/lib/libflashinfer_cutlass_moe_sm120.so",
+                .x86_64 => "flashinfer_cutlass_moe_linux_amd64/lib/libflashinfer_cutlass_moe_sm120.so",
+            },
+        },
+        .{
+            .compat_version = 103,
+            .expected = switch (builtin.cpu.arch) {
+                .aarch64 => "flashinfer_cutlass_moe_linux_arm64/lib/libflashinfer_cutlass_moe_sm103.so",
+                .x86_64 => "flashinfer_cutlass_moe_linux_amd64/lib/libflashinfer_cutlass_moe_sm103.so",
+            },
+        },
     };
-    try std.testing.expectEqualStrings(expected, path);
 
-    try load(std.testing.allocator, std.testing.io, 120);
-    const api = if (loaded_api) |*value| value else return error.NotLoaded;
-    try std.testing.expectEqual(@as(i32, 120), api.compiledSm());
+    inline for (test_case) |t| {
+        var buffer: [160]u8 = undefined;
+        const path = try libraryRunfile(t.compat_version, &buffer);
+        try std.testing.expectEqualStrings(t.expected, path);
+
+        try load(std.testing.allocator, std.testing.io, 120);
+        const api = if (loaded_api) |*value| value else return error.NotLoaded;
+        try std.testing.expectEqual(@as(i32, 120), api.compiledSm());
+    }
 }

--- a/third_party/flashinfer_cutlass_moe/flashinfer_cutlass_moe.BUILD.bazel
+++ b/third_party/flashinfer_cutlass_moe/flashinfer_cutlass_moe.BUILD.bazel
@@ -13,6 +13,11 @@ filegroup(
 )
 
 filegroup(
+    name = "lib_sm103",
+    srcs = ["lib/libflashinfer_cutlass_moe_sm103.so"],
+)
+
+filegroup(
     name = "lib_sm120",
     srcs = ["lib/libflashinfer_cutlass_moe_sm120.so"],
 )
@@ -21,6 +26,7 @@ filegroup(
     name = "libraries",
     srcs = [
         ":lib_sm100",
+        ":lib_sm103",
         ":lib_sm120",
         ":lib_sm90",
     ],

--- a/third_party/flashinfer_cutlass_moe/repo.bzl
+++ b/third_party/flashinfer_cutlass_moe/repo.bzl
@@ -1,14 +1,14 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-_RELEASE = "cutlass-moe-v0.1.0"
+_RELEASE = "cutlass-moe-v0.2.0"
 
 _ASSETS = {
     "amd64": {
-        "sha256": "d40348ad771e2bc34b3dd59602ed5f3ef47b58da06ddad582a1fd993f872fb40",
+        "sha256": "5c3a29da0fd91e2281d046eb2e467a7a40aeb24a0be8ba0487006356d45fecc4",
         "url": "https://github.com/zml/flashinfer/releases/download/{release}/flashinfer-cutlass-moe_linux-amd64.tar.gz",
     },
     "arm64": {
-        "sha256": "4278b3900d789e2ad6c207f7e698728a0b68ab200a0fc815625dfc25a2a6e1a8",
+        "sha256": "60b6fdbd193e11c24589add1eb206f59a3900cde4760e53719d6b2add492343e",
         "url": "https://github.com/zml/flashinfer/releases/download/{release}/flashinfer-cutlass-moe_linux-arm64.tar.gz",
     },
 }

--- a/zml/moe/cutlass_flashinfer.zig
+++ b/zml/moe/cutlass_flashinfer.zig
@@ -88,7 +88,7 @@ pub const Metadata = struct {
         _: std.Io,
         _: *const zml.Platform,
     ) !zml.Bufferized(Metadata) {
-        return;
+        return {};
     }
 };
 

--- a/zml/moe/cutlass_flashinfer.zig
+++ b/zml/moe/cutlass_flashinfer.zig
@@ -88,7 +88,7 @@ pub const Metadata = struct {
         _: std.Io,
         _: *const zml.Platform,
     ) !zml.Bufferized(Metadata) {
-        return .{};
+        return;
     }
 };
 

--- a/zml/moe/cutlass_flashinfer.zig
+++ b/zml/moe/cutlass_flashinfer.zig
@@ -70,44 +70,25 @@ pub const Parameters = struct {
     }
 };
 
-pub const Nvfp4Scales = struct {
-    /// Dynamic activation quantization multiplier.
-    fc1_act_global: zml.Tensor,
-    /// Interleaved E4M3 scales with shape returned by fc1BlockScaleShape().
-    fc1_weight_block: zml.Tensor,
-    /// Final GEMM1 output alpha, one value per expert.
-    fc1_global: zml.Tensor,
-    /// Dynamic activation quantization multiplier.
-    fc2_act_global: zml.Tensor,
-    /// Interleaved E4M3 scales with shape returned by fc2BlockScaleShape().
-    fc2_weight_block: zml.Tensor,
-    /// Final GEMM2 output alpha, one value per expert.
-    fc2_global: zml.Tensor,
-};
-
 pub const Metadata = struct {
     variant: Variant = .bf16xbf16,
-    nvfp4_scales: ?Nvfp4Scales = null,
 
     pub const InitOptions = struct {
         variant: Variant = .bf16xbf16,
-        nvfp4_scales: ?Nvfp4Scales = null,
     };
 
     pub fn init(opts: InitOptions) Metadata {
         return .{
             .variant = opts.variant,
-            .nvfp4_scales = opts.nvfp4_scales,
         };
     }
 
     pub fn initBuffer(
-        self: Metadata,
+        _: Metadata,
         _: std.Io,
         _: *const zml.Platform,
     ) !zml.Bufferized(Metadata) {
-        if (self.nvfp4_scales != null) return error.Nvfp4ScaleBuffersRequired;
-        return .{ .nvfp4_scales = null };
+        return .{};
     }
 };
 
@@ -385,6 +366,7 @@ fn computeCapability(platform: *const zml.Platform) !u16 {
 
     if (std.mem.eql(u8, compute_capability, "9.0")) return 90;
     if (std.mem.eql(u8, compute_capability, "10.0")) return 100;
+    if (std.mem.eql(u8, compute_capability, "10.3")) return 103;
     if (std.mem.eql(u8, compute_capability, "12.0")) return 120;
     return error.UnsupportedArchitecture;
 }
@@ -424,7 +406,10 @@ pub fn isAvailable(platform: *const zml.Platform) bool {
 pub fn isNvfp4Supported(platform: *const zml.Platform) bool {
     if (platform.state.cuda.fi_cutlass_moe_runners == null) return false;
     const compute_capability = computeCapability(platform) catch return false;
-    return compute_capability == 100 or compute_capability == 120;
+    return switch (compute_capability) {
+        100, 103, 120 => true,
+        else => false,
+    };
 }
 
 pub fn tacticCounts(
@@ -485,7 +470,12 @@ fn validateInputs(
     fc2_weights: zml.Tensor,
     topk_weights: zml.Tensor,
     topk_ids: zml.Tensor,
-    scales: Nvfp4Scales,
+    fc1_act_global: zml.Tensor,
+    fc1_weight_block: zml.Tensor,
+    fc1_global: zml.Tensor,
+    fc2_act_global: zml.Tensor,
+    fc2_weight_block: zml.Tensor,
+    fc2_global: zml.Tensor,
     options: Options,
 ) !Attributes {
     if (hidden_states.dtype() != .bf16 or
@@ -493,10 +483,10 @@ fn validateInputs(
         fc2_weights.dtype() != .f4e2m1 or
         topk_weights.dtype() != .f32 or
         topk_ids.dtype() != .i32 or
-        scales.fc1_weight_block.dtype() != .f8e4m3fn or
-        scales.fc2_weight_block.dtype() != .f8e4m3fn or
-        scales.fc1_global.dtype() != .f32 or
-        scales.fc2_global.dtype() != .f32)
+        fc1_weight_block.dtype() != .f8e4m3fn or
+        fc2_weight_block.dtype() != .f8e4m3fn or
+        fc1_global.dtype() != .f32 or
+        fc2_global.dtype() != .f32)
     {
         return error.UnsupportedType;
     }
@@ -536,21 +526,21 @@ fn validateInputs(
         topk_weights.dim(2) != top_k or
         topk_ids.dim(0) != batch or
         topk_ids.dim(1) != sequence or
-        !scales.fc1_weight_block.shape().eql(fc1BlockScaleShape(
+        !fc1_weight_block.shape().eql(fc1BlockScaleShape(
             num_experts,
             hidden_size,
             intermediate_size,
             options.activation,
         )) or
-        !scales.fc2_weight_block.shape().eql(fc2BlockScaleShape(
+        !fc2_weight_block.shape().eql(fc2BlockScaleShape(
             num_experts,
             hidden_size,
             intermediate_size,
         )) or
-        !scales.fc1_global.shape().eql(.init(.{num_experts}, .f32)) or
-        !scales.fc2_global.shape().eql(.init(.{num_experts}, .f32)) or
-        !isGlobalOrPerExpertScale(scales.fc1_act_global, num_experts) or
-        !isGlobalOrPerExpertScale(scales.fc2_act_global, num_experts))
+        !fc1_global.shape().eql(.init(.{num_experts}, .f32)) or
+        !fc2_global.shape().eql(.init(.{num_experts}, .f32)) or
+        !isGlobalOrPerExpertScale(fc1_act_global, num_experts) or
+        !isGlobalOrPerExpertScale(fc2_act_global, num_experts))
     {
         return error.InvalidShape;
     }
@@ -563,8 +553,8 @@ fn validateInputs(
         .top_k = @intCast(top_k),
         .activation = cutlassActivation(options.activation),
         .enable_pdl = options.enable_pdl,
-        .fc1_act_per_expert = scales.fc1_act_global.rank() == 1,
-        .fc2_act_per_expert = scales.fc2_act_global.rank() == 1,
+        .fc1_act_per_expert = fc1_act_global.rank() == 1,
+        .fc2_act_per_expert = fc2_act_global.rank() == 1,
         .gemm1_tactic = options.gemm1_tactic,
         .gemm2_tactic = options.gemm2_tactic,
     };
@@ -579,7 +569,12 @@ pub fn fusedExpertsNvfp4(
     fc2_weights: zml.Tensor,
     topk_weights: zml.Tensor,
     topk_ids: zml.Tensor,
-    scales: Nvfp4Scales,
+    fc1_act_global: zml.Tensor,
+    fc1_weight_block: zml.Tensor,
+    fc1_global: zml.Tensor,
+    fc2_act_global: zml.Tensor,
+    fc2_weight_block: zml.Tensor,
+    fc2_global: zml.Tensor,
     options: Options,
 ) !zml.Tensor {
     const runners = try currentRunners();
@@ -589,7 +584,12 @@ pub fn fusedExpertsNvfp4(
         fc2_weights,
         topk_weights,
         topk_ids,
-        scales,
+        fc1_act_global,
+        fc1_weight_block,
+        fc1_global,
+        fc2_act_global,
+        fc2_weight_block,
+        fc2_global,
         options,
     );
     attributes.runners = @intFromPtr(runners);
@@ -613,12 +613,12 @@ pub fn fusedExpertsNvfp4(
             .fc2_weights = fc2_weights,
             .topk_weights = topk_weights,
             .topk_ids = topk_ids,
-            .fc1_act_global = scales.fc1_act_global,
-            .fc1_weight_block = scales.fc1_weight_block,
-            .fc1_global = scales.fc1_global,
-            .fc2_act_global = scales.fc2_act_global,
-            .fc2_weight_block = scales.fc2_weight_block,
-            .fc2_global = scales.fc2_global,
+            .fc1_act_global = fc1_act_global,
+            .fc1_weight_block = fc1_weight_block,
+            .fc1_global = fc1_global,
+            .fc2_act_global = fc2_act_global,
+            .fc2_weight_block = fc2_weight_block,
+            .fc2_global = fc2_global,
         },
         .{
             .output = hidden_states.shape(),

--- a/zml/moe/moe.zig
+++ b/zml/moe/moe.zig
@@ -217,10 +217,6 @@ pub fn forwardMoe(
             if (comptime !platforms.isEnabled(.cuda)) {
                 return error.UnsupportedPlatform;
             }
-            const flashinfer_metadata = switch (metadata) {
-                .flashinfer_cutlass => |v| v,
-                else => return error.InvalidMetadata,
-            };
             if (gate_up.bias != null or down.bias != null) {
                 return error.UnsupportedBias;
             }
@@ -228,12 +224,12 @@ pub fn forwardMoe(
             const runner_options = try parameters.flashinfer_cutlass.runnerOptions();
             const expert_partition = gate_up.weight.shape().partition(.expert);
 
-            if (flashinfer_metadata.variant == .nvfp4xnvfp4) {
+            if (quant_scheme != null and quant_scheme == .nvfp4) {
                 const gate_up_weight_unpacked = unpackedWeight(gate_up);
                 const down_weight_unpacked = unpackedWeight(down);
-                const nvfp4 = flashinfer_metadata.nvfp4_scales orelse
-                    return error.MissingNvfp4Scales;
 
+                // TODO(Corentin): Do error checking on nvfp4
+                // Also, maybe pass `zml.nn.Linear` directly
                 if (expert_partition.eql(.init(.experts))) {
                     break :b zml.ops.manualComputation(
                         .{
@@ -242,12 +238,12 @@ pub fn forwardMoe(
                             topk_weights,
                             gate_up_weight_unpacked,
                             down_weight_unpacked,
-                            nvfp4.fc1_act_global,
-                            nvfp4.fc1_weight_block,
-                            nvfp4.fc1_global,
-                            nvfp4.fc2_act_global,
-                            nvfp4.fc2_weight_block,
-                            nvfp4.fc2_global,
+                            gate_up.quantization.?.input_scale.?.asMultiplier(),
+                            gate_up.quantization.?.scales,
+                            gate_up.quantization.?.global_scale.?.asMultiplier(),
+                            down.quantization.?.input_scale.?.asMultiplier(),
+                            down.quantization.?.scales,
+                            down.quantization.?.global_scale.?.asMultiplier(),
                         },
                         input.shape(),
                         .{
@@ -319,7 +315,12 @@ pub fn forwardMoe(
                     down_weight_unpacked,
                     topk_weights,
                     topk_ids,
-                    nvfp4,
+                    gate_up.quantization.?.input_scale.?.asMultiplier(),
+                    gate_up.quantization.?.scales,
+                    gate_up.quantization.?.global_scale.?.asMultiplier(),
+                    down.quantization.?.input_scale.?.asMultiplier(),
+                    down.quantization.?.scales,
+                    down.quantization.?.global_scale.?.asMultiplier(),
                     runner_options,
                 );
             }

--- a/zml/moe/moe.zig
+++ b/zml/moe/moe.zig
@@ -233,6 +233,7 @@ pub fn forwardMoe(
                 const down_weight_unpacked = unpackedWeight(down);
                 const nvfp4 = flashinfer_metadata.nvfp4_scales orelse
                     return error.MissingNvfp4Scales;
+
                 if (expert_partition.eql(.init(.experts))) {
                     break :b zml.ops.manualComputation(
                         .{
@@ -286,14 +287,12 @@ pub fn forwardMoe(
                                     sharded_inputs[4],
                                     local_topk_weights,
                                     local_topk_ids,
-                                    .{
-                                        .fc1_act_global = sharded_inputs[5],
-                                        .fc1_weight_block = sharded_inputs[6],
-                                        .fc1_global = sharded_inputs[7],
-                                        .fc2_act_global = sharded_inputs[8],
-                                        .fc2_weight_block = sharded_inputs[9],
-                                        .fc2_global = sharded_inputs[10],
-                                    },
+                                    sharded_inputs[5],
+                                    sharded_inputs[6],
+                                    sharded_inputs[7],
+                                    sharded_inputs[8],
+                                    sharded_inputs[9],
+                                    sharded_inputs[10],
                                     .{
                                         .workspace_query_device = ctx.workspace_query_device,
                                         .activation = ctx.activation,
@@ -323,9 +322,6 @@ pub fn forwardMoe(
                     nvfp4,
                     runner_options,
                 );
-            }
-            if (flashinfer_metadata.nvfp4_scales != null) {
-                return error.UnexpectedNvfp4Scales;
             }
 
             if (expert_partition.eql(.init(.experts))) {


### PR DESCRIPTION
Update flashinfer cutlass moe to retrieve sm103 compiled .so. 
Unpack forwardMoe abi by removing the Nvfp4Scales type. 