### PR TITLE
examples/llm: fix Qwen3.5 padded prefill cache

### DIFF
--- a/examples/llm/BUILD.bazel
+++ b/examples/llm/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
-load("@rules_zig//zig:defs.bzl", "zig_binary")
+load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_test")
 load("@tar.bzl//tar:mtree.bzl", "mtree_spec")
 load("@tar.bzl//tar:tar.bzl", "tar")
 
@@ -29,9 +29,20 @@ zig_binary(
     deps = ["//zml"],
 )
 
+zig_test(
+    name = "qwen3_5_cache_tests",
+    srcs = glob(["models/**/*.zig"]),
+    main = "models/qwen3_5_cache_tests.zig",
+    visibility = ["//visibility:public"],
+    deps = ["//zml"],
+)
+
 build_test(
     name = "test",
-    targets = [":llm"],
+    targets = [
+        ":llm",
+        ":qwen3_5_cache_tests",
+    ],
 )
 
 mtree_spec(

--- a/examples/llm/models/qwen3_5/inference.zig
+++ b/examples/llm/models/qwen3_5/inference.zig
@@ -11,7 +11,8 @@ const Phase = common.Phase;
 pub const CompilationParameters = struct {
     prefill_tokens: zml.Tensor,
     decode_tokens: zml.Tensor,
-    token_index: zml.Tensor,
+    generation_position: zml.Tensor,
+    linear_attention_valid_len: zml.Tensor,
     kv_cache: model.KvCache,
     rng: zml.Tensor.Rng,
     seqlen: u32,
@@ -22,7 +23,8 @@ pub const CompilationParameters = struct {
         return .{
             .prefill_tokens = .init(.{ .b = 1, .s = seqlen }, .u32),
             .decode_tokens = .init(.{ .b = 1, .s = 1 }, .u32),
-            .token_index = .init(.{}, .u32),
+            .generation_position = .init(.{}, .u32),
+            .linear_attention_valid_len = .init(.{}, .u32),
             .kv_cache = .init(config, 1, seqlen, dtype, .f32, shardings.model),
             .rng = .init(),
             .seqlen = seqlen,
@@ -36,7 +38,8 @@ pub const CompilationOptions = CompilationParameters;
 pub const Args = struct {
     io: std.Io,
     tokens_buf: *zml.Buffer,
-    token_index_buf: *zml.Buffer,
+    generation_position_buf: *zml.Buffer,
+    linear_attention_valid_len_buf: *zml.Buffer,
     kv_cache_buffers: *zml.Bufferized(model.KvCache),
     rng_buffers: *zml.Bufferized(zml.Tensor.Rng),
 };
@@ -171,7 +174,7 @@ pub fn run(runner: *KernelRunner, args: Args, layer_index_buffers: []const zml.B
                 layer.run(args.io, .{
                     .inputs = .{
                         .hidden = hidden_buffer,
-                        .token_index = args.token_index_buf.*,
+                        .token_index = args.generation_position_buf.*,
                         .cache = layer_cache,
                     },
                     .outputs = .{ .hidden = &hidden_buffer, .cache = &layer_cache },
@@ -188,7 +191,7 @@ pub fn run(runner: *KernelRunner, args: Args, layer_index_buffers: []const zml.B
                 layer.run(args.io, .{
                     .inputs = .{
                         .hidden = hidden_buffer,
-                        .token_index = args.token_index_buf.*,
+                        .linear_attention_valid_len = args.linear_attention_valid_len_buf.*,
                         .cache = layer_cache,
                     },
                     .outputs = .{ .hidden = &hidden_buffer, .cache = &layer_cache },
@@ -203,12 +206,12 @@ pub fn run(runner: *KernelRunner, args: Args, layer_index_buffers: []const zml.B
         .inputs = .{
             .hidden = hidden_buffer,
             .rng = args.rng_buffers.*,
-            .token_index = args.token_index_buf.*,
+            .token_index = args.generation_position_buf.*,
         },
         .outputs = .{
             .tokens = args.tokens_buf,
             .rng = args.rng_buffers,
-            .token_index = args.token_index_buf,
+            .token_index = args.generation_position_buf,
         },
     });
 }
@@ -258,7 +261,7 @@ fn compileFullAttention(allocator: std.mem.Allocator, io: std.Io, platform: *con
     return zml.FnExe(model.TransformerLayer.forwardSelfAttn).compile(allocator, io, platform, .{ .shardings = &parameters.shardings.all(), .program_name = phase.programName("qwen3_5", "full_attention_layer") }, .{.{
         .layer = mdl.text_model.layers[layer_index],
         .hidden = hiddenTensor(mdl, seqlen),
-        .token_index = parameters.token_index,
+        .token_index = parameters.generation_position,
         .cache = .{
             .k = parameters.kv_cache.self_attn.k,
             .v = parameters.kv_cache.self_attn.v,
@@ -276,7 +279,7 @@ fn compileLinearAttention(allocator: std.mem.Allocator, io: std.Io, platform: *c
     return zml.FnExe(model.TransformerLayer.forwardLinearAttn).compile(allocator, io, platform, .{ .shardings = &parameters.shardings.all(), .program_name = phase.programName("qwen3_5", "linear_attention_layer") }, .{.{
         .layer = mdl.text_model.layers[layer_index],
         .hidden = hiddenTensor(mdl, seqlen),
-        .token_index = parameters.token_index,
+        .linear_attention_valid_len = parameters.linear_attention_valid_len,
         .cache = .{
             .conv_state = parameters.kv_cache.gated_delta_net.conv_state,
             .recurrent_state = parameters.kv_cache.gated_delta_net.recurrent_state,
@@ -295,7 +298,7 @@ fn compileSample(allocator: std.mem.Allocator, io: std.Io, platform: *const zml.
         .sampler = mdl.sampler(),
         .hidden = hiddenTensor(mdl, seqlen),
         .rng = parameters.rng,
-        .token_index = parameters.token_index,
+        .token_index = parameters.generation_position,
     }});
 }
 

--- a/examples/llm/models/qwen3_5/model.zig
+++ b/examples/llm/models/qwen3_5/model.zig
@@ -214,17 +214,18 @@ pub const Model = struct {
     pub fn forward(
         self: Model,
         tokens_: zml.Tensor,
-        token_index: zml.Tensor,
+        generation_position: zml.Tensor,
+        linear_attention_valid_len: zml.Tensor,
         kv_cache: KvCache,
         rng: zml.Tensor.Rng,
     ) struct { zml.Tensor, KvCache, zml.Tensor.Rng } {
         const tokens = tokens_.withPartialTags(.{.s});
-        const text_model_output, const updated_kv_cache = self.text_model.forward(tokens, token_index, kv_cache);
+        const text_model_output, const updated_kv_cache = self.text_model.forward(tokens, generation_position, linear_attention_valid_len, kv_cache);
         const result = Sampler.sampleTokens(.{
             .sampler = self.sampler(),
             .hidden = text_model_output,
             .rng = rng,
-            .token_index = token_index,
+            .token_index = generation_position,
         });
         return .{ result.tokens.convert(tokens.dtype()).reuseBuffer(tokens), updated_kv_cache, result.rng };
     }
@@ -329,7 +330,8 @@ pub const TextModel = struct {
     pub fn forward(
         self: TextModel,
         tokens: zml.Tensor,
-        token_index: zml.Tensor,
+        generation_position: zml.Tensor,
+        linear_attention_valid_len: zml.Tensor,
         kv_cache: KvCache,
     ) struct { zml.Tensor, KvCache } {
         var hidden_states = EmbedTokens.forward(.{
@@ -339,7 +341,7 @@ pub const TextModel = struct {
 
         var updated_kv_cache = kv_cache;
         for (self.layers, 0..) |layer, i| {
-            hidden_states, updated_kv_cache = layer.forward(hidden_states, token_index, updated_kv_cache.atLayer(i));
+            hidden_states, updated_kv_cache = layer.forward(hidden_states, generation_position, linear_attention_valid_len, updated_kv_cache.atLayer(i));
         }
 
         return .{ hidden_states, updated_kv_cache.reuseBuffer(kv_cache) };
@@ -372,7 +374,7 @@ pub const TransformerLayer = struct {
     pub const LinearAttnInput = struct {
         layer: TransformerLayer,
         hidden: zml.Tensor,
-        token_index: zml.Tensor,
+        linear_attention_valid_len: zml.Tensor,
         cache: KvCache.GatedDeltaNetCache,
     };
 
@@ -408,7 +410,8 @@ pub const TransformerLayer = struct {
     pub fn forward(
         self: TransformerLayer,
         x0: zml.Tensor,
-        token_index: zml.Tensor,
+        generation_position: zml.Tensor,
+        linear_attention_valid_len: zml.Tensor,
         kv_cache: KvCache.LayerView,
     ) struct { zml.Tensor, KvCache } {
         const x0_replicated = x0.withPartitioning(.{ .d = .replicated });
@@ -422,7 +425,7 @@ pub const TransformerLayer = struct {
                     .self_attn => |cache| cache,
                     .linear_attn => unreachable,
                 };
-                const result = self_attn.forward(normalized_x0, token_index, cache);
+                const result = self_attn.forward(normalized_x0, generation_position, cache);
                 attention_output = result[0];
                 updated_kv_cache.self_attn = result[1].reuseBuffer(updated_kv_cache.self_attn);
             },
@@ -431,7 +434,7 @@ pub const TransformerLayer = struct {
                     .linear_attn => |cache| cache,
                     .self_attn => unreachable,
                 };
-                const result = linear_attn.forward(normalized_x0, cache);
+                const result = linear_attn.forward(normalized_x0, cache, linear_attention_valid_len);
                 attention_output = result[0];
                 updated_kv_cache.gated_delta_net = result[1].reuseBuffer(updated_kv_cache.gated_delta_net);
             },
@@ -470,7 +473,6 @@ pub const TransformerLayer = struct {
     pub fn forwardLinearAttn(input: LinearAttnInput) LinearAttnOutput {
         const self = input.layer;
         const x0 = input.hidden;
-        _ = input.token_index;
         const x0_replicated = x0.withPartitioning(.{ .d = .replicated });
         const normalized_x0 = self.input_layernorm.forward(x0_replicated);
 
@@ -478,7 +480,7 @@ pub const TransformerLayer = struct {
             .linear_attention => |linear_attn| linear_attn,
             .full_attention => unreachable,
         };
-        const attention_output, const updated_kv_cache = linear_attn.forward(normalized_x0, input.cache);
+        const attention_output, const updated_kv_cache = linear_attn.forward(normalized_x0, input.cache, input.linear_attention_valid_len);
 
         const x1 = attention_output.add(x0_replicated).withPartitioning(.{ .d = .replicated });
         const normalized_hidden = self.post_attention_layernorm.forward(x1);
@@ -828,6 +830,7 @@ pub const GatedDeltaNet = struct {
         g: zml.Tensor,
         beta: zml.Tensor,
         initial_state: ?zml.Tensor,
+        valid_len: zml.Tensor,
     ) struct { zml.Tensor, zml.Tensor } {
         const scale: f32 = 1.0 / @sqrt(@as(f32, @floatFromInt(query.dim(.khd))));
         const query_norm = zml.nn.normalizeL2(query.rename(.{ .kh = .vh }), 1e-6);
@@ -854,13 +857,14 @@ pub const GatedDeltaNet = struct {
             }, .f32));
         };
 
-        const result = zml.nn.GatedDeltaNet.forward(
+        const result = zml.nn.GatedDeltaNet.forwardWithValidLength(
             query_f32,
             key_f32,
             value_f32,
             alpha_f32,
             beta_f32,
             .{ .s = initial_recurrent_state },
+            valid_len,
         );
 
         return .{
@@ -879,7 +883,14 @@ pub const GatedDeltaNet = struct {
         return zml.Tensor.concatenate(&.{ padding, tail }, .s);
     }
 
-    pub fn forward(self: GatedDeltaNet, x: zml.Tensor, cache: KvCache.GatedDeltaNetCache) struct { zml.Tensor, KvCache.GatedDeltaNetCache } {
+    pub fn buildUpdatedConvStateFromPrefix(input: zml.Tensor, left_pad: i64, valid_len: zml.Tensor) zml.Tensor {
+        const padding_shape = input.shape().setDim(.s, left_pad);
+        const padding = zml.Tensor.zeroes(padding_shape);
+        const padded = zml.Tensor.concatenate(&.{ padding, input }, .s);
+        return padded.slice(.s, .dyn(valid_len.convert(.i64), left_pad));
+    }
+
+    pub fn forward(self: GatedDeltaNet, x: zml.Tensor, cache: KvCache.GatedDeltaNetCache, linear_attention_valid_len: zml.Tensor) struct { zml.Tensor, KvCache.GatedDeltaNetCache } {
         const key_dim = self.num_k_heads * self.head_k_dim;
         const value_dim = self.num_v_heads * self.head_v_dim;
         const conv_dim = 2 * key_dim + value_dim;
@@ -958,6 +969,7 @@ pub const GatedDeltaNet = struct {
                 if (use_cached_state) break :b cache.recurrentState();
                 break :b null;
             },
+            linear_attention_valid_len,
         );
 
         const core_attn_out_normed = self.norm
@@ -972,7 +984,10 @@ pub const GatedDeltaNet = struct {
             .rename(.{ .dout = .d })
             .withPartitioning(.{ .d = .replicated });
         const updated_cache = cache.update(
-            buildUpdatedConvState(conv_input, left_pad),
+            if (use_cached_state)
+                buildUpdatedConvState(conv_input, left_pad)
+            else
+                buildUpdatedConvStateFromPrefix(projected_qkv, left_pad, linear_attention_valid_len),
             last_recurrent_state,
         );
         return .{ output, updated_cache };

--- a/examples/llm/models/qwen3_5/session.zig
+++ b/examples/llm/models/qwen3_5/session.zig
@@ -105,6 +105,8 @@ pub const Session = struct {
     }
 
     pub fn runPrefill(self: *Session, all_tokens: []const u32) !void {
+        if (all_tokens.len == 0) return error.EmptyPrompt;
+        if (all_tokens.len > self.seqlen) return error.PromptTooLong;
         const prefill_tokens_shape = zml.Shape.init(.{ .b = 1, .s = self.seqlen }, .u32);
         const prefill_tokens_slice = try zml.Slice.alloc(self.allocator, prefill_tokens_shape);
         defer prefill_tokens_slice.free(self.allocator);
@@ -116,13 +118,16 @@ pub const Session = struct {
         var prefill_tokens_buffer = try zml.Buffer.fromSlice(self.io, self.platform, prefill_tokens_slice, replicated_sharding);
         defer prefill_tokens_buffer.deinit();
 
-        var prefill_token_index_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, 0), .u32);
-        defer prefill_token_index_buffer.deinit();
+        var generation_position_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, 0), .u32);
+        defer generation_position_buffer.deinit();
+        var linear_attention_valid_len_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, @intCast(all_tokens.len)), .u32);
+        defer linear_attention_valid_len_buffer.deinit();
 
         inference.run(&self.prefill, .{
             .io = self.io,
             .tokens_buf = &prefill_tokens_buffer,
-            .token_index_buf = &prefill_token_index_buffer,
+            .generation_position_buf = &generation_position_buffer,
+            .linear_attention_valid_len_buf = &linear_attention_valid_len_buffer,
             .kv_cache_buffers = &self.kv_cache_buffers,
             .rng_buffers = &self.rng_buffers,
         }, self.layer_index_buffers);
@@ -143,8 +148,10 @@ pub const Session = struct {
         var current_token_buffer = try zml.Buffer.fromSlice(self.io, self.platform, self.generated_token_slice, replicated_sharding);
         defer current_token_buffer.deinit();
 
-        var token_index_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, @intCast(all_tokens.items.len)), .u32);
-        defer token_index_buffer.deinit();
+        var generation_position_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, @intCast(all_tokens.items.len)), .u32);
+        defer generation_position_buffer.deinit();
+        var linear_attention_valid_len_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, 1), .u32);
+        defer linear_attention_valid_len_buffer.deinit();
 
         generation: while (true) {
             const token_id = self.generated_token_slice.items(u32)[0];
@@ -166,7 +173,8 @@ pub const Session = struct {
             inference.run(&self.decode, .{
                 .io = self.io,
                 .tokens_buf = &current_token_buffer,
-                .token_index_buf = &token_index_buffer,
+                .generation_position_buf = &generation_position_buffer,
+                .linear_attention_valid_len_buf = &linear_attention_valid_len_buffer,
                 .kv_cache_buffers = &self.kv_cache_buffers,
                 .rng_buffers = &self.rng_buffers,
             }, self.layer_index_buffers);

--- a/examples/llm/models/qwen3_5_cache_tests.zig
+++ b/examples/llm/models/qwen3_5_cache_tests.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+
+const zml = @import("zml");
+const qwen3_5 = @import("qwen3_5/model.zig");
+
+fn validPrefixConvState(input: zml.Tensor, valid_len: zml.Tensor) zml.Tensor {
+    return qwen3_5.GatedDeltaNet.buildUpdatedConvStateFromPrefix(input, 3, valid_len);
+}
+
+test "Qwen3.5 convolution cache uses only the valid prefix" {
+    const platform = zml.testing.env();
+    const input: zml.Tensor = .init(.{ .b = 1, .s = 5, .mix = 1 }, .f32);
+    const valid_len: zml.Tensor = .init(.{}, .u32);
+    var exe = try platform.compileFn(
+        std.testing.allocator,
+        std.testing.io,
+        validPrefixConvState,
+        .{ input, valid_len },
+        .{},
+    );
+    defer exe.deinit();
+
+    var input_buffer: zml.Buffer = try .fromBytes(
+        std.testing.io,
+        platform,
+        input.shape(),
+        .replicated,
+        std.mem.sliceAsBytes(&[5]f32{ 10, 20, 30, 777, 888 }),
+    );
+    defer input_buffer.deinit();
+
+    const expected = [_][3]f32{
+        .{ 0, 0, 0 },
+        .{ 0, 0, 10 },
+        .{ 0, 10, 20 },
+        .{ 10, 20, 30 },
+    };
+    for (expected, 0..) |values, length| {
+        var valid_len_buffer = try zml.Buffer.scalar(std.testing.io, platform, @as(u32, @intCast(length)), .u32);
+        defer valid_len_buffer.deinit();
+        var output = try zml.testing.autoCall(
+            std.testing.allocator,
+            std.testing.io,
+            &exe,
+            validPrefixConvState,
+            .{ input_buffer, valid_len_buffer },
+        );
+        defer output.deinit();
+        try zml.testing.expectClose(
+            std.testing.io,
+            zml.Slice.initConst(output.shape(), std.mem.sliceAsBytes(&values)),
+            output,
+            .{ .absolute_tolerance = 0, .relative_tolerance = 0, .minimum_close_fraction = 1 },
+        );
+    }
+}

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -1908,6 +1908,32 @@ pub const GatedDeltaNet = struct {
         };
     }
 
+    /// Runs the recurrent implementation while treating positions at or beyond
+    /// `valid_length` as a neutral suffix. This keeps padded compilation tails
+    /// from changing active outputs or recurrent state.
+    pub fn forwardWithValidLength(
+        queries: Tensor,
+        keys: Tensor,
+        values: Tensor,
+        alphas: Tensor,
+        betas: Tensor,
+        initial_state: Input,
+        valid_length: Tensor,
+    ) Output {
+        stdx.debug.assert(valid_length.rank() == 0 and valid_length.dtype().isInteger(), "GatedDeltaNet valid_length must be an integer scalar, got {f}", .{valid_length});
+        const valid_mask = Tensor.arange(.{ .end = queries.dim(.s) }, .i64)
+            .withTags(.{.s})
+            .cmp(.LT, valid_length.convert(.i64));
+        return forward(
+            valid_mask.broad(queries.shape()).select(queries, .zeroes(queries.shape())),
+            valid_mask.broad(keys.shape()).select(keys, .zeroes(keys.shape())),
+            valid_mask.broad(values.shape()).select(values, .zeroes(values.shape())),
+            valid_mask.broad(alphas.shape()).select(alphas, Tensor.constant(alphas.dtype().one()).broad(alphas.shape())),
+            valid_mask.broad(betas.shape()).select(betas, .zeroes(betas.shape())),
+            initial_state,
+        );
+    }
+
     /// Processes a sequence with Gated Delta Net recurrence using `stablehlo.while`.
     ///
     /// Shapes:
@@ -1948,18 +1974,19 @@ pub const GatedDeltaNet = struct {
 test "gated delta net" {
     const platform = zml.testing.env();
 
-    const queries: zml.Tensor = .init(.{ .s = 2, .h = 2, .k = 2 }, .f32);
-    const keys: zml.Tensor = .init(.{ .s = 2, .h = 2, .k = 2 }, .f32);
-    const values: zml.Tensor = .init(.{ .s = 2, .h = 2, .v = 2 }, .f32);
-    const alphas: zml.Tensor = .init(.{ .s = 2, .h = 2 }, .f32);
-    const betas: zml.Tensor = .init(.{ .s = 2, .h = 2 }, .f32);
+    const queries: zml.Tensor = .init(.{ .s = 3, .h = 2, .k = 2 }, .f32);
+    const keys: zml.Tensor = .init(.{ .s = 3, .h = 2, .k = 2 }, .f32);
+    const values: zml.Tensor = .init(.{ .s = 3, .h = 2, .v = 2 }, .f32);
+    const alphas: zml.Tensor = .init(.{ .s = 3, .h = 2 }, .f32);
+    const betas: zml.Tensor = .init(.{ .s = 3, .h = 2 }, .f32);
     const initial_s: zml.Tensor = .init(.{ .h = 2, .v = 2, .k = 2 }, .f32);
+    const valid_length: zml.Tensor = .init(.{}, .u32);
 
     var exe = try platform.compileFn(
         std.testing.allocator,
         std.testing.io,
-        GatedDeltaNet.forward,
-        .{ queries, keys, values, alphas, betas, .{ .s = initial_s } },
+        GatedDeltaNet.forwardWithValidLength,
+        .{ queries, keys, values, alphas, betas, .{ .s = initial_s }, valid_length },
         .{},
     );
     defer exe.deinit();
@@ -1969,9 +1996,10 @@ test "gated delta net" {
         platform,
         queries.shape(),
         .replicated,
-        std.mem.sliceAsBytes(&[2][2][2]f32{
+        std.mem.sliceAsBytes(&[3][2][2]f32{
             .{ .{ 1.0, 0.0 }, .{ 0.0, 1.0 } },
             .{ .{ 1.0, 1.0 }, .{ 1.0, -1.0 } },
+            .{ .{ 100, -100 }, .{ -100, 100 } },
         }),
     );
     defer queries_buffer.deinit();
@@ -1980,9 +2008,10 @@ test "gated delta net" {
         platform,
         keys.shape(),
         .replicated,
-        std.mem.sliceAsBytes(&[2][2][2]f32{
+        std.mem.sliceAsBytes(&[3][2][2]f32{
             .{ .{ 1.0, 2.0 }, .{ 0.0, 1.0 } },
             .{ .{ 2.0, 1.0 }, .{ 1.0, 0.0 } },
+            .{ .{ -200, 200 }, .{ 200, -200 } },
         }),
     );
     defer keys_buffer.deinit();
@@ -1991,9 +2020,10 @@ test "gated delta net" {
         platform,
         values.shape(),
         .replicated,
-        std.mem.sliceAsBytes(&[2][2][2]f32{
+        std.mem.sliceAsBytes(&[3][2][2]f32{
             .{ .{ 3.0, 1.0 }, .{ 2.0, 4.0 } },
             .{ .{ 1.0, 5.0 }, .{ 3.0, 0.0 } },
+            .{ .{ 300, -300 }, .{ -300, 300 } },
         }),
     );
     defer values_buffer.deinit();
@@ -2002,9 +2032,10 @@ test "gated delta net" {
         platform,
         alphas.shape(),
         .replicated,
-        std.mem.sliceAsBytes(&[2][2]f32{
+        std.mem.sliceAsBytes(&[3][2]f32{
             .{ 0.5, 0.25 },
             .{ 0.8, 0.6 },
+            .{ -10, 10 },
         }),
     );
     defer alphas_buffer.deinit();
@@ -2013,9 +2044,10 @@ test "gated delta net" {
         platform,
         betas.shape(),
         .replicated,
-        std.mem.sliceAsBytes(&[2][2]f32{
+        std.mem.sliceAsBytes(&[3][2]f32{
             .{ 1.0, 0.5 },
             .{ 0.75, 1.0 },
+            .{ 20, -20 },
         }),
     );
     defer betas_buffer.deinit();
@@ -2030,22 +2062,25 @@ test "gated delta net" {
         }),
     );
     defer initial_s_buffer.deinit();
+    var valid_length_buffer = try zml.Buffer.scalar(std.testing.io, platform, @as(u32, 2), .u32);
+    defer valid_length_buffer.deinit();
 
     var result = try zml.testing.autoCall(
         std.testing.allocator,
         std.testing.io,
         &exe,
-        GatedDeltaNet.forward,
-        .{ queries_buffer, keys_buffer, values_buffer, alphas_buffer, betas_buffer, .{ .s = initial_s_buffer } },
+        GatedDeltaNet.forwardWithValidLength,
+        .{ queries_buffer, keys_buffer, values_buffer, alphas_buffer, betas_buffer, .{ .s = initial_s_buffer }, valid_length_buffer },
     );
     defer result.outputs.deinit();
     defer result.state.s.deinit();
 
     const expected_outputs: zml.Slice = .init(
-        zml.Shape.init(.{ 2, 2, 2 }, .f32),
-        std.mem.sliceAsBytes(&[2][2][2]f32{
+        zml.Shape.init(.{ 3, 2, 2 }, .f32),
+        std.mem.sliceAsBytes(&[3][2][2]f32{
             .{ .{ 3.0, 0.0 }, .{ 1.125, 2.0 } },
             .{ .{ -11.15, 10.75 }, .{ 2.325, -1.2 } },
+            .{ .{ 0, 0 }, .{ 0, 0 } },
         }),
     );
     const expected_final_s: zml.Slice = .init(


### PR DESCRIPTION
Qwen3.5 prefill pads prompts to the compiled sequence length. Linear attention currently treats that padded suffix as active, which changes the recurrent and convolution cache state.

Pass the active length separately from the generation position, make the padded suffix neutral for the Gated Delta Net recurrence, and build the convolution cache from the valid prefix.

Tests:

- `bazel test //examples/llm:qwen3_5_cache_tests`
- `bazel test //zml:test`
- `bazel build //examples/llm:llm //examples/llm:test`
