### PR TITLE
zml/safetensors: close model discovery handles

### DIFF
--- a/examples/llm/main.zig
+++ b/examples/llm/main.zig
@@ -103,6 +103,7 @@ pub fn main(init: std.process.Init) !void {
     //
     log.info("Resolving model repository..", .{});
     const repo = try zml.safetensors.resolveModelRepo(io, args.model);
+    defer repo.close(io);
 
     log.info("Initializing model..", .{});
     var registry: zml.safetensors.TensorRegistry = try .fromRepo(allocator, io, repo);

--- a/examples/llm/models/lfm2_tests.zig
+++ b/examples/llm/models/lfm2_tests.zig
@@ -37,6 +37,7 @@ pub fn main(init: std.process.Init) !void {
     defer platform.deinit(allocator, io);
 
     const repo = try zml.safetensors.resolveModelRepo(io, args.model);
+    defer repo.close(io);
     var registry: zml.safetensors.TensorRegistry = try .fromRepo(allocator, io, repo);
     defer registry.deinit();
     var store: zml.io.TensorStore = .fromRegistry(allocator, &registry);

--- a/examples/llm/models/llama_tests.zig
+++ b/examples/llm/models/llama_tests.zig
@@ -35,6 +35,7 @@ pub fn main(init: std.process.Init) !void {
     defer platform.deinit(allocator, io);
 
     const repo = try zml.safetensors.resolveModelRepo(io, args.model);
+    defer repo.close(io);
     var registry: zml.safetensors.TensorRegistry = try .fromRepo(allocator, io, repo);
     defer registry.deinit();
     var store: zml.io.TensorStore = .fromRegistry(allocator, &registry);

--- a/zml/safetensors.zig
+++ b/zml/safetensors.zig
@@ -285,6 +285,7 @@ pub const TensorRegistry = struct {
         repo: std.Io.Dir,
     ) !TensorRegistry {
         const entrypoint = try resolveModelEntrypoint(io, repo);
+        defer entrypoint.close(io);
         return try fetchRegistry(allocator, io, repo, entrypoint);
     }
 
@@ -294,15 +295,16 @@ pub const TensorRegistry = struct {
         path: []const u8,
     ) !TensorRegistry {
         var repo = try resolveModelRepo(io, path);
+        defer repo.close(io);
 
-        if (std.mem.endsWith(u8, path, ".safetensors.index.json") or
+        const entrypoint = if (std.mem.endsWith(u8, path, ".safetensors.index.json") or
             std.mem.endsWith(u8, path, ".safetensors"))
-        {
-            return try fetchRegistry(allocator, io, repo, try repo.openFile(io, path, .{ .mode = .read_only }));
-        } else {
-            const entrypoint = try resolveModelEntrypoint(io, repo);
-            return try fetchRegistry(allocator, io, repo, entrypoint);
-        }
+            try repo.openFile(io, path, .{ .mode = .read_only })
+        else
+            try resolveModelEntrypoint(io, repo);
+        defer entrypoint.close(io);
+
+        return try fetchRegistry(allocator, io, repo, entrypoint);
     }
 
     pub fn deinit(self: *TensorRegistry) void {


### PR DESCRIPTION
Model discovery leaves its safetensors entrypoint and repository handles open after building the tensor registry, including when parsing fails.

Close handles owned by `fromRepo` and `fromPath`, and close repositories at the existing `fromRepo` call sites.