### PR TITLE
zml/Compiler: set the fork's flag defaults per target

### DIFF
--- a/zml/Compiler.zig
+++ b/zml/Compiler.zig
@@ -736,6 +736,9 @@ fn compileModuleToPjrtExecutable(arena: std.mem.Allocator, io: std.Io, platform:
                 // NVIDIA recommends these settings
                 // https://github.com/NVIDIA/JAX-Toolbox?tab=readme-ov-file#environment-variables
                 try setXlaOverrideFlag(overrides_map, "xla_gpu_enable_latency_hiding_scheduler", true, upb_arena);
+                try setXlaOverrideFlag(overrides_map, "xla_gpu_experimental_scaled_dot_with_tile_ir", true, upb_arena);
+                try setXlaOverrideFlag(overrides_map, "xla_gpu_experimental_enable_subchannel_dequantisation_fusion", true, upb_arena);
+                try setXlaOverrideFlag(overrides_map, "xla_gpu_unsupported_enable_triton_multi_output_fusion", true, upb_arena);
             },
             .rocm => {
                 // Use lld from libllvm instead of invoking the ld.lld binary.

--- a/zml/Compiler.zig
+++ b/zml/Compiler.zig
@@ -749,6 +749,9 @@ fn compileModuleToPjrtExecutable(arena: std.mem.Allocator, io: std.Io, platform:
                 // This is what AMD recommendeds in the meantime.
                 try setXlaOverrideFlag(overrides_map, "xla_gpu_enable_command_buffer", "CUBLAS,CUBLASLT,CUSTOM_CALL,CUDNN,DYNAMIC_SLICE_FUSION", upb_arena);
             },
+            .metal => {
+                try setXlaOverrideFlag(overrides_map, "xla_gpu_metal_fast_math", false, upb_arena);
+            },
             .oneapi => {
                 // More efficient for the allgather/broadcast implementation of the collective permute.
                 try setXlaOverrideFlag(overrides_map, "xla_gpu_collective_permute_connected_components", true, upb_arena);


### PR DESCRIPTION
The fork keeps upstream's flag defaults, so zml turns on what each target actually wants: 
- the Tile IR scaled-dot backend, subchannel dequantize fusion and Triton multi-output fusion on CUDA
- Metal AIR fast math off, since it lets the AIR compiler assume no NaNs and is_finite(NaN) comes back true.