### PR TITLE
ci: prevent RunOn runner stealing

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -3,7 +3,7 @@ images:
     platform: "linux"
     arch: "amd64"
     ami: "ami-04a92520784b93e73"
-    disk: large
+    volume: 80gb
     preinstall: |
       #!/bin/bash
       wget https://github.com/jbdalido/bazel-remote/releases/download/test/bazel-remote -O /usr/local/bin/bzlcache

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -3,7 +3,6 @@ images:
     platform: "linux"
     arch: "amd64"
     ami: "ami-04a92520784b93e73"
-    volume: 80gb
     preinstall: |
       #!/bin/bash
       wget https://github.com/jbdalido/bazel-remote/releases/download/test/bazel-remote -O /usr/local/bin/bzlcache

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,7 @@ jobs:
               - runner=16cpu-linux-x64
               - family=c8+c7
               - image=ubuntu24-amd64
+              - volume=80gb
               - extras=s3-cache
           - target: neuron
             bazel_opts: "--@zml//platforms:neuron=true --@zml//platforms:cpu=false"
@@ -37,6 +38,7 @@ jobs:
               - runner=16cpu-linux-x64
               - family=c8+c7
               - image=ubuntu24-amd64
+              - volume=80gb
               - extras=s3-cache
           - target: tpu
             bazel_opts: "--@zml//platforms:tpu=true --@zml//platforms:cpu=false"
@@ -47,6 +49,7 @@ jobs:
               - runner=16cpu-linux-x64
               - family=c8+c7
               - image=ubuntu24-amd64
+              - volume=80gb
               - extras=s3-cache
           - target: cuda
             bazel_opts: "--@zml//platforms:cuda=true --@zml//platforms:cpu=false"
@@ -98,6 +101,7 @@ jobs:
       - runs-on=${{ github.run_id }}-${{ github.run_attempt }}-lint
       - runner=4cpu-linux-x64
       - image=ubuntu24-amd64
+      - volume=80gb
       - extras=s3-cache
     steps:
       - uses: runs-on/action@v2.1.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,33 +23,30 @@ jobs:
             self_hosted: false
             run_tests: true
             runner_labels:
-              - runs-on
+              - runs-on=${{ github.run_id }}-${{ github.run_attempt }}-ci-cpu
               - runner=16cpu-linux-x64
               - family=c8+c7
               - image=ubuntu24-amd64
-              - run-id=${{ github.run_id }}
               - extras=s3-cache
           - target: neuron
             bazel_opts: "--@zml//platforms:neuron=true --@zml//platforms:cpu=false"
             self_hosted: false
             run_tests: false
             runner_labels:
-              - runs-on
+              - runs-on=${{ github.run_id }}-${{ github.run_attempt }}-ci-neuron
               - runner=16cpu-linux-x64
               - family=c8+c7
               - image=ubuntu24-amd64
-              - run-id=${{ github.run_id }}
               - extras=s3-cache
           - target: tpu
             bazel_opts: "--@zml//platforms:tpu=true --@zml//platforms:cpu=false"
             self_hosted: false
             run_tests: false
             runner_labels:
-              - runs-on
+              - runs-on=${{ github.run_id }}-${{ github.run_attempt }}-ci-tpu
               - runner=16cpu-linux-x64
               - family=c8+c7
               - image=ubuntu24-amd64
-              - run-id=${{ github.run_id }}
               - extras=s3-cache
           - target: cuda
             bazel_opts: "--@zml//platforms:cuda=true --@zml//platforms:cpu=false"
@@ -98,13 +95,10 @@ jobs:
 
   lint:
     runs-on:
-      [
-        "runs-on",
-        "runner=4cpu-linux-x64",
-        "image=ubuntu24-amd64",
-        "run-id=${{ github.run_id }}",
-        "extras=s3-cache",
-      ]
+      - runs-on=${{ github.run_id }}-${{ github.run_attempt }}-lint
+      - runner=4cpu-linux-x64
+      - image=ubuntu24-amd64
+      - extras=s3-cache
     steps:
       - uses: runs-on/action@v2.1.0
       - name: Checkout


### PR DESCRIPTION
Give each concurrent RunsOn job a unique routing label using the workflow run ID, run attempt, and job name. This prevents runners provisioned for one matrix job from being assigned to another compatible job.
- [Runner stealing](https://runs-on.com/docs/maintenance/troubleshooting/#runner-stealing)

---

Replace the deprecated image-level `disk: large` setting with `volume=80gb` on each RunsOn job. Storage belongs to the runner configuration rather than the custom image definition.
- [RunsOn storage labels](https://runs-on.com/docs/runners/labels/#disk)
- [Custom runners and images](https://runs-on.com/docs/runners/custom/)