### PR TITLE
zml/platform: one ComputeCapability for every CUDA gate

### DIFF
--- a/zml/attention.zig
+++ b/zml/attention.zig
@@ -25,16 +25,8 @@ pub const Backend = enum {
     pub fn auto(platform: *const zml.Platform) Backend {
         return switch (platform.target) {
             .cuda => b: {
-                const first_device = platform.pjrt_client.devices(platform.pjrt_api)[0];
-
-                if (zml.platform.cuda.tryGetComputeCapabilities(platform, first_device)) |cc| {
-                    break :b if (std.mem.eql(u8, cc, "9.0"))
-                        .cuda_fa3
-                    else
-                        .cuda_fa2;
-                }
-
-                break :b .vanilla;
+                const cc = zml.platform.cuda.computeCapability(platform) orelse break :b .vanilla;
+                break :b if (cc.is(9, 0)) .cuda_fa3 else .cuda_fa2;
             },
             .neuron => .nki,
             .metal => .metal_fa,
@@ -49,12 +41,7 @@ pub const Backend = enum {
             .nki => platform.target == .neuron,
             .metal_fa => platform.target == .metal,
             .cuda_fa2 => platform.target == .cuda,
-            .cuda_fa3 => {
-                if (platform.target != .cuda) return false;
-                const first_device = platform.pjrt_client.devices(platform.pjrt_api)[0];
-                const cc = zml.platform.cuda.tryGetComputeCapabilities(platform, first_device) orelse return false;
-                return std.mem.eql(u8, cc, "9.0");
-            },
+            .cuda_fa3 => (zml.platform.cuda.computeCapability(platform) orelse return false).is(9, 0),
         };
     }
 };

--- a/zml/attention.zig
+++ b/zml/attention.zig
@@ -26,7 +26,7 @@ pub const Backend = enum {
         return switch (platform.target) {
             .cuda => b: {
                 const cc = zml.platform.cuda.computeCapability(platform) orelse break :b .vanilla;
-                break :b if (cc.is(9, 0)) .cuda_fa3 else .cuda_fa2;
+                break :b if (cc.eql(.{ .major = 9, .minor = 0 })) .cuda_fa3 else .cuda_fa2;
             },
             .neuron => .nki,
             .metal => .metal_fa,
@@ -41,7 +41,7 @@ pub const Backend = enum {
             .nki => platform.target == .neuron,
             .metal_fa => platform.target == .metal,
             .cuda_fa2 => platform.target == .cuda,
-            .cuda_fa3 => (zml.platform.cuda.computeCapability(platform) orelse return false).is(9, 0),
+            .cuda_fa3 => if (zml.platform.cuda.computeCapability(platform)) |cc| cc.eql(.{ .major = 9, .minor = 0 }) else false,
         };
     }
 };

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -44,7 +44,7 @@ pub const Backend = enum {
             .metal => platform.target == .metal,
             .mosaic_tpu => platform.target == .tpu,
             .cuda_fa2 => platform.target == .cuda,
-            .cuda_fa3 => (zml.platform.cuda.computeCapability(platform) orelse return false).is(9, 0),
+            .cuda_fa3 => if (zml.platform.cuda.computeCapability(platform)) |cc| cc.eql(.{ .major = 9, .minor = 0 }) else false,
         };
     }
 };

--- a/zml/attention/paged_attention.zig
+++ b/zml/attention/paged_attention.zig
@@ -44,12 +44,7 @@ pub const Backend = enum {
             .metal => platform.target == .metal,
             .mosaic_tpu => platform.target == .tpu,
             .cuda_fa2 => platform.target == .cuda,
-            .cuda_fa3 => {
-                if (platform.target != .cuda) return false;
-                const first_device = platform.pjrt_client.devices(platform.pjrt_api)[0];
-                const cc = zml.platform.cuda.tryGetComputeCapabilities(platform, first_device) orelse return false;
-                return std.mem.eql(u8, cc, "9.0");
-            },
+            .cuda_fa3 => (zml.platform.cuda.computeCapability(platform) orelse return false).is(9, 0),
         };
     }
 };

--- a/zml/attention/triton_attention.zig
+++ b/zml/attention/triton_attention.zig
@@ -52,13 +52,9 @@ const SparseMlaConfig = struct {
     parallel_reduce_num_warps: usize = 1,
 };
 
-fn isCudaComputeCapability(expected: []const u8) bool {
+fn isCudaComputeCapability(major: u8, minor: u8) bool {
     const platform = zml.module.CompilationContext.current().platform;
-    if (platform.target != .cuda) return false;
-    const devices = platform.pjrt_client.devices(platform.pjrt_api);
-    if (devices.len == 0) return false;
-    const actual = zml.platform.cuda.tryGetComputeCapabilities(platform, devices[0]) orelse return false;
-    return std.mem.eql(u8, actual, expected);
+    return (zml.platform.cuda.computeCapability(platform) orelse return false).is(major, minor);
 }
 
 fn sparseMlaConfig(paged_opts: paged.PagedSparseMlaOptions, topk_count: usize, cu_count_: usize) SparseMlaConfig {
@@ -74,7 +70,7 @@ fn sparseMlaConfig(paged_opts: paged.PagedSparseMlaOptions, topk_count: usize, c
         .num_splits = 1,
         .direct_programs = undefined,
     };
-    const is_sm103 = isCudaComputeCapability("10.3");
+    const is_sm103 = isCudaComputeCapability(10, 3);
 
     // GB300 (sm_103): a single wide query benefits from more head blocks and
     // wider sparse tiles. The split selection below still derives each layer's
@@ -154,7 +150,7 @@ fn select2dConfig(options: paged.PagedAttentionOptions) Config2D {
     const max_num_stages_2d: usize = if (options.head_dim <= 128) 4 else 2;
 
     // Until we test on other platforms, gate the fix to GB300
-    const is_gb300 = isCudaComputeCapability("10.3");
+    const is_gb300 = isCudaComputeCapability(10, 3);
 
     var num_stages_2d: usize, var num_warps: usize, var tile_size: usize = if (!options.all_decode) .{ 1, 2, 64 } else .{ 3, 2, options.block_size };
 

--- a/zml/attention/triton_attention.zig
+++ b/zml/attention/triton_attention.zig
@@ -52,9 +52,9 @@ const SparseMlaConfig = struct {
     parallel_reduce_num_warps: usize = 1,
 };
 
-fn isCudaComputeCapability(major: u8, minor: u8) bool {
+fn isCudaComputeCapability(expected: zml.platform.cuda.ComputeCapability) bool {
     const platform = zml.module.CompilationContext.current().platform;
-    return (zml.platform.cuda.computeCapability(platform) orelse return false).is(major, minor);
+    return if (zml.platform.cuda.computeCapability(platform)) |cc| cc.eql(expected) else false;
 }
 
 fn sparseMlaConfig(paged_opts: paged.PagedSparseMlaOptions, topk_count: usize, cu_count_: usize) SparseMlaConfig {
@@ -70,7 +70,7 @@ fn sparseMlaConfig(paged_opts: paged.PagedSparseMlaOptions, topk_count: usize, c
         .num_splits = 1,
         .direct_programs = undefined,
     };
-    const is_sm103 = isCudaComputeCapability(10, 3);
+    const is_sm103 = isCudaComputeCapability(.{ .major = 10, .minor = 3 });
 
     // GB300 (sm_103): a single wide query benefits from more head blocks and
     // wider sparse tiles. The split selection below still derives each layer's
@@ -150,7 +150,7 @@ fn select2dConfig(options: paged.PagedAttentionOptions) Config2D {
     const max_num_stages_2d: usize = if (options.head_dim <= 128) 4 else 2;
 
     // Until we test on other platforms, gate the fix to GB300
-    const is_gb300 = isCudaComputeCapability(10, 3);
+    const is_gb300 = isCudaComputeCapability(.{ .major = 10, .minor = 3 });
 
     var num_stages_2d: usize, var num_warps: usize, var tile_size: usize = if (!options.all_decode) .{ 1, 2, 64 } else .{ 3, 2, options.block_size };
 

--- a/zml/moe/cutlass_flashinfer.zig
+++ b/zml/moe/cutlass_flashinfer.zig
@@ -357,18 +357,11 @@ const routedBf16Call = zml.ops.CustomCall(Bf16Input, Output, Attributes, ffiCall
 });
 
 fn computeCapability(platform: *const zml.Platform) !u16 {
-    if (platform.target != .cuda) return error.UnsupportedPlatform;
-    const devices = platform.pjrt_client.devices(platform.pjrt_api);
-    if (devices.len == 0) return error.NoDevices;
-
-    const compute_capability = zml.platform.cuda.tryGetComputeCapabilities(platform, devices[0]) orelse
-        return error.UnknownComputeCapability;
-
-    if (std.mem.eql(u8, compute_capability, "9.0")) return 90;
-    if (std.mem.eql(u8, compute_capability, "10.0")) return 100;
-    if (std.mem.eql(u8, compute_capability, "10.3")) return 103;
-    if (std.mem.eql(u8, compute_capability, "12.0")) return 120;
-    return error.UnsupportedArchitecture;
+    const cc = zml.platform.cuda.computeCapability(platform) orelse return error.UnsupportedPlatform;
+    return switch (cc.sm()) {
+        90, 100, 103, 120 => |sm| sm,
+        else => error.UnsupportedArchitecture,
+    };
 }
 
 pub fn load(

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -795,14 +795,40 @@ pub const CreateOptions = struct {
 
 // TODO(Corendos): Consider moving that in its own file if its size increase too much.
 pub const cuda = struct {
-    pub fn tryGetComputeCapabilities(platform: *const zml.Platform, device: *const pjrt.Device) ?[]const u8 {
-        stdx.debug.assert(platform.target == .cuda, "tryGetComputeCapabilities expects .cuda platform, got {}", .{platform.target});
-        const description = device.getDescription(platform.pjrt_api);
+    pub const ComputeCapability = struct {
+        major: u8,
+        minor: u8,
 
-        const attributes = description.attributes(platform.pjrt_api);
+        pub fn parse(text: []const u8) ?ComputeCapability {
+            var parts = std.mem.splitScalar(u8, text, '.');
+            return .{
+                .major = std.fmt.parseInt(u8, parts.first(), 10) catch return null,
+                .minor = std.fmt.parseInt(u8, parts.next() orelse "0", 10) catch return null,
+            };
+        }
+
+        pub fn is(self: ComputeCapability, major: u8, minor: u8) bool {
+            return self.major == major and self.minor == minor;
+        }
+
+        pub fn atLeast(self: ComputeCapability, major: u8, minor: u8) bool {
+            return self.major > major or (self.major == major and self.minor >= minor);
+        }
+
+        pub fn sm(self: ComputeCapability) u16 {
+            return @as(u16, self.major) * 10 + self.minor;
+        }
+    };
+
+    pub fn computeCapability(platform: *const zml.Platform) ?ComputeCapability {
+        if (platform.target != .cuda) return null;
+        const devices = platform.pjrt_client.devices(platform.pjrt_api);
+        if (devices.len == 0) return null;
+
+        const attributes = devices[0].getDescription(platform.pjrt_api).attributes(platform.pjrt_api);
         return for (attributes) |attr| {
             if (std.mem.eql(u8, attr.name(), "compute_capability")) {
-                break attr.value().string;
+                break ComputeCapability.parse(attr.value().string);
             }
         } else null;
     }

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -807,12 +807,12 @@ pub const cuda = struct {
             };
         }
 
-        pub fn is(self: ComputeCapability, major: u8, minor: u8) bool {
-            return self.major == major and self.minor == minor;
+        pub fn eql(self: ComputeCapability, other: ComputeCapability) bool {
+            return self.major == other.major and self.minor == other.minor;
         }
 
-        pub fn atLeast(self: ComputeCapability, major: u8, minor: u8) bool {
-            return self.major > major or (self.major == major and self.minor >= minor);
+        pub fn atLeast(self: ComputeCapability, other: ComputeCapability) bool {
+            return self.major > other.major or (self.major == other.major and self.minor >= other.minor);
         }
 
         pub fn sm(self: ComputeCapability) u16 {

--- a/zml/quantization.zig
+++ b/zml/quantization.zig
@@ -123,11 +123,13 @@ pub fn quantizeNvfp4(x: Tensor, input_global_scale: ?Tensor, axis: anytype) Quan
     else
         x;
     const grouped = scaled.splitAxis(axis, .{ .sc = -1, .blk = nvfp4_block_size });
-    const amax = grouped.abs().max(.blk);
 
-    const scales = amax.scale(1.0 / value_max)
+    const amax = grouped.abs()
+        .scale(1.0 / value_max)
         .clamp(.scalar(scale_min_normal, dt), .scalar(scale_max, dt))
-        .convert(.f8e4m3fn);
+        .max(.blk);
+
+    const scales = amax.convert(.f8e4m3fn);
 
     const divisor = scales.convert(dt)
         .maximum(.scalar(scale_min_normal, dt))

--- a/zml/quantization.zig
+++ b/zml/quantization.zig
@@ -147,13 +147,7 @@ pub fn quantizeNvfp4(x: Tensor, input_global_scale: ?Tensor, axis: anytype) Quan
 }
 
 fn supportsNvfp4InputQuantization(platform: *const Platform) bool {
-    if (platform.target != .cuda) return false;
-
-    const device = platform.pjrt_client.devices(platform.pjrt_api)[0];
-    const capability = platform_mod.cuda.tryGetComputeCapabilities(platform, device) orelse return false;
-    const major = std.fmt.parseInt(u8, std.mem.sliceTo(capability, '.'), 10) catch return false;
-
-    return major >= 10;
+    return (platform_mod.cuda.computeCapability(platform) orelse return false).atLeast(10, 0);
 }
 
 fn isPackedFp4(scheme: ?Quantization.Scheme, weight_dtype: DataType) bool {

--- a/zml/quantization.zig
+++ b/zml/quantization.zig
@@ -147,7 +147,7 @@ pub fn quantizeNvfp4(x: Tensor, input_global_scale: ?Tensor, axis: anytype) Quan
 }
 
 fn supportsNvfp4InputQuantization(platform: *const Platform) bool {
-    return (platform_mod.cuda.computeCapability(platform) orelse return false).atLeast(10, 0);
+    return if (platform_mod.cuda.computeCapability(platform)) |cc| cc.atLeast(.{ .major = 10, .minor = 0 }) else false;
 }
 
 fn isPackedFp4(scheme: ?Quantization.Scheme, weight_dtype: DataType) bool {


### PR DESCRIPTION
Every CUDA gate used to parse the compute capability string itself. They now share `platform.cuda.computeCapability`, which returns null off CUDA and offers `.is` / `.atLeast` / `.sm`.

Also folds the NVFP4 scale clamp into its reduce to remove one launch per projection, and is equivalent.