### PR TITLE
examples/llm: project only final LFM2 prefill token

### DIFF
--- a/examples/llm/models/lfm2/inference.zig
+++ b/examples/llm/models/lfm2/inference.zig
@@ -96,11 +96,69 @@ pub const CompiledModel = struct {
 
 pub const Inference = CompiledModel;
 
+const SamplingHead = struct {
+    pub const Input = struct {
+        lm_head: model.LmHead,
+        embed_tokens: model.TokenEmbedding,
+        hidden: zml.Tensor,
+        tokens: zml.Tensor,
+        actual_seq_len: zml.Tensor,
+        rng: zml.Tensor.Rng,
+        phase: Phase,
+    };
+
+    pub fn forward(input: Input) model.LmHead.Output {
+        if (input.phase == .decode) {
+            return model.LmHead.forward(.{
+                .lm_head = input.lm_head,
+                .embed_tokens = input.embed_tokens,
+                .hidden = input.hidden,
+                .tokens = input.tokens,
+                .rng = input.rng,
+            });
+        }
+
+        const normalized = input.lm_head.embedding_norm.forward(input.hidden);
+        const last_index = input.actual_seq_len.subConstant(1);
+        const last_hidden = normalized.slice(.seq, .dyn(last_index, 1));
+        const logits = input.embed_tokens.unembed(last_hidden);
+        const strategy = input.lm_head.sampling_strategy;
+        if (strategy.topk <= 1) {
+            const next_token = logits.argMax(.voc).indices.squeeze(.voc);
+            const tokens = input.tokens.dynamicUpdateSlice(
+                .{ .seq = last_index },
+                next_token.convert(input.tokens.dtype()),
+            ).reuseBuffer(input.tokens);
+            return .{ .tokens = tokens, .rng = input.rng };
+        }
+
+        const topk = logits.topK(.{ .topk = .voc }, strategy.topk, .{});
+        var scores = topk.values;
+        if (strategy.temperature != 1.0) {
+            scores = scores.scale(1 / strategy.temperature);
+        }
+
+        // The old prefill sampled every compiled position. Generate the same
+        // amount of noise, then select the last valid row, so the selected
+        // noise and returned RNG state remain unchanged.
+        const full_noise_shape = scores.shape().setDim(.seq, input.tokens.dim(.seq));
+        const new_rng, const full_noise = input.rng.gumbel(full_noise_shape);
+        const noise = full_noise.slice(.seq, .dyn(last_index, 1));
+        const topk_index = scores.add(noise).argMax(.topk).indices.squeeze(.topk);
+        const next_token = topk.indices.gather(.{ .topk = topk_index }, .{});
+        const tokens = input.tokens.dynamicUpdateSlice(
+            .{ .seq = last_index },
+            next_token.convert(input.tokens.dtype()),
+        ).reuseBuffer(input.tokens);
+        return .{ .tokens = tokens, .rng = new_rng };
+    }
+};
+
 pub const KernelExe = struct {
     embed: zml.FnExe(model.TokenEmbedding.forward),
     conv: zml.FnExe(model.DecoderLayer.forward),
     self_attn: zml.FnExe(model.DecoderLayer.forward),
-    sample: zml.FnExe(model.LmHead.forward),
+    sample: zml.FnExe(SamplingHead.forward),
 
     pub fn deinit(self: *const KernelExe) void {
         self.embed.deinit();
@@ -113,7 +171,7 @@ pub const KernelExe = struct {
 pub const KernelRunner = struct {
     embed: zml.FnExe(model.TokenEmbedding.forward).Runner(.{.embedding}),
     layers: []zml.FnExe(model.DecoderLayer.forward).Runner(.{.layer}),
-    sample: zml.FnExe(model.LmHead.forward).Runner(.{ .lm_head, .embed_tokens }),
+    sample: zml.FnExe(SamplingHead.forward).Runner(.{ .lm_head, .embed_tokens }),
 
     pub fn init(allocator: std.mem.Allocator, exe: *const KernelExe, buffers: *const model.Buffers) !KernelRunner {
         var embed = try zml.FnExe(model.TokenEmbedding.forward).Runner(.{.embedding}).init(&exe.embed, allocator, .{ .embedding = buffers.embed_tokens });
@@ -132,7 +190,7 @@ pub const KernelRunner = struct {
             initialized_layers += 1;
         }
 
-        var sample = try zml.FnExe(model.LmHead.forward).Runner(.{ .lm_head, .embed_tokens }).init(&exe.sample, allocator, .{
+        var sample = try zml.FnExe(SamplingHead.forward).Runner(.{ .lm_head, .embed_tokens }).init(&exe.sample, allocator, .{
             .lm_head = buffers.lm_head,
             .embed_tokens = buffers.embed_tokens,
         });
@@ -188,6 +246,7 @@ pub fn run(
         .inputs = .{
             .hidden = hidden_buffer,
             .tokens = args.tokens_buf.*,
+            .actual_seq_len = args.actual_seq_len_buf.*,
             .rng = args.rng_buf.*,
         },
         .outputs = .{
@@ -298,14 +357,14 @@ fn compileSample(
     seqlen: u32,
     phase: Phase,
     progress: *std.Progress.Node,
-) !zml.FnExe(model.LmHead.forward) {
+) !zml.FnExe(SamplingHead.forward) {
     progress.increaseEstimatedTotalItems(1);
     var node = progress.start(phase.startMessage("lm_head"), 1);
     defer node.end();
     const from: std.Io.Timestamp = .now(io, .awake);
     defer phase.logCompileDone(log, "lm_head", io, from);
 
-    return zml.FnExe(model.LmHead.forward).compile(allocator, io, platform, .{
+    return zml.FnExe(SamplingHead.forward).compile(allocator, io, platform, .{
         .shardings = &opts.shardings.all(),
         .program_name = phase.programName("lfm2", "lm_head"),
     }, .{.{
@@ -313,6 +372,8 @@ fn compileSample(
         .embed_tokens = mdl.embed_tokens,
         .hidden = zml.Tensor.init(.{ .batch = opts.batch_dim, .seq = seqlen, .d = opts.hidden_dim }, mdl.embed_tokens.weight.dtype()),
         .tokens = zml.Tensor.init(.{ .batch = opts.batch_dim, .seq = seqlen }, .u32),
+        .actual_seq_len = zml.Tensor.init(.{}, .u32),
         .rng = opts.rng,
+        .phase = phase,
     }});
 }


### PR DESCRIPTION
LFM2 prefill projected every compiled sequence position through the vocabulary head, although generation uses only the last valid prompt position. This change projects and samples only `actual_seq_len - 1`. Decode is unchanged, including top-k RNG advancement.

Validated with `LiquidAI/LFM2.5-1.2B-Instruct` in bf16 on an RTX 4090 using PJRT CUDA and FlashAttention 2. Greedy and top-k runs at compiled lengths 128, 512, and 2048 produced identical selected tokens, RNG states, and next 8 tokens.

Median prefill latency with a 66-token prompt and top-k 4:

- 128: 6.13 ms to 5.79 ms, 5.6% faster
- 512: 10.77 ms to 9.69 ms, 10.0% faster
- 2048: 35.74 ms to 30.17 ms, 15.6% faster

At length 2048, median LM-head time fell from 5.78 ms to 0.41 ms.

This may also help other supported and future models. I considered a reusable module, but each model connects sampling, token-buffer updates, and prefill/decode differently, so applying the optimization within each model's inference path is simpler.
