### PR TITLE
zml: support block-128 FP8 quantized input and f32 scale & add rocm computeCapability

### DIFF
--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -106,12 +106,16 @@ test "unpackFp4 expands the requested axis" {
 /// - **NVFP4**: values `.f4e2m1`, scales `.f8e4m3fn`, block 16 (weight-only bf16 lhs ok)
 /// - **MXFP4**: values `.f4e2m1`, scales `.f8e8m0fnu`, block 32
 /// - **MXFP8**: values `.f8e4m3fn` / `.f8e5m2`, scales `.f8e8m0fnu`, block 32
-/// - TODO: INT4/8 and FP8 with block 128 and per tensor
+/// - **Block FP8**: E4M3FN / E4M3FNUZ / E8M0 values, BF16 or F32 128x128 scales
+/// - TODO: INT4/8 and FP8 per tensor
 ///
 /// Backends:
-/// 1. TileIR if CUDA sm>=10 and same lhs/rhs dtype
-/// 2. Triton otherwise
-/// 3. Unsupported combos fall back to dequant + Dot
+/// XLA selects specialized GPU kernels (TileIR, Triton, or block-128 W8A8),
+/// with dequant + Dot as the fallback.
+///
+/// Axes follow `Tensor.dot`; XLA currently accepts one contracting axis and at
+/// most one batch axis. Scales preserve operand axis order, and each scale
+/// dimension must divide its corresponding value dimension.
 ///
 /// CPU has no specialized path.
 pub fn scaledDot(
@@ -126,7 +130,7 @@ pub fn scaledDot(
     const Axes = stdx.BoundedArray(i64, constants.MAX_RANK);
 
     const result_dtype: DataType = switch (lhs.dtype()) {
-        .f4e2m1, .f8e4m3, .f8e4m3fn, .f8e5m2, .f8e4m3b11fnuz, .f8e4m3fnuz, .f8e5m2fnuz => .bf16,
+        .f4e2m1, .f8e4m3, .f8e4m3fn, .f8e5m2, .f8e4m3b11fnuz, .f8e4m3fnuz, .f8e5m2fnuz, .f8e8m0 => .bf16,
         else => lhs.dtype(),
     };
     var res_shape: Shape = .{ ._dtype = result_dtype };
@@ -190,14 +194,94 @@ pub fn scaledDot(
             .intArray(mlir_ctx, i64, rhs_batching_axes.constSlice()),
         }),
     });
-
-    const operands: []const Tensor = &.{ lhs, rhs, lhs_scale_operand, rhs_scale_operand };
-
-    const outs = ops.composite("xla.scaled_dot", operands, &.{res_shape}, scaledDotReference, res_shape, .{
+    return ops.composite("xla.scaled_dot", &.{ lhs, rhs, lhs_scale_operand, rhs_scale_operand }, &.{res_shape}, scaledDotReference, res_shape, .{
         .composite_attributes = &.{.named(mlir_ctx, "dimension_numbers", dnums)},
-    });
+    })[0];
+}
 
-    return outs[0];
+test "block128 scaled dot layouts" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+    const platform = zml.testing.env();
+    // FIXME: Add rocm when we have a PJRT plugin with native fp8 dot support (by the end of Sept 2026)
+    if (platform.target != .cuda) return error.SkipZigTest;
+    const dtype: DataType = if (platform.target == .rocm and @import("platform.zig").rocm.computeCapability(platform) == .gfx942) .f8e4m3fnuz else .f8e4m3fn;
+    const Local = struct {
+        const Outputs = struct { actual: Tensor, expected: Tensor, linear: Tensor, linear_expected: Tensor };
+
+        fn dequantize(values: Tensor, scales: Tensor) Tensor {
+            var expanded = scales.convert(.bf16);
+            for (0..values.rank()) |axis| {
+                const factor = @divExact(values.dim(axis), scales.dim(axis));
+                const shape = expanded.shape().insert(axis + 1, .{factor});
+                const axes = Shape.range(shape.rank(), .i64).remove(axis + 1);
+                expanded = expanded.broadcast(shape, axes.dims()).reshape(expanded.shape().setDim(axis, values.dim(axis)));
+            }
+            return values.convert(.bf16).mul(expanded);
+        }
+
+        fn forward(x: Tensor, w: Tensor, scales: Tensor, fp8: DataType, prequantized: bool) Outputs {
+            const weight = w.convert(fp8);
+            const input = quantization.quantizeBlockFp8(x, .k, fp8);
+            const linear: Linear = .{ .weight = weight, .tag = Shape.toTag(.k), .quantization = .{ .scheme = .fp8_block128, .scales = scales } };
+            return .{
+                .linear = linear.forward(x),
+                .linear_expected = dequantize(input.values, input.scales).dot(dequantize(weight, scales), .k),
+                .actual = if (prequantized)
+                    scaledDot(input.values, weight, input.scales.convert(scales.dtype()), scales, .k)
+                else
+                    scaledDot(x, weight, null, scales, .k),
+                .expected = (if (prequantized) dequantize(input.values, input.scales.convert(scales.dtype())) else x)
+                    .dot(dequantize(weight, scales), .k),
+            };
+        }
+    };
+    inline for (.{
+        .{ .{ .m = 16, .k = 256 }, .{ .n = 256, .k = 256 } },
+        .{ .{ .b = 2, .m = 16, .k = 256 }, .{ .b = 2, .n = 256, .k = 256 } },
+        .{ .{ .k = 256, .b = 2, .m = 3 }, .{ .n = 256, .k = 256, .b = 2 } },
+        .{ .{ .b = 2, .k = 256, .s = 2, .m = 3 }, .{ .n = 128, .b = 2, .k = 256 } },
+        .{ .{ .b = 2, .m = 3, .k = 256 }, .{ .k = 256, .n = 128 } },
+        .{ .{ .k = 128 }, .{ .n = 128, .k = 128 } },
+        .{ .{ .m = 3, .k = 256 }, .{ .p = 2, .k = 256, .n = 128 } },
+        .{ .{ .m = 3, .k = 128 }, .{ .n = 64, .k = 128 } },
+    }) |layout| {
+        inline for (.{ DataType.f32, DataType.bf16 }) |scale_dtype| {
+            inline for (.{ false, true }) |prequantized| {
+                const x: Tensor = .init(layout[0], .bf16);
+                const w: Tensor = .init(layout[1], .bf16);
+                const scales: Tensor = .init(w.shape().setDim(.n, std.math.divCeil(i64, w.dim(.n), 128) catch unreachable).setDim(.k, @divExact(w.dim(.k), 128)).withDtype(scale_dtype), scale_dtype);
+                var exe = try platform.compileFn(allocator, io, Local.forward, .{ x, w, scales, dtype, prequantized }, .{});
+                defer exe.deinit();
+                try zml.testing.expectEqualShapes(exe.output_shapes[1], exe.output_shapes[0]);
+                var buffers: [3]zml.Buffer = undefined;
+                var initialized: usize = 0;
+                defer for (buffers[0..initialized]) |*buffer| buffer.deinit();
+                for ([_]Shape{ x.shape(), w.shape(), scales.shape() }, 0..) |shape, i| {
+                    const slice = try Slice.alloc(allocator, shape);
+                    defer slice.free(allocator);
+                    for (0..shape.count()) |j| {
+                        const value: f32 = if (i == 2) @as(f32, @floatFromInt(1 + (j * 3 + j / 4) % 7)) / 16 else @as(f32, @floatFromInt(@as(i32, @intCast((j * 7 + j / 256) % 13)) - 6)) / 4;
+                        if (shape.dtype() == .f32) {
+                            slice.items(f32)[j] = value;
+                        } else {
+                            slice.items(zml.floats.BFloat16)[j] = .fromF32(value);
+                        }
+                    }
+                    buffers[i] = try zml.Buffer.fromSlice(io, platform, slice, .replicated);
+                    initialized += 1;
+                }
+                var output = try zml.testing.autoCall(allocator, io, &exe, Local.forward, .{ buffers[0], buffers[1], buffers[2] });
+                defer zml.Buffer.deinitAll(Local.Outputs, &output);
+                var expected = try output.expected.toSliceAlloc(allocator, io);
+                defer expected.free(allocator);
+                try zml.testing.expectClose(io, expected, output.actual, .{ .absolute_tolerance = 0.125, .relative_tolerance = 0.02 });
+                var linear_expected = try output.linear_expected.toSliceAlloc(allocator, io);
+                defer linear_expected.free(allocator);
+                try zml.testing.expectClose(io, linear_expected, output.linear, .{ .absolute_tolerance = 0.125, .relative_tolerance = 0.02 });
+            }
+        }
+    }
 }
 
 /// `shape` with every dimension collapsed to 1

--- a/zml/platform.zig
+++ b/zml/platform.zig
@@ -834,6 +834,73 @@ pub const cuda = struct {
     }
 };
 
+pub const rocm = struct {
+    pub const ComputeCapability = enum {
+        /// CDNA1: MI100.
+        gfx908,
+        /// CDNA2: MI200 series.
+        gfx90a,
+        /// CDNA3: MI300 series.
+        gfx942,
+        /// CDNA4: MI350 series.
+        gfx950,
+        /// RDNA2: RX 6000 series.
+        gfx1030,
+        /// RDNA3 (Navi 31): RX 7900 series.
+        gfx1100,
+        /// RDNA3 (Navi 32): RX 7800 and RX 7700 series.
+        gfx1101,
+        /// RDNA3 (Navi 33): RX 7600 series.
+        gfx1102,
+        /// RDNA3 APU: Phoenix.
+        gfx1103,
+        /// RDNA3.5: newer Ryzen AI APUs.
+        gfx1150,
+        /// RDNA4 (Navi 44): RX 9060 family.
+        gfx1200,
+        /// RDNA4 (Navi 48): RX 9070 family.
+        gfx1201,
+
+        pub const Architecture = enum {
+            cdna1,
+            cdna2,
+            cdna3,
+            cdna4,
+            rdna2,
+            rdna3,
+            rdna3_5,
+            rdna4,
+        };
+
+        pub fn architecture(self: ComputeCapability) Architecture {
+            return switch (self) {
+                .gfx908 => .cdna1,
+                .gfx90a => .cdna2,
+                .gfx942 => .cdna3,
+                .gfx950 => .cdna4,
+                .gfx1030 => .rdna2,
+                .gfx1100, .gfx1101, .gfx1102, .gfx1103 => .rdna3,
+                .gfx1150 => .rdna3_5,
+                .gfx1200, .gfx1201 => .rdna4,
+            };
+        }
+    };
+
+    /// Assumes homogeneous devices.
+    pub fn computeCapability(platform: *const zml.Platform) ?ComputeCapability {
+        stdx.debug.assert(platform.target == .rocm, "computeCapability expects .rocm platform, got {}", .{platform.target});
+        const device = platform.pjrt_client.devices(platform.pjrt_api)[0];
+        const description = device.getDescription(platform.pjrt_api);
+
+        const attributes = description.attributes(platform.pjrt_api);
+        return for (attributes) |attr| {
+            if (std.mem.eql(u8, attr.name(), "compute_capability")) {
+                break std.meta.stringToEnum(ComputeCapability, std.mem.sliceTo(attr.value().string, ':'));
+            }
+        } else null;
+    }
+};
+
 fn dataTypeFromFfiDataType(ffi_dt: pjrt.ffi.DataType) zml.DataType {
     return switch (ffi_dt) {
         .bool => .bool,

--- a/zml/quantization.zig
+++ b/zml/quantization.zig
@@ -1,5 +1,6 @@
 //! Quantization metadata and scheme classification.
 const std = @import("std");
+
 const stdx = @import("stdx");
 
 const DataType = @import("dtype.zig").DataType;
@@ -47,8 +48,8 @@ pub const Quantization = struct {
         /// f8e4m3fn values, one bf16 or f32 scale per output channel, constant along the contraction.
         /// Emitted by llm-compressor, including for the layers an NVFP4 recipe leaves in FP8.
         fp8_per_channel,
-        /// f8e4m3fn values, one bf16 scale per 128x128 tile. The DeepSeek-style FP8 that model
-        /// vendors publish themselves, under `weight_scale_inv`.
+        /// f8e4m3fn, f8e4m3fnuz, or f8e8m0 values, one bf16 or f32 scale per 128x128 tile.
+        /// The DeepSeek-style FP8 that model vendors publish themselves, under `weight_scale_inv`.
         fp8_block128,
         /// f8e4m3fn values, one scale for the whole tensor. Spelled `[1, 1]` rather than as a
         /// scalar: XLA's composite rewriter requires the scale to have the operand's rank.
@@ -74,10 +75,11 @@ pub const Quantization = struct {
                     (scale.dtype() == .bf16 or scale.dtype() == .f32) and
                     scale.count() > 1 and scale.rank() == 2 and
                     scale.dim(0) == n and scale.dim(1) == 1,
-                .fp8_block128 => weight.dtype() == .f8e4m3fn and scale.dtype() == .bf16 and
+                .fp8_block128 => (weight.dtype() == .f8e4m3fn or weight.dtype() == .f8e4m3fnuz or weight.dtype() == .f8e8m0) and
+                    (scale.dtype() == .bf16 or scale.dtype() == .f32) and
                     scale.count() > 1 and scale.rank() == 2 and
-                    @rem(n, 128) == 0 and @rem(k, 128) == 0 and
-                    scale.dim(0) == @divExact(n, 128) and scale.dim(1) == @divExact(k, 128),
+                    scale.dim(0) == (std.math.divCeil(i64, n, 128) catch unreachable) and
+                    scale.dim(1) == (std.math.divCeil(i64, k, 128) catch unreachable),
             };
         }
 
@@ -105,7 +107,40 @@ pub fn quantizeInput(quantization: Quantization, input: Tensor, axis: Shape.Tag,
     const global_scale: ?Tensor = if (quantization.input_scale) |scale| scale.asMultiplier() else null;
     return switch (quantization.scheme) {
         .nvfp4 => if (supportsNvfp4InputQuantization(platform)) quantizeNvfp4(input, global_scale, axis) else null,
-        .mxfp8, .mxfp4, .fp8_per_channel, .fp8_block128, .fp8_per_tensor => null,
+        .fp8_block128 => switch (platform.target) {
+            .cuda => quantizeBlockFp8(input, axis, .f8e4m3fn),
+            .rocm => if (platform_mod.rocm.computeCapability(platform)) |capability| switch (capability.architecture()) {
+                .cdna4, .rdna4 => quantizeBlockFp8(input, axis, .f8e4m3fn),
+                .cdna3 => quantizeBlockFp8(input, axis, .f8e4m3fnuz),
+                .cdna1, .cdna2, .rdna2, .rdna3, .rdna3_5 => null,
+            } else null,
+            else => null,
+        },
+        .mxfp8, .mxfp4, .fp8_per_channel, .fp8_per_tensor => null,
+    };
+}
+
+/// Quantize each 128-value activation block, preserving the input's axes.
+/// Scales have the same shape with the contracting dimension divided by 128.
+pub fn quantizeBlockFp8(x: Tensor, axis: anytype, dtype: DataType) QuantizedInput {
+    stdx.debug.assert(dtype == .f8e4m3fn or dtype == .f8e4m3fnuz, "expected E4M3 FP8 dtype, got {s}", .{@tagName(dtype)});
+    stdx.debug.assert(@mod(x.dim(axis), 128) == 0, "block FP8 activation width must be divisible by 128, got {f}", .{x.shape()});
+    // Match the routed-MoE quantizer's FNUZ range.
+    const fp8_max: f32 = if (dtype == .f8e4m3fnuz) 224.0 else 448.0;
+    const grouped = x.convert(.f32).splitAxis(axis, .{ .fp8_ks = -1, .fp8_block = 128 });
+    // Put scale arithmetic before the reduction so it can fuse into the producer.
+    const scales = grouped.abs()
+        .maximum(.scalar(1e-10, .f32))
+        .scale(1.0 / fp8_max)
+        .max(.fp8_block);
+    const values = grouped.div(scales.broad(grouped.shape()))
+        .clamp(.scalar(-fp8_max, .f32), .scalar(fp8_max, .f32))
+        .convert(dtype)
+        .reshape(x.shape().withDtype(dtype));
+    return .{
+        .values = values,
+        .scales = scales.reshape(x.shape().setDim(axis, @divExact(x.dim(axis), 128)).withDtype(.f32)),
+        .global_scale = null,
     };
 }
 
@@ -194,6 +229,20 @@ test "Quantization.Scheme.classify" {
         .init(.{ .dout = 40, .sc = 48 }, .bf16),
     ));
 
+    // GLM uses f32 scales and permits a partial final 128-row tile.
+    try expect(@as(?Quantization.Scheme, .fp8_block128), Quantization.Scheme.classify(
+        .init(.{ .dout = 2048, .d = 6144 }, .f8e4m3fn),
+        .init(.{ .dout = 16, .sc = 48 }, .f32),
+    ));
+    try expect(@as(?Quantization.Scheme, .fp8_block128), Quantization.Scheme.classify(
+        .init(.{ .dout = 576, .d = 6144 }, .f8e4m3fn),
+        .init(.{ .dout = 5, .sc = 48 }, .f32),
+    ));
+    try expect(@as(?Quantization.Scheme, .fp8_block128), Quantization.Scheme.classify(
+        .init(.{ .dout = 576, .d = 6144 }, .f8e8m0),
+        .init(.{ .dout = 5, .sc = 48 }, .f32),
+    ));
+
     // Mistral's per-tensor FP8: one scale for the whole tensor, rank 0 or [1].
     try expect(@as(?Quantization.Scheme, .fp8_per_tensor), Quantization.Scheme.classify(.init(.{ .dout = 4096, .d = 4096 }, .f8e4m3fn), .init(.{}, .f32)));
     try expect(@as(?Quantization.Scheme, .fp8_per_tensor), Quantization.Scheme.classify(.init(.{ .dout = 4096, .d = 4096 }, .f8e4m3fn), .init(.{ .g = 1 }, .f32)));
@@ -275,4 +324,47 @@ test "Quantization.Scheme.classify" {
         .init(.{ .dout = 128, .d = 128 }, .f8e4m3fn),
         .init(.{ .dout = 1, .sc = 1 }, .bf16),
     ));
+}
+
+test "block FP8 quantization preserves axes and reconstructs constant blocks in FN and FNUZ" {
+    const zml = @import("zml.zig");
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+    const platform = zml.testing.env();
+    inline for (.{ DataType.f8e4m3fn, DataType.f8e4m3fnuz }) |dtype| {
+        const Local = struct {
+            const Outputs = struct { values: Tensor, scales: Tensor };
+            fn forward(x: Tensor) Outputs {
+                const input = quantizeBlockFp8(x, .k, dtype);
+                return .{ .values = input.values.convert(.f32), .scales = input.scales };
+            }
+        };
+        const x: Tensor = .init(.{ .b = 2, .k = 256, .s = 3 }, .bf16);
+        var exe = try platform.compileFn(allocator, io, Local.forward, .{x}, .{});
+        defer exe.deinit();
+        try zml.testing.expectEqualShapes(x.shape().withDtype(.f32), exe.output_shapes[0]);
+        try zml.testing.expectEqualShapes(x.shape().setDim(.k, 2).withDtype(.f32), exe.output_shapes[1]);
+        var host: [2 * 256 * 3]zml.floats.BFloat16 = undefined;
+        for (&host, 0..) |*value, i| {
+            const magnitude: f32 = if ((i / 3) % 256 < 128) 1.0 else 2.0;
+            value.* = .fromF32(switch (i % 3) {
+                0 => 0.0,
+                1 => magnitude,
+                else => -magnitude,
+            });
+        }
+        var buffer = try zml.Buffer.fromBytes(io, platform, x.shape(), .replicated, std.mem.asBytes(&host));
+        defer buffer.deinit();
+        var output = try zml.testing.autoCall(allocator, io, &exe, Local.forward, .{buffer});
+        defer zml.Buffer.deinitAll(Local.Outputs, &output);
+        var values = try output.values.toSliceAlloc(allocator, io);
+        defer values.free(allocator);
+        var scales = try output.scales.toSliceAlloc(allocator, io);
+        defer scales.free(allocator);
+        for (scales.constItems(f32)) |scale| try std.testing.expect(std.math.isFinite(scale) and scale > 0);
+        for (values.constItems(f32), 0..) |value, i| {
+            const scale_index = (i / (256 * 3)) * 6 + ((i / 3) % 256) / 128 * 3 + i % 3;
+            try std.testing.expectApproxEqAbs(host[i].toF32(), value * scales.constItems(f32)[scale_index], 1e-6);
+        }
+    }
 }


### PR DESCRIPTION
Imitating `platform.cuda.computeCapability` as fp8 support is native for e4m3fnuz on gfx942 but e4m3fn for everything else that has hardware support AFAIK. 