### PR TITLE
zml/nn: unpack FP4 along an explicit axis

### DIFF
--- a/zml/moe/moe.zig
+++ b/zml/moe/moe.zig
@@ -647,7 +647,7 @@ pub fn forwardMoe(
 fn unpackedWeight(linear: zml.nn.Linear) zml.Tensor {
     const quantization = linear.quantization orelse return linear.weight;
     return if (zml.nn.isPackedFp4(quantization.scheme, linear.weight.dtype()))
-        zml.nn.unpackFp4(linear.weight, linear.tag)
+        zml.nn.unpackFp4(linear.weight, linear.tag, linear.tag)
     else
         linear.weight;
 }

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -73,10 +73,10 @@ pub fn isPackedFp4(scheme: ?Quantization.Scheme, weight_dtype: DataType) bool {
 
 /// Unpacks two f4e2m1 values per byte along `packed_tag` and names the expanded
 /// axis `k_tag`. Group-size agnostic: NVFP4 (16) and MXFP4 (32) share this packing.
-pub fn unpackFp4(w: Tensor, packed_tag: anytype, k_tag: anytype) Tensor {
+pub fn unpackFp4(w: Tensor, packed_tag: anytype, contracting_tag: anytype) Tensor {
     stdx.debug.assert(w.dtype() == .u8 or w.dtype() == .i8, "unpackFp4 expects packed 8-bit weights, got {}", .{w.dtype()});
     const source_tag = Shape.toTag(packed_tag);
-    const result_tag = Shape.toTag(k_tag);
+    const result_tag = Shape.toTag(contracting_tag);
     return w.bitCast(.f4e2m1) // bitcast inserts a tag (it respects shlo), but maybe we should simplify it
         .merge(.{ .kb = .{ source_tag, .bitcast } })
         .renameTag(.kb, result_tag);

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -45,7 +45,7 @@ pub const Linear = struct {
 
         const weight_global_scale: ?Tensor = if (q.global_scale) |s| s.asMultiplier() else null;
 
-        const weight = if (isPackedFp4(q.scheme, self.weight.dtype())) unpackFp4(self.weight, self.tag) else self.weight;
+        const weight = if (isPackedFp4(q.scheme, self.weight.dtype())) unpackFp4(self.weight, self.tag, self.tag) else self.weight;
         const scales = if (q.scheme.isMx() and q.scales.dtype() == .u8)
             q.scales.bitCast(.f8e8m0)
         else
@@ -71,14 +71,30 @@ pub fn isPackedFp4(scheme: ?Quantization.Scheme, weight_dtype: DataType) bool {
     return (scheme == .nvfp4 or scheme == .mxfp4) and (weight_dtype == .u8 or weight_dtype == .i8);
 }
 
-/// Unpacks two f4e2m1 values per byte. `w` must be tagged with `.kw` on the packed axis,
-/// which is merged with the unpacked pair and renamed to `k_tag`. Group-size agnostic:
-/// NVFP4 (16) and MXFP4 (32) share this packing.
-pub fn unpackFp4(w: Tensor, k_tag: anytype) Tensor {
+/// Unpacks two f4e2m1 values per byte along `packed_tag` and names the expanded
+/// axis `k_tag`. Group-size agnostic: NVFP4 (16) and MXFP4 (32) share this packing.
+pub fn unpackFp4(w: Tensor, packed_tag: anytype, k_tag: anytype) Tensor {
     stdx.debug.assert(w.dtype() == .u8 or w.dtype() == .i8, "unpackFp4 expects packed 8-bit weights, got {}", .{w.dtype()});
+    const source_tag = Shape.toTag(packed_tag);
+    const result_tag = Shape.toTag(k_tag);
     return w.bitCast(.f4e2m1) // bitcast inserts a tag (it respects shlo), but maybe we should simplify it
-        .merge(.{ .kb = .{ .kw, .bitcast } })
-        .renameTag(.kb, Shape.toTag(k_tag));
+        .merge(.{ .kb = .{ source_tag, .bitcast } })
+        .renameTag(.kb, result_tag);
+}
+
+test "unpackFp4 expands the requested axis" {
+    const platform = zml.testing.env();
+    const packed_weight: Tensor = .init(.{ .out = 2, .stored = 4 }, .u8);
+    const Local = struct {
+        fn call(w: Tensor) Tensor {
+            return unpackFp4(w, .stored, .contracted);
+        }
+    };
+
+    var exe = try platform.compileFn(std.testing.allocator, std.testing.io, Local.call, .{packed_weight}, .{});
+    defer exe.deinit();
+
+    try zml.testing.expectEqualShapes(.init(.{ .out = 2, .contracted = 8 }, .f4e2m1), exe.output_shapes[0]);
 }
 
 /// Scaled matrix multiply (`xla.scaled_dot`): `acc = (lhs * lhs_scale) @ (rhs * rhs_scale)`.

--- a/zml/quantization.zig
+++ b/zml/quantization.zig
@@ -169,7 +169,7 @@ test "Quantization.Scheme.classify" {
 
     // unsloth/Qwen3.6-27B-NVFP4: compressed-tensors, carrying both of its schemes under
     // `weight_scale` -- NVFP4 on the MLPs of layers 0-55, FP8 per-channel everywhere else.
-    const nvfp4_packed: Shape = .init(.{ .dout = 17408, .kw = 2560 }, .u8);
+    const nvfp4_packed: Shape = .init(.{ .dout = 17408, .d = 2560 }, .u8);
     try expect(@as(?Quantization.Scheme, .nvfp4), Quantization.Scheme.classify(nvfp4_packed, .init(.{ .dout = 17408, .sc = 320 }, .f8e4m3fn)));
     try expect(@as(?Quantization.Scheme, .fp8_per_channel), Quantization.Scheme.classify(
         .init(.{ .dout = 17408, .d = 5120 }, .f8e4m3fn),
@@ -178,7 +178,7 @@ test "Quantization.Scheme.classify" {
 
     // nvidia/Gemma-4-31B-IT-NVFP4: ModelOpt, packed values under the plain `weight` name.
     try expect(@as(?Quantization.Scheme, .nvfp4), Quantization.Scheme.classify(
-        .init(.{ .dout = 21504, .kw = 2688 }, .u8),
+        .init(.{ .dout = 21504, .d = 2688 }, .u8),
         .init(.{ .dout = 21504, .sc = 336 }, .f8e4m3fn),
     ));
 
@@ -234,7 +234,7 @@ test "Quantization.Scheme.classify" {
     try expect(@as(?Quantization.Scheme, .mxfp4), Quantization.Scheme.classify(nvfp4_packed, .init(.{ .dout = 17408, .sc = 160 }, .f8e8m0)));
     // DeepSeek V4 stores the same packed FP4 bits in signed bytes.
     try expect(@as(?Quantization.Scheme, .mxfp4), Quantization.Scheme.classify(
-        .init(.{ .dout = 2048, .kw = 2048 }, .i8),
+        .init(.{ .dout = 2048, .d = 2048 }, .i8),
         .init(.{ .dout = 2048, .sc = 128 }, .f8e8m0),
     ));
     // Native (unpacked) f4e2m1, K no longer halved.
@@ -261,7 +261,7 @@ test "Quantization.Scheme.classify" {
     try expect(@as(?Quantization.Scheme, null), Quantization.Scheme.classify(fp8, .init(.{ .dout = 160, .sc = 80 }, .bf16)));
     // Stacked MoE weights are rank 3 and go through the MoE path, not this one.
     try expect(@as(?Quantization.Scheme, null), Quantization.Scheme.classify(
-        .init(.{ .expert = 128, .dout = 1408, .kw = 1408 }, .u8),
+        .init(.{ .expert = 128, .dout = 1408, .d = 1408 }, .u8),
         .init(.{ .expert = 128, .dout = 1408, .sc = 176 }, .f8e4m3fn),
     ));
 


### PR DESCRIPTION
Make unpackFp4 accept the packed source axis explicitly instead of requiring the hardcoded .kw tag.

Updates the Linear and MoE callers and adds regression coverage for expanding and renaming the packed axis.