### PR TITLE
zml/Compiler: Provide accurate device memory size to XLA

### DIFF
--- a/pjrt/pjrt.zig
+++ b/pjrt/pjrt.zig
@@ -77,7 +77,7 @@ pub const ApiError = error{
 inline fn interpretPjrtError(api: *const Api, pjrt_error: *Error, context: []const u8) ApiError {
     defer pjrt_error.deinit(api);
     const err_code = pjrt_error.getCode(api).toApiError();
-    log.err("[{s}] {t}: {s}", .{ context, err_code, pjrt_error.getMessage(api) });
+    log.warn("[{s}] {t}: {s}", .{ context, err_code, pjrt_error.getMessage(api) });
     return err_code;
 }
 

--- a/zml/Compiler.zig
+++ b/zml/Compiler.zig
@@ -686,6 +686,23 @@ fn compileModuleToPjrtExecutable(arena: std.mem.Allocator, io: std.Io, platform:
             c.xla_ExecutableBuildOptionsProto_set_use_spmd_partitioning(exec_build_options, true);
             c.xla_ExecutableBuildOptionsProto_set_use_shardy_partitioner(exec_build_options, use_shardy_partitioner);
 
+            // Tell XLA how much device memory PJRT actually made available.
+            // Without this, the GPU scheduler falls back to 80% of physical
+            // memory. Programs whose donated inputs and outputs exceed that
+            // artificial limit get a zero-byte temporary-memory budget and
+            // can trigger excessive rematerialization.
+            var device_memory_size: ?u64 = null;
+            for (platform.devices) |device| {
+                const bytes_limit = device.memoryStats().bytes_limit orelse {
+                    device_memory_size = null;
+                    break;
+                };
+                device_memory_size = @min(device_memory_size orelse bytes_limit, bytes_limit);
+            }
+            if (device_memory_size) |bytes_limit| {
+                c.xla_ExecutableBuildOptionsProto_set_device_memory_size(exec_build_options, @intCast(bytes_limit));
+            }
+
             c.xla_ExecutableBuildOptionsProto_set_device_assignment(exec_build_options, device_assignment_blk: {
                 const device_assignment_proto = try upb.new(c.xla_DeviceAssignmentProto, upb_arena);
 


### PR DESCRIPTION
By default, XLA assumes 80% of the memory to be available during compilation. It wasn't an issue as long as we had one executable per layer, because most of the weights weren't parts of the inputs, but for a full forward executable we exceed that 80% threshold in llmd with the cache being sized to use almost everything up to the BFC limit. So XLA ends up generating an executable the least possible temporary buffers even though it has more than that.