### PR TITLE
zml: remove implicit donation [bugfix]

### DIFF
--- a/zml/Compiler.zig
+++ b/zml/Compiler.zig
@@ -290,6 +290,7 @@ pub fn compile(
     var compiler: Compiler = .init(allocator, st_io.io(), platform, opts);
     defer compiler.deinit();
 
+    log.warn("compiling: {s}", .{opts.program_name});
     var result = emitMlir(&compiler, func, args) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         else => unreachable,
@@ -545,16 +546,20 @@ fn finalizeMlirFunc(compiler: *Compiler, fn_scope: *Scope, input_info: std.Multi
     _ = fn_return.appendTo(fn_scope.block);
 
     // Resolve donations
+    std.log.warn("donations: ", .{});
     for (output_info.items(.id), 0..) |output_id, output_index| {
         if (fn_scope.id_to_donation.get(output_id)) |donated_input| {
+            const input_id = input_info.items(.id)[donated_input];
             const aliasing_output: *?u32 = &input_info.items(.aliasing_output)[donated_input];
+            if (output_id == input_id) continue;
+
             if (aliasing_output.*) |previous_aliased_output| {
                 std.debug.panic("Input {d} buffer {} was reused twice with `reuseBuffer` for output {} and output {}. Expected `reuseBuffer` to be called at most once", .{ donated_input, input_info.items(.shape)[donated_input], previous_aliased_output, output_index });
             }
-
             aliasing_output.* = @intCast(output_index);
         }
     }
+    std.log.warn("input_info.items(.aliasing_output): {any}", .{input_info.items(.aliasing_output)});
 
     // Input sharding/memory/aliasing attributes
     const input_attributes = try arena.alloc(*const mlir.Attribute, input_info.len);

--- a/zml/Compiler.zig
+++ b/zml/Compiler.zig
@@ -87,11 +87,16 @@ pub const Error = std.mem.Allocator.Error ||
     pjrtx.Client.CompileError ||
     error{MissingDeviceInTile};
 
+pub const Donation = union(enum) {
+    implicit: u32,
+    explicit: u32,
+};
+
 pub const Scope = struct {
     compiler: *Compiler,
     block: *mlir.Block,
     id_to_argument: std.AutoArrayHashMapUnmanaged(Tensor.Id, *const mlir.Value),
-    id_to_donation: std.AutoArrayHashMapUnmanaged(Tensor.Id, usize),
+    id_to_donation: std.AutoArrayHashMapUnmanaged(Tensor.Id, Donation),
     id_to_memory: std.AutoArrayHashMapUnmanaged(Tensor.Id, Memory.Kind),
     arena: std.heap.ArenaAllocator,
 
@@ -290,7 +295,6 @@ pub fn compile(
     var compiler: Compiler = .init(allocator, st_io.io(), platform, opts);
     defer compiler.deinit();
 
-    log.warn("compiling: {s}", .{opts.program_name});
     var result = emitMlir(&compiler, func, args) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         else => unreachable,
@@ -474,7 +478,7 @@ fn createBlockArguments(compiler: *Compiler, scope: *Scope, v: anytype) error{Ou
             if (gop.found_existing) std.debug.panic("Tensor with id {} has already been used once as an argument", .{tensor.id});
 
             // Associate each input argument with their own buffer
-            ctx.scope.id_to_donation.putNoClobber(ctx.scope.arena.allocator(), tensor.id, ctx.current_argument_id) catch @panic("OOM");
+            ctx.scope.id_to_donation.putNoClobber(ctx.scope.arena.allocator(), tensor.id, .{ .implicit = ctx.current_argument_id }) catch @panic("OOM");
 
             defer ctx.current_argument_id += 1;
 
@@ -546,20 +550,20 @@ fn finalizeMlirFunc(compiler: *Compiler, fn_scope: *Scope, input_info: std.Multi
     _ = fn_return.appendTo(fn_scope.block);
 
     // Resolve donations
-    std.log.warn("donations: ", .{});
-    for (output_info.items(.id), 0..) |output_id, output_index| {
-        if (fn_scope.id_to_donation.get(output_id)) |donated_input| {
-            const input_id = input_info.items(.id)[donated_input];
+    for (0.., output_info.items(.id)) |output_index, output_id| {
+        if (fn_scope.id_to_donation.get(output_id)) |donation| {
+            const donated_input = switch (donation) {
+                // don't emit implicit donation since they modify the way the function is called
+                .implicit => continue,
+                .explicit => |input| input,
+            };
             const aliasing_output: *?u32 = &input_info.items(.aliasing_output)[donated_input];
-            if (output_id == input_id) continue;
-
             if (aliasing_output.*) |previous_aliased_output| {
                 std.debug.panic("Input {d} buffer {} was reused twice with `reuseBuffer` for output {} and output {}. Expected `reuseBuffer` to be called at most once", .{ donated_input, input_info.items(.shape)[donated_input], previous_aliased_output, output_index });
             }
             aliasing_output.* = @intCast(output_index);
         }
     }
-    std.log.warn("input_info.items(.aliasing_output): {any}", .{input_info.items(.aliasing_output)});
 
     // Input sharding/memory/aliasing attributes
     const input_attributes = try arena.alloc(*const mlir.Attribute, input_info.len);

--- a/zml/buffer.zig
+++ b/zml/buffer.zig
@@ -203,13 +203,14 @@ pub const Buffer = struct {
     pub fn uninitialized(
         _: std.Io,
         platform: *const Platform,
-        sh: Shape,
+        shape_: Shape,
         sharding: Sharding,
         opts: UnitializedOptions,
     ) !Buffer {
+        const sh = shape_.packedShape();
         var res: Buffer = .{
             ._platform = platform,
-            ._shape = sh,
+            ._shape = shape_,
             ._sharding = sharding.resolve(platform),
             ._shards = .empty,
         };

--- a/zml/slice.zig
+++ b/zml/slice.zig
@@ -147,11 +147,12 @@ pub const Slice = struct {
     }
 
     pub fn items(slice: Slice, comptime T: type) []T {
-        stdx.debug.assertComptime(@bitSizeOf(T) >= 8, "zml.Slice stores packed sub-bytes type so you need to pass a packed type here like @Vector({}, {}). Got: {}", .{ @divFloor(8, @bitSizeOf(T)), T, T });
+        stdx.debug.assertComptime(T == bool or @bitSizeOf(T) >= 8, "zml.Slice stores packed sub-bytes type so you need to pass a packed type here like @Vector({}, {}). Got: {}", .{ @divFloor(8, @bitSizeOf(T)), T, T });
         return @ptrCast(@alignCast(slice.data()));
     }
 
     pub fn constItems(slice: Slice, comptime T: type) []const T {
+        stdx.debug.assertComptime(T == bool or @bitSizeOf(T) >= 8, "zml.Slice stores packed sub-bytes type so you need to pass a packed type here like @Vector({}, {}). Got: {}", .{ @divFloor(8, @bitSizeOf(T)), T, T });
         return @ptrCast(@alignCast(slice.constData()));
     }
 
@@ -256,7 +257,8 @@ pub const Slice = struct {
             // Special case input tensor is a scalar
             return switch (slice.dtype()) {
                 inline else => |dt| {
-                    const val: dt.toZigType() = slice.constItems(dt.toZigType())[0];
+                    const single_ptr: *const dt.toZigType() = @ptrCast(@alignCast(slice.bytes.ptr));
+                    const val = single_ptr.*;
                     return switch (comptime dt.class()) {
                         // Since we have custom floats, we need to explicitly convert to float32 ourselves.
                         .float => stdx.fmt.formatFloat(floats.floatCast(f32, val), options, writer),
@@ -495,6 +497,14 @@ test "slice pretty print rank 0" {
     const data: [1]i32 = .{0};
     const slice = Slice.init(.init(.{}, .i32), std.mem.asBytes(&data));
     const expected = "0";
+    try std.testing.expectFmt(expected, "{d}", .{slice});
+}
+
+test "slice pretty print bool" {
+    const data: [2]bool = .{ true, false };
+    const slice = Slice.init(.init(.{2}, .bool), std.mem.asBytes(&data));
+    const expected = "1,0";
+    try std.testing.expectEqualSlices(bool, &data, slice.constItems(bool));
     try std.testing.expectFmt(expected, "{d}", .{slice});
 }
 

--- a/zml/slice.zig
+++ b/zml/slice.zig
@@ -503,7 +503,7 @@ test "slice pretty print rank 0" {
 test "slice pretty print bool" {
     const data: [2]bool = .{ true, false };
     const slice = Slice.init(.init(.{2}, .bool), std.mem.asBytes(&data));
-    const expected = "1,0";
+    const expected = "{1,0}";
     try std.testing.expectEqualSlices(bool, &data, slice.constItems(bool));
     try std.testing.expectFmt(expected, "{d}", .{slice});
 }

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -207,7 +207,12 @@ pub const Tensor = struct {
     pub fn toMemory(self: Tensor, kind: Memory.Kind) Tensor {
         const ctx = Compiler.current();
         switch (ctx.platform.target) {
-            .cpu, .neuron, .metal => return self,
+            .cpu, .neuron, .metal => {
+                var res = self;
+                res.id = nextTensorId();
+                res._value = self.value();
+                return res;
+            },
             .cuda, .rocm, .tpu, .oneapi => {},
         }
 
@@ -237,6 +242,35 @@ pub const Tensor = struct {
         const res = _result(self._shape, op.result(0));
         ctx.currentScope().id_to_memory.putNoClobber(ctx.currentScope().arena.allocator(), res.id, kind) catch @panic("OOM");
         return res;
+    }
+
+    test toMemory {
+        const zml = @import("zml.zig");
+        const platform = zml.testing.env();
+        const io = std.testing.io;
+
+        const inputs: [8]f32 = .{ -3.0, -2, -1, 1, 2, 3, 5, -5 };
+        const x_t = Tensor.init(.{8}, .f32);
+
+        const Local = struct {
+            fn memcpyH2D(x: Tensor) Tensor {
+                return x.onMemory(.host_pinned).toMemory(.device);
+            }
+        };
+
+        const exe = try zml.module.compile(std.testing.allocator, std.testing.io, Local.memcpyH2D, .{x_t}, platform, .{});
+        defer exe.deinit();
+
+        var x_h = try zml.Buffer.fromBytesOpts(io, platform, x_t.shape(), .replicated, @ptrCast(&inputs), .{ .memory = .host_pinned });
+        defer x_h.deinit();
+
+        const x_h_ptr: [*]f32 = @ptrCast(@alignCast(x_h.opaqueDevicePtr(0)));
+        try std.testing.expectEqualSlices(f32, &inputs, x_h_ptr[0..8]);
+
+        var x_d = try zml.testing.autoCall(std.testing.allocator, io, &exe, Local.memcpyH2D, .{x_h});
+        defer x_d.deinit();
+
+        try zml.testing.expectClose(std.testing.io, x_h, x_d, .exact_match);
     }
 
     /// Copy all the given tensor to the specified memory.
@@ -334,6 +368,7 @@ pub const Tensor = struct {
         if (scope.id_to_donation.get(origin.id)) |origin_donation| {
             const gop = scope.id_to_donation.getOrPut(scope.arena.allocator(), self.id) catch unreachable;
             gop.value_ptr.* = origin_donation;
+            std.log.warn("giving Buffer {} from {}({f}) to {}({f})", .{ origin_donation, origin.id, origin, self.id, self });
         }
         return self;
     }
@@ -343,9 +378,9 @@ pub const Tensor = struct {
         const platform = zml.testing.env();
         const io = std.testing.io;
 
-        const inputs: [2][6]f32 = .{ .{ -3.0, -2, -1, 1, 2, 3 }, .{ 1, 2, 3, 4, 5, -5 } };
-        const left = Tensor.init(.{ 2, 6 }, .f32);
-        const right = Tensor.init(.{ 2, 6 }, .f32);
+        const inputs: [6]@Vector(2, i4) = .{ .{ -3.0, -2 }, .{ -1, 1 }, .{ 2, 3 }, .{ 1, 2 }, .{ 3, 4 }, .{ 5, -5 } };
+        const left = Tensor.init(.{ 6, 2 }, .i4);
+        const right = Tensor.init(.{ 6, 2 }, .i4);
 
         const Local = struct {
             fn memcopy(x: Tensor, y: Tensor) Tensor {

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -207,12 +207,7 @@ pub const Tensor = struct {
     pub fn toMemory(self: Tensor, kind: Memory.Kind) Tensor {
         const ctx = Compiler.current();
         switch (ctx.platform.target) {
-            .cpu, .neuron, .metal => {
-                var res = self;
-                res.id = nextTensorId();
-                res._value = self.value();
-                return res;
-            },
+            .cpu, .neuron, .metal => return self,
             .cuda, .rocm, .tpu, .oneapi => {},
         }
 
@@ -365,10 +360,13 @@ pub const Tensor = struct {
     pub fn reuseBuffer(self: Tensor, origin: Tensor) Tensor {
         const compilation_context = Compiler.current();
         const scope = compilation_context.currentScope();
-        if (scope.id_to_donation.get(origin.id)) |origin_donation| {
-            const gop = scope.id_to_donation.getOrPut(scope.arena.allocator(), self.id) catch unreachable;
-            gop.value_ptr.* = origin_donation;
-            std.log.warn("giving Buffer {} from {}({f}) to {}({f})", .{ origin_donation, origin.id, origin, self.id, self });
+        if (scope.id_to_donation.get(origin.id)) |og_donation| {
+            // reuseBuffer is making the donation explicit
+            const donation: Compiler.Donation = switch (og_donation) {
+                .implicit => |input| .{ .explicit = input },
+                .explicit => og_donation,
+            };
+            scope.id_to_donation.put(scope.arena.allocator(), self.id, donation) catch @panic("OOM");
         }
         return self;
     }
@@ -379,38 +377,48 @@ pub const Tensor = struct {
         const io = std.testing.io;
 
         const inputs: [6]@Vector(2, i4) = .{ .{ -3.0, -2 }, .{ -1, 1 }, .{ 2, 3 }, .{ 1, 2 }, .{ 3, 4 }, .{ 5, -5 } };
-        const left = Tensor.init(.{ 6, 2 }, .i4);
-        const right = Tensor.init(.{ 6, 2 }, .i4);
+        const x_t = Tensor.init(.{ 6, 2 }, .i4);
+        const y_t = Tensor.init(.{ 6, 2 }, .i4);
+        const z_t = Tensor.init(.{ 6, 2 }, .i4);
 
         const Local = struct {
-            fn memcopy(x: Tensor, y: Tensor) Tensor {
-                return x.addConstant(1).reuseBuffer(y);
+            fn memcopy(x: Tensor, y: Tensor, z: Tensor) [2]Tensor {
+                // the first output reuses the given y, but the second ouput does NOT reuse z.
+                return .{ x.addConstant(1).reuseBuffer(y), z };
             }
         };
 
-        const exe = try zml.module.compile(std.testing.allocator, std.testing.io, Local.memcopy, .{ left, right }, platform, .{});
+        const exe = try zml.module.compile(std.testing.allocator, std.testing.io, Local.memcopy, .{ x_t, y_t, z_t }, platform, .{});
         defer exe.deinit();
 
-        var left_d = try zml.Buffer.fromBytes(io, platform, left.shape(), .replicated, @ptrCast(&inputs));
-        defer left_d.deinit();
+        var x_d = try zml.Buffer.fromBytes(io, platform, x_t.shape(), .replicated, @ptrCast(&inputs));
+        defer x_d.deinit();
 
-        var right_d = try zml.Buffer.uninitialized(io, platform, left.shape(), .replicated, .{});
-        defer right_d.deinit();
+        var y_d = try zml.Buffer.uninitialized(io, platform, y_t.shape(), .replicated, .{});
+        defer y_d.deinit();
 
-        var right_memory: [Platform.MAX_NUM_DEVICES]*anyopaque = undefined;
-        for (0..right_d.numShards()) |dev| {
-            right_memory[dev] = right_d.opaqueDevicePtr(dev);
+        var z_d = try zml.Buffer.uninitialized(io, platform, z_t.shape(), .replicated, .{});
+        defer z_d.deinit();
+
+        var y_memory: [Platform.MAX_NUM_DEVICES]*anyopaque = undefined;
+        for (0..y_d.numShards()) |dev| {
+            y_memory[dev] = y_d.opaqueDevicePtr(dev);
         }
 
-        const output_d = try zml.testing.autoCall(std.testing.allocator, io, &exe, Local.memcopy, .{ left_d, right_d });
+        const y2_d, const z2_d = try zml.testing.autoCall(std.testing.allocator, io, &exe, Local.memcopy, .{ x_d, y_d, z_d });
 
         var output_memory: [Platform.MAX_NUM_DEVICES]*anyopaque = undefined;
-        for (0..output_d.numShards()) |dev| {
-            output_memory[dev] = output_d.opaqueDevicePtr(dev);
+        for (0..y2_d.numShards()) |dev| {
+            output_memory[dev] = y2_d.opaqueDevicePtr(dev);
         }
 
-        // Check that right_d and output_d point to the same addresses on the devices.
-        try std.testing.expectEqualSlices(*anyopaque, right_memory[0..right_d.numShards()], output_memory[0..output_d.numShards()]);
+        // Check that y_d and y2_d point to the same addresses on the devices.
+        try std.testing.expectEqualSlices(*anyopaque, y_memory[0..y_d.numShards()], output_memory[0..y2_d.numShards()]);
+
+        // Check that z_d and z2_d DO NOT POINT to the same addresses
+        for (0..z2_d.numShards()) |dev| {
+            try std.testing.expect(z2_d.opaqueDevicePtr(dev) != z_d.opaqueDevicePtr(dev));
+        }
     }
 
     /// Returns a Tensor containing the absolute value of each element of the input Tensor.


### PR DESCRIPTION
in #738 I accidentally introduced implicit donation `fn foo(x: Tensor) Tensor { return x; }` would not make a copy of the input tensor but return the same pointers.

I'm not sure an implicit copies is better than an implicit aliasing, but fixing since this is an un-planned breaking change.

Also fixing a compiler error for `.items(bool)` after #724.

Note: this is an argument for snapshot testing: the CI should check if a given PR changes the emitted IR for a given model.