### PR TITLE
zml/nn: add chunkwise Gated DeltaNet prefill

### DIFF
--- a/examples/llm/BUILD.bazel
+++ b/examples/llm/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
-load("@rules_zig//zig:defs.bzl", "zig_binary")
+load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_test")
 load("@tar.bzl//tar:mtree.bzl", "mtree_spec")
 load("@tar.bzl//tar:tar.bzl", "tar")
 
@@ -29,9 +29,20 @@ zig_binary(
     deps = ["//zml"],
 )
 
+zig_test(
+    name = "qwen3_5_cache_tests",
+    srcs = glob(["models/**/*.zig"]),
+    main = "models/qwen3_5_cache_tests.zig",
+    visibility = ["//visibility:public"],
+    deps = ["//zml"],
+)
+
 build_test(
     name = "test",
-    targets = [":llm"],
+    targets = [
+        ":llm",
+        ":qwen3_5_cache_tests",
+    ],
 )
 
 mtree_spec(

--- a/examples/llm/main.zig
+++ b/examples/llm/main.zig
@@ -21,6 +21,7 @@ const Args = struct {
     backend: ?zml.attention.Backend = null,
     attnd_ip: ?[]const u8 = null,
     profile: bool = false,
+    experimental_chunkwise_gdn: bool = false,
 
     pub const help =
         \\ Use llm --model=<path> [options]
@@ -35,6 +36,7 @@ const Args = struct {
         \\   --backend=<text>    Attention backend to use ([vanilla, attnd, nki, cuda_fa2, cuda_fa3], default: auto-selection)
         \\   --attnd-ip=<addr>   Register and prefer the `attnd` backend at the provided `IP:PORT`
         \\   --profile           Capture a PJRT profile for non-interactive runs and write a Perfetto trace
+        \\   --experimental-chunkwise-gdn  Use chunkwise GDN for supported model prefills
         \\
     ;
 };
@@ -115,6 +117,7 @@ pub fn main(init: std.process.Init) !void {
         .sampling_strategy = .{
             .topk = args.topk,
         },
+        .experimental_chunkwise_gdn = args.experimental_chunkwise_gdn,
     };
 
     var model = try models.LoadedModel.load(allocator, io, repo, store.view(), generation);

--- a/examples/llm/models/common.zig
+++ b/examples/llm/models/common.zig
@@ -9,6 +9,7 @@ pub const SessionOptions = struct {
 
 pub const GenerationOptions = struct {
     sampling_strategy: zml.nn.SamplingStrategy = .{},
+    experimental_chunkwise_gdn: bool = false,
 };
 
 pub const Phase = enum {

--- a/examples/llm/models/qwen3_5/inference.zig
+++ b/examples/llm/models/qwen3_5/inference.zig
@@ -11,7 +11,8 @@ const Phase = common.Phase;
 pub const CompilationParameters = struct {
     prefill_tokens: zml.Tensor,
     decode_tokens: zml.Tensor,
-    token_index: zml.Tensor,
+    generation_position: zml.Tensor,
+    linear_attention_valid_len: zml.Tensor,
     kv_cache: model.KvCache,
     rng: zml.Tensor.Rng,
     seqlen: u32,
@@ -22,7 +23,8 @@ pub const CompilationParameters = struct {
         return .{
             .prefill_tokens = .init(.{ .b = 1, .s = seqlen }, .u32),
             .decode_tokens = .init(.{ .b = 1, .s = 1 }, .u32),
-            .token_index = .init(.{}, .u32),
+            .generation_position = .init(.{}, .u32),
+            .linear_attention_valid_len = .init(.{}, .u32),
             .kv_cache = .init(config, 1, seqlen, dtype, .f32, shardings.model),
             .rng = .init(),
             .seqlen = seqlen,
@@ -36,7 +38,8 @@ pub const CompilationOptions = CompilationParameters;
 pub const Args = struct {
     io: std.Io,
     tokens_buf: *zml.Buffer,
-    token_index_buf: *zml.Buffer,
+    generation_position_buf: *zml.Buffer,
+    linear_attention_valid_len_buf: *zml.Buffer,
     kv_cache_buffers: *zml.Bufferized(model.KvCache),
     rng_buffers: *zml.Bufferized(zml.Tensor.Rng),
 };
@@ -171,7 +174,7 @@ pub fn run(runner: *KernelRunner, args: Args, layer_index_buffers: []const zml.B
                 layer.run(args.io, .{
                     .inputs = .{
                         .hidden = hidden_buffer,
-                        .token_index = args.token_index_buf.*,
+                        .token_index = args.generation_position_buf.*,
                         .cache = layer_cache,
                     },
                     .outputs = .{ .hidden = &hidden_buffer, .cache = &layer_cache },
@@ -188,7 +191,7 @@ pub fn run(runner: *KernelRunner, args: Args, layer_index_buffers: []const zml.B
                 layer.run(args.io, .{
                     .inputs = .{
                         .hidden = hidden_buffer,
-                        .token_index = args.token_index_buf.*,
+                        .linear_attention_valid_len = args.linear_attention_valid_len_buf.*,
                         .cache = layer_cache,
                     },
                     .outputs = .{ .hidden = &hidden_buffer, .cache = &layer_cache },
@@ -203,12 +206,12 @@ pub fn run(runner: *KernelRunner, args: Args, layer_index_buffers: []const zml.B
         .inputs = .{
             .hidden = hidden_buffer,
             .rng = args.rng_buffers.*,
-            .token_index = args.token_index_buf.*,
+            .token_index = args.generation_position_buf.*,
         },
         .outputs = .{
             .tokens = args.tokens_buf,
             .rng = args.rng_buffers,
-            .token_index = args.token_index_buf,
+            .token_index = args.generation_position_buf,
         },
     });
 }
@@ -258,7 +261,7 @@ fn compileFullAttention(allocator: std.mem.Allocator, io: std.Io, platform: *con
     return zml.FnExe(model.TransformerLayer.forwardSelfAttn).compile(allocator, io, platform, .{ .shardings = &parameters.shardings.all(), .program_name = phase.programName("qwen3_5", "full_attention_layer") }, .{.{
         .layer = mdl.text_model.layers[layer_index],
         .hidden = hiddenTensor(mdl, seqlen),
-        .token_index = parameters.token_index,
+        .token_index = parameters.generation_position,
         .cache = .{
             .k = parameters.kv_cache.self_attn.k,
             .v = parameters.kv_cache.self_attn.v,
@@ -276,7 +279,7 @@ fn compileLinearAttention(allocator: std.mem.Allocator, io: std.Io, platform: *c
     return zml.FnExe(model.TransformerLayer.forwardLinearAttn).compile(allocator, io, platform, .{ .shardings = &parameters.shardings.all(), .program_name = phase.programName("qwen3_5", "linear_attention_layer") }, .{.{
         .layer = mdl.text_model.layers[layer_index],
         .hidden = hiddenTensor(mdl, seqlen),
-        .token_index = parameters.token_index,
+        .linear_attention_valid_len = parameters.linear_attention_valid_len,
         .cache = .{
             .conv_state = parameters.kv_cache.gated_delta_net.conv_state,
             .recurrent_state = parameters.kv_cache.gated_delta_net.recurrent_state,
@@ -295,7 +298,7 @@ fn compileSample(allocator: std.mem.Allocator, io: std.Io, platform: *const zml.
         .sampler = mdl.sampler(),
         .hidden = hiddenTensor(mdl, seqlen),
         .rng = parameters.rng,
-        .token_index = parameters.token_index,
+        .token_index = parameters.generation_position,
     }});
 }
 

--- a/examples/llm/models/qwen3_5/inference.zig
+++ b/examples/llm/models/qwen3_5/inference.zig
@@ -17,6 +17,7 @@ pub const CompilationParameters = struct {
     rng: zml.Tensor.Rng,
     seqlen: u32,
     shardings: common.Shardings,
+    prefill_gdn_options: zml.nn.GatedDeltaNet.Options = .{},
 
     pub fn init(mdl: model.Model, config: model.Config, seqlen: u32, shardings: common.Shardings) CompilationParameters {
         const dtype = mdl.text_model.embed_tokens.weight.dtype();
@@ -59,9 +60,9 @@ pub const CompiledModel = struct {
         parameters: CompilationParameters,
         progress: *std.Progress.Node,
     ) !CompiledModel {
-        const prefill = try compileKernel(allocator, io, platform, qwen_model, parameters, @intCast(parameters.prefill_tokens.dim(.s)), .prefill, progress);
+        const prefill = try compileKernel(allocator, io, platform, qwen_model, parameters, @intCast(parameters.prefill_tokens.dim(.s)), .prefill, parameters.prefill_gdn_options, progress);
         errdefer prefill.deinit();
-        const decode = try compileKernel(allocator, io, platform, qwen_model, parameters, @intCast(parameters.decode_tokens.dim(.s)), .decode, progress);
+        const decode = try compileKernel(allocator, io, platform, qwen_model, parameters, @intCast(parameters.decode_tokens.dim(.s)), .decode, .{ .algorithm = .recurrent }, progress);
         return .{
             .loaded_model = loaded_model,
             .prefill = prefill,
@@ -224,6 +225,7 @@ fn compileKernel(
     parameters: CompilationOptions,
     seqlen: usize,
     phase: Phase,
+    gdn_options: zml.nn.GatedDeltaNet.Options,
     progress: *std.Progress.Node,
 ) !KernelExe {
     const full_index = findFirstLayerIndex(qwen_model.config.text_config.layer_types, .full_attention) orelse return error.MissingFullAttentionLayer;
@@ -233,7 +235,7 @@ fn compileKernel(
     errdefer embed.deinit();
     const full_attention = try compileFullAttention(allocator, io, platform, qwen_model, parameters, seqlen, full_index, phase, progress);
     errdefer full_attention.deinit();
-    const linear_attention = try compileLinearAttention(allocator, io, platform, qwen_model, parameters, seqlen, linear_index, phase, progress);
+    const linear_attention = try compileLinearAttention(allocator, io, platform, qwen_model, parameters, seqlen, linear_index, phase, gdn_options, progress);
     errdefer linear_attention.deinit();
     const sample = try compileSample(allocator, io, platform, qwen_model, parameters, seqlen, phase, progress);
     errdefer sample.deinit();
@@ -270,14 +272,14 @@ fn compileFullAttention(allocator: std.mem.Allocator, io: std.Io, platform: *con
     }});
 }
 
-fn compileLinearAttention(allocator: std.mem.Allocator, io: std.Io, platform: *const zml.Platform, mdl: model.Model, parameters: CompilationOptions, seqlen: usize, layer_index: usize, phase: Phase, progress: *std.Progress.Node) !zml.FnExe(model.TransformerLayer.forwardLinearAttn) {
+fn compileLinearAttention(allocator: std.mem.Allocator, io: std.Io, platform: *const zml.Platform, mdl: model.Model, parameters: CompilationOptions, seqlen: usize, layer_index: usize, phase: Phase, gdn_options: zml.nn.GatedDeltaNet.Options, progress: *std.Progress.Node) !zml.FnExe(model.TransformerLayer.forwardLinearAttn) {
     progress.increaseEstimatedTotalItems(1);
     var node = progress.start(phase.startMessage("linear attention layer"), 1);
     defer node.end();
     const from: std.Io.Timestamp = .now(io, .awake);
     defer phase.logCompileDone(log, "linear attention layer", io, from);
     return zml.FnExe(model.TransformerLayer.forwardLinearAttn).compile(allocator, io, platform, .{ .shardings = &parameters.shardings.all(), .program_name = phase.programName("qwen3_5", "linear_attention_layer") }, .{.{
-        .layer = mdl.text_model.layers[layer_index],
+        .layer = mdl.text_model.layers[layer_index].withGdnOptions(gdn_options),
         .hidden = hiddenTensor(mdl, seqlen),
         .linear_attention_valid_len = parameters.linear_attention_valid_len,
         .cache = .{

--- a/examples/llm/models/qwen3_5/model.zig
+++ b/examples/llm/models/qwen3_5/model.zig
@@ -214,17 +214,18 @@ pub const Model = struct {
     pub fn forward(
         self: Model,
         tokens_: zml.Tensor,
-        token_index: zml.Tensor,
+        generation_position: zml.Tensor,
+        linear_attention_valid_len: zml.Tensor,
         kv_cache: KvCache,
         rng: zml.Tensor.Rng,
     ) struct { zml.Tensor, KvCache, zml.Tensor.Rng } {
         const tokens = tokens_.withPartialTags(.{.s});
-        const text_model_output, const updated_kv_cache = self.text_model.forward(tokens, token_index, kv_cache);
+        const text_model_output, const updated_kv_cache = self.text_model.forward(tokens, generation_position, linear_attention_valid_len, kv_cache);
         const result = Sampler.sampleTokens(.{
             .sampler = self.sampler(),
             .hidden = text_model_output,
             .rng = rng,
-            .token_index = token_index,
+            .token_index = generation_position,
         });
         return .{ result.tokens.convert(tokens.dtype()).reuseBuffer(tokens), updated_kv_cache, result.rng };
     }
@@ -329,7 +330,8 @@ pub const TextModel = struct {
     pub fn forward(
         self: TextModel,
         tokens: zml.Tensor,
-        token_index: zml.Tensor,
+        generation_position: zml.Tensor,
+        linear_attention_valid_len: zml.Tensor,
         kv_cache: KvCache,
     ) struct { zml.Tensor, KvCache } {
         var hidden_states = EmbedTokens.forward(.{
@@ -339,7 +341,7 @@ pub const TextModel = struct {
 
         var updated_kv_cache = kv_cache;
         for (self.layers, 0..) |layer, i| {
-            hidden_states, updated_kv_cache = layer.forward(hidden_states, token_index, updated_kv_cache.atLayer(i));
+            hidden_states, updated_kv_cache = layer.forward(hidden_states, generation_position, linear_attention_valid_len, updated_kv_cache.atLayer(i));
         }
 
         return .{ hidden_states, updated_kv_cache.reuseBuffer(kv_cache) };
@@ -372,7 +374,7 @@ pub const TransformerLayer = struct {
     pub const LinearAttnInput = struct {
         layer: TransformerLayer,
         hidden: zml.Tensor,
-        token_index: zml.Tensor,
+        linear_attention_valid_len: zml.Tensor,
         cache: KvCache.GatedDeltaNetCache,
     };
 
@@ -408,7 +410,8 @@ pub const TransformerLayer = struct {
     pub fn forward(
         self: TransformerLayer,
         x0: zml.Tensor,
-        token_index: zml.Tensor,
+        generation_position: zml.Tensor,
+        linear_attention_valid_len: zml.Tensor,
         kv_cache: KvCache.LayerView,
     ) struct { zml.Tensor, KvCache } {
         const x0_replicated = x0.withPartitioning(.{ .d = .replicated });
@@ -422,7 +425,7 @@ pub const TransformerLayer = struct {
                     .self_attn => |cache| cache,
                     .linear_attn => unreachable,
                 };
-                const result = self_attn.forward(normalized_x0, token_index, cache);
+                const result = self_attn.forward(normalized_x0, generation_position, cache);
                 attention_output = result[0];
                 updated_kv_cache.self_attn = result[1].reuseBuffer(updated_kv_cache.self_attn);
             },
@@ -431,7 +434,7 @@ pub const TransformerLayer = struct {
                     .linear_attn => |cache| cache,
                     .self_attn => unreachable,
                 };
-                const result = linear_attn.forward(normalized_x0, cache);
+                const result = linear_attn.forward(normalized_x0, cache, linear_attention_valid_len);
                 attention_output = result[0];
                 updated_kv_cache.gated_delta_net = result[1].reuseBuffer(updated_kv_cache.gated_delta_net);
             },
@@ -470,7 +473,6 @@ pub const TransformerLayer = struct {
     pub fn forwardLinearAttn(input: LinearAttnInput) LinearAttnOutput {
         const self = input.layer;
         const x0 = input.hidden;
-        _ = input.token_index;
         const x0_replicated = x0.withPartitioning(.{ .d = .replicated });
         const normalized_x0 = self.input_layernorm.forward(x0_replicated);
 
@@ -478,7 +480,7 @@ pub const TransformerLayer = struct {
             .linear_attention => |linear_attn| linear_attn,
             .full_attention => unreachable,
         };
-        const attention_output, const updated_kv_cache = linear_attn.forward(normalized_x0, input.cache);
+        const attention_output, const updated_kv_cache = linear_attn.forward(normalized_x0, input.cache, input.linear_attention_valid_len);
 
         const x1 = attention_output.add(x0_replicated).withPartitioning(.{ .d = .replicated });
         const normalized_hidden = self.post_attention_layernorm.forward(x1);
@@ -828,6 +830,7 @@ pub const GatedDeltaNet = struct {
         g: zml.Tensor,
         beta: zml.Tensor,
         initial_state: ?zml.Tensor,
+        valid_len: zml.Tensor,
     ) struct { zml.Tensor, zml.Tensor } {
         const scale: f32 = 1.0 / @sqrt(@as(f32, @floatFromInt(query.dim(.khd))));
         const query_norm = zml.nn.normalizeL2(query.rename(.{ .kh = .vh }), 1e-6);
@@ -854,13 +857,14 @@ pub const GatedDeltaNet = struct {
             }, .f32));
         };
 
-        const result = zml.nn.GatedDeltaNet.forward(
+        const result = zml.nn.GatedDeltaNet.forwardWithValidLength(
             query_f32,
             key_f32,
             value_f32,
             alpha_f32,
             beta_f32,
             .{ .s = initial_recurrent_state },
+            valid_len,
         );
 
         return .{
@@ -879,7 +883,14 @@ pub const GatedDeltaNet = struct {
         return zml.Tensor.concatenate(&.{ padding, tail }, .s);
     }
 
-    pub fn forward(self: GatedDeltaNet, x: zml.Tensor, cache: KvCache.GatedDeltaNetCache) struct { zml.Tensor, KvCache.GatedDeltaNetCache } {
+    pub fn buildUpdatedConvStateFromPrefix(input: zml.Tensor, left_pad: i64, valid_len: zml.Tensor) zml.Tensor {
+        const padding_shape = input.shape().setDim(.s, left_pad);
+        const padding = zml.Tensor.zeroes(padding_shape);
+        const padded = zml.Tensor.concatenate(&.{ padding, input }, .s);
+        return padded.slice(.s, .dyn(valid_len.convert(.i64), left_pad));
+    }
+
+    pub fn forward(self: GatedDeltaNet, x: zml.Tensor, cache: KvCache.GatedDeltaNetCache, linear_attention_valid_len: zml.Tensor) struct { zml.Tensor, KvCache.GatedDeltaNetCache } {
         const key_dim = self.num_k_heads * self.head_k_dim;
         const value_dim = self.num_v_heads * self.head_v_dim;
         const conv_dim = 2 * key_dim + value_dim;
@@ -958,6 +969,7 @@ pub const GatedDeltaNet = struct {
                 if (use_cached_state) break :b cache.recurrentState();
                 break :b null;
             },
+            linear_attention_valid_len,
         );
 
         const core_attn_out_normed = self.norm
@@ -972,7 +984,10 @@ pub const GatedDeltaNet = struct {
             .rename(.{ .dout = .d })
             .withPartitioning(.{ .d = .replicated });
         const updated_cache = cache.update(
-            buildUpdatedConvState(conv_input, left_pad),
+            if (use_cached_state)
+                buildUpdatedConvState(conv_input, left_pad)
+            else
+                buildUpdatedConvStateFromPrefix(projected_qkv, left_pad, linear_attention_valid_len),
             last_recurrent_state,
         );
         return .{ output, updated_cache };

--- a/examples/llm/models/qwen3_5/model.zig
+++ b/examples/llm/models/qwen3_5/model.zig
@@ -47,6 +47,7 @@ pub const RopeParameters = struct {
 pub const LoadedModel = struct {
     inner: Model,
     parsed_config: std.json.Parsed(Config),
+    gdn_algorithm: zml.nn.GatedDeltaNet.Algorithm,
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -66,6 +67,7 @@ pub const LoadedModel = struct {
         return .{
             .inner = try .init(allocator, store, parsed_config.value, options),
             .parsed_config = parsed_config,
+            .gdn_algorithm = if (generation.experimental_chunkwise_gdn) .chunkwise else .recurrent,
         };
     }
 
@@ -125,7 +127,8 @@ pub const LoadedModel = struct {
         progress: *std.Progress.Node,
     ) !inference.CompiledModel {
         _ = backend;
-        const params = inference.CompilationParameters.init(self.inner, self.parsed_config.value, @intCast(seqlen), shardings);
+        var params = inference.CompilationParameters.init(self.inner, self.parsed_config.value, @intCast(seqlen), shardings);
+        params.prefill_gdn_options.algorithm = self.gdn_algorithm;
         return inference.CompiledModel.init(allocator, io, platform, self, self.inner, params, progress);
     }
 };
@@ -405,6 +408,15 @@ pub const TransformerLayer = struct {
         }
         Mlp.unloadBuffers(&self.mlp);
         RmsNorm.unloadBuffers(&self.post_attention_layernorm);
+    }
+
+    pub fn withGdnOptions(self: TransformerLayer, options: zml.nn.GatedDeltaNet.Options) TransformerLayer {
+        var result = self;
+        switch (result.attn) {
+            .linear_attention => |*linear_attn| linear_attn.gdn_options = options,
+            .full_attention => {},
+        }
+        return result;
     }
 
     pub fn forward(
@@ -784,6 +796,7 @@ pub const GatedDeltaNet = struct {
     head_k_dim: i64,
     head_v_dim: i64,
     conv_kernel_size: i64,
+    gdn_options: zml.nn.GatedDeltaNet.Options = .{},
 
     fn initProj(store: zml.io.TensorStore.View, partitions: anytype) zml.nn.Linear {
         return .init(store.createTensor("weight", .{ .dout, .d }, partitions), null, .d);
@@ -823,7 +836,7 @@ pub const GatedDeltaNet = struct {
         RmsNormGated.unloadBuffers(&self.norm);
     }
 
-    fn recurrentGatedDeltaRule(
+    fn gatedDeltaRule(
         query: zml.Tensor,
         key: zml.Tensor,
         value: zml.Tensor,
@@ -831,16 +844,17 @@ pub const GatedDeltaNet = struct {
         beta: zml.Tensor,
         initial_state: ?zml.Tensor,
         valid_len: zml.Tensor,
+        options: zml.nn.GatedDeltaNet.Options,
     ) struct { zml.Tensor, zml.Tensor } {
         const scale: f32 = 1.0 / @sqrt(@as(f32, @floatFromInt(query.dim(.khd))));
         const query_norm = zml.nn.normalizeL2(query.rename(.{ .kh = .vh }), 1e-6);
         const key_norm = zml.nn.normalizeL2(key.rename(.{ .kh = .vh }), 1e-6);
 
-        const query_f32, const key_f32, const value_f32, const alpha_f32, const beta_f32 = .{
+        const query_f32, const key_f32, const value_f32, const log_decay_f32, const beta_f32 = .{
             query_norm.convert(.f32).scale(scale).rename(.{ .vh = .h, .khd = .k }),
             key_norm.convert(.f32).rename(.{ .vh = .h, .khd = .k }),
             value.convert(.f32).rename(.{ .vh = .h, .vhd = .v }),
-            g.convert(.f32).exp().rename(.{ .vh = .h }),
+            g.convert(.f32).rename(.{ .vh = .h }),
             beta.convert(.f32).rename(.{ .vh = .h }),
         };
 
@@ -857,15 +871,26 @@ pub const GatedDeltaNet = struct {
             }, .f32));
         };
 
-        const result = zml.nn.GatedDeltaNet.forwardWithValidLength(
-            query_f32,
-            key_f32,
-            value_f32,
-            alpha_f32,
-            beta_f32,
-            .{ .s = initial_recurrent_state },
-            valid_len,
-        );
+        const result = switch (options.algorithm) {
+            .chunkwise => zml.nn.GatedDeltaNet.forwardChunkwiseWithLogDecay(
+                query_f32,
+                key_f32,
+                value_f32,
+                log_decay_f32,
+                beta_f32,
+                .{ .s = initial_recurrent_state },
+                valid_len,
+            ),
+            .recurrent => zml.nn.GatedDeltaNet.forwardWithValidLength(
+                query_f32,
+                key_f32,
+                value_f32,
+                log_decay_f32.exp(),
+                beta_f32,
+                .{ .s = initial_recurrent_state },
+                valid_len,
+            ),
+        };
 
         return .{
             result.outputs.rename(.{ .h = .vh, .v = .vhd }).convert(query.dtype()),
@@ -959,7 +984,7 @@ pub const GatedDeltaNet = struct {
             break :b key.stutter1d(key.axis(.kh), self.qk_head_repetition);
         };
 
-        const core_attn_out, const last_recurrent_state = recurrentGatedDeltaRule(
+        const core_attn_out, const last_recurrent_state = gatedDeltaRule(
             query_for_rule,
             key_for_rule,
             value,
@@ -970,6 +995,7 @@ pub const GatedDeltaNet = struct {
                 break :b null;
             },
             linear_attention_valid_len,
+            self.gdn_options,
         );
 
         const core_attn_out_normed = self.norm

--- a/examples/llm/models/qwen3_5/session.zig
+++ b/examples/llm/models/qwen3_5/session.zig
@@ -105,6 +105,8 @@ pub const Session = struct {
     }
 
     pub fn runPrefill(self: *Session, all_tokens: []const u32) !void {
+        if (all_tokens.len == 0) return error.EmptyPrompt;
+        if (all_tokens.len > self.seqlen) return error.PromptTooLong;
         const prefill_tokens_shape = zml.Shape.init(.{ .b = 1, .s = self.seqlen }, .u32);
         const prefill_tokens_slice = try zml.Slice.alloc(self.allocator, prefill_tokens_shape);
         defer prefill_tokens_slice.free(self.allocator);
@@ -116,13 +118,16 @@ pub const Session = struct {
         var prefill_tokens_buffer = try zml.Buffer.fromSlice(self.io, self.platform, prefill_tokens_slice, replicated_sharding);
         defer prefill_tokens_buffer.deinit();
 
-        var prefill_token_index_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, 0), .u32);
-        defer prefill_token_index_buffer.deinit();
+        var generation_position_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, 0), .u32);
+        defer generation_position_buffer.deinit();
+        var linear_attention_valid_len_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, @intCast(all_tokens.len)), .u32);
+        defer linear_attention_valid_len_buffer.deinit();
 
         inference.run(&self.prefill, .{
             .io = self.io,
             .tokens_buf = &prefill_tokens_buffer,
-            .token_index_buf = &prefill_token_index_buffer,
+            .generation_position_buf = &generation_position_buffer,
+            .linear_attention_valid_len_buf = &linear_attention_valid_len_buffer,
             .kv_cache_buffers = &self.kv_cache_buffers,
             .rng_buffers = &self.rng_buffers,
         }, self.layer_index_buffers);
@@ -143,8 +148,10 @@ pub const Session = struct {
         var current_token_buffer = try zml.Buffer.fromSlice(self.io, self.platform, self.generated_token_slice, replicated_sharding);
         defer current_token_buffer.deinit();
 
-        var token_index_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, @intCast(all_tokens.items.len)), .u32);
-        defer token_index_buffer.deinit();
+        var generation_position_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, @intCast(all_tokens.items.len)), .u32);
+        defer generation_position_buffer.deinit();
+        var linear_attention_valid_len_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, 1), .u32);
+        defer linear_attention_valid_len_buffer.deinit();
 
         generation: while (true) {
             const token_id = self.generated_token_slice.items(u32)[0];
@@ -166,7 +173,8 @@ pub const Session = struct {
             inference.run(&self.decode, .{
                 .io = self.io,
                 .tokens_buf = &current_token_buffer,
-                .token_index_buf = &token_index_buffer,
+                .generation_position_buf = &generation_position_buffer,
+                .linear_attention_valid_len_buf = &linear_attention_valid_len_buffer,
                 .kv_cache_buffers = &self.kv_cache_buffers,
                 .rng_buffers = &self.rng_buffers,
             }, self.layer_index_buffers);

--- a/examples/llm/models/qwen3_5_cache_tests.zig
+++ b/examples/llm/models/qwen3_5_cache_tests.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+
+const zml = @import("zml");
+const qwen3_5 = @import("qwen3_5/model.zig");
+
+fn validPrefixConvState(input: zml.Tensor, valid_len: zml.Tensor) zml.Tensor {
+    return qwen3_5.GatedDeltaNet.buildUpdatedConvStateFromPrefix(input, 3, valid_len);
+}
+
+test "Qwen3.5 convolution cache uses only the valid prefix" {
+    const platform = zml.testing.env();
+    const input: zml.Tensor = .init(.{ .b = 1, .s = 5, .mix = 1 }, .f32);
+    const valid_len: zml.Tensor = .init(.{}, .u32);
+    var exe = try platform.compileFn(
+        std.testing.allocator,
+        std.testing.io,
+        validPrefixConvState,
+        .{ input, valid_len },
+        .{},
+    );
+    defer exe.deinit();
+
+    var input_buffer: zml.Buffer = try .fromBytes(
+        std.testing.io,
+        platform,
+        input.shape(),
+        .replicated,
+        std.mem.sliceAsBytes(&[5]f32{ 10, 20, 30, 777, 888 }),
+    );
+    defer input_buffer.deinit();
+
+    const expected = [_][3]f32{
+        .{ 0, 0, 0 },
+        .{ 0, 0, 10 },
+        .{ 0, 10, 20 },
+        .{ 10, 20, 30 },
+    };
+    for (expected, 0..) |values, length| {
+        var valid_len_buffer = try zml.Buffer.scalar(std.testing.io, platform, @as(u32, @intCast(length)), .u32);
+        defer valid_len_buffer.deinit();
+        var output = try zml.testing.autoCall(
+            std.testing.allocator,
+            std.testing.io,
+            &exe,
+            validPrefixConvState,
+            .{ input_buffer, valid_len_buffer },
+        );
+        defer output.deinit();
+        try zml.testing.expectClose(
+            std.testing.io,
+            zml.Slice.initConst(output.shape(), std.mem.sliceAsBytes(&values)),
+            output,
+            .{ .absolute_tolerance = 0, .relative_tolerance = 0, .minimum_close_fraction = 1 },
+        );
+    }
+}

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -2,6 +2,7 @@
 const std = @import("std");
 
 const mlir = @import("mlir");
+const dialects = @import("mlir/dialects");
 const stdx = @import("stdx");
 
 const constants = @import("constants.zig");
@@ -1819,6 +1820,15 @@ pub fn sdpa(q_: Tensor, k_: Tensor, v_: Tensor, opts: SdpaOpts) Tensor {
 }
 
 pub const GatedDeltaNet = struct {
+    pub const Algorithm = enum {
+        recurrent,
+        chunkwise,
+    };
+
+    pub const Options = struct {
+        algorithm: Algorithm = .recurrent,
+    };
+
     /// Query tensor .{ .s, .h, .k }.
     queries: Tensor,
     /// Key tensor .{ .s, .h, .k }.
@@ -1908,6 +1918,29 @@ pub const GatedDeltaNet = struct {
         };
     }
 
+    const PreparedLogDecayInputs = struct {
+        queries: Tensor,
+        keys: Tensor,
+        values: Tensor,
+        log_decay: Tensor,
+        betas: Tensor,
+    };
+
+    fn prepareLogDecayInputs(queries: Tensor, keys: Tensor, values: Tensor, log_decay: Tensor, betas: Tensor, valid_length: Tensor) PreparedLogDecayInputs {
+        stdx.debug.assert(valid_length.rank() == 0 and valid_length.dtype().isInteger(), "GatedDeltaNet valid_length must be an integer scalar, got {f}", .{valid_length});
+        const valid_mask = Tensor.arange(.{ .end = queries.dim(.s) }, .i64)
+            .withTags(.{.s})
+            .cmp(.LT, valid_length.convert(.i64));
+        return .{
+            .queries = valid_mask.broad(queries.shape()).select(queries, .zeroes(queries.shape())),
+            .keys = valid_mask.broad(keys.shape()).select(keys, .zeroes(keys.shape())),
+            .values = valid_mask.broad(values.shape()).select(values, .zeroes(values.shape())),
+            // Log-space zero is the neutral forget decay for inactive tokens.
+            .log_decay = valid_mask.broad(log_decay.shape()).select(log_decay, .zeroes(log_decay.shape())),
+            .betas = valid_mask.broad(betas.shape()).select(betas, .zeroes(betas.shape())),
+        };
+    }
+
     /// Runs the recurrent implementation while treating positions at or beyond
     /// `valid_length` as a neutral suffix. This keeps padded compilation tails
     /// from changing active outputs or recurrent state.
@@ -1969,7 +2002,238 @@ pub const GatedDeltaNet = struct {
             .state = .{ .s = final_state.s },
         };
     }
+
+    /// Processes a prefill sequence in fixed-size chunks while preserving the
+    /// recurrent state needed by subsequent decode calls.
+    pub fn forwardChunkwiseWithLogDecay(
+        queries: Tensor,
+        keys: Tensor,
+        values: Tensor,
+        log_decay: Tensor,
+        betas: Tensor,
+        initial_state: Input,
+        valid_length: Tensor,
+    ) Output {
+        const prepared = prepareLogDecayInputs(queries, keys, values, log_decay, betas, valid_length);
+        const gdn: GatedDeltaNet = .{
+            .queries = prepared.queries,
+            .keys = prepared.keys,
+            .values = prepared.values,
+            .alphas = prepared.log_decay.exp(),
+            .betas = prepared.betas,
+        };
+        validateInitialState(gdn, .{
+            .step = .scalar(0, .i32),
+            .s = initial_state.s,
+            .outputs = .zeroes(values.shape()),
+        });
+        return chunkwiseForward(
+            prepared.queries,
+            prepared.keys,
+            prepared.values,
+            prepared.log_decay,
+            prepared.betas,
+            initial_state,
+        );
+    }
+
+    const chunk_size: i64 = 64;
+    const chunk_dot_precision: dialects.stablehlo.DotPrecision = .highest;
+
+    const PreparedChunkScan = struct {
+        queries: Tensor,
+        keys: Tensor,
+        cumulative_log_decay: Tensor,
+        u: Tensor,
+        w: Tensor,
+    };
+
+    fn prepareChunkScan(queries: Tensor, keys: Tensor, values: Tensor, log_decay: Tensor, betas: Tensor) PreparedChunkScan {
+        const sequence_length = queries.dim(.s);
+        const chunk_count = @divTrunc(sequence_length + chunk_size - 1, chunk_size);
+        const padded_length = chunk_count * chunk_size;
+        const pad_count = padded_length - sequence_length;
+        const padded_q = queries.pad(0, .{ .s = Tensor.Pad{ .high = pad_count } });
+        const padded_k = keys.pad(0, .{ .s = Tensor.Pad{ .high = pad_count } });
+        const padded_v = values.pad(0, .{ .s = Tensor.Pad{ .high = pad_count } });
+        const padded_log_decay = log_decay.pad(0, .{ .s = Tensor.Pad{ .high = pad_count } });
+        const padded_beta = betas.pad(0, .{ .s = Tensor.Pad{ .high = pad_count } });
+
+        const q_chunks = padded_q.splitAxis(.s, .{ .n = chunk_count, .c = chunk_size });
+        const k_chunks = padded_k.splitAxis(.s, .{ .n = chunk_count, .c = chunk_size });
+        const v_chunks = padded_v.splitAxis(.s, .{ .n = chunk_count, .c = chunk_size });
+        const log_decay_chunks = padded_log_decay.splitAxis(.s, .{ .n = chunk_count, .c = chunk_size });
+        const beta_chunks = padded_beta.splitAxis(.s, .{ .n = chunk_count, .c = chunk_size });
+        const cumulative_log_decay = log_decay_chunks.cumulativeSum(.c);
+
+        const k_row = k_chunks.rename(.{ .c = .row });
+        const k_col = k_chunks.rename(.{ .c = .col });
+        const p_row = cumulative_log_decay.rename(.{ .c = .row });
+        const p_col = cumulative_log_decay.rename(.{ .c = .col });
+        const beta_row = beta_chunks.rename(.{ .c = .row });
+        const kkt = k_row.dotWithPrecision(k_col, .k, chunk_dot_precision);
+        const lower_strict = kkt
+            .mul(p_row.broad(kkt.shape()).sub(p_col.broad(kkt.shape())).exp())
+            .mul(beta_row.broad(kkt.shape()))
+            .triangular(.{ .row, .col }, -1)
+            .contiguous(.{ .row, .col });
+        const identity = Tensor.iota(lower_strict.shape(), .row)
+            .cmp(.EQ, Tensor.iota(lower_strict.shape(), .col))
+            .convert(lower_strict.dtype());
+        const system = lower_strict.add(identity);
+
+        const v_rhs = v_chunks.rename(.{ .c = .row })
+            .mul(beta_row.broad(v_chunks.rename(.{ .c = .row }).shape()));
+        const k_rhs = k_row
+            .mul(beta_row.broad(k_row.shape()))
+            .mul(p_row.exp().broad(k_row.shape()));
+        const rhs = Tensor.concatenate(&.{
+            v_rhs.rename(.{ .v = .rhs }),
+            k_rhs.rename(.{ .k = .rhs }),
+        }, .rhs).contiguous(.{ .row, .rhs });
+        const solved = system.triangularSolve(rhs, .{
+            .left_side = true,
+            .lower = true,
+            .unit_diagonal = true,
+            .transpose_a = .NO_TRANSPOSE,
+        });
+
+        return .{
+            .queries = q_chunks,
+            .keys = k_chunks,
+            .cumulative_log_decay = cumulative_log_decay,
+            .u = solved.slice(.rhs, .{ .start = 0, .end = values.dim(.v) }).rename(.{ .rhs = .v }),
+            .w = solved.slice(.rhs, .{ .start = values.dim(.v), .end = values.dim(.v) + keys.dim(.k) }).rename(.{ .rhs = .k }),
+        };
+    }
+
+    fn scanPreparedChunks(prepared: PreparedChunkScan, initial_state: Input) Output {
+        const Scan = struct {
+            q: Tensor,
+            k: Tensor,
+            p: Tensor,
+            u: Tensor,
+            w: Tensor,
+            chunk_count: i64,
+
+            pub const State = struct {
+                recurrent: Tensor,
+                outputs: Tensor,
+                step: Tensor,
+            };
+
+            pub fn cond(self: @This(), state: @This().State) Tensor {
+                return state.step.cmp(.LT, Tensor.scalar(self.chunk_count, .i32));
+            }
+
+            pub fn body(self: @This(), state: @This().State) @This().State {
+                const q = self.q.slice(.n, .dynSingle(state.step)).rename(.{ .c = .row }).contiguous(.{ .row, .k });
+                const k = self.k.slice(.n, .dynSingle(state.step)).rename(.{ .c = .row }).contiguous(.{ .row, .k });
+                const p = self.p.slice(.n, .dynSingle(state.step)).rename(.{ .c = .row }).contiguous(.{.row});
+                const u = self.u.slice(.n, .dynSingle(state.step));
+                const w = self.w.slice(.n, .dynSingle(state.step));
+
+                const delta = u.sub(w.dotWithPrecision(state.recurrent, .k, chunk_dot_precision));
+                const qk = q.dotWithPrecision(k.rename(.{ .row = .col }), .k, chunk_dot_precision);
+                const gamma = p.broad(qk.shape())
+                    .sub(p.rename(.{ .row = .col }).broad(qk.shape()))
+                    .exp()
+                    .triangular(.{ .row, .col }, 0);
+                const output = q.mul(p.exp().broad(q.shape()))
+                    .dotWithPrecision(state.recurrent, .k, chunk_dot_precision)
+                    .add(qk.mul(gamma).dotWithPrecision(delta.rename(.{ .row = .col }), .col, chunk_dot_precision));
+
+                const p_end = p.slice(.row, .single(-1));
+                const weighted_k = k.mul(p_end.broad(p.shape()).sub(p).exp().broad(k.shape()));
+                const recurrent = state.recurrent.mul(p_end.exp().broad(state.recurrent.shape()))
+                    .add(delta.dotWithPrecision(weighted_k, .row, chunk_dot_precision));
+                const output_chunk = output.rename(.{ .row = .c }).transpose(state.outputs.shape().drop(.n));
+                return .{
+                    .recurrent = recurrent,
+                    .outputs = state.outputs.dynamicUpdateSlice(.{ .n = state.step }, output_chunk),
+                    .step = state.step.addConstant(1),
+                };
+            }
+        };
+
+        const final = ops.@"while"(Scan, .{
+            .q = prepared.queries,
+            .k = prepared.keys,
+            .p = prepared.cumulative_log_decay,
+            .u = prepared.u,
+            .w = prepared.w,
+            .chunk_count = prepared.queries.dim(.n),
+        }, .{
+            .recurrent = initial_state.s,
+            .outputs = .zeroes(prepared.queries.shape().drop(.k).append(.{ .v = prepared.u.dim(.v) })),
+            .step = .scalar(0, .i32),
+        });
+        return .{
+            .outputs = final.outputs.merge(.{ .s = .{ .n, .c } }),
+            .state = .{ .s = final.recurrent },
+        };
+    }
+
+    fn chunkwiseForward(
+        queries: Tensor,
+        keys: Tensor,
+        values: Tensor,
+        log_decay: Tensor,
+        betas: Tensor,
+        initial_state: Input,
+    ) Output {
+        switch (zml.Compiler.current().platform.target) {
+            .cpu, .cuda => {},
+            else => stdx.debug.panic("chunkwise GDN is not validated on {s}", .{@tagName(zml.Compiler.current().platform.target)}),
+        }
+
+        const sequence_length = queries.dim(.s);
+        const padded = scanPreparedChunks(
+            prepareChunkScan(queries, keys, values, log_decay, betas),
+            initial_state,
+        );
+        return .{
+            .outputs = padded.outputs.slice(.s, .{ .start = 0, .end = sequence_length }),
+            .state = padded.state,
+        };
+    }
 };
+
+const GatedDeltaNetComparison = struct {
+    recurrent: GatedDeltaNet.Output,
+    chunkwise: GatedDeltaNet.Output,
+};
+
+fn compareGatedDeltaNet(
+    queries: Tensor,
+    keys: Tensor,
+    values: Tensor,
+    log_decay: Tensor,
+    betas: Tensor,
+    initial_state: GatedDeltaNet.Input,
+    valid_length: Tensor,
+) GatedDeltaNetComparison {
+    return .{
+        .recurrent = GatedDeltaNet.forwardWithValidLength(
+            queries,
+            keys,
+            values,
+            log_decay.exp(),
+            betas,
+            initial_state,
+            valid_length,
+        ),
+        .chunkwise = GatedDeltaNet.forwardChunkwiseWithLogDecay(
+            queries,
+            keys,
+            values,
+            log_decay,
+            betas,
+            initial_state,
+            valid_length,
+        ),
+    };
+}
 
 test "gated delta net" {
     const platform = zml.testing.env();
@@ -2098,6 +2362,86 @@ test "gated delta net" {
     try zml.testing.expectClose(std.testing.io, expected_final_s, result.state.s, .{
         .absolute_tolerance = 1e-4,
         .relative_tolerance = 1e-4,
+    });
+}
+
+test "gated delta net chunkwise crosses chunk boundary" {
+    const platform = zml.testing.env();
+    if (platform.target != .cpu and platform.target != .cuda) return error.SkipZigTest;
+
+    const sequence_length = 65;
+    const queries: Tensor = .init(.{ .s = sequence_length, .h = 1, .k = 2 }, .f32);
+    const keys: Tensor = .init(.{ .s = sequence_length, .h = 1, .k = 2 }, .f32);
+    const values: Tensor = .init(.{ .s = sequence_length, .h = 1, .v = 2 }, .f32);
+    const log_decay: Tensor = .init(.{ .s = sequence_length, .h = 1 }, .f32);
+    const betas: Tensor = .init(.{ .s = sequence_length, .h = 1 }, .f32);
+    const initial_s: Tensor = .init(.{ .h = 1, .v = 2, .k = 2 }, .f32);
+    const valid_length: Tensor = .init(.{}, .u32);
+
+    var exe = try platform.compileFn(
+        std.testing.allocator,
+        std.testing.io,
+        compareGatedDeltaNet,
+        .{ queries, keys, values, log_decay, betas, .{ .s = initial_s }, valid_length },
+        .{},
+    );
+    defer exe.deinit();
+
+    var queries_data: [sequence_length][1][2]f32 = undefined;
+    var keys_data: [sequence_length][1][2]f32 = undefined;
+    var values_data: [sequence_length][1][2]f32 = undefined;
+    var log_decay_data: [sequence_length][1]f32 = undefined;
+    var betas_data: [sequence_length][1]f32 = undefined;
+    for (0..sequence_length) |i| {
+        const fi: f32 = @floatFromInt(i);
+        const alternating: f32 = if (i % 2 == 0) 1 else -1;
+        queries_data[i][0] = .{ 0.1 + 0.001 * fi, alternating * 0.15 };
+        keys_data[i][0] = .{ 0.08 + 0.0005 * fi, alternating * 0.12 };
+        values_data[i][0] = .{ 0.2 + 0.002 * fi, -0.1 + 0.001 * fi };
+        log_decay_data[i][0] = -0.01 - 0.001 * @as(f32, @floatFromInt(i % 5));
+        betas_data[i][0] = 0.2 + 0.05 * @as(f32, @floatFromInt(i % 3));
+    }
+
+    var queries_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, queries.shape(), .replicated, std.mem.sliceAsBytes(&queries_data));
+    defer queries_buffer.deinit();
+    var keys_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, keys.shape(), .replicated, std.mem.sliceAsBytes(&keys_data));
+    defer keys_buffer.deinit();
+    var values_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, values.shape(), .replicated, std.mem.sliceAsBytes(&values_data));
+    defer values_buffer.deinit();
+    var log_decay_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, log_decay.shape(), .replicated, std.mem.sliceAsBytes(&log_decay_data));
+    defer log_decay_buffer.deinit();
+    var betas_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, betas.shape(), .replicated, std.mem.sliceAsBytes(&betas_data));
+    defer betas_buffer.deinit();
+    var initial_s_buffer: zml.Buffer = try .fromBytes(
+        std.testing.io,
+        platform,
+        initial_s.shape(),
+        .replicated,
+        std.mem.sliceAsBytes(&[1][2][2]f32{.{ .{ 0.1, -0.05 }, .{ 0.025, 0.075 } }}),
+    );
+    defer initial_s_buffer.deinit();
+    var valid_length_buffer = try zml.Buffer.scalar(std.testing.io, platform, @as(u32, sequence_length), .u32);
+    defer valid_length_buffer.deinit();
+
+    var result = try zml.testing.autoCall(
+        std.testing.allocator,
+        std.testing.io,
+        &exe,
+        compareGatedDeltaNet,
+        .{ queries_buffer, keys_buffer, values_buffer, log_decay_buffer, betas_buffer, .{ .s = initial_s_buffer }, valid_length_buffer },
+    );
+    defer result.recurrent.outputs.deinit();
+    defer result.recurrent.state.s.deinit();
+    defer result.chunkwise.outputs.deinit();
+    defer result.chunkwise.state.s.deinit();
+
+    try zml.testing.expectClose(std.testing.io, result.recurrent.outputs, result.chunkwise.outputs, .{
+        .absolute_tolerance = 2e-4,
+        .relative_tolerance = 2e-4,
+    });
+    try zml.testing.expectClose(std.testing.io, result.recurrent.state.s, result.chunkwise.state.s, .{
+        .absolute_tolerance = 2e-4,
+        .relative_tolerance = 2e-4,
     });
 }
 

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -1908,6 +1908,32 @@ pub const GatedDeltaNet = struct {
         };
     }
 
+    /// Runs the recurrent implementation while treating positions at or beyond
+    /// `valid_length` as a neutral suffix. This keeps padded compilation tails
+    /// from changing active outputs or recurrent state.
+    pub fn forwardWithValidLength(
+        queries: Tensor,
+        keys: Tensor,
+        values: Tensor,
+        alphas: Tensor,
+        betas: Tensor,
+        initial_state: Input,
+        valid_length: Tensor,
+    ) Output {
+        stdx.debug.assert(valid_length.rank() == 0 and valid_length.dtype().isInteger(), "GatedDeltaNet valid_length must be an integer scalar, got {f}", .{valid_length});
+        const valid_mask = Tensor.arange(.{ .end = queries.dim(.s) }, .i64)
+            .withTags(.{.s})
+            .cmp(.LT, valid_length.convert(.i64));
+        return forward(
+            valid_mask.broad(queries.shape()).select(queries, .zeroes(queries.shape())),
+            valid_mask.broad(keys.shape()).select(keys, .zeroes(keys.shape())),
+            valid_mask.broad(values.shape()).select(values, .zeroes(values.shape())),
+            valid_mask.broad(alphas.shape()).select(alphas, Tensor.constant(alphas.dtype().one()).broad(alphas.shape())),
+            valid_mask.broad(betas.shape()).select(betas, .zeroes(betas.shape())),
+            initial_state,
+        );
+    }
+
     /// Processes a sequence with Gated Delta Net recurrence using `stablehlo.while`.
     ///
     /// Shapes:
@@ -1948,18 +1974,19 @@ pub const GatedDeltaNet = struct {
 test "gated delta net" {
     const platform = zml.testing.env();
 
-    const queries: zml.Tensor = .init(.{ .s = 2, .h = 2, .k = 2 }, .f32);
-    const keys: zml.Tensor = .init(.{ .s = 2, .h = 2, .k = 2 }, .f32);
-    const values: zml.Tensor = .init(.{ .s = 2, .h = 2, .v = 2 }, .f32);
-    const alphas: zml.Tensor = .init(.{ .s = 2, .h = 2 }, .f32);
-    const betas: zml.Tensor = .init(.{ .s = 2, .h = 2 }, .f32);
+    const queries: zml.Tensor = .init(.{ .s = 3, .h = 2, .k = 2 }, .f32);
+    const keys: zml.Tensor = .init(.{ .s = 3, .h = 2, .k = 2 }, .f32);
+    const values: zml.Tensor = .init(.{ .s = 3, .h = 2, .v = 2 }, .f32);
+    const alphas: zml.Tensor = .init(.{ .s = 3, .h = 2 }, .f32);
+    const betas: zml.Tensor = .init(.{ .s = 3, .h = 2 }, .f32);
     const initial_s: zml.Tensor = .init(.{ .h = 2, .v = 2, .k = 2 }, .f32);
+    const valid_length: zml.Tensor = .init(.{}, .u32);
 
     var exe = try platform.compileFn(
         std.testing.allocator,
         std.testing.io,
-        GatedDeltaNet.forward,
-        .{ queries, keys, values, alphas, betas, .{ .s = initial_s } },
+        GatedDeltaNet.forwardWithValidLength,
+        .{ queries, keys, values, alphas, betas, .{ .s = initial_s }, valid_length },
         .{},
     );
     defer exe.deinit();
@@ -1969,9 +1996,10 @@ test "gated delta net" {
         platform,
         queries.shape(),
         .replicated,
-        std.mem.sliceAsBytes(&[2][2][2]f32{
+        std.mem.sliceAsBytes(&[3][2][2]f32{
             .{ .{ 1.0, 0.0 }, .{ 0.0, 1.0 } },
             .{ .{ 1.0, 1.0 }, .{ 1.0, -1.0 } },
+            .{ .{ 100, -100 }, .{ -100, 100 } },
         }),
     );
     defer queries_buffer.deinit();
@@ -1980,9 +2008,10 @@ test "gated delta net" {
         platform,
         keys.shape(),
         .replicated,
-        std.mem.sliceAsBytes(&[2][2][2]f32{
+        std.mem.sliceAsBytes(&[3][2][2]f32{
             .{ .{ 1.0, 2.0 }, .{ 0.0, 1.0 } },
             .{ .{ 2.0, 1.0 }, .{ 1.0, 0.0 } },
+            .{ .{ -200, 200 }, .{ 200, -200 } },
         }),
     );
     defer keys_buffer.deinit();
@@ -1991,9 +2020,10 @@ test "gated delta net" {
         platform,
         values.shape(),
         .replicated,
-        std.mem.sliceAsBytes(&[2][2][2]f32{
+        std.mem.sliceAsBytes(&[3][2][2]f32{
             .{ .{ 3.0, 1.0 }, .{ 2.0, 4.0 } },
             .{ .{ 1.0, 5.0 }, .{ 3.0, 0.0 } },
+            .{ .{ 300, -300 }, .{ -300, 300 } },
         }),
     );
     defer values_buffer.deinit();
@@ -2002,9 +2032,10 @@ test "gated delta net" {
         platform,
         alphas.shape(),
         .replicated,
-        std.mem.sliceAsBytes(&[2][2]f32{
+        std.mem.sliceAsBytes(&[3][2]f32{
             .{ 0.5, 0.25 },
             .{ 0.8, 0.6 },
+            .{ -10, 10 },
         }),
     );
     defer alphas_buffer.deinit();
@@ -2013,9 +2044,10 @@ test "gated delta net" {
         platform,
         betas.shape(),
         .replicated,
-        std.mem.sliceAsBytes(&[2][2]f32{
+        std.mem.sliceAsBytes(&[3][2]f32{
             .{ 1.0, 0.5 },
             .{ 0.75, 1.0 },
+            .{ 20, -20 },
         }),
     );
     defer betas_buffer.deinit();
@@ -2030,22 +2062,25 @@ test "gated delta net" {
         }),
     );
     defer initial_s_buffer.deinit();
+    var valid_length_buffer = try zml.Buffer.scalar(std.testing.io, platform, @as(u32, 2), .u32);
+    defer valid_length_buffer.deinit();
 
     var result = try zml.testing.autoCall(
         std.testing.allocator,
         std.testing.io,
         &exe,
-        GatedDeltaNet.forward,
-        .{ queries_buffer, keys_buffer, values_buffer, alphas_buffer, betas_buffer, .{ .s = initial_s_buffer } },
+        GatedDeltaNet.forwardWithValidLength,
+        .{ queries_buffer, keys_buffer, values_buffer, alphas_buffer, betas_buffer, .{ .s = initial_s_buffer }, valid_length_buffer },
     );
     defer result.outputs.deinit();
     defer result.state.s.deinit();
 
     const expected_outputs: zml.Slice = .init(
-        zml.Shape.init(.{ 2, 2, 2 }, .f32),
-        std.mem.sliceAsBytes(&[2][2][2]f32{
+        zml.Shape.init(.{ 3, 2, 2 }, .f32),
+        std.mem.sliceAsBytes(&[3][2][2]f32{
             .{ .{ 3.0, 0.0 }, .{ 1.125, 2.0 } },
             .{ .{ -11.15, 10.75 }, .{ 2.325, -1.2 } },
+            .{ .{ 0, 0 }, .{ 0, 0 } },
         }),
     );
     const expected_final_s: zml.Slice = .init(

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -560,10 +560,10 @@ pub const Tensor = struct {
     /// Solves the system of linear equations formed by the input tensors.
     pub fn triangularSolve(self: Tensor, other: Tensor, opts: dialects.stablehlo.TriangularSolveOpts) Tensor {
         stdx.debug.assert(self.dtype() == other.dtype(), "triangularSolve expects tensors to be of the same type, got {} and {}", .{ self.dtype(), other.dtype() });
-        stdx.debug.assert(self.rank() <= 2 and self.rank() == other.rank(), "triangularSolve expects tensors to have the same rank and be <= 2, got {} and {}", .{ self.rank(), other.rank() });
+        stdx.debug.assert(self.rank() >= 2 and self.rank() == other.rank(), "triangularSolve expects tensors to have the same rank >= 2, got {} and {}", .{ self.rank(), other.rank() });
 
         const op = dialects.stablehlo.triangular_solve(mlirCtx(), self.value(), other.value(), opts, .unknown(mlirCtx())).appendTo(currentBlock());
-        return _result(self._shape, op.result(0));
+        return _result(other._shape, op.result(0));
     }
 
     /// Returns a Tensor containing the element-wise rounding towards the nearest integer, breaking ties away from zero, of the input Tensor.

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -1396,8 +1396,13 @@ pub const Tensor = struct {
     /// Axes with the same tag on both sides, and which aren't contracting,
     /// are considered "batching axes".
     pub fn dot(lhs: Tensor, rhs: Tensor, args: anytype) Tensor {
+        return lhs.dotWithPrecision(rhs, args, .fast);
+    }
+
+    /// Matrix multiplication with an explicit StableHLO precision contract.
+    pub fn dotWithPrecision(lhs: Tensor, rhs: Tensor, args: anytype, precision: dialects.stablehlo.DotPrecision) Tensor {
         const dot_axes = lhs.dotAxes(rhs, args);
-        return lhs.dotGeneral(rhs, dot_axes.contracting.constSlice(), dot_axes.batching.constSlice());
+        return lhs.dotGeneralWithPrecision(rhs, dot_axes.contracting.constSlice(), dot_axes.batching.constSlice(), precision);
     }
 
     pub const DotAxes = struct {
@@ -1504,6 +1509,16 @@ pub const Tensor = struct {
         contracting_axes: []const [2]i8,
         batching_axes: []const [2]i8,
     ) Tensor {
+        return lhs.dotGeneralWithPrecision(rhs, contracting_axes, batching_axes, .fast);
+    }
+
+    pub fn dotGeneralWithPrecision(
+        lhs: Tensor,
+        rhs: Tensor,
+        contracting_axes: []const [2]i8,
+        batching_axes: []const [2]i8,
+        precision: dialects.stablehlo.DotPrecision,
+    ) Tensor {
         stdx.debug.assert(lhs.dtype() == rhs.dtype(), "dotGeneral expects tensors to be of the same type, got {} and {}", .{ lhs.dtype(), rhs.dtype() });
 
         const Axes = stdx.BoundedArray(i64, constants.MAX_RANK);
@@ -1564,7 +1579,7 @@ pub const Tensor = struct {
                 .rhs_batching_dimensions = rhs_batching_axes.constSlice(),
                 .lhs_contracting_dimensions = lhs_contracting_axes.constSlice(),
                 .rhs_contracting_dimensions = rhs_contracting_axes.constSlice(),
-                .dot_precision = .fast,
+                .dot_precision = precision,
             },
             .unknown(mlirCtx()),
         ).appendTo(currentBlock());


### PR DESCRIPTION
Depends on #753 and #754.

## Summary

Dense Qwen3.5 currently evaluates Gated DeltaNet prefill recurrently, one token per loop iteration. This adds a fixed 64-token chunkwise reformulation using a batched rectangular-RHS triangular solve and highest-precision dot products.

For Qwen3.5, the new path is available only through `--experimental-chunkwise-gdn`. Default prefill remains recurrent, and single-token decode is always recurrent. The experimental implementation is currently limited to CPU and CUDA.

## Performance

Exploratory Qwen3.5-4B application-TTFT measurements on an idle RTX 4090:

| Prompt tokens | Recurrent median | Chunkwise median | Speedup |
|---:|---:|---:|---:|
| 128 | 42.76 ms | 19.69 ms | 2.17x |
| 512 | 139.63 ms | 47.45 ms | 2.94x |
| 1024 | 275.27 ms | 87.44 ms | 3.15x |
| 2048 | 566.79 ms | 183.52 ms | 3.09x |
| 4096 | 1221.51 ms | 365.82 ms | 3.34x |

The isolated GDN core was 2.92x to 7.23x faster over the measured 64–4096-token range, and the gain survived the rest of the model. Decode stayed effectively unchanged because it continues to use the recurrent path.

This looks worthwhile as an explicit opt-in: the speedup is visible in end-to-end prompt processing, not only in an isolated kernel. These measurements are still specific to the tested model and RTX 4090, so this change does not introduce an automatic dispatch policy.

The CUDA qualification used the same C64 direct-RHS/highest algorithm in an instrumented research worktree; this PR removes the alternative strategies and harness-only controls.

## Correctness

The selected C64 algorithm passed FP64 recurrence-oracle and core output/final-state checks, including partial final chunks, the 64/65 and 256/257 boundaries, nonzero initial state, padded-tail invariance, split/resume continuation, and repeated-launch determinism.

The two implementations are mathematically equivalent, but they are not bit-for-bit identical: recurrent GDN accumulates one token at a time, while chunkwise GDN groups the same work into triangular solves and matrix multiplications. That changes the order of BF16/FP32 rounding. Small differences can grow through later model layers and occasionally change a token when the top logits are already very close.

The measured quality result does not show a regression. Across 18 paired cases and 144 teacher-forced positions, the perplexity ratio was 0.9997, all 109 stable-margin top-1 choices agreed, and the three changed top-1 choices were all low-margin positions where small rounding changes can alter the ordering. The sample was not large enough to prove the unusually tight 0.5% non-inferiority bound, so automatic dispatch remains disabled. If useful, I can extend this with a larger natural-text sample and targeted Qwen reasoning, coding, and long-context evaluations.

## Testing

- `bazel build //zml:test //examples/llm:llm`
- `bazel test //zml:test --test_output=errors`
- focused recurrent-versus-chunkwise boundary test at T=65
- CUDA Qwen3.5-4B core, prefill, TTFT, decode, continuation, and teacher-forced quality harnesses across boundary and long-prompt cases

The build/test commands and correctness checks above passed. I can also run additional hardware or model-quality coverage if maintainers want it before considering automatic dispatch.
