### PR TITLE
zml/quantization: bump plugin and support block 128 quant

### DIFF
--- a/platforms/cuda/cuda.bzl
+++ b/platforms/cuda/cuda.bzl
@@ -11,8 +11,8 @@ CUDA_VARIANT = "cuda13.3"
 CUDA_REDIST_JSON_SHA256 = "507eddaab1360336bc0fe17b77552e0b7dfe1e74da888671c3a2f5fad7775db1"
 
 CUDNN_REDIST_PREFIX = "https://developer.download.nvidia.com/compute/cudnn/redist/"
-CUDNN_VERSION = "9.22.0"
-CUDNN_REDIST_JSON_SHA256 = "3dbb9002d52112ef69aa09187f523ef1ff07f8baf3892ee01e540af639d8f55f"
+CUDNN_VERSION = "9.24.0"
+CUDNN_REDIST_JSON_SHA256 = "89a0626f1925d9f4ceb8d6bc0b2de160b30e92afaae5471e6cfbb50234ae5488"
 
 NVSHMEM_REDIST_PREFIX = "https://developer.download.nvidia.com/compute/nvshmem/redist/"
 NVSHMEM_VERSION = "3.6.5"
@@ -213,15 +213,15 @@ _UBUNTU_PACKAGES = {
     ],
 }
 
-PJRT_CUDA_RELEASE = "manual-2026-07-31T19-22-00Z"
+PJRT_CUDA_RELEASE = "manual-2026-09-03T15-04-00Z"
 
 _PJRT_CUDA_ASSETS = {
     "amd64": {
-        "sha256": "c3fe395ed8b0493975e4afeba454e0cbecec7eac540488522fd4523103e353f3",
+        "sha256": "d8558a442c6fd755d19cdc396bbd6b74c8ae5a2105f706c8c23306b7ac339bfc",
         "url": "https://github.com/zml/pjrt-artifacts/releases/download/{release}/pjrt-cuda_linux-amd64.tar.gz",
     },
     "arm64": {
-        "sha256": "3c23c31dbfb3a97ca1bf8558d1e8347431fa30c192236d97de7bd6539d354ca5",
+        "sha256": "af5fec9ae4bbdf3f0ae95c845107b4379ec840af0d72273f95b2e2374e6c8084",
         "url": "https://github.com/zml/pjrt-artifacts/releases/download/{release}/pjrt-cuda_linux-arm64.tar.gz",
     },
 }

--- a/zml/Compiler.zig
+++ b/zml/Compiler.zig
@@ -719,6 +719,9 @@ fn compileModuleToPjrtExecutable(arena: std.mem.Allocator, io: std.Io, platform:
                 // NVIDIA recommends these settings
                 // https://github.com/NVIDIA/JAX-Toolbox?tab=readme-ov-file#environment-variables
                 try setXlaOverrideFlag(overrides_map, "xla_gpu_enable_latency_hiding_scheduler", true, upb_arena);
+                try setXlaOverrideFlag(overrides_map, "xla_gpu_experimental_scaled_dot_with_tile_ir", true, upb_arena);
+                try setXlaOverrideFlag(overrides_map, "xla_gpu_experimental_enable_subchannel_dequantisation_fusion", true, upb_arena);
+                try setXlaOverrideFlag(overrides_map, "xla_gpu_unsupported_enable_triton_multi_output_fusion", true, upb_arena);
             },
             .rocm => {
                 // Use lld from libllvm instead of invoking the ld.lld binary.

--- a/zml/quantization.zig
+++ b/zml/quantization.zig
@@ -10,6 +10,7 @@ const Tensor = @import("tensor.zig").Tensor;
 
 pub const nvfp4_block_size = 16;
 pub const mx_block_size = 32;
+pub const fp8_block_size = 128;
 
 pub const Quantization = struct {
     scheme: Scheme, // decided when the checkpoint is read
@@ -105,7 +106,8 @@ pub fn quantizeInput(quantization: Quantization, input: Tensor, axis: Shape.Tag,
     const global_scale: ?Tensor = if (quantization.input_scale) |scale| scale.asMultiplier() else null;
     return switch (quantization.scheme) {
         .nvfp4 => if (supportsNvfp4InputQuantization(platform)) quantizeNvfp4(input, global_scale, axis) else null,
-        .mxfp8, .mxfp4, .fp8_per_channel, .fp8_block128, .fp8_per_tensor => null,
+        .fp8_block128 => if (supportsNvfp4InputQuantization(platform)) quantizeFp8Block128(input, global_scale, axis) else null,
+        .mxfp8, .mxfp4, .fp8_per_channel, .fp8_per_tensor => null,
     };
 }
 
@@ -138,6 +140,37 @@ pub fn quantizeNvfp4(x: Tensor, input_global_scale: ?Tensor, axis: anytype) Quan
     const values = grouped.div(divisor)
         .convert(.f4e2m1)
         .reshape(x.shape().withDtype(.f4e2m1));
+
+    return .{
+        .values = values,
+        .scales = scales.squeeze(.blk),
+        .global_scale = input_global_scale,
+    };
+}
+
+pub fn quantizeFp8Block128(x: Tensor, input_global_scale: ?Tensor, axis: anytype) QuantizedInput {
+    const value_max = DataType.f8e4m3fn.maxValue().as(f32);
+
+    stdx.debug.assert(x.shape().hasTag(axis) != null, "quantizeFp8Block128 expects x to have {any} tag, got {f}", .{ axis, x.shape() });
+    stdx.debug.assert(@rem(x.dim(axis), fp8_block_size) == 0, "quantizeFp8Block128 expects {any} to be a multiple of {}, got {f}", .{ axis, fp8_block_size, x.shape() });
+
+    const dt = x.dtype();
+    const scaled = if (input_global_scale) |igs|
+        x.div(igs.convert(dt).broad(x.shape()))
+    else
+        x;
+    const grouped = scaled.splitAxis(axis, .{ .sc = -1, .blk = fp8_block_size });
+
+    const wide = grouped.convert(.f32);
+    const scales = wide.abs().scale(1.0 / value_max).max(.blk);
+
+    const divisor = scales
+        .maximum(.scalar(std.math.floatMin(f32), .f32))
+        .broad(wide.shape());
+
+    const values = wide.div(divisor)
+        .convert(.f8e4m3fn)
+        .reshape(x.shape().withDtype(.f8e4m3fn));
 
     return .{
         .values = values,

--- a/zml/quantization.zig
+++ b/zml/quantization.zig
@@ -106,7 +106,7 @@ pub fn quantizeInput(quantization: Quantization, input: Tensor, axis: Shape.Tag,
     const global_scale: ?Tensor = if (quantization.input_scale) |scale| scale.asMultiplier() else null;
     return switch (quantization.scheme) {
         .nvfp4 => if (supportsNvfp4InputQuantization(platform)) quantizeNvfp4(input, global_scale, axis) else null,
-        .fp8_block128 => if (supportsNvfp4InputQuantization(platform)) quantizeFp8Block128(input, global_scale, axis) else null,
+        .fp8_block128 => quantizeFp8Block128(input, global_scale, axis),
         .mxfp8, .mxfp4, .fp8_per_channel, .fp8_per_tensor => null,
     };
 }

--- a/zml/quantization.zig
+++ b/zml/quantization.zig
@@ -123,11 +123,13 @@ pub fn quantizeNvfp4(x: Tensor, input_global_scale: ?Tensor, axis: anytype) Quan
     else
         x;
     const grouped = scaled.splitAxis(axis, .{ .sc = -1, .blk = nvfp4_block_size });
-    const amax = grouped.abs().max(.blk);
 
-    const scales = amax.scale(1.0 / value_max)
+    const amax = grouped.abs()
+        .scale(1.0 / value_max)
         .clamp(.scalar(scale_min_normal, dt), .scalar(scale_max, dt))
-        .convert(.f8e4m3fn);
+        .max(.blk);
+
+    const scales = amax.convert(.f8e4m3fn);
 
     const divisor = scales.convert(dt)
         .maximum(.scalar(scale_min_normal, dt))


### PR DESCRIPTION
Support FP8 block 128 activation quantization
Also fix NVFP4 quantization to dispatch one kernel instead of two