### PR TITLE
zml/ops: refactor `manualComputation`

### DIFF
--- a/examples/sharding/main.zig
+++ b/examples/sharding/main.zig
@@ -43,7 +43,7 @@ const DemoModel = struct {
                 y: zml.Tensor,
                 gate: zml.Tensor,
 
-                fn body(ctx: @This(), _: std.mem.Allocator, output_sharded: zml.Shape) zml.Tensor {
+                fn body(ctx: @This(), output_sharded: zml.Shape) zml.Tensor {
                     const local_result = ctx.y.relu().mul(ctx.gate);
                     return local_result.reshape(output_sharded);
                 }

--- a/examples/sharding/main.zig
+++ b/examples/sharding/main.zig
@@ -39,15 +39,17 @@ const DemoModel = struct {
 
         const gate = y.scale(0.01).sigmoid();
         return zml.ops.manualComputation(
-            .{ y, gate },
-            y.shape(),
-            {},
             (struct {
-                fn body(_: void, _: std.mem.Allocator, sharded_inputs: []const zml.Tensor, output_sharded: zml.Shape) zml.Tensor {
-                    const local_result = sharded_inputs[0].relu().mul(sharded_inputs[1]);
+                y: zml.Tensor,
+                gate: zml.Tensor,
+
+                fn body(ctx: @This(), _: std.mem.Allocator, output_sharded: zml.Shape) zml.Tensor {
+                    const local_result = ctx.y.relu().mul(ctx.gate);
                     return local_result.reshape(output_sharded);
                 }
             }).body,
+            .{ .y = y, .gate = gate },
+            y.shape(),
         );
     }
 };

--- a/zml/attention/flashattn.zig
+++ b/zml/attention/flashattn.zig
@@ -958,7 +958,7 @@ pub const paged_fa2 = struct {
                         },
                         opts: zml.ops.CustomCallOptions,
 
-                        fn body(self: @This(), _: std.mem.Allocator, output: zml.Shape) zml.Tensor {
+                        fn body(self: @This(), output: zml.Shape) zml.Tensor {
                             return zml.ops.customCall(Decode.custom_call_name, self.inputs, output, self.metadata, self.opts);
                         }
                     }).body,
@@ -1044,7 +1044,7 @@ pub const paged_fa2 = struct {
                         },
                         opts: zml.ops.CustomCallOptions,
 
-                        fn body(self: @This(), _: std.mem.Allocator, output: zml.Shape) zml.Tensor {
+                        fn body(self: @This(), output: zml.Shape) zml.Tensor {
                             return zml.ops.customCall(Prefill.custom_call_name, self.inputs, output, self.metadata, self.opts);
                         }
                     }).body,
@@ -1119,7 +1119,7 @@ pub const paged_fa2 = struct {
                         },
                         opts: zml.ops.CustomCallOptions,
 
-                        fn body(self: @This(), _: std.mem.Allocator, output: zml.Shape) zml.Tensor {
+                        fn body(self: @This(), output: zml.Shape) zml.Tensor {
                             return zml.ops.customCall(Decode.custom_call_name, self.inputs, output, self.metadata, self.opts);
                         }
                     }).body,
@@ -1596,7 +1596,7 @@ pub const paged_fa3 = struct {
                         },
                         opts: zml.ops.CustomCallOptions,
 
-                        fn body(self: @This(), _: std.mem.Allocator, output: zml.Shape) zml.Tensor {
+                        fn body(self: @This(), output: zml.Shape) zml.Tensor {
                             return zml.ops.customCall(Decode.custom_call_name, self.inputs, output, self.metadata, self.opts);
                         }
                     }).body,
@@ -1673,7 +1673,7 @@ pub const paged_fa3 = struct {
                         },
                         opts: zml.ops.CustomCallOptions,
 
-                        fn body(self: @This(), _: std.mem.Allocator, output: zml.Shape) zml.Tensor {
+                        fn body(self: @This(), output: zml.Shape) zml.Tensor {
                             return zml.ops.customCall(Prefill.custom_call_name, self.inputs, output, self.metadata, self.opts);
                         }
                     }).body,
@@ -1738,7 +1738,7 @@ pub const paged_fa3 = struct {
                         },
                         opts: zml.ops.CustomCallOptions,
 
-                        fn body(self: @This(), _: std.mem.Allocator, output: zml.Shape) zml.Tensor {
+                        fn body(self: @This(), output: zml.Shape) zml.Tensor {
                             return zml.ops.customCall(Decode.custom_call_name, self.inputs, output, self.metadata, self.opts);
                         }
                     }).body,

--- a/zml/attention/flashattn.zig
+++ b/zml/attention/flashattn.zig
@@ -947,20 +947,34 @@ pub const paged_fa2 = struct {
 
                 const output_shape = q2.shape();
                 var o = zml.ops.manualComputation(
+                    (struct {
+                        inputs: struct { zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor },
+                        metadata: struct {
+                            is_causal: bool,
+                            max_seqlen_k: usize,
+                            num_heads: i64,
+                            window_size_left: i32,
+                            softmax_scale: ?f32,
+                        },
+                        opts: zml.ops.CustomCallOptions,
+
+                        fn body(self: @This(), _: std.mem.Allocator, output: zml.Shape) zml.Tensor {
+                            return zml.ops.customCall(Decode.custom_call_name, self.inputs, output, self.metadata, self.opts);
+                        }
+                    }).body,
                     .{
-                        q2,
-                        k_cache,
-                        v_cache,
-                        cu_seqlens_q,
-                        dummy_cu_seqlens_k,
-                        seqused_k,
-                        block_table,
-                        softmax_lse,
-                        softmax_lse_accum,
-                        out_accum,
-                    },
-                    output_shape,
-                    .{
+                        .inputs = .{
+                            q2,
+                            k_cache,
+                            v_cache,
+                            cu_seqlens_q,
+                            dummy_cu_seqlens_k,
+                            seqused_k,
+                            block_table,
+                            softmax_lse,
+                            softmax_lse_accum,
+                            out_accum,
+                        },
                         .metadata = .{
                             .is_causal = opts.is_causal,
                             .max_seqlen_k = decode_parameters.options.max_seqlen_k,
@@ -972,11 +986,7 @@ pub const paged_fa2 = struct {
                             .has_side_effect = false,
                         },
                     },
-                    (struct {
-                        fn body(ctx_: anytype, _: std.mem.Allocator, sharded_inputs: []const zml.Tensor, output: zml.Shape) zml.Tensor {
-                            return zml.ops.customCall(Decode.custom_call_name, sharded_inputs, output, ctx_.metadata, ctx_.opts);
-                        }
-                    }).body,
+                    output_shape,
                 );
 
                 if (seqlenq_ngroups_swapped) {
@@ -1022,20 +1032,35 @@ pub const paged_fa2 = struct {
 
                 const output_shape = q2.shape();
                 var o = zml.ops.manualComputation(
+                    (struct {
+                        inputs: struct { zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor },
+                        metadata: struct {
+                            is_causal: bool,
+                            max_seqlen_k: usize,
+                            max_seqlen_q: usize,
+                            num_heads: i64,
+                            window_size_left: i32,
+                            softmax_scale: ?f32,
+                        },
+                        opts: zml.ops.CustomCallOptions,
+
+                        fn body(self: @This(), _: std.mem.Allocator, output: zml.Shape) zml.Tensor {
+                            return zml.ops.customCall(Prefill.custom_call_name, self.inputs, output, self.metadata, self.opts);
+                        }
+                    }).body,
                     .{
-                        q2,
-                        k_cache,
-                        v_cache,
-                        cu_seqlens_q_prefill,
-                        dummy_cu_seqlens_k_prefill,
-                        seqused_k_prefill,
-                        block_table_prefill,
-                        softmax_lse_prefill,
-                        softmax_lse_accum_prefill,
-                        out_accum_prefill,
-                    },
-                    output_shape,
-                    .{
+                        .inputs = .{
+                            q2,
+                            k_cache,
+                            v_cache,
+                            cu_seqlens_q_prefill,
+                            dummy_cu_seqlens_k_prefill,
+                            seqused_k_prefill,
+                            block_table_prefill,
+                            softmax_lse_prefill,
+                            softmax_lse_accum_prefill,
+                            out_accum_prefill,
+                        },
                         .metadata = .{
                             .is_causal = opts.is_causal,
                             .max_seqlen_k = mixed_parameters.options.max_seqlen_k,
@@ -1048,11 +1073,7 @@ pub const paged_fa2 = struct {
                             .has_side_effect = false,
                         },
                     },
-                    (struct {
-                        fn body(ctx_: anytype, _: std.mem.Allocator, sharded_inputs: []const zml.Tensor, output: zml.Shape) zml.Tensor {
-                            return zml.ops.customCall(Prefill.custom_call_name, sharded_inputs, output, ctx_.metadata, ctx_.opts);
-                        }
-                    }).body,
+                    output_shape,
                 );
 
                 o = o.splitAxis(.h, .{ .hkv = num_kv_heads, .hg = num_head_groups });
@@ -1087,20 +1108,34 @@ pub const paged_fa2 = struct {
 
                 const output_shape_decode = q_decode.shape();
                 var o_decode = zml.ops.manualComputation(
+                    (struct {
+                        inputs: struct { zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor },
+                        metadata: struct {
+                            is_causal: bool,
+                            max_seqlen_k: usize,
+                            num_heads: i64,
+                            window_size_left: i32,
+                            softmax_scale: ?f32,
+                        },
+                        opts: zml.ops.CustomCallOptions,
+
+                        fn body(self: @This(), _: std.mem.Allocator, output: zml.Shape) zml.Tensor {
+                            return zml.ops.customCall(Decode.custom_call_name, self.inputs, output, self.metadata, self.opts);
+                        }
+                    }).body,
                     .{
-                        q_decode,
-                        k_cache,
-                        v_cache,
-                        cu_seqlens_q_decode,
-                        dummy_cu_seqlens_k_decode,
-                        seqused_k_decode,
-                        block_table_decode,
-                        softmax_lse_decode,
-                        softmax_lse_accum_decode,
-                        out_accum_decode,
-                    },
-                    output_shape_decode,
-                    .{
+                        .inputs = .{
+                            q_decode,
+                            k_cache,
+                            v_cache,
+                            cu_seqlens_q_decode,
+                            dummy_cu_seqlens_k_decode,
+                            seqused_k_decode,
+                            block_table_decode,
+                            softmax_lse_decode,
+                            softmax_lse_accum_decode,
+                            out_accum_decode,
+                        },
                         .metadata = .{
                             .is_causal = opts.is_causal,
                             .max_seqlen_k = mixed_parameters.options.max_seqlen_k,
@@ -1112,11 +1147,7 @@ pub const paged_fa2 = struct {
                             .has_side_effect = false,
                         },
                     },
-                    (struct {
-                        fn body(ctx_: anytype, _: std.mem.Allocator, sharded_inputs: []const zml.Tensor, output: zml.Shape) zml.Tensor {
-                            return zml.ops.customCall(Decode.custom_call_name, sharded_inputs, output, ctx_.metadata, ctx_.opts);
-                        }
-                    }).body,
+                    output_shape_decode,
                 );
 
                 if (seqlenq_ngroups_swapped) {
@@ -1556,20 +1587,32 @@ pub const paged_fa3 = struct {
 
                 const output_shape = q2.shape();
                 var o = zml.ops.manualComputation(
+                    (struct {
+                        inputs: struct { zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor },
+                        metadata: struct {
+                            is_causal: bool,
+                            max_seqlen_k: usize,
+                            window_size_left: i32,
+                        },
+                        opts: zml.ops.CustomCallOptions,
+
+                        fn body(self: @This(), _: std.mem.Allocator, output: zml.Shape) zml.Tensor {
+                            return zml.ops.customCall(Decode.custom_call_name, self.inputs, output, self.metadata, self.opts);
+                        }
+                    }).body,
                     .{
-                        q2,
-                        k_cache,
-                        v_cache,
-                        cu_seqlens_q,
-                        seqused_k,
-                        block_table,
-                        softmax_lse,
-                        softmax_lse_accum,
-                        out_accum,
-                        scheduler_metadata,
-                    },
-                    output_shape,
-                    .{
+                        .inputs = .{
+                            q2,
+                            k_cache,
+                            v_cache,
+                            cu_seqlens_q,
+                            seqused_k,
+                            block_table,
+                            softmax_lse,
+                            softmax_lse_accum,
+                            out_accum,
+                            scheduler_metadata,
+                        },
                         .metadata = .{
                             .is_causal = opts.is_causal,
                             .max_seqlen_k = decode_parameters.options.max_seqlen_k,
@@ -1579,11 +1622,7 @@ pub const paged_fa3 = struct {
                             .has_side_effect = false,
                         },
                     },
-                    (struct {
-                        fn body(ctx_: anytype, _: std.mem.Allocator, sharded_inputs: []const zml.Tensor, output: zml.Shape) zml.Tensor {
-                            return zml.ops.customCall(Decode.custom_call_name, sharded_inputs, output, ctx_.metadata, ctx_.opts);
-                        }
-                    }).body,
+                    output_shape,
                 );
 
                 o = o.splitAxis(.h, .{ .hkv = num_kv_heads, .hg = num_head_groups });
@@ -1624,20 +1663,33 @@ pub const paged_fa3 = struct {
 
                 const output_shape = q2.shape();
                 var o = zml.ops.manualComputation(
+                    (struct {
+                        inputs: struct { zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor },
+                        metadata: struct {
+                            is_causal: bool,
+                            max_seqlen_k: usize,
+                            max_seqlen_q: usize,
+                            window_size_left: i32,
+                        },
+                        opts: zml.ops.CustomCallOptions,
+
+                        fn body(self: @This(), _: std.mem.Allocator, output: zml.Shape) zml.Tensor {
+                            return zml.ops.customCall(Prefill.custom_call_name, self.inputs, output, self.metadata, self.opts);
+                        }
+                    }).body,
                     .{
-                        q2,
-                        k_cache,
-                        v_cache,
-                        cu_seqlens_q_prefill,
-                        seqused_k_prefill,
-                        block_table_prefill,
-                        softmax_lse_prefill,
-                        softmax_lse_accum_prefill,
-                        out_accum_prefill,
-                        scheduler_metadata_prefill,
-                    },
-                    output_shape,
-                    .{
+                        .inputs = .{
+                            q2,
+                            k_cache,
+                            v_cache,
+                            cu_seqlens_q_prefill,
+                            seqused_k_prefill,
+                            block_table_prefill,
+                            softmax_lse_prefill,
+                            softmax_lse_accum_prefill,
+                            out_accum_prefill,
+                            scheduler_metadata_prefill,
+                        },
                         .metadata = .{
                             .is_causal = opts.is_causal,
                             .max_seqlen_k = mixed_parameters.options.max_seqlen_k,
@@ -1646,11 +1698,7 @@ pub const paged_fa3 = struct {
                         },
                         .opts = zml.ops.CustomCallOptions{ .has_side_effect = false },
                     },
-                    (struct {
-                        fn body(ctx_: anytype, _: std.mem.Allocator, sharded_inputs: []const zml.Tensor, output: zml.Shape) zml.Tensor {
-                            return zml.ops.customCall(Prefill.custom_call_name, sharded_inputs, output, ctx_.metadata, ctx_.opts);
-                        }
-                    }).body,
+                    output_shape,
                 );
 
                 o = o.splitAxis(.h, .{ .hkv = num_kv_heads, .hg = num_head_groups });
@@ -1681,20 +1729,32 @@ pub const paged_fa3 = struct {
 
                 const decode_output_shape = q_decode.shape();
                 var o_decode = zml.ops.manualComputation(
+                    (struct {
+                        inputs: struct { zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor, zml.Tensor },
+                        metadata: struct {
+                            is_causal: bool,
+                            max_seqlen_k: usize,
+                            window_size_left: i32,
+                        },
+                        opts: zml.ops.CustomCallOptions,
+
+                        fn body(self: @This(), _: std.mem.Allocator, output: zml.Shape) zml.Tensor {
+                            return zml.ops.customCall(Decode.custom_call_name, self.inputs, output, self.metadata, self.opts);
+                        }
+                    }).body,
                     .{
-                        q_decode,
-                        k_cache,
-                        v_cache,
-                        cu_seqlens_q_decode,
-                        seqused_k_decode,
-                        block_table_decode,
-                        softmax_lse_decode,
-                        softmax_lse_accum_decode,
-                        out_accum_decode,
-                        scheduler_metadata_decode,
-                    },
-                    decode_output_shape,
-                    .{
+                        .inputs = .{
+                            q_decode,
+                            k_cache,
+                            v_cache,
+                            cu_seqlens_q_decode,
+                            seqused_k_decode,
+                            block_table_decode,
+                            softmax_lse_decode,
+                            softmax_lse_accum_decode,
+                            out_accum_decode,
+                            scheduler_metadata_decode,
+                        },
                         .metadata = .{
                             .is_causal = opts.is_causal,
                             .max_seqlen_k = mixed_parameters.options.max_seqlen_k,
@@ -1702,11 +1762,7 @@ pub const paged_fa3 = struct {
                         },
                         .opts = zml.ops.CustomCallOptions{ .has_side_effect = false },
                     },
-                    (struct {
-                        fn body(ctx_: anytype, _: std.mem.Allocator, sharded_inputs: []const zml.Tensor, output: zml.Shape) zml.Tensor {
-                            return zml.ops.customCall(Decode.custom_call_name, sharded_inputs, output, ctx_.metadata, ctx_.opts);
-                        }
-                    }).body,
+                    decode_output_shape,
                 );
                 o_decode = o_decode.splitAxis(.h, .{ .hkv = num_kv_heads, .hg = num_head_groups });
 

--- a/zml/attention/nki/attention.zig
+++ b/zml/attention/nki/attention.zig
@@ -54,46 +54,60 @@ pub fn attention(q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, token_index: zml.T
             .withPartitioning(.{ .row = .replicated, .col = .replicated });
 
         return zml.ops.manualComputation(
-            .{ q_sharded, k_sharded, v_sharded, token_index_2d },
-            q_sharded.shape(),
-            parameters,
             (struct {
-                fn body(context: Parameters, _: std.mem.Allocator, sharded_inputs: []const zml.Tensor, output: zml.Shape) zml.Tensor {
-                    stdx.debug.assert(sharded_inputs.len == 4, "NKI decode attention expects 4 sharded inputs, got {}", .{sharded_inputs.len});
-                    const kernel = context.decode_kernel;
+                q: zml.Tensor,
+                k: zml.Tensor,
+                v: zml.Tensor,
+                token_index: zml.Tensor,
+                parameters: Parameters,
+
+                fn body(self: @This(), _: std.mem.Allocator, output: zml.Shape) zml.Tensor {
+                    const kernel = self.parameters.decode_kernel;
                     return zml.ops.neuronNki(
-                        .{ sharded_inputs[0], sharded_inputs[1], sharded_inputs[2], sharded_inputs[3] },
+                        .{ self.q, self.k, self.v, self.token_index },
                         .{output},
                         .{
                             .name = kernel.name,
                             .entrypoint = kernel.entrypoint,
                             .source_path = kernel.source_path,
-                            .compiler_target = context.compiler_target,
+                            .compiler_target = self.parameters.compiler_target,
                         },
                     )[0];
                 }
             }).body,
+            .{
+                .q = q_sharded,
+                .k = k_sharded,
+                .v = v_sharded,
+                .token_index = token_index_2d,
+                .parameters = parameters,
+            },
+            q_sharded.shape(),
         ).convert(q.dtype());
     }
 
     return zml.ops.manualComputation(
-        .{ q_sharded, k_sharded, v_sharded },
-        q_sharded.shape(),
-        parameters,
         (struct {
-            fn body(context: Parameters, _: std.mem.Allocator, sharded_inputs: []const zml.Tensor, output: zml.Shape) zml.Tensor {
-                const kernel = context.prefill_kernel;
+            q: zml.Tensor,
+            k: zml.Tensor,
+            v: zml.Tensor,
+            parameters: Parameters,
+
+            fn body(self: @This(), _: std.mem.Allocator, output: zml.Shape) zml.Tensor {
+                const kernel = self.parameters.prefill_kernel;
                 return zml.ops.neuronNki(
-                    .{ sharded_inputs[0], sharded_inputs[1], sharded_inputs[2] },
+                    .{ self.q, self.k, self.v },
                     .{output},
                     .{
                         .name = kernel.name,
                         .entrypoint = kernel.entrypoint,
                         .source_path = kernel.source_path,
-                        .compiler_target = context.compiler_target,
+                        .compiler_target = self.parameters.compiler_target,
                     },
                 )[0];
             }
         }).body,
+        .{ .q = q_sharded, .k = k_sharded, .v = v_sharded, .parameters = parameters },
+        q_sharded.shape(),
     ).convert(q.dtype());
 }

--- a/zml/attention/nki/attention.zig
+++ b/zml/attention/nki/attention.zig
@@ -1,5 +1,3 @@
-const std = @import("std");
-
 const platforms = @import("platforms");
 
 const zml = @import("../../zml.zig");
@@ -61,7 +59,7 @@ pub fn attention(q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, token_index: zml.T
                 token_index: zml.Tensor,
                 parameters: Parameters,
 
-                fn body(self: @This(), _: std.mem.Allocator, output: zml.Shape) zml.Tensor {
+                fn body(self: @This(), output: zml.Shape) zml.Tensor {
                     const kernel = self.parameters.decode_kernel;
                     return zml.ops.neuronNki(
                         .{ self.q, self.k, self.v, self.token_index },
@@ -93,7 +91,7 @@ pub fn attention(q: zml.Tensor, k: zml.Tensor, v: zml.Tensor, token_index: zml.T
             v: zml.Tensor,
             parameters: Parameters,
 
-            fn body(self: @This(), _: std.mem.Allocator, output: zml.Shape) zml.Tensor {
+            fn body(self: @This(), output: zml.Shape) zml.Tensor {
                 const kernel = self.parameters.prefill_kernel;
                 return zml.ops.neuronNki(
                     .{ self.q, self.k, self.v },

--- a/zml/attention/tpu_attention.zig
+++ b/zml/attention/tpu_attention.zig
@@ -223,34 +223,27 @@ pub const mosaic_tpu = struct {
         const prepared = prepareInputs(parameters, q, kv_cache);
 
         const q_out = zml.ops.manualComputation(
-            .{
-                prepared.q,
-                prepared.kv_pages,
-                prepared.seq_lens,
-                prepared.block_table,
-                prepared.query_start_len,
-                prepared.num_seqs,
-            },
-            prepared.q.shape(),
-            .{
-                .opts = opts,
-                .parameters = parameters,
-            },
             (struct {
-                fn body(body_context: anytype, allocator: std.mem.Allocator, sharded_inputs: []const zml.Tensor, output: zml.Shape) zml.Tensor {
-                    _ = allocator;
-                    stdx.debug.assert(sharded_inputs.len == 6, "mosaic_tpu ragged paged manualComputation expects 6 inputs, got {}", .{sharded_inputs.len});
+                q: zml.Tensor,
+                kv_pages: zml.Tensor,
+                seq_lens: zml.Tensor,
+                block_table: zml.Tensor,
+                query_start_len: zml.Tensor,
+                num_seqs: zml.Tensor,
+                opts: AttentionOptions,
+                parameters: Parameters,
 
+                fn body(self: @This(), _: std.mem.Allocator, output: zml.Shape) zml.Tensor {
                     const prepared_inputs: PreparedInputs = .{
-                        .q = sharded_inputs[0],
-                        .kv_pages = sharded_inputs[1],
-                        .seq_lens = sharded_inputs[2],
-                        .block_table = sharded_inputs[3],
-                        .query_start_len = sharded_inputs[4],
-                        .num_seqs = sharded_inputs[5],
+                        .q = self.q,
+                        .kv_pages = self.kv_pages,
+                        .seq_lens = self.seq_lens,
+                        .block_table = self.block_table,
+                        .query_start_len = self.query_start_len,
+                        .num_seqs = self.num_seqs,
                     };
 
-                    const cfg = buildCfg(prepared_inputs, body_context.parameters, body_context.opts);
+                    const cfg = buildCfg(prepared_inputs, self.parameters, self.opts);
                     const q_out = raggedPagedKernelCall(
                         prepared_inputs.q,
                         prepared_inputs.kv_pages,
@@ -264,6 +257,17 @@ pub const mosaic_tpu = struct {
                     return q_out;
                 }
             }).body,
+            .{
+                .q = prepared.q,
+                .kv_pages = prepared.kv_pages,
+                .seq_lens = prepared.seq_lens,
+                .block_table = prepared.block_table,
+                .query_start_len = prepared.query_start_len,
+                .num_seqs = prepared.num_seqs,
+                .opts = opts,
+                .parameters = parameters,
+            },
+            prepared.q.shape(),
         );
 
         const restored = restoreQueryHeads(q, q_out);

--- a/zml/attention/tpu_attention.zig
+++ b/zml/attention/tpu_attention.zig
@@ -233,7 +233,7 @@ pub const mosaic_tpu = struct {
                 opts: AttentionOptions,
                 parameters: Parameters,
 
-                fn body(self: @This(), _: std.mem.Allocator, output: zml.Shape) zml.Tensor {
+                fn body(self: @This(), output: zml.Shape) zml.Tensor {
                     const prepared_inputs: PreparedInputs = .{
                         .q = self.q,
                         .kv_pages = self.kv_pages,

--- a/zml/attention/triton_attention.zig
+++ b/zml/attention/triton_attention.zig
@@ -351,7 +351,7 @@ pub const paged = struct {
                 opts: AttentionOptions,
                 options: Options,
 
-                fn body(self: @This(), _: std.mem.Allocator, _: zml.Shape) zml.Tensor {
+                fn body(self: @This(), _: zml.Shape) zml.Tensor {
                     const parameters_: Parameters = .{
                         .block_table = self.block_table,
                         .seq_lens = self.seq_lens,
@@ -996,7 +996,7 @@ pub const paged = struct {
                 opts: MlaOptions,
                 options: Options,
 
-                fn body(self: @This(), _: std.mem.Allocator, _: zml.Shape) zml.Tensor {
+                fn body(self: @This(), _: zml.Shape) zml.Tensor {
                     const block_size = self.kv_cache.dim(.k_chunk);
 
                     const parameters_: Parameters = .{

--- a/zml/attention/triton_attention.zig
+++ b/zml/attention/triton_attention.zig
@@ -341,38 +341,36 @@ pub const paged = struct {
 
     pub fn pagedAttention(parameters: Parameters, q: zml.Tensor, k_cache: zml.Tensor, v_cache: zml.Tensor, opts: AttentionOptions) zml.Tensor {
         const output = zml.ops.manualComputation(
-            .{
-                q,
-                k_cache,
-                v_cache,
-                parameters.block_table,
-                parameters.seq_lens,
-                parameters.query_start_len,
-            },
-            q.shape(),
-            .{
-                .opts = opts,
-                .options = parameters.options_,
-            },
             (struct {
-                fn body(ctx_: anytype, _: std.mem.Allocator, sharded_inputs: []const zml.Tensor, _: zml.Shape) zml.Tensor {
-                    const q_ = sharded_inputs[0];
-                    const k_cache_ = sharded_inputs[1];
-                    const v_cache_ = sharded_inputs[2];
-                    const parameters_: Parameters = .{ .block_table = sharded_inputs[3], .seq_lens = sharded_inputs[4], .query_start_len = sharded_inputs[5], .options_ = ctx_.options };
+                q: zml.Tensor,
+                k_cache: zml.Tensor,
+                v_cache: zml.Tensor,
+                block_table: zml.Tensor,
+                seq_lens: zml.Tensor,
+                query_start_len: zml.Tensor,
+                opts: AttentionOptions,
+                options: Options,
+
+                fn body(self: @This(), _: std.mem.Allocator, _: zml.Shape) zml.Tensor {
+                    const parameters_: Parameters = .{
+                        .block_table = self.block_table,
+                        .seq_lens = self.seq_lens,
+                        .query_start_len = self.query_start_len,
+                        .options_ = self.options,
+                    };
 
                     const cu_count = getCuCount();
-                    const num_heads: usize = @intCast(q_.dim(.hkv) * q_.dim(.hg));
-                    const num_kv_heads: usize = @intCast(k_cache_.dim(.hkv));
+                    const num_heads: usize = @intCast(self.q.dim(.hkv) * self.q.dim(.hg));
+                    const num_kv_heads: usize = @intCast(self.k_cache.dim(.hkv));
                     const num_queries_per_kv: usize = num_heads / num_kv_heads;
                     // Intel decode: pack exactly one GQA group per tile (block_q == 1) so the
                     // single decode query token doesn't carry masked-out fp32 acc lanes.
                     // oneAPI decode keeps one GQA group per tile, padded to a power of two so tt.make_range emits legal Triton IR.
-                    const block_m: usize = if (!ctx_.options.is_prefill and isOneapiTarget())
+                    const block_m: usize = if (!self.options.is_prefill and isOneapiTarget())
                         std.math.ceilPowerOfTwoAssert(usize, num_queries_per_kv)
                     else if (num_queries_per_kv <= 16) 16 else std.math.ceilPowerOfTwoAssert(usize, num_queries_per_kv);
                     const block_q: usize = block_m / num_queries_per_kv;
-                    const num_tokens: usize = @intCast(q_.dim(.b));
+                    const num_tokens: usize = @intCast(self.q.dim(.b));
                     const num_seqs: usize = @intCast(parameters_.block_table.dim(.b));
                     const total_q_blocks: usize = num_tokens / block_q + num_seqs;
                     const target_num_prgms: usize = cu_count * 4;
@@ -380,23 +378,23 @@ pub const paged = struct {
 
                     const paged_attention_opts: PagedAttentionOptions = .{
                         .cu_count = getCuCount(),
-                        .all_decode = !ctx_.options.is_prefill,
+                        .all_decode = !self.options.is_prefill,
                         .num_tokens = num_tokens,
                         .num_heads = num_heads,
                         .num_kv_heads = num_kv_heads,
-                        .head_dim = @intCast(q_.dim(.hd)),
+                        .head_dim = @intCast(self.q.dim(.hd)),
                         .batch_size = @intCast(parameters_.block_table.dim(.b)),
-                        .block_size = @intCast(k_cache_.dim(.k_chunk)),
-                        .num_blocks = @intCast(k_cache_.dim(.page)),
+                        .block_size = @intCast(self.k_cache.dim(.k_chunk)),
+                        .num_blocks = @intCast(self.k_cache.dim(.page)),
                         .max_num_block_per_seq = @intCast(parameters_.block_table.dim(.p)),
-                        .sliding_window = if (ctx_.opts.sliding_window < 0) 0 else @intCast(ctx_.opts.sliding_window),
+                        .sliding_window = if (self.opts.sliding_window < 0) 0 else @intCast(self.opts.sliding_window),
                         .block_m = block_m,
                         .block_q = block_q,
                         .total_q_blocks = total_q_blocks,
                         .target_num_prgms = target_num_prgms,
                         .num_2d_prgms = num_2d_prgms,
-                        .max_seqlen_q = ctx_.options.max_seqlen_q,
-                        .scale = ctx_.opts.scale,
+                        .max_seqlen_q = self.options.max_seqlen_q,
+                        .scale = self.opts.scale,
                     };
 
                     const use_2d_kernel = use2dKernel(
@@ -405,15 +403,26 @@ pub const paged = struct {
                         paged_attention_opts.num_kv_heads,
                     );
                     const output = if (use_2d_kernel)
-                        pagedAttention2d(parameters_, q_, k_cache_, v_cache_, ctx_.opts, paged_attention_opts)
+                        pagedAttention2d(parameters_, self.q, self.k_cache, self.v_cache, self.opts, paged_attention_opts)
                     else if (isOneapiTarget())
-                        pagedAttention3dOneapi(parameters_, q_, k_cache_, v_cache_, ctx_.opts, paged_attention_opts)
+                        pagedAttention3dOneapi(parameters_, self.q, self.k_cache, self.v_cache, self.opts, paged_attention_opts)
                     else
-                        pagedAttention3d(parameters_, q_, k_cache_, v_cache_, ctx_.opts, paged_attention_opts);
+                        pagedAttention3d(parameters_, self.q, self.k_cache, self.v_cache, self.opts, paged_attention_opts);
 
                     return output;
                 }
             }).body,
+            .{
+                .q = q,
+                .k_cache = k_cache,
+                .v_cache = v_cache,
+                .block_table = parameters.block_table,
+                .seq_lens = parameters.seq_lens,
+                .query_start_len = parameters.query_start_len,
+                .opts = opts,
+                .options = parameters.options_,
+            },
+            q.shape(),
         );
 
         return output;
@@ -975,64 +984,70 @@ pub const paged = struct {
     pub fn pagedSparseMla(parameters: Parameters, q: zml.Tensor, kv_cache: zml.Tensor, sink: ?zml.Tensor, topk: zml.Tensor, tokens_pos: zml.Tensor, opts: MlaOptions) zml.Tensor {
         const output_shape = q.shape().set(.hd, opts.value_rank);
         return zml.ops.manualComputation(
-            .{
-                q,
-                kv_cache,
-                sink,
-                topk,
-                tokens_pos,
-                parameters.block_table,
-                parameters.seq_lens,
-                parameters.query_start_len,
-            },
-            output_shape,
-            .{
-                .opts = opts,
-                .options = parameters.options_,
-            },
             (struct {
-                fn body(ctx_: anytype, _: std.mem.Allocator, sharded_inputs: []const zml.Tensor, _: zml.Shape) zml.Tensor {
-                    const q_ = sharded_inputs[0];
-                    const kv_cache_ = sharded_inputs[1];
+                q: zml.Tensor,
+                kv_cache: zml.Tensor,
+                sink: ?zml.Tensor,
+                topk: zml.Tensor,
+                tokens_pos: zml.Tensor,
+                block_table: zml.Tensor,
+                seq_lens: zml.Tensor,
+                query_start_len: zml.Tensor,
+                opts: MlaOptions,
+                options: Options,
 
-                    const block_size = kv_cache_.dim(.k_chunk);
+                fn body(self: @This(), _: std.mem.Allocator, _: zml.Shape) zml.Tensor {
+                    const block_size = self.kv_cache.dim(.k_chunk);
 
                     const parameters_: Parameters = .{
-                        .block_table = sharded_inputs[5],
-                        .seq_lens = sharded_inputs[6],
-                        .query_start_len = sharded_inputs[7],
-                        .options_ = ctx_.options,
+                        .block_table = self.block_table,
+                        .seq_lens = self.seq_lens,
+                        .query_start_len = self.query_start_len,
+                        .options_ = self.options,
                     };
 
-                    const topk_final = topkToPhysical(parameters_, sharded_inputs[3], sharded_inputs[4], block_size);
-                    const active_query_count = sharded_inputs[7]
-                        .slice(.b, .{ .start = sharded_inputs[7].dim(.b) - 1 })
+                    const topk_final = topkToPhysical(parameters_, self.topk, self.tokens_pos, block_size);
+                    const active_query_count = self.query_start_len
+                        .slice(.b, .{ .start = self.query_start_len.dim(.b) - 1 })
                         .squeeze(.b);
-                    stdx.debug.assert(topk_final.dim(.q) == q_.dim(.q), "expected topk q dim ({}) to match q dim ({})", .{ topk_final.dim(.q), q_.dim(.q) });
+                    stdx.debug.assert(topk_final.dim(.q) == self.q.dim(.q), "expected topk q dim ({}) to match q dim ({})", .{ topk_final.dim(.q), self.q.dim(.q) });
 
-                    const num_heads: usize = @intCast(q_.dim(.h));
+                    const num_heads: usize = @intCast(self.q.dim(.h));
                     const paged_opts: PagedSparseMlaOptions = .{
-                        .qk_rank = @intCast(q_.dim(.hd)),
-                        .value_rank = @intCast(ctx_.opts.value_rank),
+                        .qk_rank = @intCast(self.q.dim(.hd)),
+                        .value_rank = @intCast(self.opts.value_rank),
                         .num_heads = num_heads,
-                        .block_size = @intCast(kv_cache_.dim(.k_chunk)),
-                        .rope_rank = @intCast(ctx_.opts.rope_rank),
-                        .scale = ctx_.opts.scale,
-                        .total_q_blocks = @intCast(q_.dim(.q)),
-                        .num_kv_splits = ctx_.opts.num_kv_splits,
-                        .all_decode = !ctx_.options.is_prefill,
+                        .block_size = @intCast(self.kv_cache.dim(.k_chunk)),
+                        .rope_rank = @intCast(self.opts.rope_rank),
+                        .scale = self.opts.scale,
+                        .total_q_blocks = @intCast(self.q.dim(.q)),
+                        .num_kv_splits = self.opts.num_kv_splits,
+                        .all_decode = !self.options.is_prefill,
                     };
 
                     return pagedSparseMlaKernel(
-                        q_,
-                        kv_cache_,
-                        sharded_inputs[2],
+                        self.q,
+                        self.kv_cache,
+                        self.sink,
                         topk_final,
                         active_query_count,
                         paged_opts,
                     );
                 }
             }).body,
+            .{
+                .q = q,
+                .kv_cache = kv_cache,
+                .sink = sink,
+                .topk = topk,
+                .tokens_pos = tokens_pos,
+                .block_table = parameters.block_table,
+                .seq_lens = parameters.seq_lens,
+                .query_start_len = parameters.query_start_len,
+                .opts = opts,
+                .options = parameters.options_,
+            },
+            output_shape,
         );
     }
 };

--- a/zml/moe/moe.zig
+++ b/zml/moe/moe.zig
@@ -232,80 +232,94 @@ pub fn forwardMoe(
                 // Also, maybe pass `zml.nn.Linear` directly
                 if (expert_partition.eql(.init(.experts))) {
                     break :b zml.ops.manualComputation(
-                        .{
-                            input,
-                            topk_ids,
-                            topk_weights,
-                            gate_up_weight_unpacked,
-                            down_weight_unpacked,
-                            gate_up.quantization.?.input_scale.?.asMultiplier(),
-                            gate_up.quantization.?.scales,
-                            gate_up.quantization.?.global_scale.?.asMultiplier(),
-                            down.quantization.?.input_scale.?.asMultiplier(),
-                            down.quantization.?.scales,
-                            down.quantization.?.global_scale.?.asMultiplier(),
-                        },
-                        input.shape(),
-                        .{
-                            .activation = runner_options.activation,
-                            .enable_pdl = runner_options.enable_pdl,
-                            .gemm1_tactic = runner_options.gemm1_tactic,
-                            .gemm2_tactic = runner_options.gemm2_tactic,
-                            .workspace_query_device = runner_options.workspace_query_device,
-                        },
                         (struct {
+                            input: zml.Tensor,
+                            topk_ids: zml.Tensor,
+                            topk_weights: zml.Tensor,
+                            gate_up_weight_unpacked: zml.Tensor,
+                            down_weight_unpacked: zml.Tensor,
+                            gate_up_input_scale: zml.Tensor,
+                            gate_up_scales: zml.Tensor,
+                            gate_up_global_scale: zml.Tensor,
+                            down_input_scale: zml.Tensor,
+                            down_scales: zml.Tensor,
+                            down_global_scale: zml.Tensor,
+                            activation: cutlass_flashinfer.Activation,
+                            enable_pdl: bool,
+                            gemm1_tactic: i32,
+                            gemm2_tactic: i32,
+                            workspace_query_device: i32,
+
                             fn body(
-                                ctx: anytype,
+                                self: @This(),
                                 _: std.mem.Allocator,
-                                sharded_inputs: []const zml.Tensor,
                                 _: zml.Shape,
                             ) zml.Tensor {
-                                const local_num_experts = sharded_inputs[3].dim(.expert);
+                                const local_num_experts = self.gate_up_weight_unpacked.dim(.expert);
                                 const partition_id = zml.ops.partitionId().convert(.i32);
                                 const expert_start = partition_id.scale(local_num_experts).convert(.i32);
                                 const expert_end = expert_start.addConstant(local_num_experts);
 
-                                const local_route_mask = sharded_inputs[1]
+                                const local_route_mask = self.topk_ids
                                     .cmp(.GE, expert_start)
-                                    .logical(.AND, sharded_inputs[1].cmp(.LT, expert_end));
+                                    .logical(.AND, self.topk_ids.cmp(.LT, expert_end));
                                 const local_topk_ids = local_route_mask.select(
-                                    sharded_inputs[1].sub(expert_start),
+                                    self.topk_ids.sub(expert_start),
                                     zml.Tensor.scalar(0, .i32),
                                 );
                                 const local_topk_weights = local_route_mask.select(
-                                    sharded_inputs[2],
-                                    zml.Tensor.scalar(0, sharded_inputs[2].dtype()),
+                                    self.topk_weights,
+                                    zml.Tensor.scalar(0, self.topk_weights.dtype()),
                                 );
 
                                 const local_output = cutlass_flashinfer.fusedExpertsNvfp4(
-                                    sharded_inputs[0],
-                                    sharded_inputs[3],
-                                    sharded_inputs[4],
+                                    self.input,
+                                    self.gate_up_weight_unpacked,
+                                    self.down_weight_unpacked,
                                     local_topk_weights,
                                     local_topk_ids,
-                                    sharded_inputs[5],
-                                    sharded_inputs[6],
-                                    sharded_inputs[7],
-                                    sharded_inputs[8],
-                                    sharded_inputs[9],
-                                    sharded_inputs[10],
+                                    self.gate_up_input_scale,
+                                    self.gate_up_scales,
+                                    self.gate_up_global_scale,
+                                    self.down_input_scale,
+                                    self.down_scales,
+                                    self.down_global_scale,
                                     .{
-                                        .workspace_query_device = ctx.workspace_query_device,
-                                        .activation = ctx.activation,
-                                        .enable_pdl = ctx.enable_pdl,
-                                        .gemm1_tactic = ctx.gemm1_tactic,
-                                        .gemm2_tactic = ctx.gemm2_tactic,
+                                        .workspace_query_device = self.workspace_query_device,
+                                        .activation = self.activation,
+                                        .enable_pdl = self.enable_pdl,
+                                        .gemm1_tactic = self.gemm1_tactic,
+                                        .gemm2_tactic = self.gemm2_tactic,
                                     },
                                 ) catch |err| stdx.debug.panic(
                                     "FlashInfer CUTLASS NVFP4 MoE backend failed: {}",
                                     .{err},
                                 );
                                 const local_reshaped = local_output
-                                    .reshape(sharded_inputs[0].shape().dims())
+                                    .reshape(self.input.shape().dims())
                                     .withTags(.{ .b, .s, .d });
                                 return zml.ops.allReduce(local_reshaped, zml.Tensor.add);
                             }
                         }).body,
+                        .{
+                            .input = input,
+                            .topk_ids = topk_ids,
+                            .topk_weights = topk_weights,
+                            .gate_up_weight_unpacked = gate_up_weight_unpacked,
+                            .down_weight_unpacked = down_weight_unpacked,
+                            .gate_up_input_scale = gate_up.quantization.?.input_scale.?.asMultiplier(),
+                            .gate_up_scales = gate_up.quantization.?.scales,
+                            .gate_up_global_scale = gate_up.quantization.?.global_scale.?.asMultiplier(),
+                            .down_input_scale = down.quantization.?.input_scale.?.asMultiplier(),
+                            .down_scales = down.quantization.?.scales,
+                            .down_global_scale = down.quantization.?.global_scale.?.asMultiplier(),
+                            .activation = runner_options.activation,
+                            .enable_pdl = runner_options.enable_pdl,
+                            .gemm1_tactic = runner_options.gemm1_tactic,
+                            .gemm2_tactic = runner_options.gemm2_tactic,
+                            .workspace_query_device = runner_options.workspace_query_device,
+                        },
+                        input.shape(),
                     );
                 }
 
@@ -327,62 +341,76 @@ pub fn forwardMoe(
 
             if (expert_partition.eql(.init(.experts))) {
                 break :b zml.ops.manualComputation(
-                    .{ input, topk_ids, topk_weights, gate_up.weight, down.weight },
-                    input.shape(),
-                    .{
-                        .activation = runner_options.activation,
-                        .enable_pdl = runner_options.enable_pdl,
-                        .gemm1_tactic = runner_options.gemm1_tactic,
-                        .gemm2_tactic = runner_options.gemm2_tactic,
-                        .workspace_query_device = runner_options.workspace_query_device,
-                    },
                     (struct {
+                        input: zml.Tensor,
+                        topk_ids: zml.Tensor,
+                        topk_weights: zml.Tensor,
+                        weights_gate_up: zml.Tensor,
+                        weights_down: zml.Tensor,
+                        activation: cutlass_flashinfer.Activation,
+                        enable_pdl: bool,
+                        gemm1_tactic: i32,
+                        gemm2_tactic: i32,
+                        workspace_query_device: i32,
+
                         fn body(
-                            ctx: anytype,
+                            self: @This(),
                             _: std.mem.Allocator,
-                            sharded_inputs: []const zml.Tensor,
                             _: zml.Shape,
                         ) zml.Tensor {
-                            const local_num_experts = sharded_inputs[3].dim(.expert);
+                            const local_num_experts = self.weights_gate_up.dim(.expert);
                             const partition_id = zml.ops.partitionId().convert(.i32);
                             const expert_start = partition_id.scale(local_num_experts).convert(.i32);
                             const expert_end = expert_start.addConstant(local_num_experts);
 
-                            const local_route_mask = sharded_inputs[1]
+                            const local_route_mask = self.topk_ids
                                 .cmp(.GE, expert_start)
-                                .logical(.AND, sharded_inputs[1].cmp(.LT, expert_end));
+                                .logical(.AND, self.topk_ids.cmp(.LT, expert_end));
                             const local_topk_ids = local_route_mask.select(
-                                sharded_inputs[1].sub(expert_start),
+                                self.topk_ids.sub(expert_start),
                                 zml.Tensor.scalar(0, .i32),
                             );
                             const local_topk_weights = local_route_mask.select(
-                                sharded_inputs[2],
-                                zml.Tensor.scalar(0, sharded_inputs[2].dtype()),
+                                self.topk_weights,
+                                zml.Tensor.scalar(0, self.topk_weights.dtype()),
                             );
 
                             const local_output = cutlass_flashinfer.fusedExpertsBf16(
-                                sharded_inputs[0],
-                                sharded_inputs[3],
-                                sharded_inputs[4],
+                                self.input,
+                                self.weights_gate_up,
+                                self.weights_down,
                                 local_topk_weights,
                                 local_topk_ids,
                                 .{
-                                    .workspace_query_device = ctx.workspace_query_device,
-                                    .activation = ctx.activation,
-                                    .enable_pdl = ctx.enable_pdl,
-                                    .gemm1_tactic = ctx.gemm1_tactic,
-                                    .gemm2_tactic = ctx.gemm2_tactic,
+                                    .workspace_query_device = self.workspace_query_device,
+                                    .activation = self.activation,
+                                    .enable_pdl = self.enable_pdl,
+                                    .gemm1_tactic = self.gemm1_tactic,
+                                    .gemm2_tactic = self.gemm2_tactic,
                                 },
                             ) catch |err| stdx.debug.panic(
                                 "FlashInfer CUTLASS MoE backend failed: {}",
                                 .{err},
                             );
                             const local_reshaped = local_output
-                                .reshape(sharded_inputs[0].shape().dims())
+                                .reshape(self.input.shape().dims())
                                 .withTags(.{ .b, .s, .d });
                             return zml.ops.allReduce(local_reshaped, zml.Tensor.add);
                         }
                     }).body,
+                    .{
+                        .input = input,
+                        .topk_ids = topk_ids,
+                        .topk_weights = topk_weights,
+                        .weights_gate_up = gate_up.weight,
+                        .weights_down = down.weight,
+                        .activation = runner_options.activation,
+                        .enable_pdl = runner_options.enable_pdl,
+                        .gemm1_tactic = runner_options.gemm1_tactic,
+                        .gemm2_tactic = runner_options.gemm2_tactic,
+                        .workspace_query_device = runner_options.workspace_query_device,
+                    },
+                    input.shape(),
                 );
             }
 
@@ -425,28 +453,28 @@ pub fn forwardMoe(
                 );
             }
 
-            const manual_inputs: []const zml.Tensor = if (quant_scheme == .mxfp4)
-                &.{ input, topk_ids, topk_weights, gate_up.weight, down.weight, gate_up_scales.?, down_scales.? }
-            else
-                &.{ input, topk_ids, topk_weights, gate_up.weight, down.weight };
             break :b zml.ops.manualComputation(
-                manual_inputs,
-                input.shape(),
-                .{
-                    .activation = parameters.triton.activation,
-                    .global_num_experts = global_num_experts,
-                    .bias_gate_up = gate_up.bias,
-                    .bias_down = down.bias,
-                    .quant_scheme = quant_scheme,
-                    .activation_threshold = opts.activation_threshold,
-                },
                 (struct {
-                    fn body(ctx: anytype, _: std.mem.Allocator, sharded_inputs: []const zml.Tensor, _: zml.Shape) zml.Tensor {
-                        const local_num_experts = sharded_inputs[3].dim(.expert);
+                    input: zml.Tensor,
+                    topk_ids: zml.Tensor,
+                    topk_weights: zml.Tensor,
+                    weights_gate_up: zml.Tensor,
+                    weights_down: zml.Tensor,
+                    activation: triton.Parameters.ActivationMode,
+                    global_num_experts: i64,
+                    bias_gate_up: ?zml.Tensor,
+                    bias_down: ?zml.Tensor,
+                    quant_scheme: ?zml.Quantization.Scheme,
+                    activation_threshold: ?f32,
+                    scales_gate_up: ?zml.Tensor,
+                    scales_down: ?zml.Tensor,
+
+                    fn call(self: @This(), _: std.mem.Allocator, _: zml.Shape) zml.Tensor {
+                        const local_num_experts = self.weights_gate_up.dim(.expert);
                         const partition_id = zml.ops.partitionId().convert(.i32);
                         const expert_start = partition_id.scale(local_num_experts).convert(.i32);
                         // List of global expert ids
-                        const global_expert_ids = zml.Tensor.arange(.{ .end = ctx.global_num_experts }, .i32).withTags(.{.expert});
+                        const global_expert_ids = zml.Tensor.arange(.{ .end = self.global_num_experts }, .i32).withTags(.{.expert});
 
                         // Mapping of local experts to global expert ids, -1 if the global expert is not present in the local partition
                         const local_expert_mask = global_expert_ids.cmp(.GE, expert_start)
@@ -457,28 +485,44 @@ pub fn forwardMoe(
                         );
 
                         const local_output = triton.fusedExpertsImpl(
-                            sharded_inputs[0],
-                            sharded_inputs[3],
-                            sharded_inputs[4],
-                            sharded_inputs[2],
-                            sharded_inputs[1],
+                            self.input,
+                            self.weights_gate_up,
+                            self.weights_down,
+                            self.topk_weights,
+                            self.topk_ids,
                             .{},
                             .{
-                                .activation = ctx.activation,
-                                .global_num_experts = ctx.global_num_experts,
+                                .activation = self.activation,
+                                .global_num_experts = self.global_num_experts,
                                 .expert_map = expert_map,
-                                .w1_scale = if (ctx.quant_scheme == .mxfp4) sharded_inputs[5] else null,
-                                .w2_scale = if (ctx.quant_scheme == .mxfp4) sharded_inputs[6] else null,
-                                .w1_bias = ctx.bias_gate_up,
-                                .w2_bias = ctx.bias_down,
-                                .quant_scheme = ctx.quant_scheme,
-                                .activation_threshold = ctx.activation_threshold,
+                                .w1_scale = self.scales_gate_up,
+                                .w2_scale = self.scales_down,
+                                .w1_bias = self.bias_gate_up,
+                                .w2_bias = self.bias_down,
+                                .quant_scheme = self.quant_scheme,
+                                .activation_threshold = self.activation_threshold,
                             },
                         ) catch |err| stdx.debug.panic("moe backend failed: {}", .{err});
-                        const local_reshaped = local_output.reshape(sharded_inputs[0].shape().dims()).withTags(.{ .b, .s, .d });
+                        const local_reshaped = local_output.reshape(self.input.shape().dims()).withTags(.{ .b, .s, .d });
                         return zml.ops.allReduce(local_reshaped, zml.Tensor.add);
                     }
-                }).body,
+                }).call,
+                .{
+                    .input = input,
+                    .topk_ids = topk_ids,
+                    .topk_weights = topk_weights,
+                    .weights_gate_up = gate_up.weight,
+                    .weights_down = down.weight,
+                    .activation = parameters.triton.activation,
+                    .global_num_experts = global_num_experts,
+                    .bias_gate_up = gate_up.bias,
+                    .bias_down = down.bias,
+                    .quant_scheme = quant_scheme,
+                    .activation_threshold = opts.activation_threshold,
+                    .scales_gate_up = gate_up_scales,
+                    .scales_down = down_scales,
+                },
+                input.shape(),
             );
         },
         .mosaic_tpu => b: {
@@ -492,22 +536,24 @@ pub fn forwardMoe(
             if (expert_partition.eql(.init(.experts))) {
                 const global_num_experts = down.weight.dim(.expert);
                 const partial_output = zml.ops.manualComputation(
-                    .{ input, topk_ids, topk_weights, gate_up.weight, down.weight },
-                    input.shape(),
-                    .{
-                        .activation = parameters.mosaic_tpu.activation,
-                        .global_num_experts = global_num_experts,
-                        .gate_up_scales = gate_up_scales,
-                        .bias_gate_up = gate_up.bias,
-                        .down_scales = down_scales,
-                        .bias_down = down.bias,
-                    },
                     (struct {
-                        fn body(ctx: anytype, _: std.mem.Allocator, sharded_inputs: []const zml.Tensor, _: zml.Shape) zml.Tensor {
-                            const local_num_experts = sharded_inputs[3].dim(.expert);
+                        input: zml.Tensor,
+                        topk_ids: zml.Tensor,
+                        topk_weights: zml.Tensor,
+                        weights_gate_up: zml.Tensor,
+                        weights_down: zml.Tensor,
+                        activation: mosaic_tpu.ActivationMode,
+                        global_num_experts: i64,
+                        gate_up_scales: ?zml.Tensor,
+                        bias_gate_up: ?zml.Tensor,
+                        down_scales: ?zml.Tensor,
+                        bias_down: ?zml.Tensor,
+
+                        fn body(self: @This(), _: std.mem.Allocator, _: zml.Shape) zml.Tensor {
+                            const local_num_experts = self.weights_gate_up.dim(.expert);
                             const partition_id = zml.ops.partitionId().convert(.i32);
                             const expert_start = partition_id.scale(local_num_experts).convert(.i32);
-                            const global_expert_ids = zml.Tensor.arange(.{ .end = ctx.global_num_experts }, .i32).withTags(.{.expert});
+                            const global_expert_ids = zml.Tensor.arange(.{ .end = self.global_num_experts }, .i32).withTags(.{.expert});
 
                             const local_expert_mask = global_expert_ids.cmp(.GE, expert_start)
                                 .logical(.AND, global_expert_ids.cmp(.LT, expert_start.addConstant(local_num_experts)));
@@ -516,25 +562,39 @@ pub fn forwardMoe(
                                 zml.Tensor.scalar(-1, .i32),
                             );
                             const local_output = mosaic_tpu.fusedExpertsImpl(
-                                sharded_inputs[0],
-                                sharded_inputs[3],
-                                sharded_inputs[4],
-                                sharded_inputs[2],
-                                sharded_inputs[1],
+                                self.input,
+                                self.weights_gate_up,
+                                self.weights_down,
+                                self.topk_weights,
+                                self.topk_ids,
                                 .{},
                                 .{
-                                    .activation = ctx.activation,
-                                    .global_num_experts = ctx.global_num_experts,
+                                    .activation = self.activation,
+                                    .global_num_experts = self.global_num_experts,
                                     .expert_map = expert_map,
-                                    .w1_scale = ctx.gate_up_scales,
-                                    .w2_scale = ctx.down_scales,
-                                    .w1_bias = ctx.bias_gate_up,
-                                    .w2_bias = ctx.bias_down,
+                                    .w1_scale = self.gate_up_scales,
+                                    .w2_scale = self.down_scales,
+                                    .w1_bias = self.bias_gate_up,
+                                    .w2_bias = self.bias_down,
                                 },
                             ) catch |err| stdx.debug.panic("moe backend failed: {}", .{err});
-                            return local_output.reshape(sharded_inputs[0].shape().dims()).withTags(.{ .b, .s, .d });
+                            return local_output.reshape(self.input.shape().dims()).withTags(.{ .b, .s, .d });
                         }
                     }).body,
+                    .{
+                        .input = input,
+                        .topk_ids = topk_ids,
+                        .topk_weights = topk_weights,
+                        .weights_gate_up = gate_up.weight,
+                        .weights_down = down.weight,
+                        .activation = parameters.mosaic_tpu.activation,
+                        .global_num_experts = global_num_experts,
+                        .gate_up_scales = gate_up_scales,
+                        .bias_gate_up = gate_up.bias,
+                        .down_scales = down_scales,
+                        .bias_down = down.bias,
+                    },
+                    input.shape(),
                 );
                 break :b zml.ops.allReduce(partial_output, zml.Tensor.add);
             }

--- a/zml/moe/moe.zig
+++ b/zml/moe/moe.zig
@@ -252,7 +252,6 @@ pub fn forwardMoe(
 
                             fn body(
                                 self: @This(),
-                                _: std.mem.Allocator,
                                 _: zml.Shape,
                             ) zml.Tensor {
                                 const local_num_experts = self.gate_up_weight_unpacked.dim(.expert);
@@ -355,7 +354,6 @@ pub fn forwardMoe(
 
                         fn body(
                             self: @This(),
-                            _: std.mem.Allocator,
                             _: zml.Shape,
                         ) zml.Tensor {
                             const local_num_experts = self.weights_gate_up.dim(.expert);
@@ -469,7 +467,7 @@ pub fn forwardMoe(
                     scales_gate_up: ?zml.Tensor,
                     scales_down: ?zml.Tensor,
 
-                    fn call(self: @This(), _: std.mem.Allocator, _: zml.Shape) zml.Tensor {
+                    fn call(self: @This(), _: zml.Shape) zml.Tensor {
                         const local_num_experts = self.weights_gate_up.dim(.expert);
                         const partition_id = zml.ops.partitionId().convert(.i32);
                         const expert_start = partition_id.scale(local_num_experts).convert(.i32);
@@ -549,7 +547,7 @@ pub fn forwardMoe(
                         down_scales: ?zml.Tensor,
                         bias_down: ?zml.Tensor,
 
-                        fn body(self: @This(), _: std.mem.Allocator, _: zml.Shape) zml.Tensor {
+                        fn body(self: @This(), _: zml.Shape) zml.Tensor {
                             const local_num_experts = self.weights_gate_up.dim(.expert);
                             const partition_id = zml.ops.partitionId().convert(.i32);
                             const expert_start = partition_id.scale(local_num_experts).convert(.i32);

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -1968,7 +1968,7 @@ fn manualComputationInternal(
     comptime body_fn: anytype,
 ) error{OutOfMemory}![]Tensor {
     const BodyReturnT = manualComputationReturnType(body_fn);
-    const BodyOutputShapesT = stdx.meta.FnParam(body_fn, 2);
+    const BodyOutputShapesT = stdx.meta.FnParam(body_fn, 1);
 
     const ctx = Compiler.current();
     const scope = ctx.currentScope();
@@ -2037,7 +2037,7 @@ fn manualComputationInternal(
 
             const local_inputs = manualComputationLocalizeInputs(allocator, inputs, local_input_tensors);
             const body_output_shapes = manualComputationOutputShapesArg(BodyOutputShapesT, local_output_shapes);
-            const body_result = @call(.auto, body_fn, .{ local_inputs, arena, body_output_shapes });
+            const body_result = @call(.auto, body_fn, .{ local_inputs, body_output_shapes });
             const local_outputs = manualComputationBodyToSlice(BodyReturnT, arena, body_result);
             stdx.debug.assert(local_outputs.len == outputs.len, "manualComputation body returned {} values, expected {}", .{ local_outputs.len, outputs.len });
 
@@ -2108,7 +2108,7 @@ fn manualComputationInternal(
             defer ctx.manual_computation_depth -= 1;
             const local_inputs = manualComputationLocalizeInputs(allocator, inputs, local_input_tensors);
             const body_output_shapes = manualComputationOutputShapesArg(BodyOutputShapesT, local_output_shapes);
-            const body_result = @call(.auto, body_fn, .{ local_inputs, arena, body_output_shapes });
+            const body_result = @call(.auto, body_fn, .{ local_inputs, body_output_shapes });
             const local_outputs = manualComputationBodyToSlice(BodyReturnT, arena, body_result);
             stdx.debug.assert(local_outputs.len == outputs.len, "manualComputation body returned {} values, expected {}", .{ local_outputs.len, outputs.len });
             for (0..outputs.len) |i| {
@@ -2174,22 +2174,21 @@ test "manualComputation handler API" {
     const lhs = Tensor.constant(DataType.f32.constant(1)).broad(shape);
     const rhs = Tensor.constant(DataType.f32.constant(2)).broad(shape);
 
-    const WithAllocator = struct {
+    const Configured = struct {
         lhs: Tensor,
         bias: ?Tensor,
         missing_bias: ?Tensor,
         enabled: bool,
         rhs: Tensor,
 
-        pub fn compute(self: @This(), allocator: std.mem.Allocator, output_shape: Shape) Tensor {
-            _ = allocator;
+        pub fn compute(self: @This(), output_shape: Shape) Tensor {
             stdx.debug.assert(self.enabled, "manualComputation did not preserve handler configuration", .{});
             stdx.debug.assert(self.missing_bias == null, "manualComputation did not preserve a null optional tensor", .{});
             return self.lhs.add(self.rhs).add(self.bias.?).reshape(output_shape);
         }
     };
-    const with_allocator = manualComputation(
-        WithAllocator.compute,
+    const configured = manualComputation(
+        Configured.compute,
         .{
             .lhs = lhs,
             .bias = rhs,
@@ -2199,20 +2198,20 @@ test "manualComputation handler API" {
         },
         shape,
     );
-    try zml.testing.expectEqualShapes(shape, with_allocator.shape());
+    try zml.testing.expectEqualShapes(shape, configured.shape());
 
-    const without_allocator = manualComputation(
+    const passthrough = manualComputation(
         (struct {
             input: Tensor,
 
-            pub fn call(self: @This(), _: std.mem.Allocator, output_shape: Shape) Tensor {
+            pub fn call(self: @This(), output_shape: Shape) Tensor {
                 return self.input.reshape(output_shape);
             }
         }).call,
-        .{ .input = with_allocator },
+        .{ .input = configured },
         shape,
     );
-    try zml.testing.expectEqualShapes(shape, without_allocator.shape());
+    try zml.testing.expectEqualShapes(shape, passthrough.shape());
 
     const NestedInputs = struct {
         pair: [2]Tensor,
@@ -2232,7 +2231,7 @@ test "manualComputation handler API" {
         slice_inputs: []const Tensor,
         original_values: [5]usize,
 
-        pub fn compute(self: @This(), _: std.mem.Allocator, output_shape: Shape) Tensor {
+        pub fn compute(self: @This(), output_shape: Shape) Tensor {
             const localized_inputs = [_]Tensor{
                 self.nested_inputs.pair[0],
                 self.nested_inputs.pair[1],
@@ -2500,7 +2499,7 @@ pub fn shardingAwareTypedCustomCall(
         input: Input,
         attributes: Attributes,
 
-        fn body(self: @This(), _: std.mem.Allocator, sharded_output_shapes: []const Shape) []const Tensor {
+        fn body(self: @This(), sharded_output_shapes: []const Shape) []const Tensor {
             return typedCustomCall(target_name, opts, self.input, sharded_output_shapes, self.attributes);
         }
     };

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -2264,263 +2264,6 @@ test "manualComputation handler API" {
     try zml.testing.expectEqualShapes(shape, nested.shape());
 }
 
-pub fn manualComputationLegacy(
-    inputs: anytype,
-    outputs: anytype,
-    body_context: anytype,
-    comptime body_fn: anytype,
-) manualComputationReturnType(body_fn) {
-    const inputs_: []const Tensor = switch (@typeInfo(@TypeOf(inputs))) {
-        .@"struct" => |struct_info| b: {
-            if (@TypeOf(inputs) == Tensor) {
-                break :b &[1]Tensor{inputs};
-            }
-            if (!struct_info.is_tuple) @compileError("Expected tuple inputs");
-            var inputs_flat: [struct_info.fields.len]Tensor = undefined;
-            meta.collectBuf((struct {
-                pub fn func(t: Tensor) Tensor {
-                    return t;
-                }
-            }).func, {}, &inputs, &inputs_flat);
-            break :b &inputs_flat;
-        },
-        .array => &inputs,
-        .pointer => |pointer_info| b: {
-            if (pointer_info.size != .slice) @compileError("Expected input slice");
-            break :b inputs;
-        },
-        else => @compileError("Unsupported manualComputation input type: " ++ @typeName(@TypeOf(inputs))),
-    };
-
-    const output_shapes: []const Shape = switch (@typeInfo(@TypeOf(outputs))) {
-        .void => &.{},
-        .@"struct" => |struct_info| b: {
-            if (@TypeOf(outputs) == Shape) {
-                break :b &[1]Shape{outputs};
-            }
-            if (!struct_info.is_tuple) @compileError("Expected tuple output shapes");
-            var output_shapes_flat: [struct_info.fields.len]Shape = undefined;
-            meta.collectBuf((struct {
-                pub fn func(t: Shape) Shape {
-                    return t;
-                }
-            }).func, {}, &outputs, &output_shapes_flat);
-            break :b &output_shapes_flat;
-        },
-        .array => &outputs,
-        .pointer => |pointer_info| b: {
-            if (pointer_info.size != .slice) @compileError("Expected output shape slice");
-            break :b outputs;
-        },
-        else => @compileError("Unsupported manualComputation output type: " ++ @typeName(@TypeOf(outputs))),
-    };
-
-    const sharded_outputs: []const Tensor = manualComputationInternalLegacy(inputs_, output_shapes, body_context, body_fn) catch |err| switch (err) {
-        error.OutOfMemory => @panic("OOM"),
-    };
-    const ReturnT = manualComputationReturnType(body_fn);
-    return manualComputationSliceToReturn(ReturnT, sharded_outputs);
-}
-
-fn manualComputationInternalLegacy(
-    inputs: []const Tensor,
-    outputs: []const Shape,
-    body_context: anytype,
-    comptime body_fn: anytype,
-) error{OutOfMemory}![]Tensor {
-    const BodyReturnT = manualComputationReturnType(body_fn);
-    const BodyInputsT = stdx.meta.FnParam(body_fn, 2);
-    const BodyOutputShapesT = stdx.meta.FnParam(body_fn, 3);
-
-    const ctx = Compiler.current();
-    const scope = ctx.currentScope();
-
-    var arena_state: std.heap.ArenaAllocator = .init(std.heap.page_allocator);
-    defer arena_state.deinit();
-    const arena = arena_state.allocator();
-
-    const input_shapes = try arena.alloc(Shape, inputs.len);
-    const input_values = try arena.alloc(*const mlir.Value, inputs.len);
-
-    for (inputs, 0..) |input, i| {
-        input_shapes[i] = input.shape();
-        input_values[i] = input.value();
-    }
-    const local_input_shapes = try arena.alloc(Shape, inputs.len);
-    const local_output_shapes = try arena.alloc(Shape, outputs.len);
-    const input_shardings = try arena.alloc(Sharding, inputs.len);
-    const output_shardings = try arena.alloc(Sharding, outputs.len);
-
-    for (input_shapes, 0..) |shape, i| {
-        const sharding = ctx.partitioning.selectSharding(shape) catch |err| switch (err) {
-            error.NoSuitableSharding => std.debug.panic(
-                "failed to shard manualComputation input {f}({d}) because it's using unknown sharding. Pass more shardings to `.compile`. Known shardings: {f}",
-                .{ shape, i, stdx.fmt.slice(ctx.partitioning.shardings) },
-            ),
-        };
-        input_shardings[i] = sharding;
-        local_input_shapes[i] = sharding.shardedShape(shape) catch std.debug.panic("can't shard {f} for {f}", .{ shape, sharding });
-    }
-    for (outputs, 0..) |shape, i| {
-        const sharding = ctx.partitioning.selectSharding(shape) catch |err| switch (err) {
-            error.NoSuitableSharding => std.debug.panic(
-                "failed to shard manualComputation output {f}({d}) because it's using unknown sharding. Pass more shardings to `.compile`. Known shardings: {f}",
-                .{ shape, i, stdx.fmt.slice(ctx.partitioning.shardings) },
-            ),
-        };
-        output_shardings[i] = sharding;
-        local_output_shapes[i] = sharding.shardedShape(shape) catch std.debug.panic("can't shard {f} for {f}", .{ shape, sharding });
-    }
-
-    return switch (ctx.partitioning.partitioner) {
-        .shardy => {
-            const in_shardings_attr = try Sharding.sdyPerValueShardingAttr(arena, ctx.mlir_ctx, input_shapes, input_shardings);
-            const out_shardings_attr = try Sharding.sdyPerValueShardingAttr(arena, ctx.mlir_ctx, outputs, output_shardings);
-            const manual_axes_attr = try Sharding.sdyManualAxesAttr(arena, ctx.mlir_ctx, input_shapes, input_shardings, outputs, output_shardings);
-
-            const block_types = try arena.alloc(*const mlir.Type, inputs.len);
-            for (local_input_shapes, 0..) |input_shape, i| {
-                block_types[i] = mlirx.Type.rankedTensor(ctx.mlir_ctx, input_shape);
-            }
-            const block_locs = try arena.alloc(*const mlir.Location, inputs.len);
-            @memset(block_locs, mlir.Location.unknown(ctx.mlir_ctx));
-
-            const manual_block = mlir.Block.init(block_types, block_locs);
-            errdefer manual_block.deinit();
-
-            const manual_scope = ctx.pushBlock(manual_block);
-            defer manual_scope.pop();
-
-            const local_inputs = try arena.alloc(Tensor, inputs.len);
-            for (0..inputs.len) |i| {
-                local_inputs[i] = Tensor._result(local_input_shapes[i], manual_block.argument(i));
-            }
-
-            ctx.manual_computation_depth += 1;
-            defer ctx.manual_computation_depth -= 1;
-
-            const body_inputs = manualComputationInputsArg(BodyInputsT, local_inputs);
-            const body_output_shapes = manualComputationOutputShapesArg(BodyOutputShapesT, local_output_shapes);
-            const body_result = @call(.auto, body_fn, .{ body_context, arena, body_inputs, body_output_shapes });
-            const local_outputs = manualComputationBodyToSlice(BodyReturnT, arena, body_result);
-            stdx.debug.assert(local_outputs.len == outputs.len, "manualComputation body returned {} values, expected {}", .{ local_outputs.len, outputs.len });
-
-            const local_output_values = try arena.alloc(*const mlir.Value, outputs.len);
-            for (0..outputs.len) |i| {
-                stdx.debug.assert(local_outputs[i].shape().eql(local_output_shapes[i]), "manualComputation body returned shape {f}, expected {f}", .{ local_outputs[i].shape(), local_output_shapes[i] });
-                local_output_values[i] = local_outputs[i].value();
-            }
-
-            _ = mlir.Operation.make(ctx.mlir_ctx, "sdy.return", .{
-                .operands = .{ .flat = local_output_values },
-                .verify = false,
-                .location = .unknown(ctx.mlir_ctx),
-            }).appendTo(manual_block);
-
-            const global_result_types = try arena.alloc(*const mlir.Type, outputs.len);
-            for (outputs, 0..) |output_shape, i| {
-                global_result_types[i] = mlirx.Type.rankedTensor(ctx.mlir_ctx, output_shape);
-            }
-
-            const op = mlir.Operation.make(ctx.mlir_ctx, "sdy.manual_computation", .{
-                .operands = .{ .flat = input_values },
-                .results = .{ .flat = global_result_types },
-                .blocks = &.{manual_block},
-                .attributes = &.{
-                    .named(ctx.mlir_ctx, "in_shardings", in_shardings_attr),
-                    .named(ctx.mlir_ctx, "out_shardings", out_shardings_attr),
-                    .named(ctx.mlir_ctx, "manual_axes", manual_axes_attr),
-                },
-                .verify = true,
-                .location = .unknown(ctx.mlir_ctx),
-            }).appendTo(scope.block);
-
-            // Use the compiler allocator to return memory to the parent
-            const sharded_outputs = ctx.alloc(Tensor, outputs.len);
-            for (outputs, 0..) |output, i| {
-                sharded_outputs[i] = Tensor._result(output, op.result(i));
-            }
-            return sharded_outputs;
-        },
-        .gspmd => {
-            const local_input_values = try arena.alloc(*const mlir.Value, inputs.len);
-            for (0..inputs.len) |i| {
-                const local_type = mlirx.Type.rankedTensor(ctx.mlir_ctx, local_input_shapes[i]);
-                const full_to_shard = dialects.stablehlo.custom_call(
-                    ctx.mlir_ctx,
-                    &.{input_values[i]},
-                    &.{local_type},
-                    .{
-                        .call_target_name = "SPMDFullToShardShape",
-                        .has_side_effect = false,
-                        .backend_config = .{ .original = "" },
-                        .additional_attributes = &.{
-                            .named(ctx.mlir_ctx, "mhlo.sharding", .string(ctx.mlir_ctx, "{manual}")),
-                        },
-                    },
-                    .unknown(ctx.mlir_ctx),
-                ).appendTo(scope.block);
-                local_input_values[i] = full_to_shard.result(0);
-            }
-
-            const local_inputs = try arena.alloc(Tensor, inputs.len);
-            for (0..inputs.len) |i| {
-                local_inputs[i] = Tensor._result(local_input_shapes[i], local_input_values[i]);
-            }
-
-            ctx.manual_computation_depth += 1;
-            defer ctx.manual_computation_depth -= 1;
-            const body_inputs = manualComputationInputsArg(BodyInputsT, local_inputs);
-            const body_output_shapes = manualComputationOutputShapesArg(BodyOutputShapesT, local_output_shapes);
-            const body_result = @call(.auto, body_fn, .{ body_context, arena, body_inputs, body_output_shapes });
-            const local_outputs = manualComputationBodyToSlice(BodyReturnT, arena, body_result);
-            stdx.debug.assert(local_outputs.len == outputs.len, "manualComputation body returned {} values, expected {}", .{ local_outputs.len, outputs.len });
-            for (0..outputs.len) |i| {
-                stdx.debug.assert(local_outputs[i].shape().eql(local_output_shapes[i]), "manualComputation body returned shape {f}, expected {f}", .{ local_outputs[i].shape(), local_output_shapes[i] });
-            }
-
-            // Skip optimization barrier for custom call that don't return values
-            if (outputs.len == 0) return &.{};
-
-            const global_values = try arena.alloc(*const mlir.Value, outputs.len);
-            const global_types = try arena.alloc(*const mlir.Type, outputs.len);
-            for (outputs, output_shardings, 0..) |output_shape, output_sharding, i| {
-                const gspmd_attr = try ctx.partitioning.tensorShardingAttr(arena, ctx.mlir_ctx, output_shape, output_sharding);
-
-                global_types[i] = mlirx.Type.rankedTensor(ctx.mlir_ctx, output_shape);
-                const shard_to_full = dialects.stablehlo.custom_call(
-                    ctx.mlir_ctx,
-                    &.{local_outputs[i].value()},
-                    &.{global_types[i]},
-                    .{
-                        .call_target_name = "SPMDShardToFullShape",
-                        .has_side_effect = false,
-                        .backend_config = .{ .original = "" },
-                        .additional_attributes = &.{
-                            .named(ctx.mlir_ctx, "mhlo.sharding", gspmd_attr),
-                        },
-                    },
-                    .unknown(ctx.mlir_ctx),
-                ).appendTo(scope.block);
-                global_values[i] = shard_to_full.result(0);
-            }
-
-            const barrier = dialects.stablehlo.optimizationBarrier(
-                ctx.mlir_ctx,
-                global_values,
-                global_types,
-                .unknown(ctx.mlir_ctx),
-            ).appendTo(scope.block);
-
-            const sharded_outputs = ctx.alloc(Tensor, outputs.len);
-            for (outputs, 0..) |output_shape, i| {
-                sharded_outputs[i] = Tensor._result(output_shape, barrier.result(i));
-            }
-            return sharded_outputs;
-        },
-    };
-}
-
 fn manualComputationReturnType(comptime body_fn: anytype) type {
     const ReturnT = stdx.meta.FnReturn(body_fn);
     if (ReturnT == void or ReturnT == Tensor) return ReturnT;
@@ -2545,30 +2288,6 @@ fn manualComputationBodyToSlice(comptime ReturnT: type, allocator: std.mem.Alloc
     }
 
     return result;
-}
-
-fn manualComputationInputsArg(comptime InputsT: type, local_inputs: []const Tensor) InputsT {
-    if (InputsT == void) {
-        stdx.debug.assert(local_inputs.len == 0, "manualComputation body expects no inputs, got {}", .{local_inputs.len});
-        return;
-    }
-    if (InputsT == Tensor) {
-        stdx.debug.assert(local_inputs.len == 1, "manualComputation body expects one input, got {}", .{local_inputs.len});
-        return local_inputs[0];
-    }
-
-    return switch (@typeInfo(InputsT)) {
-        .pointer => |pointer_info| b: {
-            if (pointer_info.size != .slice or pointer_info.child != Tensor) {
-                @compileError("manualComputation body inputs must be void, Tensor, []Tensor, or []const Tensor; got " ++ @typeName(InputsT));
-            }
-            break :b if (pointer_info.is_const)
-                local_inputs
-            else
-                @constCast(local_inputs);
-        },
-        else => @compileError("manualComputation body inputs must be void, Tensor, []Tensor, or []const Tensor; got " ++ @typeName(InputsT)),
-    };
 }
 
 fn manualComputationOutputShapesArg(comptime OutputShapesT: type, local_output_shapes: []const Shape) OutputShapesT {
@@ -2772,22 +2491,24 @@ pub fn shardingAwareTypedCustomCall(
     const Output = @TypeOf(output);
     const Attributes = @TypeOf(attributes);
 
-    // Convert to slices so that manualComputationInternalLegacy can inspect the input/output.
-    var input_tensors: [@typeInfo(Input).@"struct".fields.len]Tensor = undefined;
-    inline for (@typeInfo(Input).@"struct".fields, 0..) |field, i| {
-        input_tensors[i] = @field(input, field.name);
-    }
-
     var output_shapes: [@typeInfo(Output).@"struct".fields.len]Shape = undefined;
     inline for (@typeInfo(Output).@"struct".fields, 0..) |field, i| {
         output_shapes[i] = @field(output, field.name);
     }
 
-    const output_tensors: []const Tensor = manualComputationInternalLegacy(&input_tensors, &output_shapes, attributes, (struct {
-        fn body(attributes_: Attributes, _: std.mem.Allocator, sharded_input_tensors: []const Tensor, sharded_output_shapes: []const Shape) []const Tensor {
-            return typedCustomCall(target_name, opts, sharded_input_tensors, sharded_output_shapes, attributes_);
+    const Handler = struct {
+        input: Input,
+        attributes: Attributes,
+
+        fn body(self: @This(), _: std.mem.Allocator, sharded_output_shapes: []const Shape) []const Tensor {
+            return typedCustomCall(target_name, opts, self.input, sharded_output_shapes, self.attributes);
         }
-    }).body) catch @panic("OOM");
+    };
+    const output_tensors = manualComputation(
+        Handler.body,
+        .{ .input = input, .attributes = attributes },
+        @as([]const Shape, &output_shapes),
+    );
 
     // Convert the slice back to a struct
     var out: ShapeToTensor(Output) = undefined;

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -1943,7 +1943,7 @@ pub fn manualComputation(
     return manualComputationSliceToReturn(ReturnT, sharded_outputs);
 }
 
-fn manualComputationLocalizeInputs(allocator: std.mem.Allocator, inputs: anytype, local_tensors: []const Tensor) @TypeOf(inputs) {
+fn manualComputationLocalizeInputs(allocator: std.mem.Allocator, inputs: anytype, local_tensors: []const Tensor) !@TypeOf(inputs) {
     const Context = struct {
         local_tensors: []const Tensor,
         input_idx: usize = 0,
@@ -1957,7 +1957,7 @@ fn manualComputationLocalizeInputs(allocator: std.mem.Allocator, inputs: anytype
 
     var context: Context = .{ .local_tensors = local_tensors };
     var local_inputs: @TypeOf(inputs) = undefined;
-    meta.mapAlloc(Context.localize, allocator, &context, inputs, &local_inputs) catch unreachable;
+    try meta.mapAlloc(Context.localize, allocator, &context, inputs, &local_inputs);
     stdx.debug.assert(context.input_idx == local_tensors.len, "manualComputation localized {} inputs, expected {}", .{ context.input_idx, local_tensors.len });
     return local_inputs;
 }
@@ -1977,10 +1977,8 @@ fn manualComputationInternal(
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const allocator = ctx.arena.allocator();
-
-    const input_shapes = meta.collectAlloc(Tensor.shape, {}, allocator, &inputs) catch unreachable;
-    const input_values = meta.collectAlloc(Tensor.value, {}, allocator, &inputs) catch unreachable;
+    const input_shapes = try meta.collectAlloc(Tensor.shape, {}, arena, &inputs);
+    const input_values = try meta.collectAlloc(Tensor.value, {}, arena, &inputs);
 
     const local_input_shapes = try arena.alloc(Shape, input_shapes.len);
     const local_output_shapes = try arena.alloc(Shape, outputs.len);
@@ -2035,7 +2033,7 @@ fn manualComputationInternal(
             ctx.manual_computation_depth += 1;
             defer ctx.manual_computation_depth -= 1;
 
-            const local_inputs = manualComputationLocalizeInputs(allocator, inputs, local_input_tensors);
+            const local_inputs = try manualComputationLocalizeInputs(arena, inputs, local_input_tensors);
             const body_output_shapes = manualComputationOutputShapesArg(BodyOutputShapesT, local_output_shapes);
             const body_result = @call(.auto, body_fn, .{ local_inputs, body_output_shapes });
             const local_outputs = manualComputationBodyToSlice(BodyReturnT, arena, body_result);
@@ -2106,7 +2104,7 @@ fn manualComputationInternal(
 
             ctx.manual_computation_depth += 1;
             defer ctx.manual_computation_depth -= 1;
-            const local_inputs = manualComputationLocalizeInputs(allocator, inputs, local_input_tensors);
+            const local_inputs = try manualComputationLocalizeInputs(arena, inputs, local_input_tensors);
             const body_output_shapes = manualComputationOutputShapesArg(BodyOutputShapesT, local_output_shapes);
             const body_result = @call(.auto, body_fn, .{ local_inputs, body_output_shapes });
             const local_outputs = manualComputationBodyToSlice(BodyReturnT, arena, body_result);

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -1909,6 +1909,362 @@ pub fn customCall(target_name: [:0]const u8, inputs: anytype, outputs: anytype, 
 }
 
 pub fn manualComputation(
+    comptime body_fn: anytype,
+    inputs: stdx.meta.FnParam(body_fn, 0),
+    outputs: anytype,
+) manualComputationReturnType(body_fn) {
+    const output_shapes: []const Shape = switch (@typeInfo(@TypeOf(outputs))) {
+        .void => &.{},
+        .@"struct" => |struct_info| b: {
+            if (@TypeOf(outputs) == Shape) {
+                break :b &[1]Shape{outputs};
+            }
+            if (!struct_info.is_tuple) @compileError("Expected tuple output shapes");
+            var output_shapes_flat: [struct_info.fields.len]Shape = undefined;
+            meta.collectBuf((struct {
+                pub fn func(t: Shape) Shape {
+                    return t;
+                }
+            }).func, {}, &outputs, &output_shapes_flat);
+            break :b &output_shapes_flat;
+        },
+        .array => &outputs,
+        .pointer => |pointer_info| b: {
+            if (pointer_info.size != .slice) @compileError("Expected output shape slice");
+            break :b outputs;
+        },
+        else => @compileError("Unsupported manualComputation output type: " ++ @typeName(@TypeOf(outputs))),
+    };
+
+    const sharded_outputs: []const Tensor = manualComputationInternal(inputs, output_shapes, body_fn) catch |err| switch (err) {
+        error.OutOfMemory => @panic("OOM"),
+    };
+    const ReturnT = manualComputationReturnType(body_fn);
+    return manualComputationSliceToReturn(ReturnT, sharded_outputs);
+}
+
+fn manualComputationLocalizeInputs(allocator: std.mem.Allocator, inputs: anytype, local_tensors: []const Tensor) @TypeOf(inputs) {
+    const Context = struct {
+        local_tensors: []const Tensor,
+        input_idx: usize = 0,
+
+        fn localize(self: *@This(), _: Tensor) Tensor {
+            stdx.debug.assert(self.input_idx < self.local_tensors.len, "manualComputation ran out of localized inputs", .{});
+            defer self.input_idx += 1;
+            return self.local_tensors[self.input_idx];
+        }
+    };
+
+    var context: Context = .{ .local_tensors = local_tensors };
+    var local_inputs: @TypeOf(inputs) = undefined;
+    meta.mapAlloc(Context.localize, allocator, &context, inputs, &local_inputs) catch unreachable;
+    stdx.debug.assert(context.input_idx == local_tensors.len, "manualComputation localized {} inputs, expected {}", .{ context.input_idx, local_tensors.len });
+    return local_inputs;
+}
+
+fn manualComputationInternal(
+    inputs: anytype,
+    outputs: []const Shape,
+    comptime body_fn: anytype,
+) error{OutOfMemory}![]Tensor {
+    const BodyReturnT = manualComputationReturnType(body_fn);
+    const BodyOutputShapesT = stdx.meta.FnParam(body_fn, 2);
+
+    const ctx = Compiler.current();
+    const scope = ctx.currentScope();
+
+    var arena_state: std.heap.ArenaAllocator = .init(std.heap.page_allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const allocator = ctx.arena.allocator();
+
+    const input_shapes = meta.collectAlloc(Tensor.shape, {}, allocator, &inputs) catch unreachable;
+    const input_values = meta.collectAlloc(Tensor.value, {}, allocator, &inputs) catch unreachable;
+
+    const local_input_shapes = try arena.alloc(Shape, input_shapes.len);
+    const local_output_shapes = try arena.alloc(Shape, outputs.len);
+    const input_shardings = try arena.alloc(Sharding, input_shapes.len);
+    const output_shardings = try arena.alloc(Sharding, outputs.len);
+
+    for (input_shapes, 0..) |shape, i| {
+        const sharding = ctx.partitioning.selectSharding(shape) catch |err| switch (err) {
+            error.NoSuitableSharding => std.debug.panic(
+                "failed to shard manualComputation input {f}({d}) because it's using unknown sharding. Pass more shardings to `.compile`. Known shardings: {f}",
+                .{ shape, i, stdx.fmt.slice(ctx.partitioning.shardings) },
+            ),
+        };
+        input_shardings[i] = sharding;
+        local_input_shapes[i] = sharding.shardedShape(shape) catch std.debug.panic("can't shard {f} for {f}", .{ shape, sharding });
+    }
+    for (outputs, 0..) |shape, i| {
+        const sharding = ctx.partitioning.selectSharding(shape) catch |err| switch (err) {
+            error.NoSuitableSharding => std.debug.panic(
+                "failed to shard manualComputation output {f}({d}) because it's using unknown sharding. Pass more shardings to `.compile`. Known shardings: {f}",
+                .{ shape, i, stdx.fmt.slice(ctx.partitioning.shardings) },
+            ),
+        };
+        output_shardings[i] = sharding;
+        local_output_shapes[i] = sharding.shardedShape(shape) catch std.debug.panic("can't shard {f} for {f}", .{ shape, sharding });
+    }
+
+    return switch (ctx.partitioning.partitioner) {
+        .shardy => {
+            const in_shardings_attr = try Sharding.sdyPerValueShardingAttr(arena, ctx.mlir_ctx, input_shapes, input_shardings);
+            const out_shardings_attr = try Sharding.sdyPerValueShardingAttr(arena, ctx.mlir_ctx, outputs, output_shardings);
+            const manual_axes_attr = try Sharding.sdyManualAxesAttr(arena, ctx.mlir_ctx, input_shapes, input_shardings, outputs, output_shardings);
+
+            const block_types = try arena.alloc(*const mlir.Type, input_shapes.len);
+            for (local_input_shapes, 0..) |input_shape, i| {
+                block_types[i] = mlirx.Type.rankedTensor(ctx.mlir_ctx, input_shape);
+            }
+            const block_locs = try arena.alloc(*const mlir.Location, input_shapes.len);
+            @memset(block_locs, mlir.Location.unknown(ctx.mlir_ctx));
+
+            const manual_block = mlir.Block.init(block_types, block_locs);
+            errdefer manual_block.deinit();
+
+            const manual_scope = ctx.pushBlock(manual_block);
+            defer manual_scope.pop();
+
+            const local_input_tensors = try arena.alloc(Tensor, input_shapes.len);
+            for (0..input_shapes.len) |i| {
+                local_input_tensors[i] = Tensor._result(local_input_shapes[i], manual_block.argument(i));
+            }
+
+            ctx.manual_computation_depth += 1;
+            defer ctx.manual_computation_depth -= 1;
+
+            const local_inputs = manualComputationLocalizeInputs(allocator, inputs, local_input_tensors);
+            const body_output_shapes = manualComputationOutputShapesArg(BodyOutputShapesT, local_output_shapes);
+            const body_result = @call(.auto, body_fn, .{ local_inputs, arena, body_output_shapes });
+            const local_outputs = manualComputationBodyToSlice(BodyReturnT, arena, body_result);
+            stdx.debug.assert(local_outputs.len == outputs.len, "manualComputation body returned {} values, expected {}", .{ local_outputs.len, outputs.len });
+
+            const local_output_values = try arena.alloc(*const mlir.Value, outputs.len);
+            for (0..outputs.len) |i| {
+                stdx.debug.assert(local_outputs[i].shape().eql(local_output_shapes[i]), "manualComputation body returned shape {f}, expected {f}", .{ local_outputs[i].shape(), local_output_shapes[i] });
+                local_output_values[i] = local_outputs[i].value();
+            }
+
+            _ = mlir.Operation.make(ctx.mlir_ctx, "sdy.return", .{
+                .operands = .{ .flat = local_output_values },
+                .verify = false,
+                .location = .unknown(ctx.mlir_ctx),
+            }).appendTo(manual_block);
+
+            const global_result_types = try arena.alloc(*const mlir.Type, outputs.len);
+            for (outputs, 0..) |output_shape, i| {
+                global_result_types[i] = mlirx.Type.rankedTensor(ctx.mlir_ctx, output_shape);
+            }
+
+            const op = mlir.Operation.make(ctx.mlir_ctx, "sdy.manual_computation", .{
+                .operands = .{ .flat = input_values },
+                .results = .{ .flat = global_result_types },
+                .blocks = &.{manual_block},
+                .attributes = &.{
+                    .named(ctx.mlir_ctx, "in_shardings", in_shardings_attr),
+                    .named(ctx.mlir_ctx, "out_shardings", out_shardings_attr),
+                    .named(ctx.mlir_ctx, "manual_axes", manual_axes_attr),
+                },
+                .verify = true,
+                .location = .unknown(ctx.mlir_ctx),
+            }).appendTo(scope.block);
+
+            // Use the compiler allocator to return memory to the parent
+            const sharded_outputs = ctx.alloc(Tensor, outputs.len);
+            for (outputs, 0..) |output, i| {
+                sharded_outputs[i] = Tensor._result(output, op.result(i));
+            }
+            return sharded_outputs;
+        },
+        .gspmd => {
+            const local_input_values = try arena.alloc(*const mlir.Value, input_shapes.len);
+            for (0..input_shapes.len) |i| {
+                const local_type = mlirx.Type.rankedTensor(ctx.mlir_ctx, local_input_shapes[i]);
+                const full_to_shard = dialects.stablehlo.custom_call(
+                    ctx.mlir_ctx,
+                    &.{input_values[i]},
+                    &.{local_type},
+                    .{
+                        .call_target_name = "SPMDFullToShardShape",
+                        .has_side_effect = false,
+                        .backend_config = .{ .original = "" },
+                        .additional_attributes = &.{
+                            .named(ctx.mlir_ctx, "mhlo.sharding", .string(ctx.mlir_ctx, "{manual}")),
+                        },
+                    },
+                    .unknown(ctx.mlir_ctx),
+                ).appendTo(scope.block);
+                local_input_values[i] = full_to_shard.result(0);
+            }
+
+            const local_input_tensors = try arena.alloc(Tensor, input_shapes.len);
+            for (0..input_shapes.len) |i| {
+                local_input_tensors[i] = Tensor._result(local_input_shapes[i], local_input_values[i]);
+            }
+
+            ctx.manual_computation_depth += 1;
+            defer ctx.manual_computation_depth -= 1;
+            const local_inputs = manualComputationLocalizeInputs(allocator, inputs, local_input_tensors);
+            const body_output_shapes = manualComputationOutputShapesArg(BodyOutputShapesT, local_output_shapes);
+            const body_result = @call(.auto, body_fn, .{ local_inputs, arena, body_output_shapes });
+            const local_outputs = manualComputationBodyToSlice(BodyReturnT, arena, body_result);
+            stdx.debug.assert(local_outputs.len == outputs.len, "manualComputation body returned {} values, expected {}", .{ local_outputs.len, outputs.len });
+            for (0..outputs.len) |i| {
+                stdx.debug.assert(local_outputs[i].shape().eql(local_output_shapes[i]), "manualComputation body returned shape {f}, expected {f}", .{ local_outputs[i].shape(), local_output_shapes[i] });
+            }
+
+            // Skip optimization barrier for custom call that don't return values
+            if (outputs.len == 0) return &.{};
+
+            const global_values = try arena.alloc(*const mlir.Value, outputs.len);
+            const global_types = try arena.alloc(*const mlir.Type, outputs.len);
+            for (outputs, output_shardings, 0..) |output_shape, output_sharding, i| {
+                const gspmd_attr = try ctx.partitioning.tensorShardingAttr(arena, ctx.mlir_ctx, output_shape, output_sharding);
+
+                global_types[i] = mlirx.Type.rankedTensor(ctx.mlir_ctx, output_shape);
+                const shard_to_full = dialects.stablehlo.custom_call(
+                    ctx.mlir_ctx,
+                    &.{local_outputs[i].value()},
+                    &.{global_types[i]},
+                    .{
+                        .call_target_name = "SPMDShardToFullShape",
+                        .has_side_effect = false,
+                        .backend_config = .{ .original = "" },
+                        .additional_attributes = &.{
+                            .named(ctx.mlir_ctx, "mhlo.sharding", gspmd_attr),
+                        },
+                    },
+                    .unknown(ctx.mlir_ctx),
+                ).appendTo(scope.block);
+                global_values[i] = shard_to_full.result(0);
+            }
+
+            const barrier = dialects.stablehlo.optimizationBarrier(
+                ctx.mlir_ctx,
+                global_values,
+                global_types,
+                .unknown(ctx.mlir_ctx),
+            ).appendTo(scope.block);
+
+            const sharded_outputs = ctx.alloc(Tensor, outputs.len);
+            for (outputs, 0..) |output_shape, i| {
+                sharded_outputs[i] = Tensor._result(output_shape, barrier.result(i));
+            }
+            return sharded_outputs;
+        },
+    };
+}
+
+test "manualComputation handler API" {
+    const zml = @import("zml.zig");
+    const platform = zml.testing.env();
+
+    var comp: zml.Compiler = .init(std.testing.allocator, std.testing.io, platform, .{});
+    defer comp.deinit();
+    comp.activate();
+    defer comp.deactivate();
+
+    const block = mlir.Block.init(&.{}, &.{});
+    const scope = comp.pushBlock(block);
+    defer scope.pop();
+
+    const shape = Shape.init(.{8}, .f32);
+    const lhs = Tensor.constant(DataType.f32.constant(1)).broad(shape);
+    const rhs = Tensor.constant(DataType.f32.constant(2)).broad(shape);
+
+    const WithAllocator = struct {
+        lhs: Tensor,
+        bias: ?Tensor,
+        missing_bias: ?Tensor,
+        enabled: bool,
+        rhs: Tensor,
+
+        pub fn compute(self: @This(), allocator: std.mem.Allocator, output_shape: Shape) Tensor {
+            _ = allocator;
+            stdx.debug.assert(self.enabled, "manualComputation did not preserve handler configuration", .{});
+            stdx.debug.assert(self.missing_bias == null, "manualComputation did not preserve a null optional tensor", .{});
+            return self.lhs.add(self.rhs).add(self.bias.?).reshape(output_shape);
+        }
+    };
+    const with_allocator = manualComputation(
+        WithAllocator.compute,
+        .{
+            .lhs = lhs,
+            .bias = rhs,
+            .missing_bias = null,
+            .enabled = true,
+            .rhs = rhs,
+        },
+        shape,
+    );
+    try zml.testing.expectEqualShapes(shape, with_allocator.shape());
+
+    const without_allocator = manualComputation(
+        (struct {
+            input: Tensor,
+
+            pub fn call(self: @This(), _: std.mem.Allocator, output_shape: Shape) Tensor {
+                return self.input.reshape(output_shape);
+            }
+        }).call,
+        .{ .input = with_allocator },
+        shape,
+    );
+    try zml.testing.expectEqualShapes(shape, without_allocator.shape());
+
+    const NestedInputs = struct {
+        pair: [2]Tensor,
+        optional: ?struct { tensor: Tensor },
+    };
+    const slice_inputs = [_]Tensor{ lhs, rhs };
+    const original_values = [_]usize{
+        @intFromPtr(lhs.value()),
+        @intFromPtr(rhs.value()),
+        @intFromPtr(lhs.value()),
+        @intFromPtr(lhs.value()),
+        @intFromPtr(rhs.value()),
+    };
+
+    const NestedStruct = struct {
+        nested_inputs: NestedInputs,
+        slice_inputs: []const Tensor,
+        original_values: [5]usize,
+
+        pub fn compute(self: @This(), _: std.mem.Allocator, output_shape: Shape) Tensor {
+            const localized_inputs = [_]Tensor{
+                self.nested_inputs.pair[0],
+                self.nested_inputs.pair[1],
+                self.nested_inputs.optional.?.tensor,
+                self.slice_inputs[0],
+                self.slice_inputs[1],
+            };
+            for (localized_inputs, self.original_values) |input, original_value| {
+                stdx.debug.assert(@intFromPtr(input.value()) != original_value, "manualComputation did not localize a nested input", .{});
+            }
+
+            var result = localized_inputs[0];
+            for (localized_inputs[1..]) |input| result = result.add(input);
+            return result.reshape(output_shape);
+        }
+    };
+    const nested = manualComputation(
+        NestedStruct.compute,
+        .{
+            .nested_inputs = .{
+                .pair = .{ lhs, rhs },
+                .optional = .{ .tensor = lhs },
+            },
+            .slice_inputs = &slice_inputs,
+            .original_values = original_values,
+        },
+        shape,
+    );
+    try zml.testing.expectEqualShapes(shape, nested.shape());
+}
+
+pub fn manualComputationLegacy(
     inputs: anytype,
     outputs: anytype,
     body_context: anytype,
@@ -1959,14 +2315,14 @@ pub fn manualComputation(
         else => @compileError("Unsupported manualComputation output type: " ++ @typeName(@TypeOf(outputs))),
     };
 
-    const sharded_outputs: []const Tensor = manualComputationInternal(inputs_, output_shapes, body_context, body_fn) catch |err| switch (err) {
+    const sharded_outputs: []const Tensor = manualComputationInternalLegacy(inputs_, output_shapes, body_context, body_fn) catch |err| switch (err) {
         error.OutOfMemory => @panic("OOM"),
     };
     const ReturnT = manualComputationReturnType(body_fn);
     return manualComputationSliceToReturn(ReturnT, sharded_outputs);
 }
 
-fn manualComputationInternal(
+fn manualComputationInternalLegacy(
     inputs: []const Tensor,
     outputs: []const Shape,
     body_context: anytype,
@@ -2416,7 +2772,7 @@ pub fn shardingAwareTypedCustomCall(
     const Output = @TypeOf(output);
     const Attributes = @TypeOf(attributes);
 
-    // Convert to slices so that manualComputationInternal can inspect the input/output.
+    // Convert to slices so that manualComputationInternalLegacy can inspect the input/output.
     var input_tensors: [@typeInfo(Input).@"struct".fields.len]Tensor = undefined;
     inline for (@typeInfo(Input).@"struct".fields, 0..) |field, i| {
         input_tensors[i] = @field(input, field.name);
@@ -2427,7 +2783,7 @@ pub fn shardingAwareTypedCustomCall(
         output_shapes[i] = @field(output, field.name);
     }
 
-    const output_tensors: []const Tensor = manualComputationInternal(&input_tensors, &output_shapes, attributes, (struct {
+    const output_tensors: []const Tensor = manualComputationInternalLegacy(&input_tensors, &output_shapes, attributes, (struct {
         fn body(attributes_: Attributes, _: std.mem.Allocator, sharded_input_tensors: []const Tensor, sharded_output_shapes: []const Shape) []const Tensor {
             return typedCustomCall(target_name, opts, sharded_input_tensors, sharded_output_shapes, attributes_);
         }

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -4594,7 +4594,7 @@ pub const Tensor = struct {
                     input: Tensor,
                     name: []const u8,
 
-                    fn body(body_ctx: @This(), _: std.mem.Allocator, _: void) void {
+                    fn body(body_ctx: @This(), _: void) void {
                         ops.customCall("zml$print", body_ctx.input, {}, .{ .name = body_ctx.name }, .{ .has_side_effect = true });
                     }
                 }).body, .{ .input = input, .name = full_name }, {});

--- a/zml/tensor.zig
+++ b/zml/tensor.zig
@@ -4590,11 +4590,14 @@ pub const Tensor = struct {
         defer ctx.arena.allocator().free(full_name);
         switch (ctx.platform.target) {
             .cpu, .cuda, .rocm, .tpu, .metal => {
-                ops.manualComputation(input, {}, full_name, (struct {
-                    fn body(_full_name: []const u8, _: std.mem.Allocator, sharded_input: Tensor, _: void) void {
-                        ops.customCall("zml$print", sharded_input, {}, .{ .name = _full_name }, .{ .has_side_effect = true });
+                ops.manualComputation((struct {
+                    input: Tensor,
+                    name: []const u8,
+
+                    fn body(body_ctx: @This(), _: std.mem.Allocator, _: void) void {
+                        ops.customCall("zml$print", body_ctx.input, {}, .{ .name = body_ctx.name }, .{ .has_side_effect = true });
                     }
-                }).body);
+                }).body, .{ .input = input, .name = full_name }, {});
             },
             .oneapi, .neuron => {},
         }


### PR DESCRIPTION
Simplify `manualComputation` by merging `inputs` and `body_context` into a single `input` argument.
Internally, collect all and shard all tensors (including `?Tensor`) from `input` before invoking
the body function.