### PR TITLE
zml/moe: support block-128 FP8 and parallel expert execution

### DIFF
--- a/zml/BUILD.bazel
+++ b/zml/BUILD.bazel
@@ -76,6 +76,7 @@ zig_library(
 zig_library(
     name = "zml",
     srcs = [
+        "Compiler.zig",
         "Sharding.zig",
         "attention.zig",
         "attention/attnd.zig",
@@ -99,7 +100,6 @@ zig_library(
         "mem.zig",
         "meta.zig",
         "mlirx.zig",
-        "Compiler.zig",
         "moe/cutlass_flashinfer.zig",
         "moe/metal.zig",
         "moe/moe.zig",

--- a/zml/meta.zig
+++ b/zml/meta.zig
@@ -231,6 +231,10 @@ pub fn mapAlloc(comptime cb: anytype, allocator: std.mem.Allocator, ctx: FnParam
                 }
                 to.* = items;
             },
+            .many => if (FromStruct == [*:0]const u8 and ToStruct == FromStruct and From != u8) {
+                // Tensor axis tags are borrowed immutable strings.
+                to.* = from;
+            } else stdx.debug.compileError("zml.meta.mapAlloc doesn't support: {}", .{FromStruct}),
             else => stdx.debug.compileError("zml.meta.mapAlloc doesn't support: {}", .{FromStruct}),
         },
         .optional => if (from) |f| {
@@ -260,6 +264,7 @@ test mapAlloc {
         array: [2]A,
         slice: []const A,
         other: u8,
+        tag: [*:0]const u8,
         // We want to allow conversion from comptime to runtime, because Zig type inference works like this.
         comptime static_val: u8 = 8,
         comptime static_slice: [2]A = .{ .{ .a = 11 }, .{ .a = 12 } },
@@ -270,6 +275,7 @@ test mapAlloc {
         array: [2]B,
         slice: []const B,
         other: u8,
+        tag: [*:0]const u8,
         static_val: u8,
         static_slice: []B,
         field_with_empty: struct { B, Empty },
@@ -279,6 +285,7 @@ test mapAlloc {
         .field = .{ .a = 4 },
         .array = .{ .{ .a = 5 }, .{ .a = 6 } },
         .other = 7,
+        .tag = "feature",
         .slice = &.{ .{ .a = 9 }, .{ .a = 10 } },
         .field_with_empty = .{ .{ .a = 9 }, .{} },
     };
@@ -292,6 +299,7 @@ test mapAlloc {
     try testing.expectEqual(5, bb.array[0].b);
     try testing.expectEqual(6, bb.array[1].b);
     try testing.expectEqual(7, bb.other);
+    try testing.expectEqual(aa.tag, bb.tag);
     try testing.expectEqual(8, bb.static_val);
     try testing.expectEqual(9, bb.slice[0].b);
     try testing.expectEqual(10, bb.slice[1].b);

--- a/zml/moe/moe.zig
+++ b/zml/moe/moe.zig
@@ -195,6 +195,121 @@ pub const Metadata = union(Backend) {
 
 pub const Options = struct {
     activation_threshold: ?f32 = null,
+    quant_scheme: ?zml.Quantization.Scheme = null,
+};
+
+pub const TritonMoe = struct {
+    input: zml.Tensor,
+    topk_ids: zml.Tensor,
+    topk_weights: zml.Tensor,
+    weights_gate_up: zml.Tensor,
+    weights_down: zml.Tensor,
+    gate_up_scale: ?zml.Tensor,
+    down_scale: ?zml.Tensor,
+    activation: triton.Parameters.ActivationMode,
+    global_num_experts: i64,
+    quant_scheme: ?zml.Quantization.Scheme,
+    activation_threshold: ?f32,
+
+    /// Validate global expert-parallel tensors before entering manualComputation.
+    /// The resulting tensors must be localized together with the caller's inputs.
+    pub fn initExpertParallel(
+        input: zml.Tensor,
+        topk_ids: zml.Tensor,
+        topk_weights: zml.Tensor,
+        gate_up: zml.nn.Linear,
+        down: zml.nn.Linear,
+        opts: Options,
+        activation: triton.Parameters.ActivationMode,
+    ) !TritonMoe {
+        if (!gate_up.weight.shape().partition(.expert).eql(.init(.experts)) or
+            !down.weight.shape().partition(.expert).eql(.init(.experts)))
+        {
+            return error.ExpectedExpertParallelSharding;
+        }
+        if (gate_up.weight.shape().remove(.expert).hasAtLeastOnePartitionedAxis() or
+            down.weight.shape().remove(.expert).hasAtLeastOnePartitionedAxis())
+        {
+            return error.UnsupportedTensorParallelSharding;
+        }
+        const gate_up_quant = gate_up.quantization orelse return error.MissingWeightScale;
+        const gate_up_scale = gate_up_quant.scales;
+        const down_quant = down.quantization orelse return error.MissingWeightScale;
+        const down_scale = down_quant.scales;
+        if (!gate_up_scale.shape().partition(.expert).eql(.init(.experts)) or
+            !down_scale.shape().partition(.expert).eql(.init(.experts)))
+        {
+            return error.InconsistentExpertSharding;
+        }
+        if (gate_up_scale.shape().remove(.expert).hasAtLeastOnePartitionedAxis() or
+            down_scale.shape().remove(.expert).hasAtLeastOnePartitionedAxis())
+        {
+            return error.UnsupportedTensorParallelSharding;
+        }
+        if (gate_up.bias != null or down.bias != null) return error.UnsupportedBias;
+        if (gate_up_quant.global_scale != null or down_quant.global_scale != null) return error.UnsupportedQuantization;
+        if (gate_up_quant.scheme != .fp8_block128 or down_quant.scheme != .fp8_block128 or
+            (opts.quant_scheme != null and opts.quant_scheme != .fp8_block128)) return error.UnsupportedQuantization;
+
+        return .{
+            .input = input,
+            .topk_ids = topk_ids,
+            .topk_weights = topk_weights,
+            .weights_gate_up = gate_up.weight,
+            .weights_down = down.weight,
+            .gate_up_scale = gate_up_scale,
+            .down_scale = down_scale,
+            .activation = activation,
+            .global_num_experts = gate_up.weight.dim(.expert),
+            .quant_scheme = gate_up_quant.scheme,
+            .activation_threshold = opts.activation_threshold,
+        };
+    }
+
+    /// Compute the local expert contribution inside manualComputation.
+    /// The caller is responsible for summing contributions across partitions.
+    pub fn forwardLocal(self: TritonMoe, prepared: ?zml.quantization.QuantizedInput) zml.Tensor {
+        return self.forward(self.expertMap(), prepared);
+    }
+
+    fn expertMap(self: TritonMoe) zml.Tensor {
+        const local_num_experts = self.weights_gate_up.dim(.expert);
+        const expert_start = zml.ops.partitionId().convert(.i32).scale(local_num_experts).convert(.i32);
+        const global_expert_ids = zml.Tensor.arange(.{ .end = self.global_num_experts }, .i32).withTags(.{.expert});
+        const local_expert_mask = global_expert_ids.cmp(.GE, expert_start)
+            .logical(.AND, global_expert_ids.cmp(.LT, expert_start.addConstant(local_num_experts)));
+        return local_expert_mask.select(global_expert_ids.sub(expert_start), zml.Tensor.scalar(-1, .i32));
+    }
+
+    fn forward(self: TritonMoe, expert_map: ?zml.Tensor, prepared_a1: ?zml.quantization.QuantizedInput) zml.Tensor {
+        const output = triton.fusedExpertsImpl(
+            self.input,
+            self.weights_gate_up,
+            self.weights_down,
+            self.topk_weights,
+            self.topk_ids,
+            .{},
+            .{
+                .activation = self.activation,
+                .global_num_experts = self.global_num_experts,
+                .expert_map = expert_map,
+                .w1_scale = self.gate_up_scale,
+                .w2_scale = self.down_scale,
+                .quant_scheme = self.quant_scheme,
+                .activation_threshold = self.activation_threshold,
+                .prepared_a1 = prepared_a1,
+            },
+        ) catch |err| stdx.debug.panic("moe backend failed: {}", .{err});
+        return output.reshape(self.input.shape().dims()).withTags(.{ .b, .s, .d });
+    }
+
+    fn expertParallel(self: TritonMoe, _: zml.Shape) zml.Tensor {
+        return zml.ops.allReduce(self.forwardLocal(null), zml.Tensor.add);
+    }
+
+    fn tensorParallel(self: TritonMoe, _: zml.Shape) zml.Tensor {
+        return zml.ops.allReduce(self.forward(null, null), zml.Tensor.add);
+    }
 };
 
 pub fn forwardMoe(
@@ -434,6 +549,36 @@ pub fn forwardMoe(
 
             const global_num_experts = gate_up.weight.dim(.expert);
             const expert_partition = gate_up.weight.shape().partition(.expert);
+            const model_partition = zml.Shape.PartitionSpec.init(.model);
+            const gate_up_tensor_parallel = gate_up.weight.shape().partition(1).eql(model_partition);
+            const down_tensor_parallel = down.weight.shape().partition(2).eql(model_partition);
+
+            if (gate_up_tensor_parallel != down_tensor_parallel) {
+                return error.InconsistentTensorParallelSharding;
+            }
+
+            if (gate_up_tensor_parallel) {
+                if (gate_up.bias != null or down.bias != null) return error.UnsupportedBias;
+                if ((gate_up_scales == null) != (down_scales == null)) return error.MissingWeightScale;
+
+                break :b zml.ops.manualComputation(
+                    TritonMoe.tensorParallel,
+                    .{
+                        .input = input,
+                        .topk_ids = topk_ids,
+                        .topk_weights = topk_weights,
+                        .weights_gate_up = gate_up.weight,
+                        .weights_down = down.weight,
+                        .gate_up_scale = gate_up_scales,
+                        .down_scale = down_scales,
+                        .activation = parameters.triton.activation,
+                        .global_num_experts = global_num_experts,
+                        .quant_scheme = quant_scheme,
+                        .activation_threshold = opts.activation_threshold,
+                    },
+                    input.shape(),
+                );
+            }
 
             if (!expert_partition.eql(.init(.experts))) {
                 break :b try triton.fusedExpertsImpl(
@@ -456,74 +601,21 @@ pub fn forwardMoe(
                 );
             }
 
+            if (gate_up.bias != null or down.bias != null) return error.UnsupportedBias;
             break :b zml.ops.manualComputation(
-                (struct {
-                    input: zml.Tensor,
-                    topk_ids: zml.Tensor,
-                    topk_weights: zml.Tensor,
-                    weights_gate_up: zml.Tensor,
-                    weights_down: zml.Tensor,
-                    activation: triton.Parameters.ActivationMode,
-                    global_num_experts: i64,
-                    bias_gate_up: ?zml.Tensor,
-                    bias_down: ?zml.Tensor,
-                    quant_scheme: ?zml.Quantization.Scheme,
-                    activation_threshold: ?f32,
-                    scales_gate_up: ?zml.Tensor,
-                    scales_down: ?zml.Tensor,
-
-                    fn call(self: @This(), _: zml.Shape) zml.Tensor {
-                        const local_num_experts = self.weights_gate_up.dim(.expert);
-                        const partition_id = zml.ops.partitionId().convert(.i32);
-                        const expert_start = partition_id.scale(local_num_experts).convert(.i32);
-                        // List of global expert ids
-                        const global_expert_ids = zml.Tensor.arange(.{ .end = self.global_num_experts }, .i32).withTags(.{.expert});
-
-                        // Mapping of local experts to global expert ids, -1 if the global expert is not present in the local partition
-                        const local_expert_mask = global_expert_ids.cmp(.GE, expert_start)
-                            .logical(.AND, global_expert_ids.cmp(.LT, expert_start.addConstant(local_num_experts)));
-                        const expert_map = local_expert_mask.select(
-                            global_expert_ids.sub(expert_start),
-                            zml.Tensor.scalar(-1, .i32),
-                        );
-
-                        const local_output = triton.fusedExpertsImpl(
-                            self.input,
-                            self.weights_gate_up,
-                            self.weights_down,
-                            self.topk_weights,
-                            self.topk_ids,
-                            .{},
-                            .{
-                                .activation = self.activation,
-                                .global_num_experts = self.global_num_experts,
-                                .expert_map = expert_map,
-                                .w1_scale = self.scales_gate_up,
-                                .w2_scale = self.scales_down,
-                                .w1_bias = self.bias_gate_up,
-                                .w2_bias = self.bias_down,
-                                .quant_scheme = self.quant_scheme,
-                                .activation_threshold = self.activation_threshold,
-                            },
-                        ) catch |err| stdx.debug.panic("moe backend failed: {}", .{err});
-                        const local_reshaped = local_output.reshape(self.input.shape().dims()).withTags(.{ .b, .s, .d });
-                        return zml.ops.allReduce(local_reshaped, zml.Tensor.add);
-                    }
-                }).call,
+                TritonMoe.expertParallel,
                 .{
                     .input = input,
                     .topk_ids = topk_ids,
                     .topk_weights = topk_weights,
                     .weights_gate_up = gate_up.weight,
                     .weights_down = down.weight,
+                    .gate_up_scale = gate_up_scales,
+                    .down_scale = down_scales,
                     .activation = parameters.triton.activation,
                     .global_num_experts = global_num_experts,
-                    .bias_gate_up = gate_up.bias,
-                    .bias_down = down.bias,
                     .quant_scheme = quant_scheme,
                     .activation_threshold = opts.activation_threshold,
-                    .scales_gate_up = gate_up_scales,
-                    .scales_down = down_scales,
                 },
                 input.shape(),
             );

--- a/zml/moe/moe.zig
+++ b/zml/moe/moe.zig
@@ -33,6 +33,7 @@ pub const Backend = enum {
                     .flashinfer_cutlass
                 else
                     .triton,
+                .f8e4m3fn, .f8e4m3fnuz => .triton,
                 .f4e2m1 => if (cutlass_flashinfer.isNvfp4Supported(platform))
                     .flashinfer_cutlass
                 else
@@ -40,7 +41,11 @@ pub const Backend = enum {
                 .f8e8m0, .f16, .f32 => .triton,
                 else => error.UnsupportedDataType,
             },
-            .rocm, .oneapi => switch (weights_dtype) {
+            .rocm => switch (weights_dtype) {
+                .bf16, .f16, .f32, .f8e4m3fn, .f8e4m3fnuz => .triton,
+                else => error.UnsupportedDataType,
+            },
+            .oneapi => switch (weights_dtype) {
                 .bf16, .f16, .f32 => .triton,
                 else => error.UnsupportedDataType,
             },

--- a/zml/moe/triton.zig
+++ b/zml/moe/triton.zig
@@ -38,6 +38,7 @@ pub const Options = struct {
     w2_zp: ?Tensor = null,
     a1_scale: ?Tensor = null,
     a2_scale: ?Tensor = null,
+    prepared_a1: ?zml.quantization.QuantizedInput = null,
     block_shape: ?[]const i64 = null,
     w1_bias: ?Tensor = null,
     w2_bias: ?Tensor = null,
@@ -265,8 +266,17 @@ pub fn fusedExpertsImpl(
     } else routing_id_valid.select(routing.expert_ids, Tensor.scalar(-1, .i32));
 
     const hidden_quant, const a_scale = switch (quantization_mode) {
-        .bf16 => .{ hidden, Tensor.scalar(1.0, .f32) },
-        .block128_fp8 => quantizePerTokenGroupFp8(hidden, 128, gate_up.dtype()),
+        .bf16 => blk: {
+            if (opts.prepared_a1 != null) return error.UnsupportedQuantization;
+            break :blk .{ hidden, Tensor.scalar(1.0, .f32) };
+        },
+        .block128_fp8 => blk: {
+            if (opts.prepared_a1) |prepared| {
+                try validatePreparedBlock128Activation(prepared, hidden, gate_up);
+                break :blk .{ prepared.values, prepared.scales };
+            }
+            break :blk quantizePerTokenGroupFp8(hidden, 128, gate_up.dtype());
+        },
     };
 
     const b_bias_1 =
@@ -653,6 +663,19 @@ fn quantizePerTokenGroupFp8(x: Tensor, group_size: i64, output_dtype: DataType) 
     return .{ outs.y_q, outs.y_s };
 }
 
+/// Quantize one BF16 activation matrix with the same block-128 producer used
+/// by routed FP8 MoE GEMM1. The explicit pair can be passed back through
+/// `Options.prepared_a1` and reused by another native block-scaled dot.
+pub fn prepareBlock128Fp8Activation(x: Tensor, output_dtype: DataType) zml.quantization.QuantizedInput {
+    stdx.debug.assert(x.dtype() == .bf16, "block FP8 activation preparation expects BF16, got {f}", .{x.shape()});
+    const q, const scale = quantizePerTokenGroupFp8(x, 128, output_dtype);
+    return .{
+        .values = q.reshape(x.shape().withDtype(q.dtype())),
+        .scales = scale.reshape(x.shape().setDim(1, @divExact(x.dim(1), 128)).withDtype(.f32)),
+        .global_scale = null,
+    };
+}
+
 // =============================================================================
 // Config / validation helpers
 // =============================================================================
@@ -896,6 +919,22 @@ fn validateOptions(opts: Options) !void {
     if (opts.w1_zp != null or opts.w2_zp != null) return error.UnsupportedOption;
     if (opts.a1_scale != null or opts.a2_scale != null or opts.block_shape != null) return error.UnsupportedOption;
     if (opts.w1_bias != null or opts.w2_bias != null) return error.UnsupportedOption;
+}
+
+fn validatePreparedBlock128Activation(
+    prepared: zml.quantization.QuantizedInput,
+    hidden: Tensor,
+    gate_up: Tensor,
+) !void {
+    if (prepared.global_scale != null) return error.UnsupportedQuantization;
+    if (prepared.values.dtype() != gate_up.dtype() or prepared.scales.dtype() != .f32) return error.UnsupportedType;
+    if (prepared.values.rank() != 2 or prepared.scales.rank() != 2) return error.InvalidShape;
+    if (prepared.values.dim(0) != hidden.dim(0) or prepared.values.dim(1) != hidden.dim(1)) return error.InvalidShape;
+    if (prepared.scales.dim(0) != hidden.dim(0) or
+        prepared.scales.dim(1) != @divExact(hidden.dim(1), 128))
+    {
+        return error.InvalidShape;
+    }
 }
 
 fn validateInputs(hidden: Tensor, gate_up: Tensor, down: Tensor, weights: Tensor, ids: Tensor) !void {

--- a/zml/moe/triton.zig
+++ b/zml/moe/triton.zig
@@ -15,6 +15,7 @@ const a16w4_kernel = @import("triton_kernels/a16w4_kernel.zig");
 const kernels = @import("triton_kernels/triton_kernels.zig");
 
 const log = std.log.scoped(.moe_triton);
+const rawScaleEpsilon: f32 = 1e-10;
 
 test {
     std.testing.refAllDecls(@This());
@@ -130,8 +131,52 @@ fn applyActivation(x: Tensor, mode: Parameters.ActivationMode, activation_thresh
 // Top-level entry point
 // =============================================================================
 
-fn isMxFp8(quant_scheme: ?zml.Quantization.Scheme) bool {
-    return quant_scheme != null and quant_scheme.? == .mxfp8;
+fn hasBlock128Scale(weight: Tensor, maybe_scale: ?Tensor) bool {
+    if (weight.rank() != 3 or
+        (weight.dtype() != .f8e4m3fn and weight.dtype() != .f8e4m3fnuz))
+    {
+        return false;
+    }
+
+    const scale = maybe_scale orelse return false;
+    if (scale.rank() != 3 or scale.dim(0) != weight.dim(0)) return false;
+
+    const n_blocks = std.math.divCeil(i64, weight.dim(1), 128) catch unreachable;
+    const k_blocks = std.math.divCeil(i64, weight.dim(2), 128) catch unreachable;
+    return scale.dim(1) == n_blocks and scale.dim(2) == k_blocks;
+}
+
+const QuantizationMode = enum {
+    bf16,
+    block128_fp8,
+};
+
+fn resolveQuantizationMode(w1: Tensor, w2: Tensor, opts: Options) !QuantizationMode {
+    const w1_block128 = hasBlock128Scale(w1, opts.w1_scale);
+    const w2_block128 = hasBlock128Scale(w2, opts.w2_scale);
+    const inferred: QuantizationMode = if (w1.dtype() == .bf16 and w2.dtype() == .bf16 and
+        opts.w1_scale == null and opts.w2_scale == null)
+        .bf16
+    else if (w1_block128 and w2_block128)
+        .block128_fp8
+    else
+        return error.UnsupportedQuantization;
+
+    if (opts.quant_scheme) |scheme| switch (scheme) {
+        .fp8_block128 => if (inferred != .block128_fp8) return error.UnsupportedQuantization,
+        .mxfp4 => unreachable,
+        else => return error.UnsupportedQuantization,
+    };
+    if (inferred == .block128_fp8) {
+        if (w1.dtype() != w2.dtype()) return error.UnsupportedType;
+        const w1_scale = opts.w1_scale.?;
+        const w2_scale = opts.w2_scale.?;
+        if ((w1_scale.dtype() != .bf16 and w1_scale.dtype() != .f32) or
+            (w2_scale.dtype() != .bf16 and w2_scale.dtype() != .f32)) return error.UnsupportedType;
+        if (@mod(w1.dim(1), 2) != 0) return error.InvalidShape;
+        if (@mod(w1.dim(2), 128) != 0 or @mod(@divExact(w1.dim(1), 2), 128) != 0) return error.InvalidShape;
+    }
+    return inferred;
 }
 
 pub fn fusedExpertsImpl(
@@ -174,18 +219,24 @@ pub fn fusedExpertsImpl(
         );
     }
 
-    const options = applyJsonTokenConfig(opts, hidden_states.dim(0)) catch |err| fallback: {
-        log.warn("Failed to load MoE launch config from JSON ({}), falling back to built-in token heuristic", .{err});
-        break :fallback applyDefaultTokenConfig(opts, hidden_states.dim(0), w1.dim(0));
-    };
+    const quantization_mode = try resolveQuantizationMode(w1, w2, opts);
     const b = hidden_states.dim(.b);
     const s = hidden_states.dim(.s);
+    const num_tokens = b * s;
+    var options = applyJsonTokenConfig(opts, num_tokens) catch |err| fallback: {
+        log.warn("Failed to load MoE launch config from JSON ({}), falling back to built-in token heuristic", .{err});
+        break :fallback applyDefaultTokenConfig(opts, num_tokens, w1.dim(0));
+    };
+    switch (quantization_mode) {
+        .bf16 => {},
+        .block128_fp8 => options.block_size_k = 128,
+    }
 
-    const hidden = hidden_states.reshape(.{ .token = b * s, .in = hidden_states.dim(.d) }).withTags(.{ .token, .in });
+    const hidden = hidden_states.reshape(.{ .token = num_tokens, .in = hidden_states.dim(.d) }).withTags(.{ .token, .in });
     const gate_up = w1.withTags(.{ .expert, .out, .in });
     const down = w2.withTags(.{ .expert, .out, .mid });
-    const weights = topk_weights.reshape(.{ .token = b * s, .in = topk_weights.dim(.top_expert) }).withTags(.{ .token, .topk });
-    const ids = topk_ids.reshape(.{ .token = b * s, .in = topk_ids.dim(.top_expert) }).withTags(.{ .token, .topk });
+    const weights = topk_weights.reshape(.{ .token = num_tokens, .in = topk_weights.dim(.top_expert) }).withTags(.{ .token, .topk });
+    const ids = topk_ids.reshape(.{ .token = num_tokens, .in = topk_ids.dim(.top_expert) }).withTags(.{ .token, .topk });
 
     try validateInputs(hidden, gate_up, down, weights, ids);
 
@@ -194,31 +245,29 @@ pub fn fusedExpertsImpl(
     if (opts.expert_map) |expert_map| {
         if (expert_map.dtype() != .i32) return error.UnsupportedType;
         if (expert_map.rank() != 1 or expert_map.dim(.expert) != num_experts) return error.InvalidShape;
+    } else if (num_experts != gate_up.dim(.expert)) {
+        return error.InvalidShape;
     }
     const routing = prepareRouting(ids, num_experts, block_size_m);
 
-    const expert_ids = if (opts.expert_map) |expert_map|
-        expert_map.gather(.{ .expert = routing.expert_ids }, .{}).withTags(.{.g})
-    else
-        routing.expert_ids;
-
-    var hidden_quant = hidden;
-    var a_scale = opts.a1_scale orelse Tensor.scalar(1.0, .f32);
-
-    if (gate_up.dtype() == .f8e4m3fn) {
-        hidden_quant, a_scale = quantizePerTokenGroupFp8(hidden, fp8ActivationGroupSize(hidden));
-    }
-
-    const first_cfg = makeFusedMoeConfig(
-        hidden_quant,
-        gate_up,
-        options,
-        routing.naive_block_assignment,
-        ids.dim(.topk),
-        false,
-        false,
-        .bf16,
+    const routing_id_valid = routing.expert_ids.cmp(.GE, Tensor.scalar(0, .i32))
+        .logical(.AND, routing.expert_ids.cmp(.LT, Tensor.scalar(num_experts, .i32)));
+    const safe_routing_ids = routing_id_valid.select(
+        routing.expert_ids,
+        Tensor.zeroes(routing.expert_ids.shape()),
     );
+    const expert_ids = if (opts.expert_map) |expert_map| mapped: {
+        const local_ids = expert_map.gather(.{ .expert = safe_routing_ids }, .{}).withTags(.{.g});
+        const local_id_valid = routing_id_valid
+            .logical(.AND, local_ids.cmp(.GE, Tensor.scalar(0, .i32)))
+            .logical(.AND, local_ids.cmp(.LT, Tensor.scalar(gate_up.dim(.expert), .i32)));
+        break :mapped local_id_valid.select(local_ids, Tensor.scalar(-1, .i32));
+    } else routing_id_valid.select(routing.expert_ids, Tensor.scalar(-1, .i32));
+
+    const hidden_quant, const a_scale = switch (quantization_mode) {
+        .bf16 => .{ hidden, Tensor.scalar(1.0, .f32) },
+        .block128_fp8 => quantizePerTokenGroupFp8(hidden, 128, gate_up.dtype()),
+    };
 
     const b_bias_1 =
         opts.w1_bias orelse
@@ -226,6 +275,17 @@ pub fn fusedExpertsImpl(
         Tensor.zeroes(Shape.init(.{ .expert = gate_up.dim(.expert), .out = gate_up.dim(.out) }, .bf16));
 
     const b_scale_1 = opts.w1_scale orelse Tensor.scalar(1.0, .f32);
+
+    const first_cfg = makeFusedMoeConfig(
+        hidden_quant,
+        gate_up,
+        a_scale,
+        b_scale_1,
+        quantization_mode,
+        options,
+        routing.naive_block_assignment,
+        ids.dim(.topk),
+    );
 
     const first_out = callFusedMoe(
         hidden_quant,
@@ -244,23 +304,16 @@ pub fn fusedExpertsImpl(
         Shape.init(.{ .token = routing.num_assignments, .out = gate_up.dim(.out) }, .bf16),
     );
 
-    const activated = applyActivation(first_out, options.activation, options.activation_threshold);
-    var activated_quant = activated;
-    a_scale = opts.a2_scale orelse Tensor.scalar(1.0, .f32);
-    if (down.dtype() == .f8e4m3fn) {
-        activated_quant, a_scale = quantizePerTokenGroupFp8(activated, fp8ActivationGroupSize(activated));
-    }
-
-    const second_cfg = makeFusedMoeConfig(
-        activated_quant,
-        down,
-        options,
-        routing.naive_block_assignment,
-        1,
-        true,
-        false,
-        .bf16,
-    );
+    const activated_quant, const a2_scale = switch (quantization_mode) {
+        .bf16 => .{
+            applyActivation(first_out, options.activation, options.activation_threshold),
+            Tensor.scalar(1.0, .f32),
+        },
+        .block128_fp8 => blk: {
+            const activated = applyActivation(first_out, options.activation, options.activation_threshold);
+            break :blk quantizePerTokenGroupFp8(activated, 128, down.dtype());
+        },
+    };
 
     const b_bias_2 =
         opts.w2_bias orelse
@@ -269,11 +322,22 @@ pub fn fusedExpertsImpl(
 
     const b_scale_2 = opts.w2_scale orelse Tensor.scalar(1.0, .f32);
 
+    const second_cfg = makeFusedMoeConfig(
+        activated_quant,
+        down,
+        a2_scale,
+        b_scale_2,
+        quantization_mode,
+        options,
+        routing.naive_block_assignment,
+        1,
+    );
+
     const second_out = callFusedMoe(
         activated_quant,
         down,
         b_bias_2,
-        a_scale,
+        a2_scale,
         b_scale_2,
         weights,
         routing.sorted_token_ids,
@@ -286,9 +350,53 @@ pub fn fusedExpertsImpl(
         Shape.init(.{ .token = b * s, .topk = ids.dim(.topk), .out = down.dim(.out) }, .bf16),
     );
 
-    const output = second_out.sum(.topk).squeeze(.topk);
+    // Materialize each expert's down projection as BF16, then apply router
+    // weights and accumulate in FP32.
+    const output = reduceExpertRoutes(
+        second_out,
+        weights,
+        ids,
+        opts.expert_map,
+        num_experts,
+        gate_up.dim(.expert),
+    );
 
     return output.reshape(.{ .b = b, .token = s, .out = down.dim(.out) });
+}
+
+/// Applies router weights to materialized BF16 expert outputs, accumulates the
+/// route dimension in FP32, and narrows only the final per-token result.
+fn reduceExpertRoutes(
+    routes: Tensor,
+    weights: Tensor,
+    ids: Tensor,
+    expert_map: ?Tensor,
+    global_num_experts: i64,
+    local_num_experts: i64,
+) Tensor {
+    // Negative, out-of-range, and non-local routes can leave output slots
+    // unwritten. Mask both operands so invalid NaN/Inf weights cannot
+    // propagate through a zero route.
+    const route_global_valid = ids.cmp(.GE, Tensor.scalar(0, .i32))
+        .logical(.AND, ids.cmp(.LT, Tensor.scalar(global_num_experts, .i32)));
+    const route_is_valid = if (expert_map) |map| local: {
+        const safe_ids = route_global_valid.select(ids, Tensor.scalar(0, .i32));
+        const local_ids = map
+            .gather(.{ .expert = safe_ids }, .{})
+            .withTags(ids.shape().tags());
+        break :local route_global_valid
+            .logical(.AND, local_ids.cmp(.GE, Tensor.scalar(0, .i32)))
+            .logical(.AND, local_ids.cmp(.LT, Tensor.scalar(local_num_experts, .i32)));
+    } else route_global_valid;
+    const active_routes = route_is_valid
+        .broad(routes.shape().withDtype(.bool))
+        .select(routes, Tensor.zeroes(routes.shape()));
+    const active_weights = route_is_valid.select(weights, Tensor.zeroes(weights.shape()));
+
+    const weighted_routes = active_routes
+        .convert(.f32)
+        .mul(active_weights.convert(.f32).broad(routes.shape().withDtype(.f32)));
+    return weighted_routes.sum(.topk).squeeze(.topk).convert(.bf16);
 }
 
 /// Build the inputs tuple for FusedMoe and invoke it via `K.call(...)`.
@@ -319,8 +427,8 @@ fn callFusedMoe(
         (std.math.divCeil(i64, em_effective, block_size_m) catch unreachable) *
         (std.math.divCeil(i64, b.dim(1), block_size_n) catch unreachable);
 
-    const stride_asm: i64 = if (cfg.b_scale_dtype != null and a_scale.rank() == 2) a_scale.dim(1) else 0;
-    const stride_ask: i64 = if (cfg.b_scale_dtype != null and a_scale.rank() == 2) 1 else 0;
+    const stride_asm: i64 = if (cfg.a_scale_dtype != null and a_scale.rank() == 2) a_scale.dim(1) else 0;
+    const stride_ask: i64 = if (cfg.a_scale_dtype != null and a_scale.rank() == 2) 1 else 0;
     const stride_bse: i64 = if (cfg.b_scale_dtype != null and b_scale.rank() == 3)
         b_scale.dim(1) * b_scale.dim(2)
     else
@@ -416,8 +524,9 @@ fn alignBlockSize(topk_ids: Tensor, num_experts: i64, block_size_m: i64) struct 
     else
         num_assignments + num_experts * (block_size_m - 1);
     const max_num_m_blocks = std.math.divCeil(i64, max_num_tokens_padded, block_size_m) catch unreachable;
-    const warp_size: i64 = 32;
-    const padded_num_experts = (std.math.divCeil(i64, num_experts, warp_size) catch unreachable) * warp_size;
+    // Triton ranges and the histogram built over them require a power-of-two
+    // width. A warp multiple is insufficient for GLM's 288 experts.
+    const padded_num_experts: i64 = @intCast(std.math.ceilPowerOfTwoAssert(usize, @intCast(num_experts)));
     const sort_block_size: i64 = 256;
     const sort_grid_x: i64 = @min(std.math.divCeil(i64, num_assignments, sort_block_size) catch unreachable, 65535);
 
@@ -502,13 +611,19 @@ fn alignBlockSize(topk_ids: Tensor, num_experts: i64, block_size_m: i64) struct 
     return .{ sorted_token_ids, expert_ids, num_tokens_post_padded };
 }
 
-fn quantizePerTokenGroupFp8(x: Tensor, group_size: i64) struct { Tensor, Tensor } {
+fn quantizePerTokenGroupFp8(x: Tensor, group_size: i64, output_dtype: DataType) struct { Tensor, Tensor } {
     stdx.debug.assert(x.rank() == 2, "expected a rank-2 activation matrix, got {f}", .{x.shape()});
     stdx.debug.assert(@mod(x.dim(1), group_size) == 0, "activation width must be divisible by group size {d}, got {d}", .{ group_size, x.dim(1) });
 
     const groups_per_row = @divExact(x.dim(1), group_size);
-    const quantized = Tensor.zeroes(Shape.init(.{ .token = x.dim(0), .feature = x.dim(1) }, .f8e4m3fn));
-    const scales = Tensor.zeroes(Shape.init(.{ .token = x.dim(0), .group = groups_per_row }, .bf16));
+    const scale_dtype: DataType = .f32;
+    const fp8_max: f32 = switch (output_dtype) {
+        .f8e4m3fn => 448.0,
+        .f8e4m3fnuz => 224.0,
+        else => stdx.debug.panic("unsupported FP8 activation dtype: {}", .{output_dtype}),
+    };
+    const quantized = Tensor.zeroes(Shape.init(.{ .token = x.dim(0), .feature = x.dim(1) }, output_dtype));
+    const scales = Tensor.zeroes(Shape.init(.{ .token = x.dim(0), .group = groups_per_row }, scale_dtype));
 
     const outs = kernels.PerTokenGroupQuantFp8.Kernel.call(
         .{
@@ -516,17 +631,17 @@ fn quantizePerTokenGroupFp8(x: Tensor, group_size: i64) struct { Tensor, Tensor 
             .group_size_ptr = Tensor.constant(.{ .i64 = group_size }).reshape(.{1}),
             .y_num_columns_ptr = Tensor.constant(.{ .i64 = x.dim(1) }).reshape(.{1}),
             .y_row_stride_ptr = Tensor.constant(.{ .i64 = x.dim(1) }).reshape(.{1}),
-            .eps_ptr = Tensor.scalar(1e-6, .f32),
+            .eps_ptr = Tensor.scalar(rawScaleEpsilon, .f32),
         },
         .{ .y_q = quantized.shape(), .y_s = scales.shape() },
         .{
             .cfg = .{
                 .input_dtype = toDType(x.dtype()),
-                .output_dtype = .f8e4m3fn,
-                .scale_dtype = .bf16,
+                .output_dtype = toDType(output_dtype),
+                .scale_dtype = toDType(scale_dtype),
                 .block = @intCast(group_size),
-                .fp8_min = -448.0,
-                .fp8_max = 448.0,
+                .fp8_min = -fp8_max,
+                .fp8_max = fp8_max,
                 .use_ue8m0 = false,
             },
             .grid = .{ @intCast(x.dim(0) * groups_per_row), 1, 1 },
@@ -545,21 +660,25 @@ fn quantizePerTokenGroupFp8(x: Tensor, group_size: i64) struct { Tensor, Tensor 
 fn makeFusedMoeConfig(
     a: Tensor,
     b: Tensor,
+    a_scale: Tensor,
+    b_scale: Tensor,
+    quantization_mode: QuantizationMode,
     opts: Options,
     naive_block_assignment: bool,
     top_k: i64,
-    mul_routed_weight: bool,
-    has_bias: bool,
-    output_dtype: DataType,
 ) kernels.FusedMoe.Cfg {
-    var use_fp8 = isMxFp8(opts.quant_scheme);
-    if (b.dtype() == .f8e4m3fn) use_fp8 = true;
     return .{
         .a_dtype = toDType(a.dtype()),
         .b_dtype = toDType(b.dtype()),
-        .c_dtype = toDType(output_dtype),
-        .a_scale_dtype = if (use_fp8) .bf16 else null,
-        .b_scale_dtype = if (use_fp8) .bf16 else null,
+        .c_dtype = .bf16,
+        .a_scale_dtype = switch (quantization_mode) {
+            .bf16 => null,
+            .block128_fp8 => toDType(a_scale.dtype()),
+        },
+        .b_scale_dtype = switch (quantization_mode) {
+            .bf16 => null,
+            .block128_fp8 => toDType(b_scale.dtype()),
+        },
         .b_bias_dtype = null,
         .topk_weights_dtype = null,
         .block_size_m = @intCast(opts.block_size_m),
@@ -568,14 +687,85 @@ fn makeFusedMoeConfig(
         .group_size_m = @intCast(opts.group_size_m),
         .top_k = @intCast(top_k),
         .naive_block_assignment = naive_block_assignment,
-        .mul_routed_weight = mul_routed_weight,
+        .mul_routed_weight = false,
         .compute_type = .bf16,
-        .use_fp8_w8a8 = use_fp8,
+        .block128_fp8 = switch (quantization_mode) {
+            .bf16 => false,
+            .block128_fp8 => true,
+        },
         .use_int8_w8a8 = false,
         .use_int8_w8a16 = false,
         .per_channel_quant = false,
-        .has_bias = has_bias,
+        .has_bias = false,
     };
+}
+
+test "Triton MoE resolves and validates quantization" {
+    const fn_activation: Tensor = .init(.{ .token = 8, .in = 1024 }, .f8e4m3fn);
+    const fn_weight: Tensor = .init(.{ .expert = 288, .out = 2048, .in = 1024 }, .f8e4m3fn);
+    const fn_activation_scale: Tensor = .init(.{ .token = 8, .group = 8 }, .f32);
+    const weight_scale: Tensor = .init(.{ .expert = 288, .nb = 16, .kb = 8 }, .f32);
+    const fn_cfg = makeFusedMoeConfig(
+        fn_activation,
+        fn_weight,
+        fn_activation_scale,
+        weight_scale,
+        .block128_fp8,
+        .{ .quant_scheme = .fp8_block128 },
+        false,
+        8,
+    );
+
+    try std.testing.expectEqual(@as(?DType, .f32), fn_cfg.a_scale_dtype);
+    try std.testing.expectEqual(@as(?DType, .f32), fn_cfg.b_scale_dtype);
+
+    const fnuz_activation: Tensor = .init(.{ .token = 8, .in = 1024 }, .f8e4m3fnuz);
+    const fnuz_weight: Tensor = .init(.{ .expert = 288, .out = 2048, .in = 1024 }, .f8e4m3fnuz);
+    const fnuz_activation_scale: Tensor = .init(.{ .token = 8, .group = 8 }, .f32);
+    const fnuz_cfg = makeFusedMoeConfig(
+        fnuz_activation,
+        fnuz_weight,
+        fnuz_activation_scale,
+        weight_scale,
+        .block128_fp8,
+        .{ .quant_scheme = .fp8_block128 },
+        false,
+        8,
+    );
+
+    try std.testing.expectEqual(@as(?DType, .f32), fnuz_cfg.a_scale_dtype);
+    try std.testing.expectEqual(@as(?DType, .f32), fnuz_cfg.b_scale_dtype);
+
+    try std.testing.expectEqual(QuantizationMode.block128_fp8, try resolveQuantizationMode(
+        fn_weight,
+        fn_weight,
+        .{ .w1_scale = weight_scale, .w2_scale = weight_scale },
+    ));
+    const bf16_weight: Tensor = .init(.{ .expert = 288, .out = 2048, .in = 1024 }, .bf16);
+    try std.testing.expectEqual(QuantizationMode.bf16, try resolveQuantizationMode(bf16_weight, bf16_weight, .{}));
+    try std.testing.expectError(error.UnsupportedQuantization, resolveQuantizationMode(
+        bf16_weight,
+        bf16_weight,
+        .{ .quant_scheme = .fp8_block128 },
+    ));
+    const odd_weight: Tensor = .init(.{ .expert = 288, .out = 2047, .in = 1024 }, .f8e4m3fn);
+    try std.testing.expectError(error.InvalidShape, resolveQuantizationMode(
+        odd_weight,
+        fn_weight,
+        .{ .w1_scale = weight_scale, .w2_scale = weight_scale },
+    ));
+    const malformed_scale: Tensor = .init(.{ .expert = 288, .nb = 15, .kb = 8 }, .f32);
+    try std.testing.expectError(error.UnsupportedQuantization, resolveQuantizationMode(
+        fn_weight,
+        fn_weight,
+        .{ .w1_scale = malformed_scale, .w2_scale = weight_scale },
+    ));
+
+    try std.testing.expectError(error.UnsupportedQuantization, resolveQuantizationMode(
+        fn_weight,
+        fn_weight,
+        .{ .quant_scheme = .mxfp8, .w1_scale = weight_scale, .w2_scale = weight_scale },
+    ));
 }
 
 const DefaultTokenBucket = struct {
@@ -592,7 +782,7 @@ fn applyDefaultTokenConfig(opts: Options, num_tokens: i64, num_experts: i64) Opt
     var out = opts;
     if (!opts.dynamic_launch_by_num_tokens) return out;
 
-    // General default policy for NVIDIA bf16/fp16 and fp8 per-tensor.
+    // General default policy for BF16. Block-scaled FP8 overrides K below.
     // Tile sizes scale with batch size: small batches are more memory-bound,
     // while larger batches benefit from wider M/N tiles and more warps.
     if (num_tokens <= 32) {
@@ -606,7 +796,7 @@ fn applyDefaultTokenConfig(opts: Options, num_tokens: i64, num_experts: i64) Opt
     }
 
     out.block_size_n = if (num_tokens <= 64) 64 else 128;
-    out.block_size_k = if (isMxFp8(opts.quant_scheme) or num_tokens <= 64) 128 else 64;
+    out.block_size_k = if (opts.quant_scheme == .fp8_block128 or num_tokens <= 64) 128 else 64;
 
     const tokens_per_expert = @divFloor(num_tokens, @max(num_experts, 1));
     out.group_size_m = if (tokens_per_expert > 128) 16 else 1;
@@ -694,16 +884,14 @@ fn applyJsonTokenConfig(opts: Options, num_tokens: i64) !Options {
     return out;
 }
 
-fn fp8ActivationGroupSize(x: Tensor) i64 {
-    const group_size: i64 = 128;
-    stdx.debug.assert(@mod(x.dim(1), group_size) == 0, "FP8 activation width must be divisible by {d}, got {d}", .{ group_size, x.dim(1) });
-    return group_size;
-}
-
 fn validateOptions(opts: Options) !void {
     if (opts.inplace) return error.Unimplemented;
     if (opts.apply_router_weight_on_input) return error.UnsupportedOption;
-    if (opts.quant_scheme != null and opts.quant_scheme.? != .mxfp4) return error.UnsupportedQuantization;
+    if (opts.quant_scheme) |scheme| switch (scheme) {
+        .mxfp4, .fp8_block128 => {},
+        .mxfp8 => return error.UnsupportedQuantization,
+        else => return error.UnsupportedQuantization,
+    };
     if (opts.expert_map != null and opts.global_num_experts == -1) return error.InvalidShape;
     if (opts.w1_zp != null or opts.w2_zp != null) return error.UnsupportedOption;
     if (opts.a1_scale != null or opts.a2_scale != null or opts.block_shape != null) return error.UnsupportedOption;
@@ -712,8 +900,8 @@ fn validateOptions(opts: Options) !void {
 
 fn validateInputs(hidden: Tensor, gate_up: Tensor, down: Tensor, weights: Tensor, ids: Tensor) !void {
     if (hidden.dtype() != .bf16) return error.UnsupportedType;
-    if (gate_up.dtype() != .bf16 and gate_up.dtype() != .f8e4m3fn) return error.UnsupportedType;
-    if (down.dtype() != .bf16 and down.dtype() != .f8e4m3fn) return error.UnsupportedType;
+    if (gate_up.dtype() != .bf16 and gate_up.dtype() != .f8e4m3fn and gate_up.dtype() != .f8e4m3fnuz) return error.UnsupportedType;
+    if (down.dtype() != .bf16 and down.dtype() != .f8e4m3fn and down.dtype() != .f8e4m3fnuz) return error.UnsupportedType;
     if (weights.dtype() != .f32 and weights.dtype() != .bf16) return error.UnsupportedType;
     if (ids.dtype() != .i32) return error.UnsupportedType;
     if (hidden.dim(.in) != gate_up.dim(.in)) return error.InvalidShape;

--- a/zml/moe/triton.zig
+++ b/zml/moe/triton.zig
@@ -320,6 +320,18 @@ pub fn fusedExpertsImpl(
             Tensor.scalar(1.0, .f32),
         },
         .block128_fp8 => blk: {
+            const fused_swiglu = switch (zml.Compiler.current().platform.target) {
+                .cuda, .rocm => options.activation == .silu,
+                else => false,
+            };
+            if (fused_swiglu) {
+                break :blk siluAndQuantizePerTokenGroupFp8(
+                    first_out,
+                    128,
+                    down.dtype(),
+                    options.activation_threshold,
+                );
+            }
             const activated = applyActivation(first_out, options.activation, options.activation_threshold);
             break :blk quantizePerTokenGroupFp8(activated, 128, down.dtype());
         },
@@ -361,15 +373,30 @@ pub fn fusedExpertsImpl(
     );
 
     // Materialize each expert's down projection as BF16, then apply router
-    // weights and accumulate in FP32.
-    const output = reduceExpertRoutes(
-        second_out,
-        weights,
-        ids,
-        opts.expert_map,
-        num_experts,
-        gate_up.dim(.expert),
-    );
+    // weights and accumulate in FP32. The fused reduction adds routes in
+    // source order and skips invalid/non-local routes before loading them.
+    const fused_reduction = weights.dtype() == .f32 and switch (zml.Compiler.current().platform.target) {
+        .cuda, .rocm => true,
+        else => false,
+    };
+    const output = if (fused_reduction)
+        fusedReduceExpertRoutes(
+            second_out,
+            weights,
+            ids,
+            opts.expert_map,
+            num_experts,
+            gate_up.dim(.expert),
+        )
+    else
+        reduceExpertRoutes(
+            second_out,
+            weights,
+            ids,
+            opts.expert_map,
+            num_experts,
+            gate_up.dim(.expert),
+        );
 
     return output.reshape(.{ .b = b, .token = s, .out = down.dim(.out) });
 }
@@ -407,6 +434,68 @@ fn reduceExpertRoutes(
         .convert(.f32)
         .mul(active_weights.convert(.f32).broad(routes.shape().withDtype(.f32)));
     return weighted_routes.sum(.topk).squeeze(.topk).convert(.bf16);
+}
+
+/// Fused route weighting and reduction in source order for BF16 expert
+/// outputs and FP32 router weights on CUDA and ROCm.
+fn fusedReduceExpertRoutes(
+    routes: Tensor,
+    weights: Tensor,
+    ids: Tensor,
+    expert_map: ?Tensor,
+    global_num_experts: i64,
+    local_num_experts: i64,
+) Tensor {
+    const num_tokens: usize = @intCast(routes.dim(.token));
+    const hidden_size: usize = @intCast(routes.dim(.out));
+    const block_d: usize = @intCast(std.math.gcd(@as(u64, @intCast(hidden_size)), 1024));
+    const map_operand = expert_map orelse ids;
+    return kernels.FusedReduceExpertRoutes.Kernel.call(
+        .{
+            .routes = routes,
+            .weights = weights,
+            .topk_ids = ids,
+            .expert_map = map_operand,
+        },
+        .{ .output = routes.shape().remove(.topk).withDtype(.bf16) },
+        .{
+            .cfg = .{
+                .num_tokens = num_tokens,
+                .top_k = @intCast(ids.dim(.topk)),
+                .hidden_size = hidden_size,
+                .global_num_experts = @intCast(global_num_experts),
+                .local_num_experts = @intCast(local_num_experts),
+                .block_d = block_d,
+                .has_expert_map = expert_map != null,
+            },
+            .grid = .{
+                @intCast(@divExact(hidden_size, block_d)),
+                @intCast(@min(num_tokens, 1024)),
+                1,
+            },
+            .num_warps = 2,
+            .num_stages = 1,
+        },
+    ).output;
+}
+
+test "fused route reduction emits valid Triton IR for different top-k counts" {
+    for ([_]usize{ 1, 3, 8, 16 }) |top_k| {
+        for ([_]bool{ false, true }) |has_expert_map| {
+            // emit verifies the generated MLIR, including the accumulator
+            // carried through each route's conditional branch.
+            const ir = try kernels.FusedReduceExpertRoutes.Kernel.emit(std.testing.allocator, .{
+                .num_tokens = 2,
+                .top_k = top_k,
+                .hidden_size = 128,
+                .global_num_experts = 288,
+                .local_num_experts = if (has_expert_map) 36 else 288,
+                .block_d = 128,
+                .has_expert_map = has_expert_map,
+            });
+            defer std.testing.allocator.free(ir);
+        }
+    }
 }
 
 /// Build the inputs tuple for FusedMoe and invoke it via `K.call(...)`.
@@ -674,6 +763,52 @@ pub fn prepareBlock128Fp8Activation(x: Tensor, output_dtype: DataType) zml.quant
         .scales = scale.reshape(x.shape().setDim(1, @divExact(x.dim(1), 128)).withDtype(.f32)),
         .global_scale = null,
     };
+}
+
+fn siluAndQuantizePerTokenGroupFp8(
+    x: Tensor,
+    group_size: i64,
+    output_dtype: DataType,
+    activation_threshold: ?f32,
+) struct { Tensor, Tensor } {
+    stdx.debug.assert(x.rank() == 2, "expected a rank-2 SwiGLU input, got {f}", .{x.shape()});
+    const output_columns = @divExact(x.dim(1), 2);
+    stdx.debug.assert(@mod(output_columns, group_size) == 0, "SwiGLU output width must be divisible by group size {d}, got {d}", .{ group_size, output_columns });
+
+    const groups_per_row = @divExact(output_columns, group_size);
+    const scale_dtype: DataType = .f32;
+    const fp8_max: f32 = switch (output_dtype) {
+        .f8e4m3fn => 448.0,
+        .f8e4m3fnuz => 224.0,
+        else => stdx.debug.panic("unsupported FP8 activation dtype: {}", .{output_dtype}),
+    };
+    const outs = kernels.SiluAndQuantizePerTokenGroupFp8.Kernel.call(
+        .{
+            .x = x,
+        },
+        .{
+            .q = Shape.init(.{ .token = x.dim(0), .feature = output_columns }, output_dtype),
+            .scale = Shape.init(.{ .token = x.dim(0), .group = groups_per_row }, scale_dtype),
+        },
+        .{
+            .cfg = .{
+                .input_dtype = toDType(x.dtype()),
+                .output_dtype = toDType(output_dtype),
+                .scale_dtype = toDType(scale_dtype),
+                .input_columns = @intCast(x.dim(1)),
+                .output_columns = @intCast(output_columns),
+                .block = @intCast(group_size),
+                .fp8_min = -fp8_max,
+                .fp8_max = fp8_max,
+                .eps = rawScaleEpsilon,
+                .activation_threshold = activation_threshold,
+            },
+            .grid = .{ @intCast(x.dim(0) * groups_per_row), 1, 1 },
+            .num_stages = 1,
+            .num_warps = 1,
+        },
+    );
+    return .{ outs.q, outs.scale };
 }
 
 // =============================================================================

--- a/zml/moe/triton_kernels/triton_kernels.zig
+++ b/zml/moe/triton_kernels/triton_kernels.zig
@@ -165,8 +165,8 @@ fn writeZerosToOutput(
 // fused_moe_kernel
 // =============================================================================
 
-/// Direct port of Python `fused_moe_kernel`. Bf16 / no-quant / no-bias path
-/// only — errors out for the feature flags that aren't implemented yet.
+/// Direct port of Python `fused_moe_kernel`, including the 1x128 activation /
+/// 128x128 weight block-scaled FP8 path used by DeepSeek and GLM checkpoints.
 pub const FusedMoe = struct {
     pub const Cfg = struct {
         a_dtype: DType,
@@ -184,10 +184,8 @@ pub const FusedMoe = struct {
         naive_block_assignment: bool,
         mul_routed_weight: bool,
         compute_type: DType,
-        // Validation flags — the kernel rejects configs that set any of
-        // these to true (the body only implements the bf16 / no-quant /
-        // no-bias path).
-        use_fp8_w8a8: bool,
+        // Validation flags.
+        block128_fp8: bool,
         use_int8_w8a8: bool,
         use_int8_w8a16: bool,
         per_channel_quant: bool,
@@ -206,8 +204,12 @@ pub const FusedMoe = struct {
         .run = run,
     });
     fn run(b: *Builder, cfg: Cfg) tri.FinishError!void {
-        if (cfg.use_fp8_w8a8 or cfg.use_int8_w8a8 or cfg.use_int8_w8a16 or cfg.has_bias or cfg.per_channel_quant) {
-            log.err("fused_moe_kernel: unsupported config (fp8/int8/bias/per_channel)", .{});
+        if (cfg.use_int8_w8a8 or cfg.use_int8_w8a16 or cfg.has_bias or cfg.per_channel_quant) {
+            log.err("fused_moe_kernel: unsupported config (int8/bias/per_channel)", .{});
+            return error.InvalidMlir;
+        }
+        if (cfg.block128_fp8 and cfg.block_size_k != 128) {
+            log.err("fused_moe_kernel: block-scaled FP8 requires BLOCK_SIZE_K=128", .{});
             return error.InvalidMlir;
         }
 
@@ -363,7 +365,7 @@ pub const FusedMoe = struct {
         const acc_init = b.zeros(&.{ block_size_m, block_size_n }, .f32);
 
         // Loop bounds stay i64 because `k_block` is i64. iter_args order
-        // matches Python's TTIR (a_ptrs, b_ptrs, accumulator).
+        // matches Python's TTIR for the matrix and accumulator state.
         const num_k_iters = k_block.cdiv(block_size_k);
         var loop = b.openFor(@as(i64, 0), num_k_iters, @as(i64, 1), .{ a_ptrs_init, b_ptrs_init, acc_init });
         {
@@ -397,7 +399,37 @@ pub const FusedMoe = struct {
                 .other = b.zeros(&.{ block_size_k, block_size_n }, cfg.b_dtype),
             });
 
-            const new_acc = b.dotOpts(a_val, b_val, acc, .{
+            const new_acc = if (cfg.block128_fp8) scaled: {
+                // Activation scales are [token, K/128] and weight scales are
+                // [expert, N/128, K/128]. Compute their addresses from the
+                // loop index so BF16 execution carries no scale-pointer state.
+                const stride_asm = b.load(a.stride_asm_ptr);
+                const stride_ask = b.load(a.stride_ask_ptr);
+                const stride_bse = b.load(a.stride_bse_ptr);
+                const stride_bsk = b.load(a.stride_bsk_ptr);
+                const stride_bsn = b.load(a.stride_bsn_ptr);
+                const a_scale_ptrs = a.a_scale_ptr.addPtr(
+                    offs_token.div(top_k).mul(stride_asm).add(k_iter.mul(stride_ask)),
+                );
+                const b_scale_ptrs = a.b_scale_ptr.addPtr(
+                    off_experts.mul(stride_bse)
+                        .add(offs_bn.div(128).mul(stride_bsn))
+                        .add(k_iter.mul(stride_bsk)),
+                );
+                const dot = b.dotOpts(a_val, b_val, b.zeros(&.{ block_size_m, block_size_n }, .f32), .{
+                    .input_precision = .tf32,
+                    .max_num_imprecise_acc = 0,
+                });
+                const a_s = b.loadOpts(a_scale_ptrs, .{
+                    .mask = token_mask,
+                    .other = b.zeros(&.{block_size_m}, cfg.a_scale_dtype orelse .f32),
+                }).to(.f32);
+                const b_s = b.loadOpts(b_scale_ptrs, .{
+                    .mask = offs_bn.lt(n_block),
+                    .other = b.zeros(&.{block_size_n}, cfg.b_scale_dtype orelse .f32),
+                }).to(.f32);
+                break :scaled acc.add(dot.mul(a_s.expandDims(1)).mul(b_s.expandDims(0)));
+            } else b.dotOpts(a_val, b_val, acc, .{
                 .input_precision = .tf32,
                 .max_num_imprecise_acc = 0,
             });
@@ -407,7 +439,11 @@ pub const FusedMoe = struct {
             const new_a_ptrs = a_ptrs.addPtr(b.splat(bsk_i32, &.{ block_size_m, block_size_k }));
             const new_b_ptrs = b_ptrs.addPtr(b.splat(bsk_i32, &.{ block_size_k, block_size_n }));
 
-            loop.yield(.{ new_a_ptrs, new_b_ptrs, new_acc });
+            loop.yield(.{
+                new_a_ptrs,
+                new_b_ptrs,
+                new_acc,
+            });
         }
         var accumulator = loop.results[2];
 
@@ -519,7 +555,7 @@ pub const MoeAlignBlockSize = struct {
                 .mask = mask,
                 .other = b.splat(num_experts, &.{hist_block}),
             });
-            const valid = mask.bitAnd(expert_vals.lt(num_experts));
+            const valid = mask.bitAnd(expert_vals.ge(0)).bitAnd(expert_vals.lt(num_experts));
             const h = b.histogramOpts(expert_vals, padded_num_experts, .{ .mask = valid });
             hist_loop.yield(.{hist_loop.carried[0].add(h)});
         }
@@ -627,7 +663,7 @@ pub const CountAndSortExpertTokens = struct {
                 .mask = mask,
                 .other = b.splat(num_experts, &.{block}),
             });
-            const valid = mask.bitAnd(expert_vals.lt(num_experts));
+            const valid = mask.bitAnd(expert_vals.ge(0)).bitAnd(expert_vals.lt(num_experts));
 
             // rank = atomic_add(cumsum + expert_vals, 1, mask=valid, sem="relaxed")
             const cumsum_ptrs = a.cumsum_ptr.addPtr(expert_vals);

--- a/zml/moe/triton_kernels/triton_kernels.zig
+++ b/zml/moe/triton_kernels/triton_kernels.zig
@@ -118,6 +118,69 @@ pub const PerTokenGroupQuantFp8 = struct {
     }
 };
 
+/// GLM's first expert projection is immediately followed by SwiGLU and a
+/// block-128 FP8 quantization for the down projection. Combining those two
+/// elementwise passes avoids materializing and rereading the BF16 activated
+/// tensor during decode.
+pub const SiluAndQuantizePerTokenGroupFp8 = struct {
+    pub const Cfg = struct {
+        input_dtype: DType,
+        output_dtype: DType,
+        scale_dtype: DType,
+        input_columns: usize,
+        output_columns: usize,
+        block: usize,
+        fp8_min: f32,
+        fp8_max: f32,
+        eps: f32,
+        activation_threshold: ?f32,
+    };
+    pub const Kernel = tri.Kernel(Cfg, .{
+        .name = "silu_and_quantize_per_token_group_fp8",
+        .inputs = &.{"x"},
+        .outputs = &.{ "q", "scale" },
+        .run = run,
+    });
+
+    fn run(b: *Builder, cfg: Cfg) tri.FinishError!void {
+        const a = try b.declareArgs(.{
+            .x_ptr = .{ .ptr = cfg.input_dtype },
+            .q_ptr = .{ .ptr = cfg.output_dtype },
+            .scale_ptr = .{ .ptr = cfg.scale_dtype },
+        });
+
+        const block: i64 = @intCast(cfg.block);
+        const input_columns: i64 = @intCast(cfg.input_columns);
+        const output_columns: i64 = @intCast(cfg.output_columns);
+        const groups_per_row: i64 = @divExact(output_columns, block);
+        const pid = b.programId(.x).to(.i64);
+        const row = pid.div(groups_per_row);
+        const group = pid.rem(groups_per_row);
+        const cols = b.arange(0, block, .i64);
+        const gate_offset = row.mul(input_columns).add(group.mul(block));
+        const up_offset = gate_offset.add(output_columns);
+        var gate = b.load(a.x_ptr.addPtr(gate_offset.add(cols))).to(.f32);
+        var up = b.load(a.x_ptr.addPtr(up_offset.add(cols))).to(.f32);
+        if (cfg.activation_threshold) |limit| {
+            gate = gate.minimum(limit);
+            up = up.maximum(-limit).minimum(limit);
+        }
+        const sigmoid = b.ones(&.{block}, .f32).add(b.exp(b.negf(gate)));
+        const activated = gate.div(sigmoid).mul(up);
+        const absmax = b.max(b.absf(activated)).maximum(cfg.eps);
+        const scale = absmax.mul(1.0 / cfg.fp8_max);
+        const quantized = b.clampf(
+            activated.div(scale),
+            b.splat(cfg.fp8_min, &.{block}),
+            b.splat(cfg.fp8_max, &.{block}),
+        ).to(cfg.output_dtype);
+
+        const output_offset = row.mul(output_columns).add(group.mul(block));
+        b.store(a.q_ptr.addPtr(output_offset.add(cols)), quantized);
+        b.store(a.scale_ptr.addPtr(pid), scale.to(cfg.scale_dtype));
+    }
+};
+
 // =============================================================================
 // write_zeros_to_output — helper called by FusedMoe
 // =============================================================================
@@ -160,6 +223,119 @@ fn writeZerosToOutput(
     const offs_cn_lt_full = b.broadcastTo(offs_cn_lt_2d, &.{ block_size_m, block_size_n });
     b.storeOpts(c_ptrs, accumulator, .{ .mask = token_mask_full.bitAnd(offs_cn_lt_full) });
 }
+
+// =============================================================================
+// fused_reduce_expert_routes
+// =============================================================================
+
+/// Applies FP32 router weights to materialized BF16 expert outputs, reducing
+/// routes in source order and narrowing only the final result.
+/// Invalid and non-local routes are skipped before their output or weight is
+/// loaded, matching vLLM's DeepGemm gather semantics.
+pub const FusedReduceExpertRoutes = struct {
+    pub const Cfg = struct {
+        num_tokens: usize,
+        top_k: usize,
+        hidden_size: usize,
+        global_num_experts: usize,
+        local_num_experts: usize,
+        block_d: usize,
+        has_expert_map: bool,
+    };
+    pub const Kernel = tri.Kernel(Cfg, .{
+        .name = "fused_reduce_expert_routes",
+        .inputs = &.{ "routes", "weights", "topk_ids", "expert_map" },
+        .outputs = &.{"output"},
+        .run = run,
+    });
+
+    fn run(b: *Builder, cfg: Cfg) tri.FinishError!void {
+        if (cfg.num_tokens == 0 or
+            cfg.top_k == 0 or
+            cfg.hidden_size == 0 or
+            cfg.global_num_experts == 0 or
+            cfg.local_num_experts == 0 or
+            cfg.block_d == 0 or
+            !std.math.isPowerOfTwo(cfg.block_d) or
+            @mod(cfg.hidden_size, cfg.block_d) != 0)
+        {
+            log.err("fused_reduce_expert_routes: invalid config", .{});
+            return error.InvalidMlir;
+        }
+
+        const a = try b.declareArgs(.{
+            .routes_ptr = .{ .ptr = .bf16 },
+            .weights_ptr = .{ .ptr = .f32 },
+            .topk_ids_ptr = .{ .ptr = .i32 },
+            .expert_map_ptr = .{ .ptr = .i32 },
+            .output_ptr = .{ .ptr = .bf16 },
+        });
+
+        const top_k: i64 = @intCast(cfg.top_k);
+        const num_tokens: i64 = @intCast(cfg.num_tokens);
+        const hidden_size: i64 = @intCast(cfg.hidden_size);
+        const global_num_experts: i32 = @intCast(cfg.global_num_experts);
+        const local_num_experts: i32 = @intCast(cfg.local_num_experts);
+        const block_d: i64 = @intCast(cfg.block_d);
+
+        const feature_block = b.programId(.x).to(.i64);
+        const token_start = b.programId(.y).to(.i64);
+        const token_stride = b.numPrograms(.y).to(.i64);
+        const offsets_d = feature_block.mul(block_d).add(b.arange(0, block_d, .i64));
+
+        var token_loop = b.openFor(token_start, num_tokens, token_stride, .{});
+        {
+            const token = token_loop.iv;
+            const route_row = token.mul(top_k);
+            var accumulator = b.zeros(&.{block_d}, .f32);
+
+            // This Zig loop emits one step per route while building the kernel;
+            // there is no GPU loop over top-k. Each step consumes the previous
+            // accumulator, preserving source-order FP32 addition.
+            for (0..cfg.top_k) |topk_index| {
+                const route_index = route_row.add(topk_index);
+                const global_expert_id = b.load(a.topk_ids_ptr.addPtr(route_index));
+                const global_valid = global_expert_id
+                    .ge(0)
+                    .bitAnd(global_expert_id.lt(global_num_experts));
+                const local_expert_id = if (cfg.has_expert_map) mapped: {
+                    // Guard the map lookup itself so negative and out-of-range
+                    // global ids cannot form an invalid memory access.
+                    var map_if = b.openIfElse(global_valid, .{b.scalarTy(.i32)});
+                    {
+                        map_if.yieldThen(.{b.load(a.expert_map_ptr.addPtr(global_expert_id))});
+                    }
+                    {
+                        map_if.yieldElse(.{b.liftAs(-1, .i32)});
+                    }
+                    break :mapped map_if.results[0];
+                } else global_expert_id;
+                const route_valid = global_valid
+                    .bitAnd(local_expert_id.ge(0))
+                    .bitAnd(local_expert_id.lt(local_num_experts));
+
+                // Keep the loads and multiply inside the branch. In particular,
+                // an invalid route with a NaN/Inf weight must leave the FP32
+                // accumulator unchanged rather than evaluating zero * weight.
+                var route_if = b.openIfElse(route_valid, .{b.tensorTy(&.{block_d}, .f32)});
+                {
+                    const route_offset = route_index.mul(hidden_size).add(offsets_d);
+                    const route = b.load(a.routes_ptr.addPtr(route_offset)).to(.f32);
+                    const weight = b.load(a.weights_ptr.addPtr(route_index));
+                    route_if.yieldThen(.{accumulator.add(route.mul(weight))});
+                }
+                {
+                    route_if.yieldElse(.{accumulator});
+                }
+                accumulator = route_if.results[0];
+            }
+
+            const output_offset = token.mul(hidden_size).add(offsets_d);
+            b.store(a.output_ptr.addPtr(output_offset), accumulator.to(.bf16));
+            token_loop.yield(.{});
+        }
+    }
+};
 
 // =============================================================================
 // fused_moe_kernel

--- a/zml/nn.zig
+++ b/zml/nn.zig
@@ -367,19 +367,19 @@ pub const LayerNorm = struct {
     eps: f32 = 1e-5,
 
     pub fn forward(self: LayerNorm, x: Tensor) Tensor {
-        const normed = normalizeVariance(x, self.eps);
+        const normed = normalizeVariance(x.convert(.f32), self.eps);
         const ax = x.axis(-1);
-        var out = normed.mul(self.weight.broadcast(x.shape(), &.{ax}));
-        if (self.bias) |bias| out = out.add(bias.broadcast(x.shape(), &.{ax}));
+        var out = normed.mul(self.weight.convert(.f32).broadcast(x.shape(), &.{ax}));
+        if (self.bias) |bias| out = out.add(bias.convert(.f32).broadcast(x.shape(), &.{ax}));
 
-        return out;
+        return out.convert(x.dtype());
     }
 };
 
 pub fn rmsNorm(x_: Tensor, axis: anytype, eps: f32) Tensor {
     const ax = x_.axis(axis);
     // upcast to improve precision
-    var x = x_.convert(.f32);
+    const x = x_.convert(.f32);
     const variance = x.powByConst(2).mean(ax);
     const rsqrt = Tensor.rsqrt(variance.addConstant(eps));
     return x.mul(rsqrt.broad(x.shape())).convert(x_.dtype());
@@ -399,6 +399,95 @@ pub fn normalizeVariance(x: Tensor, eps: f32) Tensor {
     const rsqrt = Tensor.rsqrt(variance.addConstant(eps));
 
     return mean_dev.mul(rsqrt).convert(x.dtype());
+}
+
+test "normalization keeps affine operations in f32" {
+    const platform = zml.testing.env();
+    const bf16 = zml.floats.BFloat16;
+
+    const input: Tensor = .init(.{ .b = 1, .d = 8 }, .bf16);
+    const weight: Tensor = .init(.{ .d = 8 }, .bf16);
+    const bias: Tensor = .init(.{ .d = 8 }, .bf16);
+
+    const Local = struct {
+        fn layerNorm(x: Tensor, w: Tensor, b: Tensor) Tensor {
+            return (LayerNorm{ .weight = w, .bias = b, .eps = 0 }).forward(x);
+        }
+
+        fn rmsNorm(x: Tensor, w: Tensor) Tensor {
+            const normalized = zml.nn.rmsNorm(x.convert(.f32), .d, 0);
+            return normalized.mul(w.convert(.f32).broadcast(x.shape(), &.{x.axis(.d)})).convert(x.dtype());
+        }
+    };
+
+    var layer_norm_exe = try platform.compileFn(std.testing.allocator, std.testing.io, Local.layerNorm, .{ input, weight, bias }, .{});
+    defer layer_norm_exe.deinit();
+    var rms_norm_exe = try platform.compileFn(std.testing.allocator, std.testing.io, Local.rmsNorm, .{ input, weight }, .{});
+    defer rms_norm_exe.deinit();
+
+    const layer_norm_input_h = [_]bf16{
+        bf16.fromF32(-6),
+        bf16.fromF32(-4),
+        bf16.fromF32(0),
+        bf16.fromF32(2),
+        bf16.fromF32(2),
+        bf16.fromF32(2),
+        bf16.fromF32(2),
+        bf16.fromF32(2),
+    };
+    const rms_norm_input_h = [_]bf16{
+        bf16.fromF32(1),
+        bf16.fromF32(1),
+        bf16.fromF32(1),
+        bf16.fromF32(2),
+        bf16.fromF32(2),
+        bf16.fromF32(3),
+        bf16.fromF32(4),
+        bf16.fromF32(6),
+    };
+    const weight_h: [8]bf16 = @splat(bf16.fromF32(10));
+    // These inputs have an exactly representable variance of 9. The affine values
+    // straddle separate BF16 rounding boundaries before and after the bias addition.
+    const bias_h: [8]bf16 = @splat(bf16.fromF32(-1.9921875));
+
+    var layer_norm_input = try zml.Buffer.fromBytes(std.testing.io, platform, input.shape(), .replicated, std.mem.sliceAsBytes(&layer_norm_input_h));
+    defer layer_norm_input.deinit();
+    var rms_norm_input = try zml.Buffer.fromBytes(std.testing.io, platform, input.shape(), .replicated, std.mem.sliceAsBytes(&rms_norm_input_h));
+    defer rms_norm_input.deinit();
+    var weight_buffer = try zml.Buffer.fromBytes(std.testing.io, platform, weight.shape(), .replicated, std.mem.sliceAsBytes(&weight_h));
+    defer weight_buffer.deinit();
+    var bias_buffer = try zml.Buffer.fromBytes(std.testing.io, platform, bias.shape(), .replicated, std.mem.sliceAsBytes(&bias_h));
+    defer bias_buffer.deinit();
+
+    var layer_norm_result = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &layer_norm_exe, Local.layerNorm, .{ layer_norm_input, weight_buffer, bias_buffer });
+    defer layer_norm_result.deinit();
+    const expected_layer_norm_h = [_]bf16{
+        bf16.fromF32(-22),
+        bf16.fromF32(-15.3125),
+        bf16.fromF32(-1.9921875),
+        bf16.fromF32(4.6875),
+        bf16.fromF32(4.6875),
+        bf16.fromF32(4.6875),
+        bf16.fromF32(4.6875),
+        bf16.fromF32(4.6875),
+    };
+    const expected_layer_norm: Slice = .init(input.shape(), std.mem.sliceAsBytes(&expected_layer_norm_h));
+    try zml.testing.expectClose(std.testing.io, expected_layer_norm, layer_norm_result, .exact_match);
+
+    var rms_norm_result = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &rms_norm_exe, Local.rmsNorm, .{ rms_norm_input, weight_buffer });
+    defer rms_norm_result.deinit();
+    const expected_rms_norm_h = [_]bf16{
+        bf16.fromF32(3.328125),
+        bf16.fromF32(3.328125),
+        bf16.fromF32(3.328125),
+        bf16.fromF32(6.65625),
+        bf16.fromF32(6.65625),
+        bf16.fromF32(10),
+        bf16.fromF32(13.3125),
+        bf16.fromF32(20),
+    };
+    const expected_rms_norm: Slice = .init(input.shape(), std.mem.sliceAsBytes(&expected_rms_norm_h));
+    try zml.testing.expectClose(std.testing.io, expected_rms_norm, rms_norm_result, .exact_match);
 }
 
 // ref: https://pytorch.org/docs/stable/generated/torch.nn.functional.normalize.html

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -113,7 +113,7 @@ pub fn allReduce(inputs: anytype, comptime func: anytype) AllReduceReturnType(@T
         break :b block;
     };
 
-    var replica_group_storage: [constants.MAX_RANK]i64 = undefined;
+    var replica_group_storage: [Platform.MAX_NUM_DEVICES]i64 = undefined;
     for (0..@intCast(num_devices)) |i| {
         replica_group_storage[i] = @intCast(i);
     }

--- a/zml/ops.zig
+++ b/zml/ops.zig
@@ -751,6 +751,59 @@ test "if" {
     }
 }
 
+test "if captures tagged quantized linear" {
+    const zml = @import("zml.zig");
+    const platform = zml.testing.env();
+
+    const IfMod = struct {
+        input: Tensor,
+        linear: zml.nn.Linear,
+
+        pub fn forward(pred: Tensor, input: Tensor, weight: Tensor, scales: Tensor) Tensor {
+            const linear: zml.nn.Linear = .{
+                .weight = weight,
+                .tag = Shape.toTag(.in),
+                .quantization = .{ .scheme = .fp8_block128, .scales = scales },
+            };
+            return @"if"(@This(), .{ .input = input, .linear = linear }, pred.convert(.bool));
+        }
+
+        pub fn onTrue(ctx: @This()) Tensor {
+            return ctx.input.dot(ctx.linear.weight, ctx.linear.tag).addConstant(1);
+        }
+
+        pub fn onFalse(ctx: @This()) Tensor {
+            return ctx.input.dot(ctx.linear.weight, ctx.linear.tag).subConstant(1);
+        }
+    };
+
+    const pred: Tensor = .init(.{}, .i32);
+    const input: Tensor = .init(.{ .b = 1, .in = 2 }, .f32);
+    const weight: Tensor = .init(.{ .out = 2, .in = 2 }, .f32);
+    const scales: Tensor = .init(.{ .out_block = 1, .in_block = 1 }, .f32);
+    var exe = try platform.compileFn(std.testing.allocator, std.testing.io, IfMod.forward, .{ pred, input, weight, scales }, .{});
+    defer exe.deinit();
+
+    var input_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, input.shape(), .replicated, std.mem.sliceAsBytes(&[2]f32{ 2, 3 }));
+    defer input_buffer.deinit();
+    var weight_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, weight.shape(), .replicated, std.mem.sliceAsBytes(&[4]f32{ 1, 0, 0, 1 }));
+    defer weight_buffer.deinit();
+    var scales_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, scales.shape(), .replicated, std.mem.sliceAsBytes(&[1]f32{1}));
+    defer scales_buffer.deinit();
+
+    inline for (.{ .{ 1, [2]f32{ 3, 4 } }, .{ 0, [2]f32{ 1, 2 } } }) |case| {
+        var pred_buffer: zml.Buffer = try .fromBytes(std.testing.io, platform, pred.shape(), .replicated, std.mem.sliceAsBytes(&[1]i32{case[0]}));
+        defer pred_buffer.deinit();
+        var result = try zml.testing.autoCall(std.testing.allocator, std.testing.io, &exe, IfMod.forward, .{ pred_buffer, input_buffer, weight_buffer, scales_buffer });
+        defer result.deinit();
+        var host = try result.toSliceAlloc(std.testing.allocator, std.testing.io);
+        defer host.free(std.testing.allocator);
+        inline for (case[1], 0..) |expected, i| {
+            try std.testing.expectEqual(expected, host.items(f32)[i]);
+        }
+    }
+}
+
 /// Simpler variant of `zml.ops.if` that assumes code-motion is supported by the backend.
 /// The two branches are evaluated before the condition, then the condition chose which branches to keep.
 pub fn if2(


### PR DESCRIPTION
Enable GLM 5.3 Flash's routed experts with block-128 FP8 projections and composable tensor- and expert-parallel execution.

- Support E4M3 FN/FNUZ weights with per-token 128-element activation groups, FP32 activation scales, and BF16 or FP32 weight scales. Validate quantization metadata and block alignment before execution.
- Fuse SwiGLU and FP8 quantization on CUDA and ROCm, and allow prepared input activations to be reused across routed and shared projections.
- Add tensor-parallel expert execution and expose TritonMoe.forwardLocal so callers can combine local contributions before a collective.
- Apply router weights to BF16 expert outputs and accumulate in FP32. Fuse masking, weighting, and reduction for arbitrary top-k with FP32 router weights on CUDA and ROCm; skip invalid and non-local routes.
- Pad routing histograms to a power of two for counts such as 288 experts, and size launch heuristics using the full batch token count.
- Keep LayerNorm affine operations in FP32, preserve borrowed tensor tags in mapAlloc captures, and size allReduce groups by the device limit.

Add regression coverage for quantization validation, top-k kernel IR, normalization precision, and tagged quantized Linear captures.