### PR TITLE
attention/flashattn: fix sliding window off-by-one error

### DIFF
--- a/zml/attention/flashattn.zig
+++ b/zml/attention/flashattn.zig
@@ -900,6 +900,7 @@ pub const paged_fa2 = struct {
         stdx.debug.assert(k_cache.shape().hasTags(.{ .page, .k_chunk, .hkv, .hd }), "Expected paged_k to have tags .page, .k_chunk, .h, .hd, got {}", .{k_cache.shape()});
         stdx.debug.assert(v_cache.shape().hasTags(.{ .page, .k_chunk, .hkv, .hd }), "Expected paged_v to have tags .page, .k_chunk, .h, .hd. got {}", .{v_cache.shape()});
         const ctx = zml.Compiler.current();
+        const window_size_left = windowSizeLeft(opts.sliding_window);
 
         const num_head_groups = q.dim(.hg);
         const num_kv_heads = q.dim(.hkv);
@@ -965,7 +966,7 @@ pub const paged_fa2 = struct {
                             .is_causal = opts.is_causal,
                             .max_seqlen_k = decode_parameters.options.max_seqlen_k,
                             .num_heads = num_heads_per_shard,
-                            .window_size_left = opts.sliding_window,
+                            .window_size_left = window_size_left,
                             .softmax_scale = opts.scale,
                         },
                         .opts = zml.ops.CustomCallOptions{
@@ -1041,7 +1042,7 @@ pub const paged_fa2 = struct {
                             .max_seqlen_k = mixed_parameters.options.max_seqlen_k,
                             .max_seqlen_q = mixed_parameters.options.max_seqlen_q,
                             .num_heads = num_heads_per_shard,
-                            .window_size_left = opts.sliding_window,
+                            .window_size_left = window_size_left,
                             .softmax_scale = opts.scale,
                         },
                         .opts = zml.ops.CustomCallOptions{
@@ -1105,7 +1106,7 @@ pub const paged_fa2 = struct {
                             .is_causal = opts.is_causal,
                             .max_seqlen_k = mixed_parameters.options.max_seqlen_k,
                             .num_heads = num_heads_per_shard,
-                            .window_size_left = opts.sliding_window,
+                            .window_size_left = window_size_left,
                             .softmax_scale = opts.scale,
                         },
                         .opts = zml.ops.CustomCallOptions{
@@ -1520,6 +1521,7 @@ pub const paged_fa3 = struct {
         stdx.debug.assert(q.shape().hasTags(.{ .b, .hg, .hkv, .hd }), "Expected q to have tags .b, .h, .hd", .{});
         stdx.debug.assert(k_cache.shape().hasTags(.{ .page, .k_chunk, .hkv, .hd }), "Expected paged_k to have tags .page, .k_chunk, .h, .hd, got {}", .{k_cache.shape()});
         stdx.debug.assert(v_cache.shape().hasTags(.{ .page, .k_chunk, .hkv, .hd }), "Expected paged_v to have tags .page, .k_chunk, .h, .hd. got {}", .{v_cache.shape()});
+        const window_size_left = windowSizeLeft(opts.sliding_window);
 
         const num_head_groups = q.dim(.hg);
         const num_kv_heads = q.dim(.hkv);
@@ -1573,7 +1575,7 @@ pub const paged_fa3 = struct {
                         .metadata = .{
                             .is_causal = opts.is_causal,
                             .max_seqlen_k = decode_parameters.options.max_seqlen_k,
-                            .window_size_left = opts.sliding_window,
+                            .window_size_left = window_size_left,
                         },
                         .opts = zml.ops.CustomCallOptions{
                             .has_side_effect = false,
@@ -1642,7 +1644,7 @@ pub const paged_fa3 = struct {
                             .is_causal = opts.is_causal,
                             .max_seqlen_k = mixed_parameters.options.max_seqlen_k,
                             .max_seqlen_q = mixed_parameters.options.max_seqlen_q,
-                            .window_size_left = opts.sliding_window,
+                            .window_size_left = window_size_left,
                         },
                         .opts = zml.ops.CustomCallOptions{ .has_side_effect = false },
                     },
@@ -1698,7 +1700,7 @@ pub const paged_fa3 = struct {
                         .metadata = .{
                             .is_causal = opts.is_causal,
                             .max_seqlen_k = mixed_parameters.options.max_seqlen_k,
-                            .window_size_left = opts.sliding_window,
+                            .window_size_left = window_size_left,
                         },
                         .opts = zml.ops.CustomCallOptions{ .has_side_effect = false },
                     },
@@ -1718,3 +1720,13 @@ pub const paged_fa3 = struct {
         return o;
     }
 };
+
+fn windowSizeLeft(sliding_window: i32) i32 {
+    return if (sliding_window > 0) sliding_window - 1 else sliding_window;
+}
+
+test "FlashAttention sliding window uses an inclusive offset" {
+    try std.testing.expectEqual(@as(i32, 2047), windowSizeLeft(2048));
+    try std.testing.expectEqual(@as(i32, 0), windowSizeLeft(1));
+    try std.testing.expectEqual(@as(i32, -1), windowSizeLeft(-1));
+}

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -402,7 +402,6 @@ test pagedAttention {
         .max_seqlen_q = 16 * 2,
     };
     const triton_parameters: Parameters = .init(.fromBackend(triton_options_args));
-    const attn_opts: AttentionOptions = .{ .is_causal = true };
     var q = try zml.testing.autoCall(allocator, io, &rng_q, zml.Tensor.Rng.normal, {});
     defer q.deinit();
     var new_k = try zml.testing.autoCall(allocator, io, &rng_k, zml.Tensor.Rng.normal, {});
@@ -448,110 +447,140 @@ test pagedAttention {
     } };
     defer zml.Buffer.deinitAll(Parameters, &triton_parameters_d);
 
-    var results_per_backend: std.enums.EnumArray(Backend, ?zml.Slice) = .initFill(null);
-    defer {
+    const all_backends = std.enums.values(Backend);
+    // stablehlo ignores these options, cuda_fa3 has no materializer in this fixture, and
+    // mosaic_tpu requires a dense KV cache instead of the split cache used by this test.
+    const option_sensitive_backends = [_]Backend{ .cuda_fa2, .triton, .metal };
+    const test_cases = [_]struct {
+        name: []const u8,
+        attention_options: AttentionOptions,
+        backends: []const Backend,
+    }{
+        .{
+            .name = "unbounded",
+            .attention_options = .{ .is_causal = true },
+            .backends = all_backends,
+        },
+        .{
+            .name = "non_causal",
+            .attention_options = .{ .is_causal = false },
+            .backends = &option_sensitive_backends,
+        },
+        .{
+            .name = "sliding_window",
+            .attention_options = .{ .is_causal = true, .sliding_window = page_size },
+            .backends = &option_sensitive_backends,
+        },
+    };
+
+    for (test_cases) |test_case| {
+        var results_per_backend: std.enums.EnumArray(Backend, ?zml.Slice) = .initFill(null);
+        defer {
+            for (std.enums.values(Backend)) |backend| {
+                if (results_per_backend.get(backend)) |slice| slice.free(allocator);
+            }
+        }
+
+        for (test_case.backends) |backend| {
+            if (!backend.isAvailable(platform)) {
+                std.log.warn("paged_attention backend {t} not available", .{backend});
+                continue;
+            }
+            std.log.warn("Testing paged_attention {s} with backend {t}", .{ test_case.name, backend });
+
+            var backend_options_args = triton_options_args;
+            backend_options_args.backend = backend;
+            const parameters: Parameters = .init(.fromBackend(backend_options_args));
+
+            const exe = try platform.compileFn(
+                allocator,
+                io,
+                pagedAttention,
+                .{ parameters, tensors.q, tensors.k, tensors.v, tensors.kv_cache, test_case.attention_options },
+                .{ .program_name = try std.fmt.allocPrint(arena, "paged_attention_{s}_{t}", .{ test_case.name, backend }), .shardings = shardings },
+            );
+            defer exe.deinit();
+
+            var parameters_d: zml.Bufferized(Parameters) = switch (parameters) {
+                // No materializer implemented for cuda fa3
+                .cuda_fa3 => continue,
+                .cuda_fa2 => |params| cuda_fa2: {
+                    var block_table_prefill: [num_prefill][max_num_pages]i32 = undefined;
+                    @memcpy(&block_table_prefill, block_table[0..num_prefill]);
+                    var block_table_decode: [num_decode][max_num_pages]i32 = undefined;
+                    @memcpy(&block_table_decode, block_table[num_prefill .. num_prefill + num_decode]);
+
+                    var cu_seqlens_q_prefill: [num_prefill + 1]i32 = undefined;
+                    @memcpy(&cu_seqlens_q_prefill, query_start_len[0 .. num_prefill + 1]);
+                    var cu_seqlens_q_decode: [num_decode + 1]i32 = undefined;
+                    for (&cu_seqlens_q_decode, query_start_len[num_prefill .. num_prefill + num_decode + 1]) |*decode_len, query_start| {
+                        decode_len.* = query_start - prefill_token_count;
+                    }
+
+                    var seqused_k_prefill: [num_prefill]i32 = undefined;
+                    @memcpy(&seqused_k_prefill, seq_lens[0..num_prefill]);
+                    var seqused_k_decode: [num_decode]i32 = undefined;
+                    @memcpy(&seqused_k_decode, seq_lens[num_prefill .. num_prefill + num_decode]);
+
+                    break :cuda_fa2 .{ .cuda_fa2 = .{ .mixed = .{
+                        .block_table_prefill = try .fromBytes(io, platform, params.mixed.block_table_prefill.shape(), .replicated, @ptrCast(&block_table_prefill)),
+                        .cu_seqlens_q_prefill = try .fromBytes(io, platform, params.mixed.cu_seqlens_q_prefill.shape(), .replicated, @ptrCast(&cu_seqlens_q_prefill)),
+                        .seqused_k_prefill = try .fromBytes(io, platform, params.mixed.seqused_k_prefill.shape(), .replicated, @ptrCast(&seqused_k_prefill)),
+
+                        .block_table_decode = try .fromBytes(io, platform, params.mixed.block_table_decode.shape(), .replicated, @ptrCast(&block_table_decode)),
+                        .cu_seqlens_q_decode = try .fromBytes(io, platform, params.mixed.cu_seqlens_q_decode.shape(), .replicated, @ptrCast(&cu_seqlens_q_decode)),
+                        .seqused_k_decode = try .fromBytes(io, platform, params.mixed.seqused_k_decode.shape(), .replicated, @ptrCast(&seqused_k_decode)),
+
+                        .metadata = .{ .decode_offset = try .scalar(io, platform, prefill_token_count, .i32) },
+                    } } };
+                },
+                .triton => triton_parameters_d,
+                inline .metal, .mosaic_tpu, .stablehlo => |_, t| @unionInit(zml.Bufferized(Parameters), @tagName(t), .{
+                    .block_table = triton_parameters_d.triton.block_table,
+                    .seq_lens = triton_parameters_d.triton.seq_lens,
+                    .query_start_len = triton_parameters_d.triton.query_start_len,
+                }),
+            };
+            // cu_fa2 creates new buffers while other reuse triton buffers.
+            defer if (backend == .cuda_fa2) zml.Buffer.deinitAll(Parameters, &parameters_d);
+
+            var output_d = try zml.testing.autoCall(allocator, io, &exe, pagedAttention, .{ parameters_d, q, new_k, new_v, kv_cache_d });
+            defer output_d.deinit();
+            results_per_backend.set(backend, try output_d.toSliceAlloc(allocator, io));
+        }
+
+        const reference_backend: Backend = .triton;
+        const reference = results_per_backend.get(reference_backend) orelse return error.SkipZigTest;
+
+        var num_failed: u32 = 0;
         for (std.enums.values(Backend)) |backend| {
-            if (results_per_backend.get(backend)) |slice| slice.free(allocator);
+            if (backend == reference_backend) continue;
+            const output_h = results_per_backend.get(backend) orelse continue;
+
+            const tolerance: zml.testing.CompareOpts = .{
+                .absolute_tolerance = 1e-2,
+                .relative_tolerance = 1e-2,
+                .epsilon_relative = 1e-6,
+            };
+
+            zml.testing.expectClose(io, reference, output_h, tolerance) catch |err| switch (err) {
+                error.TestUnexpectedResult => {
+                    num_failed += 1;
+                    std.log.err("test pagedAttention {s} failed on backend {t}\n--> reference ({t}): {d:32.3}\n--> pagedAttention({t}): {d:32.3}", .{
+                        test_case.name,
+                        backend,
+                        reference_backend,
+                        reference.subSlice(1, 0, 1).squeeze(1).subSlice(1, 0, 1).squeeze(1),
+                        backend,
+                        output_h.subSlice(1, 0, 1).squeeze(1).subSlice(1, 0, 1).squeeze(1),
+                    });
+                },
+                else => |e| return e,
+            };
         }
+
+        if (num_failed > 0) return error.TestUnexpectedResult;
     }
-
-    for (std.enums.values(Backend)) |backend| {
-        if (!backend.isAvailable(platform)) {
-            std.log.warn("paged_attention backend {t} not available", .{backend});
-            continue;
-        }
-        std.log.warn("Testing paged_attention with backend {t}", .{backend});
-
-        var backend_options_args = triton_options_args;
-        backend_options_args.backend = backend;
-        const parameters: Parameters = .init(.fromBackend(backend_options_args));
-
-        const exe = try platform.compileFn(
-            allocator,
-            io,
-            pagedAttention,
-            .{ parameters, tensors.q, tensors.k, tensors.v, tensors.kv_cache, attn_opts },
-            .{ .program_name = try std.fmt.allocPrint(arena, "paged_attention_{t}", .{backend}), .shardings = shardings },
-        );
-        defer exe.deinit();
-
-        var parameters_d: zml.Bufferized(Parameters) = switch (parameters) {
-            // No materializer implemented for cuda fa3
-            .cuda_fa3 => continue,
-            .cuda_fa2 => |params| cuda_fa2: {
-                var block_table_prefill: [num_prefill][max_num_pages]i32 = undefined;
-                @memcpy(&block_table_prefill, block_table[0..num_prefill]);
-                var block_table_decode: [num_decode][max_num_pages]i32 = undefined;
-                @memcpy(&block_table_decode, block_table[num_prefill .. num_prefill + num_decode]);
-
-                var cu_seqlens_q_prefill: [num_prefill + 1]i32 = undefined;
-                @memcpy(&cu_seqlens_q_prefill, query_start_len[0 .. num_prefill + 1]);
-                var cu_seqlens_q_decode: [num_decode + 1]i32 = undefined;
-                for (&cu_seqlens_q_decode, query_start_len[num_prefill .. num_prefill + num_decode + 1]) |*decode_len, query_start| {
-                    decode_len.* = query_start - prefill_token_count;
-                }
-
-                var seqused_k_prefill: [num_prefill]i32 = undefined;
-                @memcpy(&seqused_k_prefill, seq_lens[0..num_prefill]);
-                var seqused_k_decode: [num_decode]i32 = undefined;
-                @memcpy(&seqused_k_decode, seq_lens[num_prefill .. num_prefill + num_decode]);
-
-                break :cuda_fa2 .{ .cuda_fa2 = .{ .mixed = .{
-                    .block_table_prefill = try .fromBytes(io, platform, params.mixed.block_table_prefill.shape(), .replicated, @ptrCast(&block_table_prefill)),
-                    .cu_seqlens_q_prefill = try .fromBytes(io, platform, params.mixed.cu_seqlens_q_prefill.shape(), .replicated, @ptrCast(&cu_seqlens_q_prefill)),
-                    .seqused_k_prefill = try .fromBytes(io, platform, params.mixed.seqused_k_prefill.shape(), .replicated, @ptrCast(&seqused_k_prefill)),
-
-                    .block_table_decode = try .fromBytes(io, platform, params.mixed.block_table_decode.shape(), .replicated, @ptrCast(&block_table_decode)),
-                    .cu_seqlens_q_decode = try .fromBytes(io, platform, params.mixed.cu_seqlens_q_decode.shape(), .replicated, @ptrCast(&cu_seqlens_q_decode)),
-                    .seqused_k_decode = try .fromBytes(io, platform, params.mixed.seqused_k_decode.shape(), .replicated, @ptrCast(&seqused_k_decode)),
-
-                    .metadata = .{ .decode_offset = try .scalar(io, platform, prefill_token_count, .i32) },
-                } } };
-            },
-            .triton => triton_parameters_d,
-            inline .metal, .mosaic_tpu, .stablehlo => |_, t| @unionInit(zml.Bufferized(Parameters), @tagName(t), .{
-                .block_table = triton_parameters_d.triton.block_table,
-                .seq_lens = triton_parameters_d.triton.seq_lens,
-                .query_start_len = triton_parameters_d.triton.query_start_len,
-            }),
-        };
-        // cu_fa2 creates new buffers while other reuse triton buffers.
-        defer if (backend == .cuda_fa2) zml.Buffer.deinitAll(Parameters, &parameters_d);
-
-        var output_d = try zml.testing.autoCall(allocator, io, &exe, pagedAttention, .{ parameters_d, q, new_k, new_v, kv_cache_d });
-        defer output_d.deinit();
-        results_per_backend.set(backend, try output_d.toSliceAlloc(allocator, io));
-    }
-
-    const reference_backend: Backend = .triton;
-    const reference = results_per_backend.get(reference_backend) orelse return error.SkipZigTest;
-
-    var num_failed: u32 = 0;
-    for (std.enums.values(Backend)) |backend| {
-        if (backend == reference_backend) continue;
-        const output_h = results_per_backend.get(backend) orelse continue;
-
-        const tolerance: zml.testing.CompareOpts = .{
-            .absolute_tolerance = 1e-2,
-            .relative_tolerance = 1e-2,
-            .epsilon_relative = 1e-6,
-        };
-
-        zml.testing.expectClose(io, reference, output_h, tolerance) catch |err| switch (err) {
-            error.TestUnexpectedResult => {
-                num_failed += 1;
-                std.log.err("test pagedAttention failed on backend {0t}\n--> reference ({1t}): {2d:32.3}\n--> pagedAttention({0t}): {3d:32.3}", .{
-                    backend,
-                    reference_backend,
-                    reference.subSlice(1, 0, 1).squeeze(1).subSlice(1, 0, 1).squeeze(1),
-                    output_h.subSlice(1, 0, 1).squeeze(1).subSlice(1, 0, 1).squeeze(1),
-                });
-            },
-            else => |e| return e,
-        };
-    }
-
-    if (num_failed > 0) return error.TestUnexpectedResult;
 }
 
 fn stablehlo_pagedAttention(

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -566,13 +566,10 @@ test pagedAttention {
             zml.testing.expectClose(io, reference, output_h, tolerance) catch |err| switch (err) {
                 error.TestUnexpectedResult => {
                     num_failed += 1;
-                    std.log.err("test pagedAttention {s} failed on backend {t}\n--> reference ({t}): {d:32.3}\n--> pagedAttention({t}): {d:32.3}", .{
+                    std.log.err("test pagedAttention {s} failed on backend {t} against reference {t}", .{
                         test_case.name,
                         backend,
                         reference_backend,
-                        reference.subSlice(1, 0, 1).squeeze(1).subSlice(1, 0, 1).squeeze(1),
-                        backend,
-                        output_h.subSlice(1, 0, 1).squeeze(1).subSlice(1, 0, 1).squeeze(1),
                     });
                 },
                 else => |e| return e,

--- a/zml/slice.zig
+++ b/zml/slice.zig
@@ -286,7 +286,6 @@ pub const Slice = struct {
 
                     // The formatter consumes this physical tail using `stride`, so this
                     // rank-1 path can read raw items without requiring contiguity.
-                    std.log.warn("Printing {} elems from offset {} out of {} total elems @ {}", .{ n, slice.offset_bytes, needed_len, stride });
                     const raw_values: []const T = @ptrCast(@alignCast(slice.bytes[slice.offset_bytes..]));
                     const values = raw_values[0..needed_len];
 


### PR DESCRIPTION
We fix an off-by-one error in Flash-Attn: `window_size_left` is inclusive of the current position, so it is minus 1 compared to the actual `sliding_window` size.

Ref: https://github.com/Dao-AILab/flash-attention#how-to-use-flashattention