### PR TITLE
nn/gated_delta_net: bound GDN recurrence

### DIFF
--- a/examples/llm/models/qwen3_5/inference.zig
+++ b/examples/llm/models/qwen3_5/inference.zig
@@ -37,6 +37,7 @@ pub const Args = struct {
     io: std.Io,
     tokens_buf: *zml.Buffer,
     token_index_buf: *zml.Buffer,
+    active_length_buf: *zml.Buffer,
     kv_cache_buffers: *zml.Bufferized(model.KvCache),
     rng_buffers: *zml.Bufferized(zml.Tensor.Rng),
 };
@@ -188,7 +189,7 @@ pub fn run(runner: *KernelRunner, args: Args, layer_index_buffers: []const zml.B
                 layer.run(args.io, .{
                     .inputs = .{
                         .hidden = hidden_buffer,
-                        .token_index = args.token_index_buf.*,
+                        .active_length = args.active_length_buf.*,
                         .cache = layer_cache,
                     },
                     .outputs = .{ .hidden = &hidden_buffer, .cache = &layer_cache },
@@ -276,7 +277,7 @@ fn compileLinearAttention(allocator: std.mem.Allocator, io: std.Io, platform: *c
     return zml.FnExe(model.TransformerLayer.forwardLinearAttn).compile(allocator, io, platform, .{ .shardings = &parameters.shardings.all(), .program_name = phase.programName("qwen3_5", "linear_attention_layer") }, .{.{
         .layer = mdl.text_model.layers[layer_index],
         .hidden = hiddenTensor(mdl, seqlen),
-        .token_index = parameters.token_index,
+        .active_length = zml.Tensor.init(.{}, .u32),
         .cache = .{
             .conv_state = parameters.kv_cache.gated_delta_net.conv_state,
             .recurrent_state = parameters.kv_cache.gated_delta_net.recurrent_state,

--- a/examples/llm/models/qwen3_5/model.zig
+++ b/examples/llm/models/qwen3_5/model.zig
@@ -1004,9 +1004,10 @@ pub const RmsNormGated = struct {
     pub fn forward(self: RmsNormGated, x: zml.Tensor, gate: zml.Tensor) zml.Tensor {
         const x_f32 = x.convert(.f32);
         const gate_f32 = gate.convert(.f32);
+        const weight_f32 = self.weight.convert(.f32);
 
         const normalized = zml.nn.rmsNorm(x_f32, .d, self.eps);
-        const output = normalized.mul(self.weight.broad(x.shape()));
+        const output = normalized.mul(weight_f32.broad(x.shape()));
 
         const gated_output = output.mul(gate_f32.silu());
         return gated_output.convert(x.dtype());

--- a/examples/llm/models/qwen3_5/model.zig
+++ b/examples/llm/models/qwen3_5/model.zig
@@ -215,11 +215,12 @@ pub const Model = struct {
         self: Model,
         tokens_: zml.Tensor,
         token_index: zml.Tensor,
+        active_length: zml.Tensor,
         kv_cache: KvCache,
         rng: zml.Tensor.Rng,
     ) struct { zml.Tensor, KvCache, zml.Tensor.Rng } {
         const tokens = tokens_.withPartialTags(.{.s});
-        const text_model_output, const updated_kv_cache = self.text_model.forward(tokens, token_index, kv_cache);
+        const text_model_output, const updated_kv_cache = self.text_model.forward(tokens, token_index, active_length, kv_cache);
         const result = Sampler.sampleTokens(.{
             .sampler = self.sampler(),
             .hidden = text_model_output,
@@ -330,6 +331,7 @@ pub const TextModel = struct {
         self: TextModel,
         tokens: zml.Tensor,
         token_index: zml.Tensor,
+        active_length: zml.Tensor,
         kv_cache: KvCache,
     ) struct { zml.Tensor, KvCache } {
         var hidden_states = EmbedTokens.forward(.{
@@ -339,7 +341,7 @@ pub const TextModel = struct {
 
         var updated_kv_cache = kv_cache;
         for (self.layers, 0..) |layer, i| {
-            hidden_states, updated_kv_cache = layer.forward(hidden_states, token_index, updated_kv_cache.atLayer(i));
+            hidden_states, updated_kv_cache = layer.forward(hidden_states, token_index, active_length, updated_kv_cache.atLayer(i));
         }
 
         return .{ hidden_states, updated_kv_cache.reuseBuffer(kv_cache) };
@@ -372,7 +374,7 @@ pub const TransformerLayer = struct {
     pub const LinearAttnInput = struct {
         layer: TransformerLayer,
         hidden: zml.Tensor,
-        token_index: zml.Tensor,
+        active_length: zml.Tensor,
         cache: KvCache.GatedDeltaNetCache,
     };
 
@@ -409,6 +411,7 @@ pub const TransformerLayer = struct {
         self: TransformerLayer,
         x0: zml.Tensor,
         token_index: zml.Tensor,
+        active_length: zml.Tensor,
         kv_cache: KvCache.LayerView,
     ) struct { zml.Tensor, KvCache } {
         const x0_replicated = x0.withPartitioning(.{ .d = .replicated });
@@ -431,7 +434,7 @@ pub const TransformerLayer = struct {
                     .linear_attn => |cache| cache,
                     .self_attn => unreachable,
                 };
-                const result = linear_attn.forward(normalized_x0, cache);
+                const result = linear_attn.forward(normalized_x0, cache, active_length);
                 attention_output = result[0];
                 updated_kv_cache.gated_delta_net = result[1].reuseBuffer(updated_kv_cache.gated_delta_net);
             },
@@ -470,7 +473,6 @@ pub const TransformerLayer = struct {
     pub fn forwardLinearAttn(input: LinearAttnInput) LinearAttnOutput {
         const self = input.layer;
         const x0 = input.hidden;
-        _ = input.token_index;
         const x0_replicated = x0.withPartitioning(.{ .d = .replicated });
         const normalized_x0 = self.input_layernorm.forward(x0_replicated);
 
@@ -478,7 +480,7 @@ pub const TransformerLayer = struct {
             .linear_attention => |linear_attn| linear_attn,
             .full_attention => unreachable,
         };
-        const attention_output, const updated_kv_cache = linear_attn.forward(normalized_x0, input.cache);
+        const attention_output, const updated_kv_cache = linear_attn.forward(normalized_x0, input.cache, input.active_length);
 
         const x1 = attention_output.add(x0_replicated).withPartitioning(.{ .d = .replicated });
         const normalized_hidden = self.post_attention_layernorm.forward(x1);
@@ -806,6 +808,7 @@ pub const GatedDeltaNet = struct {
         g: zml.Tensor,
         beta: zml.Tensor,
         initial_state: ?zml.Tensor,
+        active_length: zml.Tensor,
     ) struct { zml.Tensor, zml.Tensor } {
         const scale: f32 = 1.0 / @sqrt(@as(f32, @floatFromInt(query.dim(.khd))));
         const query_norm = zml.nn.normalizeL2(query.rename(.{ .kh = .vh }), 1e-6);
@@ -839,6 +842,7 @@ pub const GatedDeltaNet = struct {
             alpha_f32,
             beta_f32,
             .{ .s = initial_recurrent_state },
+            active_length,
         );
 
         return .{
@@ -857,7 +861,13 @@ pub const GatedDeltaNet = struct {
         return zml.Tensor.concatenate(&.{ padding, tail }, .s);
     }
 
-    pub fn forward(self: GatedDeltaNet, x: zml.Tensor, cache: KvCache.GatedDeltaNetCache) struct { zml.Tensor, KvCache.GatedDeltaNetCache } {
+    fn buildUpdatedConvStateFromPrefix(input: zml.Tensor, left_pad: i64, active_length: zml.Tensor) zml.Tensor {
+        const padding = zml.Tensor.zeroes(input.shape().setDim(.s, left_pad));
+        const padded = zml.Tensor.concatenate(&.{ padding, input }, .s);
+        return padded.slice(.s, .dyn(active_length.convert(.i64), left_pad));
+    }
+
+    pub fn forward(self: GatedDeltaNet, x: zml.Tensor, cache: KvCache.GatedDeltaNetCache, active_length: zml.Tensor) struct { zml.Tensor, KvCache.GatedDeltaNetCache } {
         const key_dim = self.num_k_heads * self.head_k_dim;
         const value_dim = self.num_v_heads * self.head_v_dim;
         const conv_dim = 2 * key_dim + value_dim;
@@ -936,6 +946,7 @@ pub const GatedDeltaNet = struct {
                 if (use_cached_state) break :b cache.recurrentState();
                 break :b null;
             },
+            active_length,
         );
 
         const core_attn_out_normed = self.norm
@@ -950,7 +961,7 @@ pub const GatedDeltaNet = struct {
             .rename(.{ .dout = .d })
             .withPartitioning(.{ .d = .replicated });
         const updated_cache = cache.update(
-            buildUpdatedConvState(conv_input, left_pad),
+            if (use_cached_state) buildUpdatedConvState(conv_input, left_pad) else buildUpdatedConvStateFromPrefix(projected_qkv, left_pad, active_length),
             last_recurrent_state,
         );
         return .{ output, updated_cache };

--- a/examples/llm/models/qwen3_5/session.zig
+++ b/examples/llm/models/qwen3_5/session.zig
@@ -118,11 +118,14 @@ pub const Session = struct {
 
         var prefill_token_index_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, 0), .u32);
         defer prefill_token_index_buffer.deinit();
+        var active_length_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, @intCast(all_tokens.len)), .u32);
+        defer active_length_buffer.deinit();
 
         inference.run(&self.prefill, .{
             .io = self.io,
             .tokens_buf = &prefill_tokens_buffer,
             .token_index_buf = &prefill_token_index_buffer,
+            .active_length_buf = &active_length_buffer,
             .kv_cache_buffers = &self.kv_cache_buffers,
             .rng_buffers = &self.rng_buffers,
         }, self.layer_index_buffers);
@@ -145,6 +148,8 @@ pub const Session = struct {
 
         var token_index_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, @intCast(all_tokens.items.len)), .u32);
         defer token_index_buffer.deinit();
+        var active_length_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, 1), .u32);
+        defer active_length_buffer.deinit();
 
         generation: while (true) {
             const token_id = self.generated_token_slice.items(u32)[0];
@@ -167,6 +172,7 @@ pub const Session = struct {
                 .io = self.io,
                 .tokens_buf = &current_token_buffer,
                 .token_index_buf = &token_index_buffer,
+                .active_length_buf = &active_length_buffer,
                 .kv_cache_buffers = &self.kv_cache_buffers,
                 .rng_buffers = &self.rng_buffers,
             }, self.layer_index_buffers);

--- a/examples/llm/models/qwen3_5_moe/inference.zig
+++ b/examples/llm/models/qwen3_5_moe/inference.zig
@@ -42,8 +42,8 @@ pub const LayerIndexBuffer = union(enum) {
 pub const RunArgs = struct {
     io: std.Io,
     tokens_buffer: *zml.Buffer,
-    full_attention_token_index_buffer: *zml.Buffer,
-    linear_attention_token_index_buffer: *zml.Buffer,
+    token_index_buffer: *zml.Buffer,
+    active_length_buffer: *zml.Buffer,
     kv_cache_buffers: *zml.Bufferized(model.KvCache),
     moe_metadata_buffers: zml.Bufferized(zml.moe.Metadata),
     rng_buffers: *zml.Bufferized(zml.Tensor.Rng),
@@ -184,7 +184,7 @@ pub fn run(runner: *KernelRunner, args: RunArgs) void {
                 layer.run(args.io, .{
                     .inputs = .{
                         .hidden = hidden_buffer,
-                        .token_index = args.full_attention_token_index_buffer.*,
+                        .token_index = args.token_index_buffer.*,
                         .cache = layer_cache,
                         .moe_metadata = args.moe_metadata_buffers,
                     },
@@ -206,7 +206,7 @@ pub fn run(runner: *KernelRunner, args: RunArgs) void {
                 layer.run(args.io, .{
                     .inputs = .{
                         .hidden = hidden_buffer,
-                        .token_index = args.linear_attention_token_index_buffer.*,
+                        .active_length = args.active_length_buffer.*,
                         .cache = layer_cache,
                         .moe_metadata = args.moe_metadata_buffers,
                     },
@@ -222,12 +222,12 @@ pub fn run(runner: *KernelRunner, args: RunArgs) void {
         .inputs = .{
             .hidden = hidden_buffer,
             .rng = args.rng_buffers.*,
-            .token_index = args.full_attention_token_index_buffer.*,
+            .token_index = args.token_index_buffer.*,
         },
         .outputs = .{
             .tokens = args.tokens_buffer,
             .rng = args.rng_buffers,
-            .token_index = args.full_attention_token_index_buffer,
+            .token_index = args.token_index_buffer,
         },
     });
 }
@@ -299,7 +299,7 @@ fn compileLinearAttention(allocator: std.mem.Allocator, io: std.Io, platform: *c
     return compileExe(allocator, io, platform, model.TransformerLayer.forwardLinearAttn, .{.{
         .layer = mdl.text_model.layers[layer_index],
         .hidden = hiddenTensor(mdl, seqlen),
-        .token_index = zml.Tensor.init(.{}, .u32),
+        .active_length = zml.Tensor.init(.{}, .u32),
         .cache = .{
             .conv_state = parameters.kv_cache.gated_delta_net.conv_state,
             .recurrent_state = parameters.kv_cache.gated_delta_net.recurrent_state,

--- a/examples/llm/models/qwen3_5_moe/model.zig
+++ b/examples/llm/models/qwen3_5_moe/model.zig
@@ -1123,9 +1123,10 @@ pub const RmsNormGated = struct {
     pub fn forward(self: RmsNormGated, x: zml.Tensor, gate: zml.Tensor) zml.Tensor {
         const x_f32 = x.convert(.f32);
         const gate_f32 = gate.convert(.f32);
+        const weight_f32 = self.weight.convert(.f32);
 
         const normalized = zml.nn.rmsNorm(x_f32, .d, self.eps);
-        const output = normalized.mul(self.weight.broad(x.shape()));
+        const output = normalized.mul(weight_f32.broad(x.shape()));
 
         const gated_output = output.mul(gate_f32.silu());
         return gated_output.convert(x.dtype());

--- a/examples/llm/models/qwen3_5_moe/model.zig
+++ b/examples/llm/models/qwen3_5_moe/model.zig
@@ -230,13 +230,14 @@ pub const Model = struct {
         self: Model,
         tokens_: zml.Tensor,
         token_index: zml.Tensor,
+        active_length: zml.Tensor,
         kv_cache: KvCache,
         rng: zml.Tensor.Rng,
         moe_metadata: zml.moe.Metadata,
         moe_parameters: zml.moe.Parameters,
     ) struct { zml.Tensor, KvCache, zml.Tensor.Rng } {
         const tokens = tokens_.withPartialTags(.{.s});
-        const new_tokens, const updated_kv_cache, const new_rng = self.text_model.forward(tokens, token_index, kv_cache, self.config, rng, moe_metadata, moe_parameters);
+        const new_tokens, const updated_kv_cache, const new_rng = self.text_model.forward(tokens, token_index, active_length, kv_cache, self.config, rng, moe_metadata, moe_parameters);
         return .{ new_tokens.convert(tokens.dtype()).reuseBuffer(tokens), updated_kv_cache, new_rng };
     }
 };
@@ -351,6 +352,7 @@ pub const TextModel = struct {
         self: TextModel,
         tokens: zml.Tensor,
         token_index: zml.Tensor,
+        active_length: zml.Tensor,
         kv_cache: KvCache,
         config: Config,
         rng: zml.Tensor.Rng,
@@ -364,7 +366,7 @@ pub const TextModel = struct {
 
         var updated_kv_cache = kv_cache;
         for (self.layers, 0..) |layer, i| {
-            hidden_states, updated_kv_cache = layer.forward(hidden_states, token_index, updated_kv_cache.atLayer(i), config, moe_metadata, moe_parameters);
+            hidden_states, updated_kv_cache = layer.forward(hidden_states, token_index, active_length, updated_kv_cache.atLayer(i), config, moe_metadata, moe_parameters);
         }
 
         const result = Sampler.sampleTokens(.{
@@ -406,7 +408,7 @@ pub const TransformerLayer = struct {
     pub const LinearAttnInput = struct {
         layer: TransformerLayer,
         hidden: zml.Tensor,
-        token_index: zml.Tensor,
+        active_length: zml.Tensor,
         cache: KvCache.GatedDeltaNetCache,
         config: Config,
         moe_metadata: zml.moe.Metadata,
@@ -480,7 +482,7 @@ pub const TransformerLayer = struct {
             .linear_attn => |linear_attn| linear_attn,
             .self_attn => unreachable,
         };
-        const attention_output, const updated_kv_cache = linear_attn.forward(normalized_x0, input.cache, input.token_index);
+        const attention_output, const updated_kv_cache = linear_attn.forward(normalized_x0, input.cache, input.active_length);
 
         const x1 = attention_output.add(x0_replicated).withPartitioning(.{ .d = .replicated });
         const normalized_hidden = self.post_attention_layernorm.forward(x1);
@@ -497,6 +499,7 @@ pub const TransformerLayer = struct {
         self: TransformerLayer,
         x0: zml.Tensor,
         token_index: zml.Tensor,
+        active_length: zml.Tensor,
         kv_cache: KvCache.LayerView,
         config: Config,
         moe_metadata: zml.moe.Metadata,
@@ -515,7 +518,7 @@ pub const TransformerLayer = struct {
                 updated_kv_cache.self_attn = result[1];
             },
             .linear_attn => |*linear_attn| {
-                const result = linear_attn.forward(normalized_x0, kv_cache.cache.linear_attn, token_index);
+                const result = linear_attn.forward(normalized_x0, kv_cache.cache.linear_attn, active_length);
                 attention_output = result[0];
                 updated_kv_cache.gated_delta_net = result[1];
             },
@@ -927,7 +930,15 @@ pub const GatedDeltaNet = struct {
         zml.Buffer.deinitAll(GatedDeltaNet, self);
     }
 
-    fn recurrentGatedDeltaRule(query: zml.Tensor, key: zml.Tensor, value: zml.Tensor, g: zml.Tensor, beta: zml.Tensor, initial_state: ?zml.Tensor) struct { zml.Tensor, zml.Tensor } {
+    fn recurrentGatedDeltaRule(
+        query: zml.Tensor,
+        key: zml.Tensor,
+        value: zml.Tensor,
+        g: zml.Tensor,
+        beta: zml.Tensor,
+        initial_state: ?zml.Tensor,
+        active_length: zml.Tensor,
+    ) struct { zml.Tensor, zml.Tensor } {
         const scale: f32 = 1.0 / @sqrt(@as(f32, @floatFromInt(query.dim(.khd))));
         const query_norm = zml.nn.normalizeL2(query.rename(.{ .kh = .vh }), 1e-6);
         const key_norm = zml.nn.normalizeL2(key.rename(.{ .kh = .vh }), 1e-6);
@@ -957,6 +968,7 @@ pub const GatedDeltaNet = struct {
             alpha_f32,
             beta_f32,
             .{ .s = initial_recurrent_state },
+            active_length,
         );
 
         return .{
@@ -975,16 +987,13 @@ pub const GatedDeltaNet = struct {
         return zml.Tensor.concatenate(&.{ padding, tail }, .s);
     }
 
-    fn buildUpdatedConvStateFromPrefix(input: zml.Tensor, left_pad: i64, valid_len: zml.Tensor) zml.Tensor {
-        const start = valid_len.convert(.i64).addConstant(-left_pad).maximum(zml.Tensor.scalar(0, .i64));
-        return input.slice(.s, .dyn(start, left_pad));
+    fn buildUpdatedConvStateFromPrefix(input: zml.Tensor, left_pad: i64, active_length: zml.Tensor) zml.Tensor {
+        const padding = zml.Tensor.zeroes(input.shape().setDim(.s, left_pad));
+        const padded = zml.Tensor.concatenate(&.{ padding, input }, .s);
+        return padded.slice(.s, .dyn(active_length.convert(.i64), left_pad));
     }
 
-    fn setPaddingToZero(input: zml.Tensor, valid_mask: zml.Tensor) zml.Tensor {
-        return valid_mask.select(input, zml.Tensor.zeroes(input.shape()));
-    }
-
-    pub fn forward(self: GatedDeltaNet, x: zml.Tensor, cache: KvCache.GatedDeltaNetCache, token_index: zml.Tensor) struct { zml.Tensor, KvCache.GatedDeltaNetCache } {
+    pub fn forward(self: GatedDeltaNet, x: zml.Tensor, cache: KvCache.GatedDeltaNetCache, active_length: zml.Tensor) struct { zml.Tensor, KvCache.GatedDeltaNetCache } {
         const key_dim = self.num_k_heads * self.head_k_dim;
         const value_dim = self.num_v_heads * self.head_v_dim;
         const conv_dim = 2 * key_dim + value_dim;
@@ -1045,17 +1054,7 @@ pub const GatedDeltaNet = struct {
 
         const beta = b.sigmoid();
         const aLog_type = self.aLog.dtype();
-        var g = self.aLog.broad(a.shape()).exp().mul(softplus(a.convert(aLog_type).add(self.dt_bias.convert(aLog_type).broad(a.shape())))).negate();
-        var recurrent_value = value;
-        var recurrent_beta = beta;
-        if (!use_cached_state) {
-            const valid_mask: zml.Tensor = zml.Tensor.arange(.{ .end = x.dim(.s) }, .i64)
-                .withTags(.{.s})
-                .cmp(.LT, token_index.convert(.i64));
-            recurrent_value = setPaddingToZero(recurrent_value, valid_mask.broad(recurrent_value.shape()));
-            recurrent_beta = setPaddingToZero(recurrent_beta, valid_mask.broad(recurrent_beta.shape()));
-            g = setPaddingToZero(g, valid_mask.broad(g.shape()));
-        }
+        const g = self.aLog.broad(a.shape()).exp().mul(softplus(a.convert(aLog_type).add(self.dt_bias.convert(aLog_type).broad(a.shape())))).negate();
 
         const query_for_rule = if (self.qk_head_repetition == 1) query else query.stutter1d(query.axis(.kh), self.qk_head_repetition);
         const key_for_rule = if (self.qk_head_repetition == 1) key else key.stutter1d(key.axis(.kh), self.qk_head_repetition);
@@ -1063,10 +1062,11 @@ pub const GatedDeltaNet = struct {
         const core_attn_out, const last_recurrent_state = recurrentGatedDeltaRule(
             query_for_rule,
             key_for_rule,
-            recurrent_value,
+            value,
             g,
-            recurrent_beta,
+            beta,
             if (use_cached_state) cache.recurrentState() else null,
+            active_length,
         );
 
         const core_attn_out_normed = self.norm
@@ -1080,7 +1080,7 @@ pub const GatedDeltaNet = struct {
         const output = self.out_proj.forward(core_attn_out_normed.merge(.{ .d = .{ .vh, .vhd } }))
             .rename(.{ .dout = .d }).withPartitioning(.{ .d = .replicated });
         const updated_cache = cache.update(
-            if (use_cached_state) buildUpdatedConvState(conv_input, left_pad) else buildUpdatedConvStateFromPrefix(projected_qkv, left_pad, token_index),
+            if (use_cached_state) buildUpdatedConvState(conv_input, left_pad) else buildUpdatedConvStateFromPrefix(projected_qkv, left_pad, active_length),
             last_recurrent_state,
         );
         return .{ output, updated_cache };

--- a/examples/llm/models/qwen3_5_moe/session.zig
+++ b/examples/llm/models/qwen3_5_moe/session.zig
@@ -137,14 +137,14 @@ pub const Session = struct {
         defer tokens_buffer.deinit();
         var token_index_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, 0), .u32);
         defer token_index_buffer.deinit();
-        var valid_len_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, @intCast(all_tokens.len)), .u32);
-        defer valid_len_buffer.deinit();
+        var active_length_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, @intCast(all_tokens.len)), .u32);
+        defer active_length_buffer.deinit();
 
         inference.run(&self.prefill, .{
             .io = self.io,
             .tokens_buffer = &tokens_buffer,
-            .full_attention_token_index_buffer = &token_index_buffer,
-            .linear_attention_token_index_buffer = &valid_len_buffer,
+            .token_index_buffer = &token_index_buffer,
+            .active_length_buffer = &active_length_buffer,
             .kv_cache_buffers = &self.kv_cache_buffers,
             .moe_metadata_buffers = self.prefill_moe_metadata_buffers,
             .rng_buffers = &self.rng_buffers,
@@ -165,6 +165,8 @@ pub const Session = struct {
         defer current_token_buffer.deinit();
         var token_index_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, @intCast(all_tokens.items.len)), .u32);
         defer token_index_buffer.deinit();
+        var active_length_buffer = try zml.Buffer.scalar(self.io, self.platform, @as(u32, 1), .u32);
+        defer active_length_buffer.deinit();
 
         generation: while (true) {
             const token_id = self.generated_token_slice.items(u32)[0];
@@ -182,8 +184,8 @@ pub const Session = struct {
             inference.run(&self.decode, .{
                 .io = self.io,
                 .tokens_buffer = &current_token_buffer,
-                .full_attention_token_index_buffer = &token_index_buffer,
-                .linear_attention_token_index_buffer = &token_index_buffer,
+                .token_index_buffer = &token_index_buffer,
+                .active_length_buffer = &active_length_buffer,
                 .kv_cache_buffers = &self.kv_cache_buffers,
                 .moe_metadata_buffers = self.decode_moe_metadata_buffers,
                 .rng_buffers = &self.rng_buffers,

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -1558,6 +1558,8 @@ pub const GatedDeltaNet = struct {
     alphas: Tensor,
     /// Delta gate .{ .s, .h }.
     betas: Tensor,
+    /// Number of sequence positions to process, clamped to the input length.
+    active_length: Tensor,
 
     pub const State = struct {
         /// Per-head recurrent state with shape .{ .h, .v, .k }.
@@ -1581,7 +1583,11 @@ pub const GatedDeltaNet = struct {
     };
 
     pub fn cond(gdn: GatedDeltaNet, state: State) Tensor {
-        return state.step.cmp(.LT, .scalar(gdn.queries.dim(.s), .i32));
+        const active_length = gdn.active_length
+            .convert(.i32)
+            .maximum(.scalar(0, .i32))
+            .minimum(.scalar(gdn.queries.dim(.s), .i32));
+        return state.step.cmp(.LT, active_length);
     }
 
     /// Single-step recurrent update for Gated Delta Net.
@@ -1625,6 +1631,7 @@ pub const GatedDeltaNet = struct {
         stdx.debug.assert(gdn.values.shape().hasTags(.{ .s, .h, .v }), err_template ++ "v is missing tags {{.h, .v}}", err_args);
         stdx.debug.assert(gdn.alphas.shape().hasTags(.{ .s, .h }), err_template ++ "alphas is missing tag {{.h}}", err_args);
         stdx.debug.assert(gdn.betas.shape().hasTags(.{ .s, .h }), err_template ++ "betas is missing tag {{.h}}", err_args);
+        stdx.debug.assert(gdn.active_length.rank() == 0 and gdn.active_length.dtype().isInteger(), err_template ++ "active_length must be an integer scalar", err_args);
 
         _ = collectDims(.{.h}, &.{ state.s, gdn.queries, gdn.keys, gdn.values, gdn.alphas, gdn.betas }, .strict) catch {
             stdx.debug.panic(err_template ++ "head dimensions are inconsistent.", err_args);
@@ -1644,6 +1651,7 @@ pub const GatedDeltaNet = struct {
     /// - `values`, `outputs`: .{ .s, .h, .v }
     /// - `alphas`, `betas`: .{ .s, .h }
     /// - `initial_state.s`: .{ .h, .v, .k }
+    /// - `active_length`: integer scalar
     pub fn forward(
         queries: Tensor,
         keys: Tensor,
@@ -1651,6 +1659,7 @@ pub const GatedDeltaNet = struct {
         alphas: Tensor,
         betas: Tensor,
         initial_state: Input,
+        active_length: Tensor,
     ) Output {
         const gdn: GatedDeltaNet = .{
             .queries = queries,
@@ -1658,6 +1667,7 @@ pub const GatedDeltaNet = struct {
             .values = values,
             .alphas = alphas,
             .betas = betas,
+            .active_length = active_length,
         };
         const state: GatedDeltaNet.State = .{
             .step = .scalar(0, .i32),
@@ -1683,12 +1693,13 @@ test "gated delta net" {
     const alphas: zml.Tensor = .init(.{ .s = 2, .h = 2 }, .f32);
     const betas: zml.Tensor = .init(.{ .s = 2, .h = 2 }, .f32);
     const initial_s: zml.Tensor = .init(.{ .h = 2, .v = 2, .k = 2 }, .f32);
+    const active_length: zml.Tensor = .init(.{}, .u32);
 
     var exe = try platform.compileFn(
         std.testing.allocator,
         std.testing.io,
         GatedDeltaNet.forward,
-        .{ queries, keys, values, alphas, betas, .{ .s = initial_s } },
+        .{ queries, keys, values, alphas, betas, .{ .s = initial_s }, active_length },
         .{},
     );
     defer exe.deinit();
@@ -1759,13 +1770,15 @@ test "gated delta net" {
         }),
     );
     defer initial_s_buffer.deinit();
+    var oversized_length_buffer = try zml.Buffer.scalar(std.testing.io, platform, @as(u32, 3), .u32);
+    defer oversized_length_buffer.deinit();
 
     var result = try zml.testing.autoCall(
         std.testing.allocator,
         std.testing.io,
         &exe,
         GatedDeltaNet.forward,
-        .{ queries_buffer, keys_buffer, values_buffer, alphas_buffer, betas_buffer, .{ .s = initial_s_buffer } },
+        .{ queries_buffer, keys_buffer, values_buffer, alphas_buffer, betas_buffer, .{ .s = initial_s_buffer }, oversized_length_buffer },
     );
     defer result.outputs.deinit();
     defer result.state.s.deinit();
@@ -1790,6 +1803,41 @@ test "gated delta net" {
         .relative_tolerance = 1e-4,
     });
     try zml.testing.expectClose(std.testing.io, expected_final_s, result.state.s, .{
+        .absolute_tolerance = 1e-4,
+        .relative_tolerance = 1e-4,
+    });
+
+    var prefix_length_buffer = try zml.Buffer.scalar(std.testing.io, platform, @as(u32, 1), .u32);
+    defer prefix_length_buffer.deinit();
+    var prefix_result = try zml.testing.autoCall(
+        std.testing.allocator,
+        std.testing.io,
+        &exe,
+        GatedDeltaNet.forward,
+        .{ queries_buffer, keys_buffer, values_buffer, alphas_buffer, betas_buffer, .{ .s = initial_s_buffer }, prefix_length_buffer },
+    );
+    defer prefix_result.outputs.deinit();
+    defer prefix_result.state.s.deinit();
+
+    const expected_prefix_outputs: zml.Slice = .init(
+        zml.Shape.init(.{ 2, 2, 2 }, .f32),
+        std.mem.sliceAsBytes(&[2][2][2]f32{
+            .{ .{ 3.0, 0.0 }, .{ 1.125, 2.0 } },
+            .{ .{ 0.0, 0.0 }, .{ 0.0, 0.0 } },
+        }),
+    );
+    const expected_prefix_final_s: zml.Slice = .init(
+        zml.Shape.init(.{ 2, 2, 2 }, .f32),
+        std.mem.sliceAsBytes(&[2][2][2]f32{
+            .{ .{ 3.0, 5.0 }, .{ 0.0, 0.5 } },
+            .{ .{ 0.5, 1.125 }, .{ 0.25, 2.0 } },
+        }),
+    );
+    try zml.testing.expectClose(std.testing.io, expected_prefix_outputs, prefix_result.outputs, .{
+        .absolute_tolerance = 1e-4,
+        .relative_tolerance = 1e-4,
+    });
+    try zml.testing.expectClose(std.testing.io, expected_prefix_final_s, prefix_result.state.s, .{
         .absolute_tolerance = 1e-4,
         .relative_tolerance = 1e-4,
     });


### PR DESCRIPTION
Fixing an issue raised in https://github.com/zml/zml/pull/754, to bound the GDN recurrence in the Qwen3.5 example model to the number of active tokens.

We also make qwen3.5 and qwen3.5-moe slightly more consistent.