### PR TITLE
pjrt: report errors on already-ready events

### DIFF
--- a/pjrt/pjrt.zig
+++ b/pjrt/pjrt.zig
@@ -1338,6 +1338,10 @@ pub const Event = opaque {
 
     pub fn await(self: *Event, api: *const Api, io: std.Io) ApiError!void {
         if (self.isReady(api)) {
+            if (self.getEventError(api)) |err| {
+                return interpretPjrtError(api, err, "PJRT_Event_Error");
+            }
+
             return;
         }
 

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -581,7 +581,7 @@ pub const Platform = struct {
 
     pub fn format(self: *const Platform, writer: *std.Io.Writer) std.Io.Writer.Error!void {
         try writer.print("{s} {{ ", .{@tagName(self.target)});
-        for (self.devices(), 0..) |device, i| {
+        for (self.devices, 0..) |device, i| {
             try writer.print("{s}(\"{s}\")", .{ device.toString(), device.kind() });
             if (i < self.devices.len - 1) try writer.writeAll(", ");
         }


### PR DESCRIPTION
PJRT_Event_Await short-circuits when the event is already ready, so a failed event returned success instead of its error. Check PJRT_Event_Error on that path too.

* pjrt/pjrt.zig (Event.await): Interpret the event error before the early return.
* zml/platform.zig (Platform.format): Iterate the devices field, not a call.